### PR TITLE
fix(hooks): resolve worktree cwd to main repo for project identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "ai-memory-wiki",
  "anyhow",
  "axum",
+ "git2",
  "jiff",
  "regex",
  "serde",

--- a/crates/ai-memory-consolidate/src/bootstrap.rs
+++ b/crates/ai-memory-consolidate/src/bootstrap.rs
@@ -536,6 +536,38 @@ pub fn discover_repo_root(start: &Path) -> Result<PathBuf, BootstrapError> {
         .ok_or_else(|| BootstrapError::NotARepo(start.to_path_buf()))
 }
 
+/// Like [`discover_repo_root`], but when `start` is inside a git
+/// worktree the function follows the `.git` commondir pointer back to
+/// the **main** repository root rather than returning the worktree's
+/// own working directory.
+///
+/// This is the right choice when the caller needs a stable identity
+/// for the repository (e.g. deriving a project name) — all worktrees
+/// of the same repo should resolve to the same root.
+///
+/// # Errors
+/// Returns `BootstrapError::NotARepo` when no repository is found
+/// at or above `start`.
+pub fn discover_main_repo_root(start: &Path) -> Result<PathBuf, BootstrapError> {
+    let repo = git2::Repository::discover(start)
+        .map_err(|_| BootstrapError::NotARepo(start.to_path_buf()))?;
+    // Bare repos have no working directory; `commondir()` IS the repo root
+    // (there is no `.git/` subdirectory), so `.parent()` would return the
+    // grandparent — wrong.  Fall back to basename(cwd) via NotARepo so the
+    // router handles it safely.
+    if repo.is_bare() {
+        return Err(BootstrapError::NotARepo(start.to_path_buf()));
+    }
+    // `commondir()` returns the shared .git directory.  For a regular
+    // checkout it equals `path()` (i.e. `<repo>/.git/`); for a
+    // worktree it points to the *main* repo's `.git/` — so its parent
+    // is always the main repository root.
+    repo.commondir()
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| BootstrapError::NotARepo(start.to_path_buf()))
+}
+
 /// Read commits, format each as a one-paragraph entry. We include
 /// only commits with a substantive body (more than ~120 chars
 /// total) — drive-by typo-fix commits aren't worth tokens.

--- a/crates/ai-memory-consolidate/src/lib.rs
+++ b/crates/ai-memory-consolidate/src/lib.rs
@@ -16,8 +16,8 @@ pub mod types;
 
 pub use bootstrap::{
     Bootstrap, BootstrapConfig, BootstrapError, BootstrapOutcome, BootstrapSource,
-    DEFAULT_CHUNK_INPUT_TOKENS, SourceCounts, SourceKind, collect_sources, discover_repo_root,
-    effective_chunk_budget, plan_bootstrap_chunks, prune_sources_to_budget,
+    DEFAULT_CHUNK_INPUT_TOKENS, SourceCounts, SourceKind, collect_sources, discover_main_repo_root,
+    discover_repo_root, effective_chunk_budget, plan_bootstrap_chunks, prune_sources_to_budget,
 };
 pub use consolidator::{
     BATCH_SYSTEM_PROMPT, Consolidator, ConsolidatorError, ConsolidatorResult, build_batch_request,

--- a/crates/ai-memory-hooks/Cargo.toml
+++ b/crates/ai-memory-hooks/Cargo.toml
@@ -26,6 +26,7 @@ regex.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+git2.workspace = true
 
 [lints]
 workspace = true

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -1107,4 +1107,83 @@ mod tests {
         assert_ne!(ws, state.workspace_id);
         assert_ne!(proj, state.project_id);
     }
+
+    /// A git worktree must resolve to the same project as the main
+    /// working directory — both share the same repository identity.
+    #[tokio::test]
+    async fn worktree_resolves_to_same_project_as_main_repo() {
+        let tmp = TempDir::new().unwrap();
+        let state = make_state(&tmp).await;
+
+        // Create a real git repo inside the temp dir.
+        let main_dir = tmp.path().join("my-project");
+        std::fs::create_dir_all(&main_dir).unwrap();
+        let repo = git2::Repository::init(&main_dir).unwrap();
+
+        // git2 requires at least one commit before creating a worktree.
+        let sig = repo
+            .signature()
+            .unwrap_or_else(|_| git2::Signature::now("test", "test@test.com").unwrap());
+        let tree_id = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+
+        // Create a worktree in a sibling directory.
+        let wt_dir = tmp.path().join("my-project-feature-branch");
+        let head = repo.head().unwrap().peel_to_commit().unwrap();
+        // Create a branch for the worktree to check out.
+        let branch = repo.branch("feature-branch", &head, false).unwrap();
+        repo.worktree(
+            "feature-branch",
+            &wt_dir,
+            Some(git2::WorktreeAddOptions::new().reference(Some(&branch.into_reference()))),
+        )
+        .unwrap();
+
+        let main_cwd = main_dir.to_str().unwrap();
+        let wt_cwd = wt_dir.to_str().unwrap();
+
+        let (ws_main, proj_main) = resolve_project_ids(&state, Some(main_cwd), None, None)
+            .await
+            .unwrap();
+        let (ws_wt, proj_wt) = resolve_project_ids(&state, Some(wt_cwd), None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(ws_main, ws_wt, "same workspace");
+        assert_eq!(
+            proj_main, proj_wt,
+            "worktree must resolve to same project as main repo"
+        );
+    }
+
+    /// A directory that is NOT inside a git repo must still resolve
+    /// via basename(cwd), preserving the existing behaviour.
+    #[tokio::test]
+    async fn non_git_dir_falls_back_to_basename() {
+        let tmp = TempDir::new().unwrap();
+        let state = make_state(&tmp).await;
+
+        // Create a plain directory (no .git).
+        let plain_dir = tmp.path().join("plain-project");
+        std::fs::create_dir_all(&plain_dir).unwrap();
+        let cwd = plain_dir.to_str().unwrap();
+
+        let (_, proj) = resolve_project_ids(&state, Some(cwd), None, None)
+            .await
+            .unwrap();
+
+        // Must NOT be the server-default scratch project.
+        assert_ne!(proj, state.project_id);
+
+        // Resolve a second time with a different basename to prove
+        // they produce distinct projects (basename-based).
+        let other_dir = tmp.path().join("other-project");
+        std::fs::create_dir_all(&other_dir).unwrap();
+        let (_, proj2) = resolve_project_ids(&state, Some(other_dir.to_str().unwrap()), None, None)
+            .await
+            .unwrap();
+        assert_ne!(proj, proj2, "different basenames → different projects");
+    }
 }

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -287,22 +287,32 @@ async fn resolve_project_ids(
 
     let project_name = match (project_override, cwd_norm.as_deref()) {
         (Some(p), _) => p.to_string(),
-        (None, Some(c)) => match std::path::Path::new(c)
-            .file_name()
-            .and_then(|s| s.to_str())
-            .map(str::to_string)
-            .filter(|s| !s.is_empty())
-        {
-            Some(name) => name,
-            None => {
-                // Defensive: basename derivation failed (e.g. cwd is "/").
-                // Fall back to server defaults rather than hard-erroring.
-                state
-                    .active_project
-                    .set(state.workspace_id, state.project_id);
-                return Ok((state.workspace_id, state.project_id));
+        (None, Some(c)) => {
+            let path = std::path::Path::new(c);
+            // Resolve git repo root first — handles worktrees by following
+            // the .git gitdir pointer back to the main repository.
+            match ai_memory_consolidate::discover_main_repo_root(path)
+                .ok()
+                .and_then(|root| {
+                    root.file_name()
+                        .and_then(|s| s.to_str())
+                        .map(str::to_string)
+                })
+                .or_else(|| {
+                    path.file_name()
+                        .and_then(|s| s.to_str())
+                        .map(str::to_string)
+                        .filter(|s| !s.is_empty())
+                }) {
+                Some(name) => name,
+                None => {
+                    state
+                        .active_project
+                        .set(state.workspace_id, state.project_id);
+                    return Ok((state.workspace_id, state.project_id));
+                }
             }
-        },
+        }
         (None, None) => {
             // The early-return at the top of the function guards
             // against this branch; the explicit fallback here keeps
@@ -1185,5 +1195,36 @@ mod tests {
             .await
             .unwrap();
         assert_ne!(proj, proj2, "different basenames → different projects");
+    }
+
+    /// A bare repository must fall back to basename(cwd), not resolve
+    /// to the grandparent directory via commondir().parent().
+    #[tokio::test]
+    async fn bare_repo_falls_back_to_basename() {
+        let tmp = TempDir::new().unwrap();
+        let state = make_state(&tmp).await;
+
+        let bare_dir = tmp.path().join("my-bare-project.git");
+        git2::Repository::init_bare(&bare_dir).unwrap();
+        let cwd = bare_dir.to_str().unwrap();
+
+        let (_, proj) = resolve_project_ids(&state, Some(cwd), None, None)
+            .await
+            .unwrap();
+
+        // Must NOT be the server-default scratch project — basename should work.
+        assert_ne!(proj, state.project_id);
+
+        // The project name should come from basename, not from the grandparent.
+        // To verify: resolve with a different bare repo name and confirm different project.
+        let bare_dir2 = tmp.path().join("other-bare.git");
+        git2::Repository::init_bare(&bare_dir2).unwrap();
+        let (_, proj2) = resolve_project_ids(&state, Some(bare_dir2.to_str().unwrap()), None, None)
+            .await
+            .unwrap();
+        assert_ne!(
+            proj, proj2,
+            "different bare repo basenames → different projects"
+        );
     }
 }


### PR DESCRIPTION
## What changed

The hook router's `resolve_project_ids` now resolves git worktree
directories back to the main repository root before falling back to
`basename(cwd)`. Previously, each worktree created a separate project
entry because the router only used `basename(cwd)`, and worktrees
have their own directory names.

**Before:** Working in `MultiClubes/21258-mover-mi...` (a worktree)
created a project called `21258-mover-mi...` instead of `MultiClubes`.

**After:** All worktrees of the same repo share one project, matching
the CLI's existing behavior.

## Why

When using git worktrees, knowledge was fragmented across duplicate
projects — handoffs, queries, and recent activity were invisible
across worktrees of the same repository.

The CLI already handled this correctly via `discover_repo_root()`,
but the hook router (the hot path for interactive sessions) did not.

## How

- Added `discover_main_repo_root()` to `ai-memory-consolidate` using
  `git2::Repository::commondir().parent()` — unlike `workdir()`,
  `commondir()` always points to the main repo's `.git/` even from
  a linked worktree.
- Bare repos are guarded (`is_bare()` → fall through to basename).
- The router tries git discovery first, falls back to `basename(cwd)`
  for non-git directories, preserving existing behavior.
- Cost: one `git2::Repository::discover()` call per unique `cwd`,
  then cached.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (4 pre-existing failures in
  `render_shared` on Windows, unrelated to this change)
- [x] Manual test: `worktree_resolves_to_same_project_as_main_repo` —
  creates a real git repo + worktree via `git2`, asserts both cwd
  paths resolve to the same `(workspace_id, project_id)`
- [x] `non_git_dir_falls_back_to_basename` — plain directories still
  resolve via basename
- [x] `bare_repo_falls_back_to_basename` — bare repos fall back
  safely to basename instead of returning the grandparent directory

## Notes for reviewers

- `discover_main_repo_root` vs existing `discover_repo_root`: the
  existing function uses `workdir()` which returns the worktree's own
  directory, not the main repo. The new function uses
  `commondir().parent()` which always resolves to the main repo root.
- The new function lives in `ai-memory-consolidate::bootstrap` next
  to the existing `discover_repo_root`. Long-term it could move to a
  shared utility module, but the dependency already exists.