### PR TITLE
fix(store,mcp): omp agent_kind, handoff effective_ids and FTS5 colon …

### DIFF
--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -213,6 +213,10 @@ struct HandoffBeginArgs {
     /// next agent's `memory_handoff_accept` call.
     #[serde(default)]
     cwd: Option<String>,
+    /// Project to scope the handoff to. Omit to target the project you're
+    /// currently working in (resolved from recent hook activity).
+    #[serde(default)]
+    project: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
@@ -220,6 +224,10 @@ struct HandoffAcceptArgs {
     /// Restrict the search to handoffs created for a specific cwd.
     #[serde(default)]
     cwd: Option<String>,
+    /// Project to accept a handoff from. Omit to target the project you're
+    /// currently working in (resolved from recent hook activity).
+    #[serde(default)]
+    project: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
@@ -602,9 +610,10 @@ impl AiMemoryServer {
         // path-pattern regexes already cover when applicable, but we
         // pass each entry through anyway as defence-in-depth.
         let s = &self.sanitizer;
+        let (ws, proj) = self.effective_ids(args.project.as_deref()).await;
         let handoff = NewHandoff {
-            workspace_id: self.workspace_id,
-            project_id: self.project_id,
+            workspace_id: ws,
+            project_id: proj,
             from_session_id: None,
             from_agent: AgentKind::Other,
             to_agent: None,
@@ -645,9 +654,10 @@ impl AiMemoryServer {
         &self,
         Parameters(args): Parameters<HandoffAcceptArgs>,
     ) -> Result<CallToolResult, McpError> {
+        let (ws, proj) = self.effective_ids(args.project.as_deref()).await;
         let handoff = self
             .reader
-            .latest_open_handoff(self.workspace_id, self.project_id, args.cwd)
+            .latest_open_handoff(ws, proj, args.cwd)
             .await
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
         match handoff {
@@ -1246,6 +1256,50 @@ mod tests {
         assert!(text.contains("foo.md"), "expected hit; got {text}");
     }
 
+    /// `memory_handoff_begin` must resolve the same project as
+    /// `memory_briefing` when hooks publish `ActiveProject` (issue #2).
+    #[tokio::test]
+    async fn handoff_begin_pending_count_matches_briefing_active_project() {
+        let (_tmp, store, mut server, ws, baked) = setup_server().await;
+        let active = store
+            .writer
+            .get_or_create_project(ws, "ai-memory", Some(r"C:\GIT\ai-memory".into()))
+            .await
+            .unwrap();
+        assert_ne!(active, baked, "test needs baked default != active project");
+        server.active_project.set(ws, active);
+
+        server
+            .memory_handoff_begin(Parameters(HandoffBeginArgs {
+                summary: "fix omp CHECK".into(),
+                open_questions: vec![],
+                next_steps: vec![],
+                files_touched: vec![],
+                cwd: Some(r"C:\GIT\ai-memory".into()),
+                project: None,
+            }))
+            .await
+            .unwrap();
+
+        let briefing = server
+            .memory_briefing(Parameters(BriefingArgs {
+                recent_pages_limit: Some(5),
+                project: None,
+            }))
+            .await
+            .unwrap();
+        let text = briefing
+            .content
+            .first()
+            .and_then(|c| c.as_text())
+            .map(|t| t.text.clone())
+            .unwrap();
+        assert!(
+            text.contains("\"pending_handoff_count\": 1"),
+            "briefing should see the handoff in the active project; got {text}",
+        );
+    }
+
     #[tokio::test]
     async fn handoff_begin_then_accept_round_trips() {
         let (_tmp, _store, server, _ws, _pj) = setup_server().await;
@@ -1256,6 +1310,7 @@ mod tests {
                 next_steps: vec!["finish supersession path".into()],
                 files_touched: vec!["crates/ai-memory-store/src/writer.rs".into()],
                 cwd: Some("/tmp/aim".into()),
+                project: None,
             }))
             .await
             .unwrap();
@@ -1271,6 +1326,7 @@ mod tests {
         let accept = server
             .memory_handoff_accept(Parameters(HandoffAcceptArgs {
                 cwd: Some("/tmp/aim".into()),
+                project: None,
             }))
             .await
             .unwrap();
@@ -1287,6 +1343,7 @@ mod tests {
         let again = server
             .memory_handoff_accept(Parameters(HandoffAcceptArgs {
                 cwd: Some("/tmp/aim".into()),
+                project: None,
             }))
             .await
             .unwrap();
@@ -1355,7 +1412,10 @@ mod tests {
     async fn memory_handoff_accept_when_none_pending_returns_null() {
         let (_tmp, _store, server, _ws, _pj) = setup_server().await;
         let result = server
-            .memory_handoff_accept(Parameters(HandoffAcceptArgs { cwd: None }))
+            .memory_handoff_accept(Parameters(HandoffAcceptArgs {
+                cwd: None,
+                project: None,
+            }))
             .await
             .expect("empty-queue must be Ok, not Err");
         let text = result

--- a/crates/ai-memory-store/migrations/V07__agent_kind_omp.sql
+++ b/crates/ai-memory-store/migrations/V07__agent_kind_omp.sql
@@ -1,0 +1,30 @@
+-- Expand sessions.agent_kind CHECK to include `omp` (Oh My Pi / pi hooks).
+--
+-- Hook payloads send `agent=pi` (or `omp`), parsed to AgentKind::Omp and
+-- persisted as the wire string `omp`. V01 only allowed claude-code/codex/
+-- open-code/other, so every pi hook tripped:
+--   CHECK constraint failed: agent_kind IN (...)
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE sessions_new (
+    id               BLOB PRIMARY KEY NOT NULL,
+    workspace_id     BLOB NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    project_id       BLOB NOT NULL REFERENCES projects(id)   ON DELETE CASCADE,
+    agent_kind       TEXT NOT NULL CHECK (agent_kind IN ('claude-code','codex','open-code','omp','other')),
+    cwd              TEXT,
+    started_at       INTEGER NOT NULL,
+    ended_at         INTEGER,
+    summary_page_id  BLOB REFERENCES pages(id) ON DELETE SET NULL
+);
+
+INSERT INTO sessions_new SELECT * FROM sessions;
+
+DROP TABLE sessions;
+
+ALTER TABLE sessions_new RENAME TO sessions;
+
+CREATE INDEX idx_sessions_recent ON sessions(workspace_id, project_id, started_at DESC);
+CREATE INDEX idx_sessions_project ON sessions(project_id);
+
+PRAGMA foreign_keys = ON;

--- a/crates/ai-memory-store/src/fts_query.rs
+++ b/crates/ai-memory-store/src/fts_query.rs
@@ -1,0 +1,54 @@
+//! FTS5 `MATCH` query preparation for user/agent-supplied search text.
+//!
+//! FTS5 treats `column:term` as a column-qualified search. Natural-language
+//! queries that contain colons (`pick: handoff`, `memory: bootstrap`) make
+//! SQLite error with `no such column: pick` because only `title` and `body`
+//! exist on `pages_fts`. Colons are neutralised before each token is quoted.
+
+/// Sanitize free-text for use in `WHERE pages_fts MATCH ?`.
+///
+/// Returns an empty string when `raw` is empty/whitespace-only; callers
+/// should skip the SQL query in that case.
+#[must_use]
+pub fn prepare_fts5_query(raw: &str) -> String {
+    // Turn `pick:` / `memory:` into separate tokens so we never emit FTS5
+    // column syntax, while still matching indexed words (`pick`, `memory`).
+    let normalized: String = raw
+        .chars()
+        .map(|c| if c == ':' { ' ' } else { c })
+        .collect();
+    let tokens: Vec<String> = normalized
+        .split_whitespace()
+        .filter(|t| !t.is_empty())
+        .map(quote_fts5_token)
+        .collect();
+    tokens.join(" ")
+}
+
+fn quote_fts5_token(token: &str) -> String {
+    // FTS5 escapes `"` inside a quoted token by doubling it.
+    let escaped = token.replace('"', "\"\"");
+    format!("\"{escaped}\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn colon_is_not_column_syntax() {
+        let q = prepare_fts5_query("pick: handoff ai-memory");
+        assert_eq!(q, "\"pick\" \"handoff\" \"ai-memory\"");
+    }
+
+    #[test]
+    fn empty_yields_empty() {
+        assert_eq!(prepare_fts5_query("   "), "");
+    }
+
+    #[test]
+    fn quotes_are_escaped() {
+        let q = prepare_fts5_query(r#"say "hello""#);
+        assert_eq!(q, r#""say" """hello""""#);
+    }
+}

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -14,10 +14,13 @@ use rusqlite::Connection;
 
 pub mod decay;
 mod error;
+mod fts_query;
 mod migrations;
 mod ops;
 mod reader;
 mod writer;
+
+pub use fts_query::prepare_fts5_query;
 
 pub use decay::{DecayParams, retention_score};
 pub use error::{StoreError, StoreResult};
@@ -307,6 +310,44 @@ mod tests {
             hits[0].snippet.contains("different"),
             "snippet should come from the latest version, got: {}",
             hits[0].snippet
+        );
+    }
+
+    /// Regression: bare `word:` in agent queries is FTS5 column syntax, not
+    /// a literal token (`no such column: pick` / `memory`).
+    #[tokio::test]
+    async fn search_colon_tokens_do_not_error() {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let ws = store
+            .writer
+            .get_or_create_workspace("default")
+            .await
+            .unwrap();
+        let proj = store
+            .writer
+            .get_or_create_project(ws, "scratch", None)
+            .await
+            .unwrap();
+        store
+            .writer
+            .upsert_page(sample_page(
+                ws,
+                proj,
+                "handoff.md",
+                "pick up handoff context from ai-memory bootstrap",
+            ))
+            .await
+            .unwrap();
+
+        let hits = store
+            .reader
+            .search_pages("pick: handoff bootstrap".into(), 10)
+            .await
+            .unwrap();
+        assert!(
+            !hits.is_empty(),
+            "colon-sanitized query should match without SQLite column error"
         );
     }
 

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -1031,6 +1031,34 @@ mod tests {
         assert!(second.is_ok(), "double-accept must not error");
     }
 
+    /// Pi / OMP hooks persist `agent_kind = 'omp'`. V01's CHECK omitted
+    /// that value; regression for the hook-router WARN on every event.
+    #[test]
+    fn begin_session_accepts_omp_agent_kind() {
+        let (_tmp, mut conn, ws, proj) = fresh_db();
+        let sid = SessionId::new();
+        begin_session(
+            &mut conn,
+            &NewSession {
+                id: sid,
+                workspace_id: ws,
+                project_id: proj,
+                agent_kind: AgentKind::Omp,
+                cwd: Some(std::path::PathBuf::from(r"C:\GIT\ai-memory")),
+            },
+        )
+        .unwrap();
+
+        let stored: String = conn
+            .query_row(
+                "SELECT agent_kind FROM sessions WHERE id = ?1",
+                params![&sid.as_bytes()[..]],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, "omp");
+    }
+
     /// end_session links the synthesised summary page so callers can
     /// jump straight from session row to summary.
     #[test]

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -23,6 +23,7 @@ use serde::Serialize;
 // for a single use-site.
 
 use crate::error::{StoreError, StoreResult};
+use crate::fts_query::prepare_fts5_query;
 
 /// One hit returned by [`ReaderPool::search_pages`].
 #[derive(Debug, Clone, Serialize)]
@@ -308,7 +309,10 @@ impl ReaderPool {
     /// # Errors
     /// Propagates any SQL or pool error.
     pub async fn search_pages(&self, query: String, limit: usize) -> StoreResult<Vec<PageHit>> {
-        let query = normalize_fts_query(&query);
+        let fts_query = normalize_fts_query(&query);
+        if fts_query.is_empty() {
+            return Ok(Vec::new());
+        }
         self.with_conn(move |conn| {
             let mut stmt = conn.prepare_cached(
                 "SELECT pages.id, pages.path, pages.title, \
@@ -321,7 +325,7 @@ impl ReaderPool {
                  LIMIT ?2",
             )?;
             #[allow(clippy::cast_possible_wrap)]
-            let rows = stmt.query_map(params![query, limit as i64], |row| {
+            let rows = stmt.query_map(params![fts_query, limit as i64], |row| {
                 let id_bytes: Vec<u8> = row.get(0)?;
                 let path: String = row.get(1)?;
                 let title: String = row.get(2)?;
@@ -410,7 +414,10 @@ impl ReaderPool {
         query: String,
         limit: usize,
     ) -> StoreResult<Vec<PageHit>> {
-        let query = normalize_fts_query(&query);
+        let fts_query = normalize_fts_query(&query);
+        if fts_query.is_empty() {
+            return Ok(Vec::new());
+        }
         self.with_conn(move |conn| {
             let mut stmt = conn.prepare_cached(
                 "SELECT pages.id, pages.path, pages.title, \
@@ -428,7 +435,7 @@ impl ReaderPool {
             #[allow(clippy::cast_possible_wrap)]
             let rows = stmt.query_map(
                 params![
-                    query,
+                    fts_query,
                     workspace_id.as_bytes(),
                     project_id.as_bytes(),
                     limit as i64
@@ -2207,21 +2214,9 @@ fn count_project(
 }
 
 fn normalize_fts_query(query: &str) -> String {
-    query
-        .split_whitespace()
-        .map(|token| {
-            if should_quote_fts_token(token) {
-                format!("\"{}\"", token.replace('"', "\"\""))
-            } else {
-                token.to_string()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn should_quote_fts_token(token: &str) -> bool {
-    token.contains('-') && !(token.starts_with('"') && token.ends_with('"'))
+    // Delegates to prepare_fts5_query: neutralises `word:` column syntax and
+    // quotes tokens so `-` / `*` are not FTS5 operators.
+    prepare_fts5_query(query)
 }
 
 /// Count rows in a time-bounded window. Used by [`ReaderPool::briefing`]


### PR DESCRIPTION
## Summary

Fixes three production issues discovered while running ai-memory with Oh My Pi (OMP) hooks and MCP read tools on Windows:

1. **SQLite CHECK on `sessions.agent_kind`** — Pi hooks persist `omp`, but V01 only allowed `claude-code|codex|open-code|other`, causing every hook to fail with `CHECK constraint failed`.
2. **Handoff namespace mismatch** — `memory_handoff_begin` / `memory_handoff_accept` used the server's baked-in `--project` default while read tools (`memory_briefing`, etc.) used `effective_ids()` (ActiveProject from hooks). Handoffs were written to `scratch` but read from the active cwd project.
3. **FTS5 column syntax in agent queries** — Natural-language queries containing `word:` (e.g. `pick: handoff`) were interpreted as FTS5 column qualifiers, producing `no such column: pick` instead of search results.

## Changes

- Migration `V07__agent_kind_omp.sql` expands the `sessions.agent_kind` CHECK to include `'omp'`.
- Handoff MCP tools resolve project via `effective_ids()` (optional `project` arg), matching read tools.
- New `prepare_fts5_query()` neutralises colons and quotes tokens; wired through `normalize_fts_query()` in the reader.

## Test plan

- [x] `cargo test -p ai-memory-store search_colon`
- [x] `cargo test -p ai-memory-mcp handoff_begin_pending_count_matches_briefing_active_project`
- [x] Manual: pi hooks no longer WARN on `agent_kind` after migration V07
- [ ] Manual: `memory_handoff_begin` + `memory_briefing` show consistent `pending_handoff_count`
- [x] Manual: `memory_query` with `pick: handoff` returns hits (no SQLite error)
