### PR TITLE
fix: support arbitrary version segments in openai-compat base URLs

### DIFF
--- a/crates/ai-memory-llm/src/embedding.rs
+++ b/crates/ai-memory-llm/src/embedding.rs
@@ -114,7 +114,7 @@ impl Embedder for OpenAiEmbedder {
     }
 
     async fn embed(&self, text: &str) -> LlmResult<Vec<f32>> {
-        let url = format!("{}/v1/embeddings", normalize_openai_base(&self.base_url));
+        let url = normalize_openai_base(&self.base_url, "embeddings");
         debug!(url, model = %self.model, "POST openai/embeddings");
         let req = OpenAiEmbeddingRequest {
             input: text,
@@ -222,7 +222,7 @@ impl Embedder for VoyageEmbedder {
     }
 
     async fn embed(&self, text: &str) -> LlmResult<Vec<f32>> {
-        let url = format!("{}/v1/embeddings", normalize_openai_base(&self.base_url));
+        let url = normalize_openai_base(&self.base_url, "embeddings");
         let req = VoyageRequest {
             input: [text],
             model: &self.model,

--- a/crates/ai-memory-llm/src/openai.rs
+++ b/crates/ai-memory-llm/src/openai.rs
@@ -15,19 +15,35 @@ use crate::types::{ChatRequest, ChatResponse, Role, Usage};
 /// Default OpenAI API base.
 pub const DEFAULT_BASE_URL: &str = "https://api.openai.com";
 
-/// Trim a trailing `/` and one optional `/v1` segment off an
-/// OpenAI-style base URL so the caller can append `/v1/<endpoint>`
-/// safely. Tolerates both conventions found in the wild:
+/// Build the full URL for an OpenAI-style endpoint. Tolerates the
+/// conventions found in the wild:
 ///   * `https://api.openai.com`           (OpenAI's own docs)
 ///   * `https://openrouter.ai/api/v1`     (OpenRouter's docs)
 ///   * `http://localhost:11434/v1`        (Ollama's openai-compat path)
+///   * `https://api.z.ai/api/coding/paas/v4` (Z.AI)
 ///
 /// Without this, half the providers produce `…/v1/v1/…` 404s the
 /// first time consolidation runs.
 #[must_use]
-pub fn normalize_openai_base(url: &str) -> String {
-    let s = url.trim_end_matches('/');
-    s.strip_suffix("/v1").unwrap_or(s).to_string()
+pub fn normalize_openai_base(base: &str, endpoint: &str) -> String {
+    let s = base.trim_end_matches('/');
+
+    if s.ends_with(&format!("/{endpoint}")) {
+        return s.to_string();
+    }
+
+    if last_segment_is_version(s) {
+        return format!("{s}/{endpoint}");
+    }
+
+    format!("{s}/v1/{endpoint}")
+}
+
+fn last_segment_is_version(url: &str) -> bool {
+    url.split('/').next_back().is_some_and(|seg| {
+        let digits = seg.strip_prefix('v').unwrap_or("");
+        !digits.is_empty() && digits.len() <= 2 && digits.chars().all(|c| c.is_ascii_digit())
+    })
 }
 
 /// OpenAI Chat Completions-backed provider.
@@ -211,10 +227,7 @@ impl OpenAiProvider {
     }
 
     async fn post<B: Serialize>(&self, body: &B) -> LlmResult<OpenAiResponse> {
-        let url = format!(
-            "{}/v1/chat/completions",
-            normalize_openai_base(&self.base_url)
-        );
+        let url = normalize_openai_base(&self.base_url, "chat/completions");
         debug!(url, "POST openai");
         let resp = self
             .client
@@ -249,32 +262,69 @@ mod tests {
     use super::normalize_openai_base;
 
     #[test]
-    fn normalize_strips_trailing_slash_and_v1() {
-        // The three conventions found in the wild.
+    fn normalize_openai_base_chat_completions() {
+        let ep = "chat/completions";
+
         assert_eq!(
-            normalize_openai_base("https://api.openai.com"),
-            "https://api.openai.com"
+            normalize_openai_base("https://api.openai.com", ep),
+            "https://api.openai.com/v1/chat/completions"
         );
         assert_eq!(
-            normalize_openai_base("https://api.openai.com/"),
-            "https://api.openai.com"
+            normalize_openai_base("https://api.openai.com/", ep),
+            "https://api.openai.com/v1/chat/completions"
         );
-        // OpenRouter's docs / ai-memory's OpenRouter env entry.
         assert_eq!(
-            normalize_openai_base("https://openrouter.ai/api/v1"),
-            "https://openrouter.ai/api"
+            normalize_openai_base("https://openrouter.ai/api/v1", ep),
+            "https://openrouter.ai/api/v1/chat/completions"
         );
-        // Ollama's openai-compat path (`docker logs` shows it
-        // canonically advertised this way).
         assert_eq!(
-            normalize_openai_base("http://localhost:11434/v1"),
-            "http://localhost:11434"
+            normalize_openai_base("http://localhost:11434/v1", ep),
+            "http://localhost:11434/v1/chat/completions"
         );
-        // Don't accidentally strip a `/v1` that's part of a longer
-        // segment (e.g. `/v123/`).
+        // /v123 must not be treated as a version segment.
         assert_eq!(
-            normalize_openai_base("https://example.com/v123"),
-            "https://example.com/v123"
+            normalize_openai_base("https://example.com/v123", ep),
+            "https://example.com/v123/v1/chat/completions"
+        );
+        // Z.AI-style: non-v1 version segment in the path.
+        assert_eq!(
+            normalize_openai_base("https://api.z.ai/api/coding/paas/v4", ep),
+            "https://api.z.ai/api/coding/paas/v4/chat/completions"
+        );
+        // Full endpoint URL already provided (Z.AI or GitHub Copilot style).
+        assert_eq!(
+            normalize_openai_base("https://api.z.ai/api/coding/paas/v4/chat/completions", ep),
+            "https://api.z.ai/api/coding/paas/v4/chat/completions"
+        );
+        assert_eq!(
+            normalize_openai_base("https://api.githubcopilot.com/chat/completions", ep),
+            "https://api.githubcopilot.com/chat/completions"
+        );
+    }
+
+    #[test]
+    fn normalize_openai_base_embeddings() {
+        let ep = "embeddings";
+
+        assert_eq!(
+            normalize_openai_base("https://api.openai.com", ep),
+            "https://api.openai.com/v1/embeddings"
+        );
+        assert_eq!(
+            normalize_openai_base("https://openrouter.ai/api/v1", ep),
+            "https://openrouter.ai/api/v1/embeddings"
+        );
+        assert_eq!(
+            normalize_openai_base("http://localhost:11434/v1", ep),
+            "http://localhost:11434/v1/embeddings"
+        );
+        assert_eq!(
+            normalize_openai_base("https://example.com/v123", ep),
+            "https://example.com/v123/v1/embeddings"
+        );
+        assert_eq!(
+            normalize_openai_base("https://api.z.ai/api/coding/paas/v4", ep),
+            "https://api.z.ai/api/coding/paas/v4/embeddings"
         );
     }
 }


### PR DESCRIPTION
## Motivation

The `openai-compat` provider normalizes the configured base URL by stripping
a trailing `/v1` and then always re-appending `/v1/chat/completions` (or
`/v1/embeddings`). This works for the common cases (OpenAI, OpenRouter,
Ollama) but breaks providers that use a different version segment in their
path, such as **Z.AI** (`/v4`) or any provider that already includes the
full endpoint URL in the configured base.

## Before

`normalize_openai_base` stripped `/v1` and the caller unconditionally
re-inserted it:

```rust
pub fn normalize_openai_base(url: &str) -> String {
    let s = url.trim_end_matches('/');
    s.strip_suffix("/v1").unwrap_or(s).to_string()
}
```

With `AI_MEMORY_LLM_BASE_URL=https://api.z.ai/api/coding/paas/v4` the
resulting request URL was:

```
https://api.z.ai/api/coding/paas/v4/v1/chat/completions  ← 404
```

## After

`normalize_openai_base` now receives the target endpoint and builds the
full URL in one step, covering three cases in priority order:

1. URL already ends with `/<endpoint>` (full endpoint URL supplied) → used as-is
2. Last path segment is a version token `v\d{1,2}` (e.g. `v1`, `v4`) → append `/<endpoint>` directly
3. Bare host with no version segment → append `/v1/<endpoint>` (OpenAI default)

```rust
pub fn normalize_openai_base(base: &str, endpoint: &str) -> String { … }
```

| Configured base URL | Before | After |
|---|---|---|
| `https://api.openai.com` | `.../v1/chat/completions` ✓ | `.../v1/chat/completions` ✓ |
| `https://openrouter.ai/api/v1` | `.../v1/chat/completions` ✓ | `.../v1/chat/completions` ✓ |
| `http://localhost:11434/v1` | `.../v1/chat/completions` ✓ | `.../v1/chat/completions` ✓ |
| `https://api.z.ai/api/coding/paas/v4` | `.../v4/v1/chat/completions` ✗ | `.../v4/chat/completions` ✓ |
| `https://api.githubcopilot.com/chat/completions` | `.../chat/completions/v1/chat/completions` ✗ | `.../chat/completions` ✓ |

The same fix applies to the embedding providers (`OpenAiEmbedder`,
`VoyageEmbedder`) which shared the same pattern.

## Test plan

- Existing unit tests for `normalize_openai_base` updated to assert the
  full URL (not just the normalized base), covering all three branches
- New cases added for Z.AI-style `/v4` path and full endpoint URLs
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass