### PR TITLE
fix(wrapper): support macOS default bash (3.2) with set -u

### DIFF
--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -255,13 +255,13 @@ fi
 # binary can derive the *real* host-side project name from it. The
 # `commands::resolve_project_name` helper checks this env var first
 # and falls back to the cwd basename only if it's unset.
-exec "${DOCKER}" run --rm "${TTY_ARGS[@]}" \
+exec "${DOCKER}" run --rm ${TTY_ARGS[@]+"${TTY_ARGS[@]}"} \
   -v "${HOME}:${HOME}" \
   -v "${PWD}:/work" \
   -w /work \
   -e HOME="${HOME}" \
   -e AI_MEMORY_HOST_CWD="${PWD}" \
   -u "$(id -u):$(id -g)" \
-  "${DATA_ARGS[@]}" \
-  "${ENV_ARGS[@]}" \
+  ${DATA_ARGS[@]+"${DATA_ARGS[@]}"} \
+  ${ENV_ARGS[@]+"${ENV_ARGS[@]}"} \
   "${IMAGE}" "$@"


### PR DESCRIPTION
Fixes unbound variable error on macOS when running with the default Bash 3.2.

macOS ships with Bash 3.2, which treats empty array expansions like `"${ENV_ARGS[@]}"` as unbound variables when `set -u` is enabled.

Changes the wrapper script to use the portable `"}` syntax for TTY_ARGS, DATA_ARGS, and ENV_ARGS.

## Error

```
ai-memory --help
/Users/diego/.local/bin/ai-memory: line 258: ENV_ARGS[@]: unbound variable
```