### PR TITLE
feat: Windows support — build, test, and runtime fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "winapi-util",
 ]
 
 [[package]]

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -27,6 +27,12 @@ use crate::commands::render_shared::{
 };
 use crate::config::Config;
 
+/// Platform-appropriate extension for hook scripts: `.ps1` on
+/// Windows, `.sh` everywhere else.
+fn hook_script_ext() -> &'static str {
+    if cfg!(windows) { "ps1" } else { "sh" }
+}
+
 /// Run the `install-hooks` subcommand.
 ///
 /// # Errors
@@ -939,7 +945,7 @@ fn render_agent(
     for entry in std::fs::read_dir(hooks_dir)? {
         let entry = entry?;
         let p = entry.path();
-        if p.is_file() && p.extension().is_some_and(|e| e == "sh") {
+        if p.is_file() && p.extension().is_some_and(|e| e == hook_script_ext()) {
             println!("- {}", p.display());
         }
     }
@@ -991,7 +997,7 @@ fn stage_hook_scripts(source_dir: &Path, agent_label: &str) -> Result<PathBuf> {
     if let Ok(entries) = fs::read_dir(&dest_root) {
         for entry in entries.flatten() {
             let p = entry.path();
-            if p.is_file() && p.extension().is_some_and(|e| e == "sh") {
+            if p.is_file() && p.extension().is_some_and(|e| e == hook_script_ext()) {
                 fs::remove_file(&p).ok();
             }
         }
@@ -1003,7 +1009,7 @@ fn stage_hook_scripts(source_dir: &Path, agent_label: &str) -> Result<PathBuf> {
     {
         let entry = entry?;
         let from = entry.path();
-        if !from.is_file() || from.extension().and_then(|s| s.to_str()) != Some("sh") {
+        if !from.is_file() || from.extension().and_then(|s| s.to_str()) != Some(hook_script_ext()) {
             continue;
         }
         let to = dest_root.join(from.file_name().context("bad source file name")?);
@@ -1035,8 +1041,13 @@ fn resolve_hooks_dir(explicit: Option<&Path>, agent: AgentChoice) -> Result<Path
         // OMP/OpenClaw have no shell hook scripts → no script dir needed. Return a
         // sentinel that's never touched; the caller's apply path
         // short-circuits before any filesystem use.
-        AgentChoice::Omp => return Ok(PathBuf::from("/dev/null")),
-        AgentChoice::Openclaw => return Ok(PathBuf::from("/dev/null")),
+        AgentChoice::Omp | AgentChoice::Openclaw => {
+            return Ok(PathBuf::from(if cfg!(windows) {
+                "NUL"
+            } else {
+                "/dev/null"
+            }));
+        }
     };
     if let Some(p) = explicit {
         let path = p.join(sub);
@@ -1084,7 +1095,8 @@ fn render_claude_code(hooks_dir: &Path, server_url: &str, auth_token: Option<&st
     // that exists only on the host's filesystem — bailing would
     // sabotage the docker-only flow `setup-agent` enables.
     for (_, script) in super::render_shared::CLAUDE_CODE_EVENTS {
-        let abs = hooks_dir.join(script);
+        let actual = super::render_shared::platform_script_name(script);
+        let abs = hooks_dir.join(actual);
         if !abs.exists() {
             eprintln!(
                 "# warning: {} not present on this filesystem. \

--- a/crates/ai-memory-cli/src/commands/render_shared.rs
+++ b/crates/ai-memory-cli/src/commands/render_shared.rs
@@ -37,6 +37,17 @@ pub(crate) const CLAUDE_CODE_EVENTS: [(&str, &str); 7] = [
     ("SessionEnd", "session-end.sh"),
 ];
 
+/// Return the platform-appropriate script filename. On Windows the
+/// hook runner invokes PowerShell `.ps1` scripts; everywhere else
+/// POSIX `.sh` scripts.
+pub(crate) fn platform_script_name(sh_name: &str) -> String {
+    if cfg!(windows) {
+        sh_name.replace(".sh", ".ps1")
+    } else {
+        sh_name.to_string()
+    }
+}
+
 /// Format an `Authorization: Bearer <token>` header value, or `None`
 /// when no token is supplied. Used by every MCP client renderer in
 /// `install-mcp` and every hook-config renderer that wants to
@@ -212,7 +223,8 @@ fn build_hook_payload(
 ) -> serde_json::Value {
     let mut hooks_block = serde_json::Map::new();
     for (event, script) in events {
-        let abs = emit_root.join(script);
+        let actual_script = platform_script_name(script);
+        let abs = emit_root.join(&actual_script);
 
         // Claude Code's hook schema (per
         // https://code.claude.com/docs/en/hooks):
@@ -223,7 +235,6 @@ fn build_hook_payload(
         //   ]
         //
         // We INLINE env vars into the command string itself
-        // (`AI_MEMORY_HOOK_URL=... AI_MEMORY_AUTH_TOKEN=... /path`)
         // rather than passing them through an `env` field on the
         // hook entry. Reasons:
         //   1. CC doesn't appear to honour an `env` field at this
@@ -232,15 +243,35 @@ fn build_hook_payload(
         //      127.0.0.1 default, so POSTs go nowhere.
         //   2. Inlining the env into the command string is
         //      portable across any shell-style hook runner — POSIX
-        //      `VAR=val command` syntax is universally honoured.
+        //      `VAR=val command` syntax is universally honoured;
+        //      on Windows we use `$env:VAR='val'; & powershell …`.
         //   3. The hook scripts already read those env vars (see
         //      `hooks/claude-code/session-start.sh` etc.), so no
         //      script changes are required.
-        let mut prefix = format!("AI_MEMORY_HOOK_URL={} ", shell_quote(server_url));
-        if let Some(t) = auth_token {
-            prefix.push_str(&format!("AI_MEMORY_AUTH_TOKEN={} ", shell_quote(t)));
-        }
-        let command = format!("{prefix}{}", abs.to_string_lossy());
+        let command = if cfg!(windows) {
+            let mut parts = Vec::new();
+            parts.push(format!(
+                "$env:AI_MEMORY_HOOK_URL='{}'",
+                server_url.replace('\'', "''")
+            ));
+            if let Some(t) = auth_token {
+                parts.push(format!(
+                    "$env:AI_MEMORY_AUTH_TOKEN='{}'",
+                    t.replace('\'', "''")
+                ));
+            }
+            parts.push(format!(
+                "& powershell -NoProfile -File '{}'",
+                abs.to_string_lossy().replace('\'', "''")
+            ));
+            parts.join("; ")
+        } else {
+            let mut prefix = format!("AI_MEMORY_HOOK_URL={} ", shell_quote(server_url));
+            if let Some(t) = auth_token {
+                prefix.push_str(&format!("AI_MEMORY_AUTH_TOKEN={} ", shell_quote(t)));
+            }
+            format!("{prefix}{}", abs.to_string_lossy())
+        };
 
         // Empty matcher = fire on every event of this kind. Right
         // for ai-memory's capture hooks (every prompt, every tool
@@ -294,7 +325,11 @@ mod tests {
 
     #[test]
     fn claude_code_payload_has_seven_events() {
-        let root = PathBuf::from("/host/hooks/claude-code");
+        let root = if cfg!(windows) {
+            PathBuf::from(r"C:\host\hooks\claude-code")
+        } else {
+            PathBuf::from("/host/hooks/claude-code")
+        };
         let v = build_claude_code_payload(&root, "http://localhost:49374", None);
         let hooks = v.get("hooks").and_then(|h| h.as_object()).unwrap();
         assert_eq!(hooks.len(), 7);
@@ -305,7 +340,11 @@ mod tests {
 
     #[test]
     fn claude_code_payload_embeds_auth_token_when_provided() {
-        let root = PathBuf::from("/host/hooks/claude-code");
+        let root = if cfg!(windows) {
+            PathBuf::from(r"C:\host\hooks\claude-code")
+        } else {
+            PathBuf::from("/host/hooks/claude-code")
+        };
         let v = build_claude_code_payload(&root, "http://localhost:49374", Some("tok"));
         // Env vars are inlined into the command string so CC's
         // hook runner sees them regardless of whether it honours
@@ -316,11 +355,11 @@ mod tests {
             .and_then(|s| s.as_str())
             .unwrap();
         assert!(
-            command.contains("AI_MEMORY_AUTH_TOKEN=tok"),
+            command.contains("AI_MEMORY_AUTH_TOKEN") && command.contains("tok"),
             "command should inline the auth token; got: {command}"
         );
         assert!(
-            command.contains("AI_MEMORY_HOOK_URL=http://localhost:49374"),
+            command.contains("AI_MEMORY_HOOK_URL") && command.contains("http://localhost:49374"),
             "command should inline the hook URL; got: {command}"
         );
     }
@@ -336,7 +375,11 @@ mod tests {
     fn cursor_payload_uses_flat_shape() {
         // Flat shape: no inner `hooks: [...]` array; each event
         // maps to an array of {type, command, matcher} entries.
-        let root = PathBuf::from("/host/hooks/cursor");
+        let root = if cfg!(windows) {
+            PathBuf::from(r"C:\host\hooks\cursor")
+        } else {
+            PathBuf::from("/host/hooks/cursor")
+        };
         let v = build_profile_payload(
             &CURSOR_PROFILE,
             &root,
@@ -366,7 +409,10 @@ mod tests {
             .get("command")
             .and_then(|c| c.as_str())
             .unwrap();
-        assert!(cmd.contains("AI_MEMORY_AUTH_TOKEN=tok"));
+        assert!(
+            cmd.contains("AI_MEMORY_AUTH_TOKEN") && cmd.contains("tok"),
+            "command should inline the auth token; got: {cmd}"
+        );
         // Events are camelCase, not PascalCase.
         let events: Vec<&str> = v
             .pointer("/hooks")
@@ -386,7 +432,11 @@ mod tests {
         // Same nested shape as Claude Code, but DIFFERENT event
         // names (BeforeTool / AfterTool / PreCompress; no
         // UserPromptSubmit, no Stop).
-        let root = PathBuf::from("/host/hooks/gemini-cli");
+        let root = if cfg!(windows) {
+            PathBuf::from(r"C:\host\hooks\gemini-cli")
+        } else {
+            PathBuf::from("/host/hooks/gemini-cli")
+        };
         let v = build_profile_payload(
             &GEMINI_PROFILE,
             &root,
@@ -441,7 +491,11 @@ mod tests {
 
     #[test]
     fn claude_code_payload_uses_matcher_plus_inner_hooks_shape() {
-        let root = PathBuf::from("/host/hooks/claude-code");
+        let root = if cfg!(windows) {
+            PathBuf::from(r"C:\host\hooks\claude-code")
+        } else {
+            PathBuf::from("/host/hooks/claude-code")
+        };
         let v = build_claude_code_payload(&root, "http://localhost:49374", None);
         for (event, _) in CLAUDE_CODE_EVENTS {
             let outer = v
@@ -469,32 +523,63 @@ mod tests {
 
     #[test]
     fn claude_code_payload_omits_auth_token_when_absent() {
-        let root = PathBuf::from("/host/hooks/claude-code");
+        let root = if cfg!(windows) {
+            PathBuf::from(r"C:\host\hooks\claude-code")
+        } else {
+            PathBuf::from("/host/hooks/claude-code")
+        };
         let v = build_claude_code_payload(&root, "http://localhost:49374", None);
         let command = v
             .pointer("/hooks/SessionStart/0/hooks/0/command")
             .and_then(|s| s.as_str())
             .unwrap();
-        assert!(command.contains("AI_MEMORY_HOOK_URL="));
+        assert!(command.contains("AI_MEMORY_HOOK_URL"));
         assert!(
-            !command.contains("AI_MEMORY_AUTH_TOKEN="),
+            !command.contains("AI_MEMORY_AUTH_TOKEN"),
             "no token expected in command: {command}"
         );
     }
 
     #[test]
     fn claude_code_payload_emits_absolute_paths() {
-        let root = PathBuf::from("/home/user/.ai-memory/hooks/claude-code");
+        let root = if cfg!(windows) {
+            PathBuf::from(r"C:\Users\user\.ai-memory\hooks\claude-code")
+        } else {
+            PathBuf::from("/home/user/.ai-memory/hooks/claude-code")
+        };
         let v = build_claude_code_payload(&root, "http://localhost:49374", None);
         let cmd = v
             .pointer("/hooks/SessionStart/0/hooks/0/command")
             .and_then(|s| s.as_str())
             .unwrap();
-        // The command now has the env prefix + the absolute path,
-        // joined by a single space.
+        let script_name = platform_script_name("session-start.sh");
+        let expected_path = root.join(&script_name).to_string_lossy().to_string();
         assert!(
-            cmd.ends_with("/home/user/.ai-memory/hooks/claude-code/session-start.sh"),
-            "command should end with the absolute script path: {cmd}"
+            cmd.contains(&expected_path),
+            "command should contain the absolute script path: {cmd}"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn claude_code_payload_emits_powershell_commands_on_windows() {
+        let root = PathBuf::from(r"C:\Users\user\.ai-memory\hooks\claude-code");
+        let v = build_claude_code_payload(&root, "http://localhost:49374", Some("tok"));
+        let cmd = v
+            .pointer("/hooks/SessionStart/0/hooks/0/command")
+            .and_then(|s| s.as_str())
+            .unwrap();
+        assert!(
+            cmd.contains("$env:AI_MEMORY_HOOK_URL="),
+            "Windows command should use $env: syntax; got: {cmd}"
+        );
+        assert!(
+            cmd.contains("powershell"),
+            "Windows command should invoke powershell; got: {cmd}"
+        );
+        assert!(
+            cmd.contains(".ps1"),
+            "Windows command should reference .ps1 script; got: {cmd}"
         );
     }
 }

--- a/crates/ai-memory-hooks/src/payload.rs
+++ b/crates/ai-memory-hooks/src/payload.rs
@@ -312,15 +312,16 @@ mod tests {
             event: "session-start".into(),
             agent: Some("claude-code".into()),
         };
+        let cwd_val = if cfg!(windows) { r"C:\tmp\x" } else { "/tmp/x" };
         let raw = serde_json::json!({
             "session_id": "abc-123",
-            "cwd": "/tmp/x",
+            "cwd": cwd_val,
             "model": "claude-sonnet-4-6"
         });
         let env = HookEnvelope::from_query_and_body(q, raw);
         assert_eq!(env.event, HookEvent::SessionStart);
         assert_eq!(env.session_id.as_deref(), Some("abc-123"));
-        assert_eq!(env.cwd.as_deref(), Some("/tmp/x"));
+        assert_eq!(env.cwd.as_deref(), Some(cwd_val));
         assert_eq!(env.title_hint.as_deref(), Some("claude-sonnet-4-6"));
     }
 

--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -1165,7 +1165,14 @@ mod tests {
                 open_questions: vec!["what max channel size?".into()],
                 next_steps: vec!["finish supersession path".into()],
                 files_touched: vec!["crates/ai-memory-store/src/writer.rs".into()],
-                cwd: Some("/tmp/aim".into()),
+                cwd: Some(
+                    if cfg!(windows) {
+                        r"C:\tmp\aim"
+                    } else {
+                        "/tmp/aim"
+                    }
+                    .into(),
+                ),
             }))
             .await
             .unwrap();
@@ -1180,7 +1187,14 @@ mod tests {
         // Accepting with matching cwd returns the handoff.
         let accept = server
             .memory_handoff_accept(Parameters(HandoffAcceptArgs {
-                cwd: Some("/tmp/aim".into()),
+                cwd: Some(
+                    if cfg!(windows) {
+                        r"C:\tmp\aim"
+                    } else {
+                        "/tmp/aim"
+                    }
+                    .into(),
+                ),
             }))
             .await
             .unwrap();

--- a/crates/ai-memory-mcp/tests/admin_phase3.rs
+++ b/crates/ai-memory-mcp/tests/admin_phase3.rs
@@ -87,7 +87,11 @@ async fn seed_sessions_for_reorg(store: &Store) -> (SessionId, SessionId) {
             workspace_id: ws,
             project_id: scratch,
             agent_kind: AgentKind::ClaudeCode,
-            cwd: Some(std::path::PathBuf::from("/home/user/alpha-repo")),
+            cwd: Some(if cfg!(windows) {
+                std::path::PathBuf::from(r"C:\Users\user\alpha-repo")
+            } else {
+                std::path::PathBuf::from("/home/user/alpha-repo")
+            }),
         })
         .await
         .unwrap();
@@ -113,7 +117,11 @@ async fn seed_sessions_for_reorg(store: &Store) -> (SessionId, SessionId) {
             workspace_id: ws,
             project_id: scratch,
             agent_kind: AgentKind::ClaudeCode,
-            cwd: Some(std::path::PathBuf::from("/home/user/beta-repo")),
+            cwd: Some(if cfg!(windows) {
+                std::path::PathBuf::from(r"C:\Users\user\beta-repo")
+            } else {
+                std::path::PathBuf::from("/home/user/beta-repo")
+            }),
         })
         .await
         .unwrap();

--- a/crates/ai-memory-web/build.rs
+++ b/crates/ai-memory-web/build.rs
@@ -20,6 +20,14 @@ use sha2::{Digest, Sha256};
 const TAILWIND_VERSION: &str = "3.4.17";
 const TAILWIND_LINUX_X64_SHA256: &str =
     "7d24f7fa191d2193b78cd5f5a42a6093e14409521908529f42d80b11fde1f1d4";
+const TAILWIND_LINUX_ARM64_SHA256: &str =
+    "69b1378b8133192d7d2feb12a116fa12d035594f58db3eff215879e4ad8cf39b";
+const TAILWIND_MACOS_X64_SHA256: &str =
+    "6cbdad74be776c087ffa5e9a057512c54898f9fe8828d3362212dfe32fc933a3";
+const TAILWIND_MACOS_ARM64_SHA256: &str =
+    "a1d0c7985759accca0bf12e51ac1dcbf0f6cf2fffb62e6e0f62d091c477a10a3";
+const TAILWIND_WINDOWS_X64_SHA256: &str =
+    "67f1c5e3f5a03406a7bf5badf5ada09b79f3ae78ec43450c15f7e983068da346";
 
 fn main() {
     // Re-run triggers.
@@ -131,6 +139,10 @@ fn tailwind_slug() -> &'static str {
 fn expected_tailwind_sha256() -> &'static str {
     match tailwind_slug() {
         "tailwindcss-linux-x64" => TAILWIND_LINUX_X64_SHA256,
+        "tailwindcss-linux-arm64" => TAILWIND_LINUX_ARM64_SHA256,
+        "tailwindcss-macos-x64" => TAILWIND_MACOS_X64_SHA256,
+        "tailwindcss-macos-arm64" => TAILWIND_MACOS_ARM64_SHA256,
+        "tailwindcss-windows-x64.exe" => TAILWIND_WINDOWS_X64_SHA256,
         other => panic!(
             "No pinned Tailwind SHA-256 for {other}. Set TAILWIND_SKIP=1 and provide static/tailwind.css manually."
         ),
@@ -180,12 +192,14 @@ fn download_tailwind(out_dir: &Path) -> PathBuf {
     let url = tailwind_url();
     eprintln!("cargo:warning=Downloading Tailwind CSS CLI v{TAILWIND_VERSION} from {url}");
 
-    // Try curl first, then wget.
-    let success = try_download_curl(&url, &dest) || try_download_wget(&url, &dest);
+    // Try curl first, then wget, then PowerShell (Windows fallback).
+    let success = try_download_curl(&url, &dest)
+        || try_download_wget(&url, &dest)
+        || try_download_powershell(&url, &dest);
 
     if !success {
         panic!(
-            "Could not download Tailwind CSS CLI — curl and wget both failed.\n\
+            "Could not download Tailwind CSS CLI — curl, wget, and PowerShell all failed.\n\
              Either install curl or wget, OR set TAILWIND_SKIP=1 and place a compiled \
              tailwind.css in crates/ai-memory-web/static/tailwind.css."
         );
@@ -220,6 +234,22 @@ fn try_download_wget(url: &str, dest: &Path) -> bool {
         .args(["--quiet", "--output-document"])
         .arg(dest)
         .arg(url)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn try_download_powershell(url: &str, dest: &Path) -> bool {
+    Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            &format!(
+                "Invoke-WebRequest -Uri '{}' -OutFile '{}'",
+                url,
+                dest.display()
+            ),
+        ])
         .status()
         .map(|s| s.success())
         .unwrap_or(false)

--- a/crates/ai-memory-wiki/Cargo.toml
+++ b/crates/ai-memory-wiki/Cargo.toml
@@ -26,6 +26,9 @@ notify-debouncer-full.workspace = true
 git2.workspace = true
 async-trait.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+winapi-util = "0.1"
+
 [dev-dependencies]
 
 [lints]

--- a/crates/ai-memory-wiki/src/atomic.rs
+++ b/crates/ai-memory-wiki/src/atomic.rs
@@ -50,7 +50,14 @@ fn inode_of(path: &Path) -> std::io::Result<u64> {
     Ok(std::fs::metadata(path)?.ino())
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn inode_of(path: &Path) -> std::io::Result<u64> {
+    let file = std::fs::File::open(path)?;
+    let info = winapi_util::file::information(&file)?;
+    Ok(info.file_index())
+}
+
+#[cfg(not(any(unix, windows)))]
 fn inode_of(_path: &Path) -> std::io::Result<u64> {
     Ok(0)
 }
@@ -79,6 +86,14 @@ mod tests {
         write_atomic(&target, b"first").unwrap();
         write_atomic(&target, b"second").unwrap();
         assert_eq!(std::fs::read(&target).unwrap(), b"second");
+    }
+
+    #[test]
+    fn inode_is_nonzero_on_all_platforms() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("page.md");
+        let ino = write_atomic(&target, b"hello").unwrap();
+        assert_ne!(ino, 0, "inode should be nonzero on all supported platforms");
     }
 
     #[test]

--- a/crates/ai-memory-wiki/src/watcher.rs
+++ b/crates/ai-memory-wiki/src/watcher.rs
@@ -377,6 +377,7 @@ fn page_path_relative_to(root: &Path, abs: &Path) -> Option<PagePath> {
 mod tests {
     use super::*;
     use ai_memory_store::Store;
+    use std::path::PathBuf;
     use tempfile::TempDir;
 
     async fn setup() -> (TempDir, Store, Wiki, WorkspaceId, ProjectId) {
@@ -396,15 +397,22 @@ mod tests {
         (tmp, store, wiki, ws, proj)
     }
 
+    fn test_wiki_root() -> PathBuf {
+        if cfg!(windows) {
+            PathBuf::from(r"C:\data\wiki")
+        } else {
+            PathBuf::from("/data/wiki")
+        }
+    }
+
     /// `extract_project_ids` must parse a valid `<ws>/<proj>/<path>` triplet.
     #[test]
     fn extract_project_ids_valid_path() {
-        let wiki_root = Path::new("/data/wiki");
+        let wiki_root = test_wiki_root();
         let ws_id = WorkspaceId::new();
         let proj_id = ProjectId::new();
-        let event_path =
-            std::path::PathBuf::from(format!("/data/wiki/{}/{}/decisions/foo.md", ws_id, proj_id));
-        let result = extract_project_ids(wiki_root, &event_path);
+        let event_path = wiki_root.join(format!("{ws_id}/{proj_id}/decisions/foo.md"));
+        let result = extract_project_ids(&wiki_root, &event_path);
         assert!(
             result.is_some(),
             "must extract IDs from valid namespaced path"
@@ -418,10 +426,10 @@ mod tests {
     /// `extract_project_ids` must return `None` when the first segment is not a UUID.
     #[test]
     fn extract_project_ids_garbage_first_segment() {
-        let wiki_root = Path::new("/data/wiki");
-        let event_path = Path::new("/data/wiki/not-a-uuid/some-proj/foo.md");
+        let wiki_root = test_wiki_root();
+        let event_path = wiki_root.join("not-a-uuid/some-proj/foo.md");
         assert!(
-            extract_project_ids(wiki_root, event_path).is_none(),
+            extract_project_ids(&wiki_root, &event_path).is_none(),
             "garbage first segment must return None"
         );
     }
@@ -429,10 +437,10 @@ mod tests {
     /// `extract_project_ids` must return `None` for flat (non-namespaced) paths.
     #[test]
     fn extract_project_ids_flat_path_returns_none() {
-        let wiki_root = Path::new("/data/wiki");
-        let event_path = Path::new("/data/wiki/foo.md");
+        let wiki_root = test_wiki_root();
+        let event_path = wiki_root.join("foo.md");
         assert!(
-            extract_project_ids(wiki_root, event_path).is_none(),
+            extract_project_ids(&wiki_root, &event_path).is_none(),
             "flat path with no namespace must return None"
         );
     }
@@ -440,12 +448,11 @@ mod tests {
     /// `extract_project_ids` must return `None` when the second segment is not a valid UUID.
     #[test]
     fn extract_rejects_garbage_in_project_segment() {
-        let wiki_root = Path::new("/tmp/wiki");
+        let wiki_root = test_wiki_root();
         let ws = WorkspaceId::new().to_string();
-        let event_path =
-            std::path::PathBuf::from(format!("/tmp/wiki/{ws}/not-a-uuid/decisions/foo.md"));
+        let event_path = wiki_root.join(format!("{ws}/not-a-uuid/decisions/foo.md"));
         assert!(
-            extract_project_ids(wiki_root, &event_path).is_none(),
+            extract_project_ids(&wiki_root, &event_path).is_none(),
             "garbage project segment must return None"
         );
     }
@@ -454,13 +461,13 @@ mod tests {
     /// after the two UUID segments (would produce an empty `PagePath`).
     #[test]
     fn extract_rejects_empty_page_path() {
-        let wiki_root = Path::new("/tmp/wiki");
+        let wiki_root = test_wiki_root();
         let ws = WorkspaceId::new().to_string();
         let proj = ProjectId::new().to_string();
         // Just the project dir itself with no page path beneath.
-        let event_path = std::path::PathBuf::from(format!("/tmp/wiki/{ws}/{proj}"));
+        let event_path = wiki_root.join(format!("{ws}/{proj}"));
         assert!(
-            extract_project_ids(wiki_root, &event_path).is_none(),
+            extract_project_ids(&wiki_root, &event_path).is_none(),
             "missing page path must return None"
         );
     }

--- a/hooks/claude-code/post-tool-use.ps1
+++ b/hooks/claude-code/post-tool-use.ps1
@@ -1,0 +1,7 @@
+# Claude Code post-tool-use hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=post-tool-use&agent=claude-code" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/claude-code/pre-compact.ps1
+++ b/hooks/claude-code/pre-compact.ps1
@@ -1,0 +1,7 @@
+# Claude Code pre-compact hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=pre-compact&agent=claude-code" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/claude-code/pre-tool-use.ps1
+++ b/hooks/claude-code/pre-tool-use.ps1
@@ -1,0 +1,7 @@
+# Claude Code pre-tool-use hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=pre-tool-use&agent=claude-code" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/claude-code/session-end.ps1
+++ b/hooks/claude-code/session-end.ps1
@@ -1,0 +1,7 @@
+# Claude Code session-end hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=session-end&agent=claude-code" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/claude-code/session-start.ps1
+++ b/hooks/claude-code/session-start.ps1
@@ -1,0 +1,22 @@
+# Claude Code SessionStart hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) {
+    $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN"
+}
+
+try {
+    Invoke-RestMethod -Uri "$Server/hook?event=session-start&agent=claude-code" `
+        -Method POST -Headers $headers -Body $Payload `
+        -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null
+} catch {}
+
+try {
+    $handoff = Invoke-RestMethod -Uri "$Server/handoff?agent=claude-code" `
+        -Headers $headers -TimeoutSec 1 -ErrorAction SilentlyContinue
+    if ($handoff) { Write-Output $handoff }
+} catch {}
+
+exit 0

--- a/hooks/claude-code/stop.ps1
+++ b/hooks/claude-code/stop.ps1
@@ -1,0 +1,7 @@
+# Claude Code stop hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=stop&agent=claude-code" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/claude-code/user-prompt-submit.ps1
+++ b/hooks/claude-code/user-prompt-submit.ps1
@@ -1,0 +1,7 @@
+# Claude Code user-prompt hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=user-prompt&agent=claude-code" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/codex/post-tool-use.ps1
+++ b/hooks/codex/post-tool-use.ps1
@@ -1,0 +1,7 @@
+# Codex post-tool-use hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=post-tool-use&agent=codex" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/codex/pre-compact.ps1
+++ b/hooks/codex/pre-compact.ps1
@@ -1,0 +1,7 @@
+# Codex pre-compact hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=pre-compact&agent=codex" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/codex/pre-tool-use.ps1
+++ b/hooks/codex/pre-tool-use.ps1
@@ -1,0 +1,7 @@
+# Codex pre-tool-use hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=pre-tool-use&agent=codex" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/codex/session-end.ps1
+++ b/hooks/codex/session-end.ps1
@@ -1,0 +1,7 @@
+# Codex session-end hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=session-end&agent=codex" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/codex/session-start.ps1
+++ b/hooks/codex/session-start.ps1
@@ -1,0 +1,22 @@
+# Codex SessionStart hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) {
+    $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN"
+}
+
+try {
+    Invoke-RestMethod -Uri "$Server/hook?event=session-start&agent=codex" `
+        -Method POST -Headers $headers -Body $Payload `
+        -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null
+} catch {}
+
+try {
+    $handoff = Invoke-RestMethod -Uri "$Server/handoff?agent=codex" `
+        -Headers $headers -TimeoutSec 1 -ErrorAction SilentlyContinue
+    if ($handoff) { Write-Output $handoff }
+} catch {}
+
+exit 0

--- a/hooks/codex/stop.ps1
+++ b/hooks/codex/stop.ps1
@@ -1,0 +1,7 @@
+# Codex stop hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=stop&agent=codex" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/codex/user-prompt-submit.ps1
+++ b/hooks/codex/user-prompt-submit.ps1
@@ -1,0 +1,7 @@
+# Codex user-prompt hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=user-prompt&agent=codex" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/cursor/post-tool-use.ps1
+++ b/hooks/cursor/post-tool-use.ps1
@@ -1,0 +1,7 @@
+# Cursor post-tool-use hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=post-tool-use&agent=cursor" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/cursor/pre-compact.ps1
+++ b/hooks/cursor/pre-compact.ps1
@@ -1,0 +1,7 @@
+# Cursor pre-compact hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=pre-compact&agent=cursor" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/cursor/pre-tool-use.ps1
+++ b/hooks/cursor/pre-tool-use.ps1
@@ -1,0 +1,7 @@
+# Cursor pre-tool-use hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=pre-tool-use&agent=cursor" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/cursor/session-end.ps1
+++ b/hooks/cursor/session-end.ps1
@@ -1,0 +1,7 @@
+# Cursor session-end hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=session-end&agent=cursor" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/cursor/session-start.ps1
+++ b/hooks/cursor/session-start.ps1
@@ -1,0 +1,22 @@
+# Cursor SessionStart hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) {
+    $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN"
+}
+
+try {
+    Invoke-RestMethod -Uri "$Server/hook?event=session-start&agent=cursor" `
+        -Method POST -Headers $headers -Body $Payload `
+        -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null
+} catch {}
+
+try {
+    $handoff = Invoke-RestMethod -Uri "$Server/handoff?agent=cursor" `
+        -Headers $headers -TimeoutSec 1 -ErrorAction SilentlyContinue
+    if ($handoff) { Write-Output $handoff }
+} catch {}
+
+exit 0

--- a/hooks/cursor/stop.ps1
+++ b/hooks/cursor/stop.ps1
@@ -1,0 +1,7 @@
+# Cursor stop hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=stop&agent=cursor" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/cursor/user-prompt-submit.ps1
+++ b/hooks/cursor/user-prompt-submit.ps1
@@ -1,0 +1,7 @@
+# Cursor user-prompt hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=user-prompt&agent=cursor" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/gemini-cli/post-tool-use.ps1
+++ b/hooks/gemini-cli/post-tool-use.ps1
@@ -1,0 +1,7 @@
+# Gemini CLI post-tool-use hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=post-tool-use&agent=gemini-cli" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/gemini-cli/pre-compact.ps1
+++ b/hooks/gemini-cli/pre-compact.ps1
@@ -1,0 +1,7 @@
+# Gemini CLI pre-compact hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=pre-compact&agent=gemini-cli" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/gemini-cli/pre-tool-use.ps1
+++ b/hooks/gemini-cli/pre-tool-use.ps1
@@ -1,0 +1,7 @@
+# Gemini CLI pre-tool-use hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=pre-tool-use&agent=gemini-cli" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/gemini-cli/session-end.ps1
+++ b/hooks/gemini-cli/session-end.ps1
@@ -1,0 +1,7 @@
+# Gemini CLI session-end hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=session-end&agent=gemini-cli" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/gemini-cli/session-start.ps1
+++ b/hooks/gemini-cli/session-start.ps1
@@ -1,0 +1,22 @@
+# Gemini CLI SessionStart hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) {
+    $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN"
+}
+
+try {
+    Invoke-RestMethod -Uri "$Server/hook?event=session-start&agent=gemini-cli" `
+        -Method POST -Headers $headers -Body $Payload `
+        -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null
+} catch {}
+
+try {
+    $handoff = Invoke-RestMethod -Uri "$Server/handoff?agent=gemini-cli" `
+        -Headers $headers -TimeoutSec 1 -ErrorAction SilentlyContinue
+    if ($handoff) { Write-Output $handoff }
+} catch {}
+
+exit 0

--- a/hooks/gemini-cli/stop.ps1
+++ b/hooks/gemini-cli/stop.ps1
@@ -1,0 +1,7 @@
+# Gemini CLI stop hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=stop&agent=gemini-cli" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/gemini-cli/user-prompt-submit.ps1
+++ b/hooks/gemini-cli/user-prompt-submit.ps1
@@ -1,0 +1,7 @@
+# Gemini CLI user-prompt hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=user-prompt&agent=gemini-cli" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/opencode/post-tool-use.ps1
+++ b/hooks/opencode/post-tool-use.ps1
@@ -1,0 +1,7 @@
+# opencode post-tool-use hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=post-tool-use&agent=open-code" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/opencode/pre-compact.ps1
+++ b/hooks/opencode/pre-compact.ps1
@@ -1,0 +1,7 @@
+# opencode pre-compact hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=pre-compact&agent=open-code" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/opencode/pre-tool-use.ps1
+++ b/hooks/opencode/pre-tool-use.ps1
@@ -1,0 +1,7 @@
+# opencode pre-tool-use hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=pre-tool-use&agent=open-code" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/opencode/session-end.ps1
+++ b/hooks/opencode/session-end.ps1
@@ -1,0 +1,7 @@
+# opencode session-end hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=session-end&agent=open-code" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/opencode/session-start.ps1
+++ b/hooks/opencode/session-start.ps1
@@ -1,0 +1,22 @@
+# opencode SessionStart hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) {
+    $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN"
+}
+
+try {
+    Invoke-RestMethod -Uri "$Server/hook?event=session-start&agent=open-code" `
+        -Method POST -Headers $headers -Body $Payload `
+        -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null
+} catch {}
+
+try {
+    $handoff = Invoke-RestMethod -Uri "$Server/handoff?agent=open-code" `
+        -Headers $headers -TimeoutSec 1 -ErrorAction SilentlyContinue
+    if ($handoff) { Write-Output $handoff }
+} catch {}
+
+exit 0

--- a/hooks/opencode/stop.ps1
+++ b/hooks/opencode/stop.ps1
@@ -1,0 +1,7 @@
+# opencode stop hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=stop&agent=open-code" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0

--- a/hooks/opencode/user-prompt-submit.ps1
+++ b/hooks/opencode/user-prompt-submit.ps1
@@ -1,0 +1,7 @@
+# opencode user-prompt hook (Windows).
+$Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
+$Payload = $input | Out-String
+$headers = @{ "Content-Type" = "application/json" }
+if ($env:AI_MEMORY_AUTH_TOKEN) { $headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN" }
+try { Invoke-RestMethod -Uri "$Server/hook?event=user-prompt&agent=open-code" -Method POST -Headers $headers -Body $Payload -TimeoutSec 1 -ErrorAction SilentlyContinue | Out-Null } catch {}
+exit 0


### PR DESCRIPTION
## What changed

- **Build (P0):** `build.rs` now has pinned SHA-256 hashes for all 5 Tailwind
  platform binaries (Linux x64/arm64, macOS x64/arm64, Windows x64) and a
  PowerShell `Invoke-WebRequest` download fallback. `cargo build` no longer
  panics on Windows without `TAILWIND_SKIP=1`.
- **Tests (P1):** Path fixtures across 5 files use `cfg!(windows)` to provide
  platform-appropriate absolute paths. All 74+ tests now pass on Windows.
- **Runtime (P2):** Hook payloads on Windows use PowerShell syntax
  (`$env:VAR='val'; & powershell -NoProfile -File 'script.ps1'`) instead of
  POSIX (`VAR=val /path/script.sh`). Added `.ps1` equivalents of all 35 hook
  scripts. `install_hooks` discovers `.ps1` on Windows and uses `NUL` instead
  of `/dev/null` as sentinel.
- **Inode (P3):** `atomic.rs` now uses `winapi-util`'s
  `GetFileInformationByHandle` to get the NTFS file index, enabling the
  watcher's own-write skip optimization on Windows (previously returned 0).

## Why

The project does not build or test cleanly on Windows (see #11). These changes
make `cargo build --workspace && cargo test --workspace` pass on Windows 11
with no workarounds, and ensure the hook scripts actually work when invoked by
agent CLIs on Windows.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (all tests, no `TAILWIND_SKIP`)
- [x] Manual test: `cargo build --workspace` succeeds on Windows 11 Pro,
  Tailwind binary downloads and verifies via SHA-256. New
  `inode_is_nonzero_on_all_platforms` test confirms nonzero file index on NTFS.
  New `claude_code_payload_emits_powershell_commands_on_windows` test confirms
  PowerShell-syntax hook commands.

## Notes for reviewers

- **`winapi-util` over `windows-sys`:** The workspace has `unsafe_code = "forbid"`,
  so the inode implementation uses `winapi-util` (already a transitive dependency
  via `walkdir`) instead of raw `windows-sys` FFI calls.
- **No Linux regression:** All `cfg!(windows)` branches are compile-time; the
  Unix code paths are unchanged. Existing tests continue to use Unix paths on
  non-Windows platforms.
- **35 `.ps1` hook scripts** mirror the existing `.sh` scripts exactly, using
  `Invoke-RestMethod` instead of `curl`. The `session-start.ps1` variant
  includes the handoff GET, matching the `.sh` behavior.

Ref: #11