### PR TITLE
fix(serve): warn on embedding mismatch instead of aborting startup

### DIFF
--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -444,10 +444,18 @@ async fn configure_embedder(
         )
         .await?;
     if !mismatch.is_empty() {
-        anyhow::bail!(
-            "embedding (provider, model, dim) mismatch with stored data: {:?} \
-             — run `ai-memory embed --reembed` to migrate",
-            mismatch
+        // Refuse-on-mismatch applies to hybrid search (queries only load
+        // rows matching the configured triple), not to process liveness.
+        // Blocking startup made `embed --reembed` impossible because the
+        // CLI is an HTTP client to this server.
+        tracing::warn!(
+            stored = ?mismatch,
+            configured_provider = cfg.provider.name(),
+            configured_model = %cfg.model,
+            configured_dim = cfg.dim,
+            "stored embeddings use a different (provider, model, dim) than configured; \
+             hybrid search ignores stale rows until pages are re-embedded — \
+             run `ai-memory embed --reembed` (or wait for scheduled backfill)"
         );
     }
     info!(

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -216,11 +216,11 @@ ssh "$SERVER" "tail -100 $DEPLOY_DIR/data/logs/ai-memory.log.$(date +%F)"
   `ai-memory status` healthcheck is failing. Most likely the data
   dir's permissions don't match the container's user (uid 1000). Fix
   with `sudo chown -R 1000:1000 $DEPLOY_DIR/data` on the host.
-- **Embedding mismatch refusing to start**: ai-memory refuses to boot
-  when the configured `(provider, model, dim)` for embeddings doesn't
-  match the stored pages' embeddings. Either revert the change or run
-  `ai-memory embed --reembed` (after starting with the old config or
-  doing a manual SQL fix) to migrate.
+- **Embedding mismatch after a model change**: startup logs a warning
+  when stored `(provider, model, dim)` triples differ from config.
+  Hybrid search ignores stale rows until they are re-embedded. Start
+  the server normally, then run `ai-memory embed --reembed` (or rely
+  on scheduled embedding backfill if enabled).
 - **Container restart loop**: check
   `docker logs ai-memory` - the `ai-memory starting` line at the top
   reports the resolved config; a missing required env var (e.g.


### PR DESCRIPTION
## Summary

Fixes a startup deadlock when the configured embedding `(provider, model, dim)` differs from rows already stored in `page_embeddings` (e.g. after switching from one Gemini embedding model to another).

Previously `serve` refused to start with a fatal error pointing users to `ai-memory embed --force`, but the `embed` subcommand is a thin HTTP client to the running server — so migration was impossible without manually editing SQLite or temporarily reverting config.

## Changes

- On mismatch at startup, log a structured **warning** and continue booting with the configured embedder.
- Hybrid search already loads only rows matching the configured triple; stale rows are ignored until re-embedded.
- Update `docs/deploy.md` troubleshooting to describe warn-and-migrate flow.

## Test plan

- [x] Manual: change `AI_MEMORY_EMBEDDING_MODEL` (or provider) with existing `page_embeddings` rows → server starts with WARN instead of exit
- [x] `ai-memory embed --force` migrates rows after server is up
- [x] `cargo test -p ai-memory-consolidate embeddings` (refuse-on-mismatch query still passes)
