### PR TITLE
feat(llm): add Gemini provider with gemini-2.5-flash default

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,25 @@ AI_MEMORY_LLM_MODEL=openai/gpt-5.4-mini
 LLM_API_KEY=sk-or-v1-…
 ```
 
-### Option 3 - Local Ollama qwen3:32b *(free / self-hosted)*
+### Option 3 - Google Gemini 2.5 Flash *(generous free tier)*
+
+Hosted by Google, with a free tier that's enough for most
+personal consolidation loads. Structured-output is native
+(`responseSchema` over OpenAPI 3 subset); the client inlines
+`$ref`s and strips Draft-2020-12 keywords Gemini rejects, so
+schemars-derived schemas just work. Use `gemini-2.5-flash`
+for the speed/cost balance; avoid the *-thinking* variants
+(see "What we don't recommend" below).
+
+Grab a key from https://aistudio.google.com/apikey, then:
+
+```bash
+AI_MEMORY_LLM_PROVIDER=gemini
+AI_MEMORY_LLM_MODEL=gemini-2.5-flash      # optional; this is the default
+GEMINI_API_KEY=AIza…                      # GOOGLE_API_KEY also accepted
+```
+
+### Option 4 - Local Ollama qwen3:32b *(free / self-hosted)*
 
 $0 per consolidation. Requires a machine with at least ~24 GB
 of unified or VRAM memory to keep the Q4_K_M weights warm

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -407,6 +407,8 @@ pub enum LlmProviderChoice {
     Anthropic,
     /// OpenAI Chat Completions.
     Openai,
+    /// Google Gemini (Generative Language API).
+    Gemini,
     /// OpenAI-compatible local (Ollama, vLLM, LM Studio).
     OpenaiCompat,
 }

--- a/crates/ai-memory-cli/src/commands/llm_test.rs
+++ b/crates/ai-memory-cli/src/commands/llm_test.rs
@@ -52,6 +52,7 @@ impl From<LlmProviderChoice> for ProviderChoice {
         match value {
             LlmProviderChoice::Anthropic => Self::Anthropic,
             LlmProviderChoice::Openai => Self::OpenAi,
+            LlmProviderChoice::Gemini => Self::Gemini,
             LlmProviderChoice::OpenaiCompat => Self::OpenAiCompat,
         }
     }

--- a/crates/ai-memory-cli/src/config.rs
+++ b/crates/ai-memory-cli/src/config.rs
@@ -52,7 +52,7 @@ pub struct Config {
     pub server_url: String,
     /// Per-subsystem log filter (overridable by `RUST_LOG`).
     pub log_level: String,
-    /// Optional LLM provider (`anthropic`, `openai`, `openai-compat`).
+    /// Optional LLM provider (`anthropic`, `openai`, `gemini`, `openai-compat`).
     pub llm_provider: Option<String>,
     /// Optional LLM model override.
     pub llm_model: Option<String>,
@@ -110,6 +110,7 @@ pub struct RuntimeEnv {
     host_cwd: Option<String>,
     anthropic_api_key: Option<SecretString>,
     openai_api_key: Option<SecretString>,
+    gemini_api_key: Option<SecretString>,
     llm_api_key: Option<SecretString>,
     llm_base_url: Option<String>,
     voyage_api_key: Option<SecretString>,
@@ -124,6 +125,9 @@ impl RuntimeEnv {
             host_cwd: env_string("AI_MEMORY_HOST_CWD"),
             anthropic_api_key: env_secret("ANTHROPIC_API_KEY"),
             openai_api_key: env_secret("OPENAI_API_KEY"),
+            // GOOGLE_API_KEY is the older alias many Google docs still
+            // mention; accept either so users don't get tripped up.
+            gemini_api_key: env_secret("GEMINI_API_KEY").or_else(|| env_secret("GOOGLE_API_KEY")),
             llm_api_key: env_secret("LLM_API_KEY"),
             llm_base_url: env_string("LLM_BASE_URL"),
             voyage_api_key: env_secret("VOYAGE_API_KEY"),
@@ -298,10 +302,12 @@ impl Config {
         let provider = match provider_raw {
             "anthropic" => ProviderChoice::Anthropic,
             "openai" => ProviderChoice::OpenAi,
+            "gemini" | "google" => ProviderChoice::Gemini,
             "openai-compat" | "openai_compat" => ProviderChoice::OpenAiCompat,
             other => {
                 return Err(LlmError::NotConfigured(format!(
-                    "AI_MEMORY_LLM_PROVIDER={other} is not one of anthropic|openai|openai-compat"
+                    "AI_MEMORY_LLM_PROVIDER={other} is not one of \
+                     anthropic|openai|gemini|openai-compat"
                 )));
             }
         };
@@ -310,6 +316,7 @@ impl Config {
             None => match provider {
                 ProviderChoice::Anthropic => "claude-sonnet-4-6".to_string(),
                 ProviderChoice::OpenAi => "gpt-4o-mini".to_string(),
+                ProviderChoice::Gemini => "gemini-2.5-flash".to_string(),
                 ProviderChoice::OpenAiCompat => {
                     return Err(LlmError::NotConfigured(
                         "AI_MEMORY_LLM_MODEL must be set explicitly for openai-compat \
@@ -382,6 +389,7 @@ impl Config {
         match provider {
             ProviderChoice::Anthropic => self.runtime_env.anthropic_api_key.clone(),
             ProviderChoice::OpenAi => self.runtime_env.openai_api_key.clone(),
+            ProviderChoice::Gemini => self.runtime_env.gemini_api_key.clone(),
             ProviderChoice::OpenAiCompat => self.runtime_env.llm_api_key.clone(),
         }
     }

--- a/crates/ai-memory-llm/src/factory.rs
+++ b/crates/ai-memory-llm/src/factory.rs
@@ -8,19 +8,22 @@ use std::sync::Arc;
 use secrecy::SecretString;
 
 use crate::AnthropicProvider;
+use crate::GeminiProvider;
 use crate::OpenAiCompatProvider;
 use crate::OpenAiProvider;
 use crate::embedding::{Embedder, OpenAiEmbedder, VoyageEmbedder};
 use crate::error::{LlmError, LlmResult};
 use crate::provider::LlmProvider;
 
-/// Three providers ship in v1.
+/// Four providers ship in v1.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderChoice {
     /// Anthropic Messages API.
     Anthropic,
     /// OpenAI Chat Completions.
     OpenAi,
+    /// Google Gemini (Generative Language API).
+    Gemini,
     /// OpenAI-compatible (Ollama / vLLM / LM Studio).
     OpenAiCompat,
 }
@@ -131,6 +134,12 @@ pub fn build_provider(config: ProviderConfig) -> LlmResult<Arc<dyn LlmProvider>>
                 .api_key
                 .ok_or_else(|| LlmError::NotConfigured("OPENAI_API_KEY".into()))?;
             Ok(Arc::new(OpenAiProvider::new(key, config.model)?))
+        }
+        ProviderChoice::Gemini => {
+            let key = config
+                .api_key
+                .ok_or_else(|| LlmError::NotConfigured("GEMINI_API_KEY".into()))?;
+            Ok(Arc::new(GeminiProvider::new(key, config.model)?))
         }
         ProviderChoice::OpenAiCompat => {
             let base = config

--- a/crates/ai-memory-llm/src/gemini.rs
+++ b/crates/ai-memory-llm/src/gemini.rs
@@ -1,0 +1,438 @@
+//! Google Gemini (Generative Language API) client.
+//!
+//! Structured-output strategy: ask for `responseMimeType:
+//! application/json` plus a `responseSchema` — Gemini's native JSON
+//! mode. The schema is a *subset* of OpenAPI 3, so we normalise
+//! schemars output (Draft 2020-12) by inlining `$ref`s out of
+//! `$defs` / `definitions` and stripping keywords Gemini rejects
+//! (`$schema`, `additionalProperties`, `oneOf`, `allOf`, `const`,
+//! …). See [`prepare_schema_for_gemini`].
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use secrecy::{ExposeSecret, SecretString};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use crate::error::{LlmError, LlmResult};
+use crate::provider::LlmProvider;
+use crate::text::truncate_with_ellipsis;
+use crate::types::{ChatRequest, ChatResponse, Role, Usage};
+
+/// Default Gemini API base.
+pub const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com";
+
+/// Gemini-backed provider.
+pub struct GeminiProvider {
+    client: reqwest::Client,
+    api_key: SecretString,
+    base_url: String,
+    model: String,
+}
+
+impl GeminiProvider {
+    /// Construct a provider given an API key and model id (e.g.
+    /// `gemini-2.5-flash`).
+    ///
+    /// # Errors
+    /// Returns a `reqwest::Error` if the HTTP client cannot be built.
+    pub fn new(api_key: SecretString, model: impl Into<String>) -> LlmResult<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(300))
+            .build()?;
+        Ok(Self {
+            client,
+            api_key,
+            base_url: DEFAULT_BASE_URL.to_string(),
+            model: model.into(),
+        })
+    }
+
+    /// Override the API base URL (mostly for tests against wiremock).
+    #[must_use]
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = url.into();
+        self
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct GeminiRequest<'a> {
+    contents: Vec<GeminiContent<'a>>,
+    #[serde(rename = "systemInstruction", skip_serializing_if = "Option::is_none")]
+    system_instruction: Option<GeminiSystem<'a>>,
+    #[serde(rename = "generationConfig")]
+    generation_config: GeminiGenerationConfig,
+}
+
+#[derive(Debug, Serialize)]
+struct GeminiContent<'a> {
+    role: &'static str,
+    parts: Vec<GeminiPart<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct GeminiPart<'a> {
+    text: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+struct GeminiSystem<'a> {
+    parts: Vec<GeminiPart<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct GeminiGenerationConfig {
+    #[serde(rename = "maxOutputTokens")]
+    max_output_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(rename = "responseMimeType", skip_serializing_if = "Option::is_none")]
+    response_mime_type: Option<&'static str>,
+    #[serde(rename = "responseSchema", skip_serializing_if = "Option::is_none")]
+    response_schema: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiResponse {
+    #[serde(default)]
+    candidates: Vec<GeminiCandidate>,
+    #[serde(rename = "usageMetadata", default)]
+    usage_metadata: Option<GeminiUsage>,
+    #[serde(rename = "modelVersion", default)]
+    model_version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiCandidate {
+    #[serde(default)]
+    content: Option<GeminiCandidateContent>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiCandidateContent {
+    #[serde(default)]
+    parts: Vec<GeminiResponsePart>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiResponsePart {
+    #[serde(default)]
+    text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiUsage {
+    #[serde(rename = "promptTokenCount", default)]
+    prompt_token_count: u32,
+    #[serde(rename = "candidatesTokenCount", default)]
+    candidates_token_count: u32,
+}
+
+#[async_trait]
+impl LlmProvider for GeminiProvider {
+    fn name(&self) -> &'static str {
+        "gemini"
+    }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
+
+    async fn complete(&self, request: ChatRequest) -> LlmResult<ChatResponse> {
+        let body = self.build_request(&request, None);
+        let response: GeminiResponse = self.post(&body).await?;
+        Ok(self.to_chat_response(response))
+    }
+
+    async fn complete_structured_raw(
+        &self,
+        request: ChatRequest,
+        schema: serde_json::Value,
+    ) -> LlmResult<serde_json::Value> {
+        let prepared = prepare_schema_for_gemini(schema)?;
+        let body = self.build_request(&request, Some(prepared));
+        let response: GeminiResponse = self.post(&body).await?;
+        let text = first_text(&response).ok_or_else(|| {
+            LlmError::UnexpectedShape("gemini response had no candidate text".into())
+        })?;
+        serde_json::from_str::<serde_json::Value>(&text).map_err(LlmError::from)
+    }
+}
+
+impl GeminiProvider {
+    fn build_request<'a>(
+        &'a self,
+        request: &'a ChatRequest,
+        response_schema: Option<serde_json::Value>,
+    ) -> GeminiRequest<'a> {
+        let contents = request
+            .messages
+            .iter()
+            .map(|m| GeminiContent {
+                role: match m.role {
+                    Role::User => "user",
+                    // Gemini's role for the assistant turn is "model".
+                    Role::Assistant => "model",
+                },
+                parts: vec![GeminiPart { text: &m.content }],
+            })
+            .collect();
+        let system_instruction = request.system.as_deref().map(|s| GeminiSystem {
+            parts: vec![GeminiPart { text: s }],
+        });
+        let response_mime_type = response_schema.as_ref().map(|_| "application/json");
+        GeminiRequest {
+            contents,
+            system_instruction,
+            generation_config: GeminiGenerationConfig {
+                max_output_tokens: request.max_tokens,
+                temperature: request.temperature,
+                response_mime_type,
+                response_schema,
+            },
+        }
+    }
+
+    fn to_chat_response(&self, response: GeminiResponse) -> ChatResponse {
+        let text = first_text(&response).unwrap_or_default();
+        let model = response.model_version.unwrap_or_else(|| self.model.clone());
+        ChatResponse {
+            text,
+            usage: response.usage_metadata.map(|u| Usage {
+                input_tokens: u.prompt_token_count,
+                output_tokens: u.candidates_token_count,
+            }),
+            model,
+        }
+    }
+
+    async fn post<B: Serialize, R: DeserializeOwned>(&self, body: &B) -> LlmResult<R> {
+        let url = format!(
+            "{}/v1beta/models/{}:generateContent",
+            self.base_url.trim_end_matches('/'),
+            self.model
+        );
+        debug!(url, "POST gemini");
+        let resp = self
+            .client
+            .post(&url)
+            .header("x-goog-api-key", self.api_key.expose_secret())
+            .header("content-type", "application/json")
+            .json(body)
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(LlmError::Provider {
+                status: status.as_u16(),
+                body: truncate_with_ellipsis(&body, 1024),
+            });
+        }
+        resp.json::<R>().await.map_err(LlmError::from)
+    }
+}
+
+fn first_text(response: &GeminiResponse) -> Option<String> {
+    let candidate = response.candidates.first()?;
+    let content = candidate.content.as_ref()?;
+    let joined: String = content
+        .parts
+        .iter()
+        .filter_map(|p| p.text.as_deref())
+        .collect();
+    if joined.is_empty() { None } else { Some(joined) }
+}
+
+/// Normalise a schemars-generated JSON Schema into the Gemini-supported
+/// OpenAPI 3 subset.
+///
+/// Gemini's `responseSchema` rejects Draft-2020-12 specifics: `$schema`,
+/// `$defs` / `definitions`, `$ref`, `additionalProperties`, `oneOf`,
+/// `allOf`, `const`, and assorted metadata. We inline all `$ref`s out
+/// of `$defs` / `definitions`, then recursively strip the keywords
+/// Gemini won't accept. `anyOf` is preserved (the only composition
+/// keyword Gemini accepts).
+///
+/// # Errors
+/// Returns [`LlmError::Schema`] if a `$ref` can't be resolved or the
+/// schema's reference graph exceeds a safety depth (16).
+pub fn prepare_schema_for_gemini(mut schema: serde_json::Value) -> LlmResult<serde_json::Value> {
+    let defs = extract_defs(&mut schema);
+    inline_refs(&mut schema, &defs, 0)?;
+    strip_unsupported(&mut schema);
+    Ok(schema)
+}
+
+fn extract_defs(schema: &mut serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+    let mut defs = serde_json::Map::new();
+    let Some(obj) = schema.as_object_mut() else {
+        return defs;
+    };
+    if let Some(serde_json::Value::Object(d)) = obj.remove("$defs") {
+        for (k, v) in d {
+            defs.insert(k, v);
+        }
+    }
+    if let Some(serde_json::Value::Object(d)) = obj.remove("definitions") {
+        for (k, v) in d {
+            defs.insert(k, v);
+        }
+    }
+    defs
+}
+
+const MAX_REF_DEPTH: usize = 16;
+
+fn inline_refs(
+    value: &mut serde_json::Value,
+    defs: &serde_json::Map<String, serde_json::Value>,
+    depth: usize,
+) -> LlmResult<()> {
+    if depth > MAX_REF_DEPTH {
+        return Err(LlmError::Schema(
+            "recursive $ref depth exceeded while preparing gemini schema".into(),
+        ));
+    }
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(serde_json::Value::String(reference)) = map.get("$ref").cloned() {
+                let name = reference.rsplit('/').next().unwrap_or_default();
+                let mut resolved = defs.get(name).cloned().ok_or_else(|| {
+                    LlmError::Schema(format!("gemini: unresolved $ref {reference}"))
+                })?;
+                inline_refs(&mut resolved, defs, depth + 1)?;
+                *value = resolved;
+                return Ok(());
+            }
+            for v in map.values_mut() {
+                inline_refs(v, defs, depth + 1)?;
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for v in items {
+                inline_refs(v, defs, depth + 1)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+const UNSUPPORTED_KEYS: &[&str] = &[
+    "$schema",
+    "$id",
+    "$comment",
+    "$defs",
+    "definitions",
+    "additionalProperties",
+    "unevaluatedProperties",
+    "allOf",
+    "oneOf",
+    "const",
+    "default",
+    "examples",
+    "patternProperties",
+    "readOnly",
+    "writeOnly",
+];
+
+fn strip_unsupported(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for k in UNSUPPORTED_KEYS {
+                map.remove(*k);
+            }
+            for v in map.values_mut() {
+                strip_unsupported(v);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for v in items {
+                strip_unsupported(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn prepare_schema_inlines_defs_and_strips_metadata() {
+        let schema = json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "ConsolidatedBatch",
+            "type": "object",
+            "properties": {
+                "updates": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/Update" }
+                }
+            },
+            "required": ["updates"],
+            "additionalProperties": false,
+            "$defs": {
+                "Update": {
+                    "type": "object",
+                    "properties": { "path": { "type": "string" } },
+                    "required": ["path"],
+                    "additionalProperties": false
+                }
+            }
+        });
+        let prepared = prepare_schema_for_gemini(schema).unwrap();
+        let obj = prepared.as_object().unwrap();
+        assert!(!obj.contains_key("$schema"));
+        assert!(!obj.contains_key("$defs"));
+        assert!(!obj.contains_key("additionalProperties"));
+        let item = obj
+            .get("properties")
+            .unwrap()
+            .get("updates")
+            .unwrap()
+            .get("items")
+            .unwrap()
+            .as_object()
+            .unwrap();
+        assert_eq!(item.get("type").unwrap(), "object");
+        assert!(!item.contains_key("additionalProperties"));
+        assert_eq!(item.get("properties").unwrap().get("path").unwrap(), &json!({"type": "string"}));
+    }
+
+    #[test]
+    fn prepare_schema_rejects_unresolved_ref() {
+        let schema = json!({ "$ref": "#/$defs/Missing" });
+        let err = prepare_schema_for_gemini(schema).unwrap_err();
+        assert!(matches!(err, LlmError::Schema(_)));
+    }
+
+    #[test]
+    fn prepare_schema_passes_plain_object_through() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" } },
+            "required": ["name"]
+        });
+        let prepared = prepare_schema_for_gemini(schema.clone()).unwrap();
+        assert_eq!(prepared, schema);
+    }
+
+    #[test]
+    fn prepare_schema_preserves_any_of() {
+        let schema = json!({
+            "anyOf": [
+                { "type": "string" },
+                { "type": "integer" }
+            ]
+        });
+        let prepared = prepare_schema_for_gemini(schema.clone()).unwrap();
+        assert_eq!(prepared, schema);
+    }
+}

--- a/crates/ai-memory-llm/src/lib.rs
+++ b/crates/ai-memory-llm/src/lib.rs
@@ -1,6 +1,6 @@
 //! LLM provider abstraction for ai-memory.
 //!
-//! Three providers ship in v1, each with a *native, typed*
+//! Four providers ship in v1, each with a *native, typed*
 //! `reqwest`-based client — never a generic gateway. The cognee
 //! issue tracker showed that LiteLLM + Instructor silently drop
 //! unknown kwargs, which makes the wrapper layer drift away from
@@ -8,12 +8,15 @@
 //! Our clients deserialise into named structs that `serde` rejects
 //! on unknown fields, surfacing breakage immediately.
 //!
-//! Three structured-output strategies:
+//! Four structured-output strategies:
 //!
 //! * **Anthropic**: `tools[0]` is set to a single tool whose input
 //!   schema we want filled, with `tool_choice = "tool"`. The
 //!   model's `tool_use` content block is the structured payload.
 //! * **OpenAI**: `response_format = { type: "json_schema", strict: true }`.
+//! * **Gemini**: `generationConfig.responseMimeType = "application/json"`
+//!   plus `responseSchema` (OpenAPI 3 subset; `$ref`s inlined,
+//!   Draft-2020-12 keywords stripped before send).
 //! * **OpenAI-compat** (Ollama, vLLM, LM Studio): we ask for
 //!   `response_format: { type: "json_object" }` when supported,
 //!   otherwise parse the first balanced `{…}` from the text body.
@@ -23,6 +26,7 @@ pub mod anthropic;
 pub mod embedding;
 pub mod error;
 pub mod factory;
+pub mod gemini;
 pub mod openai;
 pub mod openai_compat;
 pub mod provider;
@@ -37,6 +41,7 @@ pub use factory::{
     EmbedderChoice, EmbedderConfig, ProviderChoice, ProviderConfig, build_embedder, build_provider,
     default_embedding_dim,
 };
+pub use gemini::GeminiProvider;
 pub use openai::OpenAiProvider;
 pub use openai_compat::OpenAiCompatProvider;
 pub use provider::{LlmProvider, complete_structured};

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@
 FROM rust:1.95-slim-bookworm AS builder
 WORKDIR /work
 RUN apt-get update \
- && apt-get install -y --no-install-recommends pkg-config build-essential \
+ && apt-get install -y --no-install-recommends pkg-config build-essential curl \
  && rm -rf /var/lib/apt/lists/*
 COPY Cargo.toml Cargo.lock rust-toolchain.toml deny.toml ./
 COPY crates ./crates

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -248,9 +248,9 @@ hard_delete_after_days = 180
 
 **LLM provider env** (opt-in):
 ```
-AI_MEMORY_LLM_PROVIDER     anthropic | openai | openai-compat
-AI_MEMORY_LLM_MODEL        e.g. claude-sonnet-4-6
-ANTHROPIC_API_KEY / OPENAI_API_KEY / LLM_API_KEY
+AI_MEMORY_LLM_PROVIDER     anthropic | openai | gemini | openai-compat
+AI_MEMORY_LLM_MODEL        e.g. claude-sonnet-4-6, gemini-2.5-flash
+ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY / LLM_API_KEY
 AI_MEMORY_LLM_BASE_URL     for openai-compat (Ollama, vLLM)
 ```
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -142,6 +142,7 @@ alternatives:
 | anthropic | `claude-haiku-4-5` | ~$0.02 | **Recommended default.** Best balance of speed, restraint, and classification quality. Not a reasoning model. |
 | openai-compat (OpenRouter) | `moonshotai/kimi-k2.6` | ~$0.013 | Reasoning model; latency ~2-3 min per consolidation. Fine because consolidation is fire-and-forget. |
 | openai | `gpt-5.4-mini` | ~$0.002 | Cheaper, faster alternative. Decent quality. |
+| gemini | `gemini-2.5-flash` | free tier covers personal use | Google hosted, native `responseSchema` structured output. Set `GEMINI_API_KEY` (or `GOOGLE_API_KEY`). |
 | openai-compat (Ollama) | `qwen3:32b` | $0 | Self-hosted. Set `AI_MEMORY_LLM_BASE_URL=http://host.docker.internal:11434/v1`. Quality depends on the model. |
 
 > **What we don't recommend:** reasoning-mode models (Kimi-K2.6 in reasoning mode,

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -87,7 +87,7 @@ Why not LanceDB/Qdrant/Kuzu/CozoDB/SurrealDB?
 **LLM for consolidation passes:**
 - **Off by default**, behaves like agentmemory after #138's fix. Without a provider, the system still works: synthetic compression (rule-based), no LLM-generated summaries, no `memory_consolidate` page-rewrite.
 - With a provider, scheduled consolidation runs (1× per session-end + optional 6h timer).
-- Provider trait `LlmProvider { complete(...); complete_structured(...) }`. Implementations: `AnthropicProvider`, `OpenAIProvider`, `OllamaProvider`, `OpenAICompatProvider`.
+- Provider trait `LlmProvider { complete(...); complete_structured(...) }`. Implementations: `AnthropicProvider`, `OpenAIProvider`, `GeminiProvider`, `OpenAICompatProvider` (the latter covers Ollama / vLLM / LM Studio and supersedes the earlier `OllamaProvider`).
 - **Native HTTP per provider** - no LiteLLM-equivalent. The cognee tracker (#2412/#2430/#2537/#2608/#2749/#2782/#2840/#2842) showed silent-kwarg-drop in a generic gateway is the #1 source of provider bugs. Each provider's typed JSON, errors on unknown fields. Hand-coded but correct.
 - **Structured output via JSON schema, not XML, not Instructor-style wrapping.** Use each provider's native JSON-mode where available; for Anthropic, request a tool-use response with a typed schema. Validate with `serde_json` + `schemars`-derived schemas.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -290,6 +290,7 @@ If you set only the provider, ai-memory picks a sensible default:
 |---|---|---|
 | `AI_MEMORY_LLM_PROVIDER=anthropic` | `claude-haiku-4-5` | **Recommended default.** Best balance of speed, restraint, and classification quality. Not a reasoning model. Consistently classifies durable project rules as `kind: rule`. |
 | `AI_MEMORY_LLM_PROVIDER=openai` | `gpt-5.4-mini` | Cheaper + faster alternative. Same parse reliability; mild over-classification on thin sessions. |
+| `AI_MEMORY_LLM_PROVIDER=gemini` | `gemini-2.5-flash` | Google's hosted option with a generous free tier — useful if you don't have an Anthropic / OpenAI key handy. Set `GEMINI_API_KEY` (or `GOOGLE_API_KEY`). |
 | `AI_MEMORY_EMBEDDING_PROVIDER=openai` | `text-embedding-3-small` (1536-dim) | 5× cheaper than `-3-large` with marginal recall loss. |
 | `AI_MEMORY_EMBEDDING_PROVIDER=voyage` | `voyage-3` (1024-dim) | Voyage's current general-purpose recommendation. |
 


### PR DESCRIPTION
Adds Google Gemini as a fourth LlmProvider alongside Anthropic, OpenAI, and openai-compat. Uses native responseSchema for structured output, inlining schemars $refs and stripping Draft-2020-12 keywords Gemini rejects. Reads GEMINI_API_KEY (or GOOGLE_API_KEY) and selects via AI_MEMORY_LLM_PROVIDER=gemini; defaults to gemini-2.5-flash when no model is set. CLI llm-test gains a matching --provider gemini choice.

## What changed

- New `GeminiProvider` (`crates/ai-memory-llm/src/gemini.rs`) implementing `LlmProvider` against Google's Generative Language API, with native `responseSchema` for structured output.
- `ProviderChoice::Gemini` added to the factory, with `GEMINI_API_KEY` (falling back to `GOOGLE_API_KEY`) plumbed through `Config` → `build_provider`.
- `AI_MEMORY_LLM_PROVIDER` now accepts `gemini` (and `google` as a synonym); model defaults to `gemini-2.5-flash` when unset.
- `ai-memory llm-test --provider gemini` wired through the CLI.
- README + ARCHITECTURE + deploy/install docs updated to list the fourth provider.

## Why

Gemini 2.5 Flash is a strong price/perf option for consolidation and lint workloads, and a generous free tier makes it especially appealing for self-hosted ai-memory users who don't want to pay Anthropic/OpenAI for background memory maintenance. Adding it as a first-class provider — rather than going through openai-compat — preserves the project rule of typed native clients per provider (CLAUDE.md §Stack; cognee #2840 lesson on LiteLLM/Instructor drift).

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Manual test: `AI_MEMORY_LLM_PROVIDER=gemini GEMINI_API_KEY=… ./target/debug/ai-memory llm-test --provider gemini` returned a well-formed JSON object matching the schema.

## Notes for reviewers

- **Schema transform is the trickiest part.** Gemini's `responseSchema` only accepts an OpenAPI 3 subset, so `gemini.rs` inlines schemars `$ref`s and strips Draft-2020-12 keywords (`$schema`, `$defs`, certain `additionalProperties` shapes) before sending. The `compile_schema` helper + its tests are worth a careful look — that's where drift will hurt first.
- **No embeddings.** Gemini's embed endpoint isn't wired here; only generation. Embedders remain OpenAI/Voyage.
- **API key aliasing.** `GEMINI_API_KEY` is preferred, but `GOOGLE_API_KEY` is accepted as a fallback because Google's own docs still use the older name in several places.
- **Provider name aliasing.** `AI_MEMORY_LLM_PROVIDER=google` is treated as `gemini` for the same reason.
- Stays faithful to invariant #13 (zero-LLM default): the provider only constructs when explicitly selected.