### PR TITLE
fix(openai): unblock memory_consolidate multi_page on OpenAI strict mode

### DIFF
--- a/crates/ai-memory-llm/src/openai.rs
+++ b/crates/ai-memory-llm/src/openai.rs
@@ -346,6 +346,22 @@ impl OpenAiProvider {
 fn enforce_strict_object_schemas(value: &mut serde_json::Value) {
     match value {
         serde_json::Value::Object(map) => {
+            // OpenAI's structured-output validator rejects any sibling
+            // keyword next to `$ref` with a 400 (per JSON Schema 2020-12
+            // §8.2.3.1, $ref siblings are ignored during validation —
+            // OpenAI hardens that into a hard error). schemars 1.x emits
+            // a field-level `description` next to `$ref` for every
+            // doc-commented field typed as an external enum (e.g.
+            // `tier: Tier` on `ConsolidatedPageUpdate`); without this
+            // strip, `memory_consolidate multi_page=true` 400s on every
+            // call. Dropping the siblings is semantically a no-op —
+            // only the documentation-only annotation is lost; the
+            // type's own description on the referenced `$defs` entry
+            // is what reaches the model.
+            if map.contains_key("$ref") {
+                map.retain(|k, _| k == "$ref");
+                return;
+            }
             let is_object = map
                 .get("type")
                 .and_then(|t| t.as_str())
@@ -538,6 +554,60 @@ mod tests {
         assert!(names.contains(&"a"));
         assert!(names.contains(&"b"));
         assert_eq!(names.len(), 2);
+    }
+
+    #[test]
+    fn enforce_strict_strips_sibling_keywords_next_to_ref() {
+        // OpenAI's structured-output validator rejects any sibling
+        // keyword next to `$ref` with a 400. schemars 1.x emits a
+        // field-level `description` next to `$ref` whenever a
+        // doc-commented field is typed as an external enum (e.g.
+        // `tier: Tier` in `ConsolidatedPageUpdate`). Without this
+        // strip, `memory_consolidate multi_page=true` 400s on every
+        // call against gpt-4o-mini. JSON Schema 2020-12 §8.2.3.1 says
+        // siblings of `$ref` are ignored during validation, so
+        // dropping them is semantically a no-op — only the
+        // documentation-only field-level description is lost (the
+        // type's own description on the referenced definition stays).
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "tier": {
+                    "$ref": "#/$defs/Tier",
+                    "description": "Tier classification."
+                }
+            }
+        });
+        enforce_strict_object_schemas(&mut schema);
+        let tier = &schema["properties"]["tier"];
+        assert_eq!(tier["$ref"], json!("#/$defs/Tier"));
+        assert!(
+            tier.get("description").is_none(),
+            "description must be stripped from a $ref node"
+        );
+        assert_eq!(
+            tier.as_object().unwrap().len(),
+            1,
+            "only $ref should remain on the node"
+        );
+    }
+
+    #[test]
+    fn enforce_strict_strips_ref_siblings_inside_array_items() {
+        // The same JSON-Schema-2020-12 rule applies anywhere $ref
+        // appears, not just on direct object properties — schemars
+        // emits it inside `items` for `Vec<EnumType>` too.
+        let mut schema = json!({
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/Tier",
+                "description": "Each element classified."
+            }
+        });
+        enforce_strict_object_schemas(&mut schema);
+        let items = &schema["items"];
+        assert_eq!(items["$ref"], json!("#/$defs/Tier"));
+        assert!(items.get("description").is_none());
     }
 
     #[test]

--- a/crates/ai-memory-llm/src/openai.rs
+++ b/crates/ai-memory-llm/src/openai.rs
@@ -362,6 +362,16 @@ fn enforce_strict_object_schemas(value: &mut serde_json::Value) {
                 map.retain(|k, _| k == "$ref");
                 return;
             }
+            // OpenAI strict mode rejects `oneOf` outright but accepts
+            // `anyOf`. schemars 1.x emits `oneOf` for every Rust enum
+            // with tagged variants (closed sets where exactly one
+            // branch matches), e.g. `Tier` and `PageKind` under `$defs`
+            // in `ConsolidatedBatch`. For non-overlapping branches the
+            // rewrite is semantically lossless and unblocks every
+            // structured-output call that touches an enum.
+            if let Some(one_of) = map.remove("oneOf") {
+                map.insert("anyOf".to_string(), one_of);
+            }
             let is_object = map
                 .get("type")
                 .and_then(|t| t.as_str())
@@ -590,6 +600,38 @@ mod tests {
             1,
             "only $ref should remain on the node"
         );
+    }
+
+    #[test]
+    fn enforce_strict_renames_oneof_to_anyof() {
+        // OpenAI structured-output strict mode rejects `oneOf` outright
+        // ("In context=(), 'oneOf' is not permitted") while accepting
+        // `anyOf`. schemars 1.x emits `oneOf` for every Rust enum with
+        // tagged variants — e.g. the `Tier` and `PageKind` enums under
+        // `$defs` in `ConsolidatedBatch`. For closed enum sets where
+        // exactly one branch matches per value, `anyOf` is semantically
+        // equivalent (no two branches overlap), so the rewrite is
+        // lossless.
+        let mut schema = json!({
+            "type": "object",
+            "$defs": {
+                "Tier": {
+                    "oneOf": [
+                        { "type": "string", "const": "working" },
+                        { "type": "string", "const": "episodic" }
+                    ]
+                }
+            },
+            "properties": { "tier": { "$ref": "#/$defs/Tier" } }
+        });
+        enforce_strict_object_schemas(&mut schema);
+        let tier_def = &schema["$defs"]["Tier"];
+        assert!(
+            tier_def.get("oneOf").is_none(),
+            "oneOf must be rewritten away"
+        );
+        let any_of = tier_def.get("anyOf").expect("oneOf must become anyOf");
+        assert_eq!(any_of.as_array().unwrap().len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

`enforce_strict_object_schemas` in `crates/ai-memory-llm/src/openai.rs` now performs two additional normalisations during its walk:

1. **Strip every sibling of `$ref`.** When an object node carries `$ref`, retain only `$ref` and short-circuit. Per JSON Schema 2020-12 §8.2.3.1, `$ref` siblings are ignored during validation, so the rewrite is semantically a no-op — only the documentation-only field-level annotation is lost; the type's own description on the referenced `$defs` entry still reaches the model.

2. **Rewrite `oneOf` → `anyOf`.** For closed enum sets the branches are non-overlapping by construction (exactly one matches per value), so `oneOf` ≡ `anyOf` in this codebase's emission. Lossless.

Together these unblock `memory_consolidate multi_page=true` end-to-end against `gpt-4o-mini` and `gpt-4o`.

## Why

Without the fix, every call to `memory_consolidate multi_page=true` (and `bootstrap` against OpenAI) returns a 400 — see #30 for the two distinct error messages.

`schemars 1.x` emits both shapes from existing types: a field-level `description` next to `$ref` for every doc-commented field typed as an external enum (e.g. `tier: Tier`, `kind: PageKind` on `ConsolidatedPageUpdate`), and `oneOf` with `{const: "x"}` branches for every Rust enum (`Tier`, `PageKind`).

Closes #30.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (454 passing, 1 ignored, 0 failing — including 3 new tests in `enforce_strict_*` that go RED on `main` and GREEN with this patch)
- [x] `cargo deny check` passes
- [x] Manual test: built image from this branch via `docker/Dockerfile`, ran with `AI_MEMORY_LLM_PROVIDER=openai`, `AI_MEMORY_LLM_MODEL=gpt-4o`, called `memory_consolidate session_id=<…> multi_page=true` via Claude Code MCP — outcome array returned, session page + `_rules/<slug>.md` persisted on disk.

## Notes for reviewers

- The `oneOf` → `anyOf` rewrite is safe only because every `schemars` emission from a Rust enum has disjoint branches by construction. If a future contributor wants a true exclusive-or across non-disjoint branches, they'd need a different normalisation — none exist in the current codebase.
- Field-level descriptions are documentation-only in 2020-12, but the loss could surprise a reader inspecting a saved schema. I judged it acceptable; the type-level description on the `$defs` entry still reaches the model. Happy to switch to inlining `$ref`s instead if you'd prefer to keep field-level descriptions visible.
- Two commits, one per normalisation — chronological order of discovery (the `oneOf` bug only surfaces after the `$ref` one is fixed). Squash welcome at merge time if the maintainer prefers.
