### PR TITLE
feat(llm): Google Gemini embeddings via embedContent API

### DIFF
--- a/crates/ai-memory-cli/src/config.rs
+++ b/crates/ai-memory-cli/src/config.rs
@@ -58,7 +58,7 @@ pub struct Config {
     pub llm_model: Option<String>,
     /// Optional LLM base URL override.
     pub llm_base_url: Option<String>,
-    /// Optional embedding provider (`openai`, `voyage`).
+    /// Optional embedding provider (`openai`, `voyage`, `google` / `gemini`).
     pub embedding_provider: Option<String>,
     /// Optional embedding model override.
     pub embedding_model: Option<String>,
@@ -346,9 +346,10 @@ impl Config {
         let provider = match provider_raw {
             "openai" => EmbedderChoice::OpenAi,
             "voyage" => EmbedderChoice::Voyage,
+            "google" | "gemini" => EmbedderChoice::Google,
             other => {
                 return Err(LlmError::NotConfigured(format!(
-                    "AI_MEMORY_EMBEDDING_PROVIDER={other} not one of openai|voyage"
+                    "AI_MEMORY_EMBEDDING_PROVIDER={other} not one of openai|voyage|google|gemini"
                 )));
             }
         };
@@ -357,6 +358,7 @@ impl Config {
             None => match provider {
                 EmbedderChoice::OpenAi => "text-embedding-3-small".to_string(),
                 EmbedderChoice::Voyage => "voyage-3".to_string(),
+                EmbedderChoice::Google => ai_memory_llm::GOOGLE_DEFAULT_EMBED_MODEL.to_string(),
             },
         };
         let dim = self
@@ -373,6 +375,13 @@ impl Config {
                 .voyage_api_key
                 .clone()
                 .ok_or_else(|| LlmError::NotConfigured("VOYAGE_API_KEY".into()))?,
+            EmbedderChoice::Google => self
+                .runtime_env
+                .gemini_api_key
+                .clone()
+                .ok_or_else(|| {
+                    LlmError::NotConfigured("GEMINI_API_KEY or GOOGLE_API_KEY".into())
+                })?,
         };
         Ok(Some(EmbedderConfig {
             provider,

--- a/crates/ai-memory-consolidate/tests/embeddings.rs
+++ b/crates/ai-memory-consolidate/tests/embeddings.rs
@@ -125,7 +125,7 @@ async fn m9_embeddings_roundtrip_via_synthetic() {
 
     // 3. Hybrid search end-to-end.
     let q = "karpathy compile artifact";
-    let qv = embedder.embed(q).await.expect("embed query");
+    let qv = embedder.embed_query(q).await.expect("embed query");
     let hybrid_hits = store
         .reader
         .hybrid_search(

--- a/crates/ai-memory-llm/src/embedding.rs
+++ b/crates/ai-memory-llm/src/embedding.rs
@@ -1,9 +1,10 @@
 //! Embedding provider abstraction.
 //!
-//! Three implementations ship in M9:
+//! Embedding implementations ship in M9:
 //!
 //! * [`OpenAiEmbedder`] — production: hits OpenAI's `/v1/embeddings`.
 //! * [`VoyageEmbedder`] — production: hits Voyage's `/v1/embeddings`.
+//! * [`GoogleEmbedder`](crate::google::GoogleEmbedder) — Gemini `embedContent`.
 //! * [`SyntheticEmbedder`] — test-only: deterministic bag-of-words
 //!   embedding so integration tests can demonstrate semantic
 //!   retrieval without an API key.
@@ -41,6 +42,16 @@ pub trait Embedder: Send + Sync {
     /// Embed one text. Returns a unit-normalised vector — callers can
     /// dot-product directly to get cosine similarity.
     async fn embed(&self, text: &str) -> LlmResult<Vec<f32>>;
+
+    /// Embed wiki page / document body (hybrid index writes).
+    async fn embed_document(&self, text: &str) -> LlmResult<Vec<f32>> {
+        self.embed(text).await
+    }
+
+    /// Embed a search query (hybrid retrieval).
+    async fn embed_query(&self, text: &str) -> LlmResult<Vec<f32>> {
+        self.embed(text).await
+    }
 }
 
 /// OpenAI Embeddings API (`text-embedding-3-small` by default, 1536 dim).
@@ -307,7 +318,7 @@ impl Embedder for SyntheticEmbedder {
 }
 
 /// Unit-normalise so dot-product equals cosine similarity.
-fn normalise(mut v: Vec<f32>) -> Vec<f32> {
+pub(crate) fn normalise(mut v: Vec<f32>) -> Vec<f32> {
     let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
     if norm > 0.0 {
         for x in &mut v {

--- a/crates/ai-memory-llm/src/factory.rs
+++ b/crates/ai-memory-llm/src/factory.rs
@@ -12,6 +12,7 @@ use crate::GeminiProvider;
 use crate::OpenAiCompatProvider;
 use crate::OpenAiProvider;
 use crate::embedding::{Embedder, OpenAiEmbedder, VoyageEmbedder};
+use crate::google::GoogleEmbedder;
 use crate::error::{LlmError, LlmResult};
 use crate::provider::LlmProvider;
 
@@ -41,13 +42,15 @@ pub struct ProviderConfig {
     pub base_url: Option<String>,
 }
 
-/// Three embedders ship in v0.2.
+/// Embedding providers available to ai-memory.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EmbedderChoice {
     /// OpenAI Embeddings API.
     OpenAi,
     /// Voyage Embeddings API.
     Voyage,
+    /// Google Gemini Embeddings API (`embedContent`).
+    Google,
 }
 
 impl EmbedderChoice {
@@ -58,6 +61,7 @@ impl EmbedderChoice {
         match self {
             Self::OpenAi => "openai",
             Self::Voyage => "voyage",
+            Self::Google => "google",
         }
     }
 }
@@ -98,6 +102,13 @@ pub fn build_embedder(config: EmbedderConfig) -> LlmResult<Arc<dyn Embedder>> {
             }
             Arc::new(e)
         }
+        EmbedderChoice::Google => {
+            let mut e = GoogleEmbedder::new(config.api_key, config.model, config.dim)?;
+            if let Some(url) = config.base_url {
+                e = e.with_base_url(url);
+            }
+            Arc::new(e)
+        }
     };
     Ok(arc)
 }
@@ -113,6 +124,9 @@ pub fn default_embedding_dim(provider: EmbedderChoice, model: &str) -> u32 {
         (EmbedderChoice::OpenAi, _) => 1536,
         (EmbedderChoice::Voyage, "voyage-3-large") => 1024,
         (EmbedderChoice::Voyage, _) => 1024,
+        (EmbedderChoice::Google, "gemini-embedding-2") => 768,
+        (EmbedderChoice::Google, "gemini-embedding-001") => 768,
+        (EmbedderChoice::Google, _) => 768,
     }
 }
 

--- a/crates/ai-memory-llm/src/google.rs
+++ b/crates/ai-memory-llm/src/google.rs
@@ -1,0 +1,224 @@
+//! Google Gemini Embeddings API (`embedContent`).
+//!
+//! See <https://ai.google.dev/gemini-api/docs/embeddings>.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use crate::embedding::{Embedder, normalise};
+use crate::error::{LlmError, LlmResult};
+use crate::text::truncate_with_ellipsis;
+
+/// Default Gemini API host.
+pub const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com";
+
+/// Default text embedding model (Matryoshka-friendly 768-dim truncation).
+pub const DEFAULT_MODEL: &str = "gemini-embedding-001";
+
+/// Gemini / Google Generative Language embeddings.
+pub struct GoogleEmbedder {
+    client: reqwest::Client,
+    api_key: SecretString,
+    base_url: String,
+    /// Wire model id, e.g. `models/gemini-embedding-001`.
+    model: String,
+    dim: u32,
+    /// True when the model id contains `embedding-2` (task prefixes in text).
+    embedding_v2: bool,
+}
+
+impl GoogleEmbedder {
+    /// Construct a Google embedder.
+    ///
+    /// # Errors
+    /// Propagates HTTP client construction errors.
+    pub fn new(api_key: SecretString, model: impl Into<String>, dim: u32) -> LlmResult<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(120))
+            .build()?;
+        let model = normalize_model_id(model.into());
+        let embedding_v2 = model.contains("embedding-2");
+        Ok(Self {
+            client,
+            api_key,
+            base_url: DEFAULT_BASE_URL.into(),
+            model,
+            dim,
+            embedding_v2,
+        })
+    }
+
+    /// Override API host (tests).
+    #[must_use]
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = url.into();
+        self
+    }
+
+    async fn embed_with_task(
+        &self,
+        text: &str,
+        task_type: Option<&'static str>,
+    ) -> LlmResult<Vec<f32>> {
+        let prepared = if self.embedding_v2 {
+            match task_type {
+                Some("RETRIEVAL_DOCUMENT") => format_document_v2(text),
+                Some("RETRIEVAL_QUERY") => format_query_v2(text),
+                _ => text.to_string(),
+            }
+        } else {
+            text.to_string()
+        };
+
+        let url = embed_url(&self.base_url, &self.model);
+        let body = GeminiEmbedRequest {
+            content: GeminiContent {
+                parts: vec![GeminiPart { text: &prepared }],
+            },
+            task_type: if self.embedding_v2 {
+                None
+            } else {
+                task_type
+            },
+            output_dimensionality: Some(self.dim),
+        };
+
+        debug!(url, model = %self.model, ?task_type, "POST google/embedContent");
+        let resp = self
+            .client
+            .post(&url)
+            .header("x-goog-api-key", self.api_key.expose_secret())
+            .json(&body)
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp.text().await.unwrap_or_default();
+            return Err(LlmError::Provider {
+                status: status.as_u16(),
+                body: truncate_with_ellipsis(&body_text, 1024),
+            });
+        }
+        let parsed: GeminiEmbedResponse = resp.json().await?;
+        let values = parsed.embedding.values;
+        if values.len() as u32 != self.dim {
+            return Err(LlmError::UnexpectedShape(format!(
+                "expected dim {}, got {}",
+                self.dim,
+                values.len()
+            )));
+        }
+        Ok(normalise(values))
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct GeminiEmbedRequest<'a> {
+    content: GeminiContent<'a>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "taskType")]
+    task_type: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "outputDimensionality")]
+    output_dimensionality: Option<u32>,
+}
+
+#[derive(Debug, Serialize)]
+struct GeminiContent<'a> {
+    parts: Vec<GeminiPart<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct GeminiPart<'a> {
+    text: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiEmbedResponse {
+    embedding: GeminiEmbeddingValues,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiEmbeddingValues {
+    values: Vec<f32>,
+}
+
+#[async_trait]
+impl Embedder for GoogleEmbedder {
+    fn provider(&self) -> &'static str {
+        "google"
+    }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
+
+    fn dim(&self) -> u32 {
+        self.dim
+    }
+
+    async fn embed(&self, text: &str) -> LlmResult<Vec<f32>> {
+        self.embed_document(text).await
+    }
+
+    async fn embed_document(&self, text: &str) -> LlmResult<Vec<f32>> {
+        self.embed_with_task(text, Some("RETRIEVAL_DOCUMENT"))
+            .await
+    }
+
+    async fn embed_query(&self, text: &str) -> LlmResult<Vec<f32>> {
+        self.embed_with_task(text, Some("RETRIEVAL_QUERY")).await
+    }
+}
+
+/// Prefix model id with `models/` when omitted.
+#[must_use]
+pub fn normalize_model_id(model: String) -> String {
+    let trimmed = model.trim();
+    if trimmed.starts_with("models/") {
+        trimmed.to_string()
+    } else {
+        format!("models/{trimmed}")
+    }
+}
+
+fn embed_url(base: &str, model: &str) -> String {
+    format!(
+        "{}/v1beta/{}:embedContent",
+        base.trim_end_matches('/'),
+        model
+    )
+}
+
+/// Asymmetric document format for `gemini-embedding-2` (see Google docs).
+#[must_use]
+pub fn format_document_v2(text: &str) -> String {
+    format!("title: none | text: {text}")
+}
+
+/// Asymmetric query format for `gemini-embedding-2`.
+#[must_use]
+pub fn format_query_v2(text: &str) -> String {
+    format!("task: search result | query: {text}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_model_adds_prefix() {
+        assert_eq!(
+            normalize_model_id("gemini-embedding-001".into()),
+            "models/gemini-embedding-001"
+        );
+    }
+
+    #[test]
+    fn v2_document_and_query_prefixes() {
+        assert!(format_document_v2("hello").contains("text: hello"));
+        assert!(format_query_v2("find auth").contains("query: find auth"));
+    }
+}

--- a/crates/ai-memory-llm/src/lib.rs
+++ b/crates/ai-memory-llm/src/lib.rs
@@ -27,6 +27,7 @@ pub mod embedding;
 pub mod error;
 pub mod factory;
 pub mod gemini;
+pub mod google;
 pub mod openai;
 pub mod openai_compat;
 pub mod provider;
@@ -42,6 +43,7 @@ pub use factory::{
     default_embedding_dim,
 };
 pub use gemini::GeminiProvider;
+pub use google::{GoogleEmbedder, DEFAULT_MODEL as GOOGLE_DEFAULT_EMBED_MODEL};
 pub use openai::OpenAiProvider;
 pub use openai_compat::OpenAiCompatProvider;
 pub use provider::{LlmProvider, complete_structured};


### PR DESCRIPTION
## Summary

Adds a **Google Gemini embeddings** provider (`AI_MEMORY_EMBEDDING_PROVIDER=google` or `gemini`) using the Generative Language `embedContent` API. Complements the existing **Gemini LLM** provider without adding new runtime dependencies beyond `reqwest`.

## Scope

- New `GoogleEmbedder` in `crates/ai-memory-llm/src/google.rs`
- `EmbedderChoice::Google` in the factory
- Config wiring for `GEMINI_API_KEY` / `GOOGLE_API_KEY` on the embedding path

**Not included:** Cursor LLM bridge, Windows install scripts, or `.env.local` templates.

## Test plan

- [x] `cargo test -p ai-memory-consolidate embeddings` (if present)
- [x] `cargo test -p ai-memory-llm`
- [x] Manual: `AI_MEMORY_EMBEDDING_PROVIDER=google AI_MEMORY_EMBEDDING_MODEL=gemini-embedding-2` + `memory_query` hybrid path
