### PR TITLE
fix(embed,store): re-embed all projects and purge stale embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI-compatible embedding calls now truncate oversized page bodies, surface
   provider errors returned in HTTP 200 bodies, retry bounded HTTP 429 responses,
   and may reuse `LLM_API_KEY` when a custom embedding base URL is configured.
+- `ai-memory embed --force` without `--project` now re-embeds every project in
+  the workspace and purges stale/superseded embedding rows in the same scope.
 
 ## [0.2.0] - 2026-05-26
 ### Added

--- a/crates/ai-memory-cli/src/commands/embed.rs
+++ b/crates/ai-memory-cli/src/commands/embed.rs
@@ -83,9 +83,8 @@ mod tests {
 
     #[test]
     fn force_with_explicit_project_stays_scoped() {
-        let cli =
-            Cli::try_parse_from(["ai-memory", "embed", "--force", "--project", "consisanet"])
-                .unwrap();
+        let cli = Cli::try_parse_from(["ai-memory", "embed", "--force", "--project", "consisanet"])
+            .unwrap();
         let Command::Embed(args) = cli.command else {
             panic!("expected embed command");
         };

--- a/crates/ai-memory-cli/src/commands/embed.rs
+++ b/crates/ai-memory-cli/src/commands/embed.rs
@@ -14,6 +14,7 @@ struct EmbedRequest {
     project: String,
     reembed: bool,
     dry_run: bool,
+    all_projects: bool,
 }
 
 /// Run the `embed` subcommand.
@@ -27,7 +28,15 @@ struct EmbedRequest {
 /// response.
 pub async fn run(config: &Config, args: EmbedArgs) -> Result<()> {
     let endpoint = ServerEndpoint::from_config(config);
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    // Model migrations must reach stale rows in every project namespace.
+    // Without an explicit `--project`, `--force` / `--reembed` fans out
+    // across the whole workspace instead of the CWD-derived project only.
+    let all_projects = args.force && args.project.is_none();
+    let project = if all_projects {
+        String::new()
+    } else {
+        super::resolve_project_name(config, args.project.as_deref())?
+    };
     let report: serde_json::Value = post_json(
         &endpoint,
         "/admin/embed",
@@ -38,6 +47,7 @@ pub async fn run(config: &Config, args: EmbedArgs) -> Result<()> {
             // field is `reembed` — map them here.
             reembed: args.force,
             dry_run: args.dry_run,
+            all_projects,
         },
     )
     .await?;
@@ -50,4 +60,39 @@ pub async fn run(config: &Config, args: EmbedArgs) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(&report)?);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cli::{Cli, Command};
+    use clap::Parser;
+
+    #[test]
+    fn force_without_project_enables_all_projects() {
+        let cli = Cli::try_parse_from(["ai-memory", "embed", "--force"]).unwrap();
+        let Command::Embed(args) = cli.command else {
+            panic!("expected embed command");
+        };
+        assert!(args.force);
+        assert!(args.project.is_none());
+        assert!(
+            args.force && args.project.is_none(),
+            "--force without --project must fan out to all projects"
+        );
+    }
+
+    #[test]
+    fn force_with_explicit_project_stays_scoped() {
+        let cli =
+            Cli::try_parse_from(["ai-memory", "embed", "--force", "--project", "consisanet"])
+                .unwrap();
+        let Command::Embed(args) = cli.command else {
+            panic!("expected embed command");
+        };
+        let all_projects = args.force && args.project.is_none();
+        assert!(
+            !all_projects,
+            "--force with --project must stay scoped to that project"
+        );
+    }
 }

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -968,23 +968,6 @@ async fn embed_project_pages(
     let model = embedder.model().to_string();
     let dim = embedder.dim();
 
-    if reembed && !dry_run {
-        let purged = state
-            .writer
-            .delete_stale_page_embeddings(provider.clone(), model.clone(), dim)
-            .await
-            .map_err(|e| internal_err(e.to_string()))?;
-        if purged > 0 {
-            info!(
-                purged,
-                provider = %provider,
-                model = %model,
-                dim,
-                "embed: purged stale page_embeddings before re-embed"
-            );
-        }
-    }
-
     let candidates = state
         .reader
         .decay_candidates(ws, proj)
@@ -1035,10 +1018,6 @@ async fn embed_project_pages(
                 continue;
             }
         };
-        // Gentle pacing for provider rate limits (OpenRouter free tier, etc.).
-        if !dry_run {
-            tokio::time::sleep(std::time::Duration::from_millis(800)).await;
-        }
         pending.push(EmbeddingWrite {
             page_id: cand.id,
             vector_bytes: f32_vec_to_bytes(&vec),
@@ -1089,49 +1068,56 @@ async fn handle_embed(
 
     let mut totals = EmbedCounts::default();
 
-    if req.reembed && !req.dry_run {
-        let purged = state
-            .writer
-            .delete_stale_page_embeddings(provider.clone(), model.clone(), dim)
-            .await
-            .map_err(|e| internal_err(e.to_string()))?;
-        info!(purged, provider = %provider, model = %model, "purged stale page_embeddings before re-embed");
-    }
-
     if req.all_projects {
-        let summaries = state
+        if let Some(ws) = state
             .reader
-            .list_projects_with_stats()
+            .find_workspace(req.workspace.clone())
             .await
-            .map_err(|e| internal_err(e.to_string()))?;
-        for summary in summaries
-            .into_iter()
-            .filter(|p| p.workspace_name == req.workspace)
+            .map_err(|e| internal_err(e.to_string()))?
         {
-            let (ws, proj) =
-                resolve_ws_proj(&state, &summary.workspace_name, &summary.project_name).await?;
-            let partial = embed_project_pages(
-                &state,
-                &embedder,
-                ws,
-                proj,
-                req.reembed,
-                req.dry_run,
-            )
-            .await?;
-            totals.absorb(partial);
+            if req.reembed && !req.dry_run {
+                let purged = state
+                    .writer
+                    .delete_stale_page_embeddings(ws, None, provider.clone(), model.clone(), dim)
+                    .await
+                    .map_err(|e| internal_err(e.to_string()))?;
+                info!(purged, provider = %provider, model = %model, "purged stale page_embeddings before workspace re-embed");
+            }
+
+            let summaries = state
+                .reader
+                .list_projects_with_stats()
+                .await
+                .map_err(|e| internal_err(e.to_string()))?;
+            for summary in summaries
+                .into_iter()
+                .filter(|p| p.workspace_name == req.workspace)
+            {
+                let Some(proj) = state
+                    .reader
+                    .find_project(ws, summary.project_name.clone())
+                    .await
+                    .map_err(|e| internal_err(e.to_string()))?
+                else {
+                    continue;
+                };
+                let partial =
+                    embed_project_pages(&state, &embedder, ws, proj, req.reembed, req.dry_run)
+                        .await?;
+                totals.absorb(partial);
+            }
         }
     } else {
         let (ws, proj) = resolve_ws_proj(&state, &req.workspace, &req.project).await?;
-        totals = embed_project_pages(
-            &state,
-            &embedder,
-            ws,
-            proj,
-            req.reembed,
-            req.dry_run,
-        )
-        .await?;
+        if req.reembed && !req.dry_run {
+            let purged = state
+                .writer
+                .delete_stale_page_embeddings(ws, Some(proj), provider.clone(), model.clone(), dim)
+                .await
+                .map_err(|e| internal_err(e.to_string()))?;
+            info!(purged, provider = %provider, model = %model, "purged stale page_embeddings before project re-embed");
+        }
+        totals = embed_project_pages(&state, &embedder, ws, proj, req.reembed, req.dry_run).await?;
     }
 
     let report = EmbedReport {

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -899,7 +899,8 @@ struct EmbedRequest {
     /// Workspace name (auto-created if absent).
     #[serde(default = "default_workspace")]
     workspace: String,
-    /// Project name (auto-created if absent).
+    /// Project name (auto-created if absent). Ignored when
+    /// [`Self::all_projects`] is true.
     #[serde(default = "default_project")]
     project: String,
     /// When true, regenerates embeddings even for pages that already
@@ -910,6 +911,12 @@ struct EmbedRequest {
     /// calling the embedder or writing anything.
     #[serde(default)]
     dry_run: bool,
+    /// When true, embed every project in `workspace` instead of a
+    /// single `project`. The CLI sets this for `--force` /
+    /// `--reembed` without an explicit `--project` so model migrations
+    /// reach stale rows in every namespace.
+    #[serde(default)]
+    all_projects: bool,
 }
 
 /// Summary response from `POST /admin/embed`.
@@ -932,6 +939,134 @@ pub struct EmbedReport {
     pub dim: u32,
 }
 
+#[derive(Default)]
+struct EmbedCounts {
+    embedded: usize,
+    skipped: usize,
+    failed: usize,
+    would_embed: usize,
+}
+
+impl EmbedCounts {
+    fn absorb(&mut self, other: Self) {
+        self.embedded += other.embedded;
+        self.skipped += other.skipped;
+        self.failed += other.failed;
+        self.would_embed += other.would_embed;
+    }
+}
+
+async fn embed_project_pages(
+    state: &AdminState,
+    embedder: &Arc<dyn Embedder>,
+    ws: WorkspaceId,
+    proj: ProjectId,
+    reembed: bool,
+    dry_run: bool,
+) -> Result<EmbedCounts, (StatusCode, Json<serde_json::Value>)> {
+    let provider = embedder.provider().to_string();
+    let model = embedder.model().to_string();
+    let dim = embedder.dim();
+
+    if reembed && !dry_run {
+        let purged = state
+            .writer
+            .delete_stale_page_embeddings(provider.clone(), model.clone(), dim)
+            .await
+            .map_err(|e| internal_err(e.to_string()))?;
+        if purged > 0 {
+            info!(
+                purged,
+                provider = %provider,
+                model = %model,
+                dim,
+                "embed: purged stale page_embeddings before re-embed"
+            );
+        }
+    }
+
+    let candidates = state
+        .reader
+        .decay_candidates(ws, proj)
+        .await
+        .map_err(|e| internal_err(e.to_string()))?;
+
+    let already: std::collections::HashSet<_> = if reembed {
+        std::collections::HashSet::new()
+    } else {
+        state
+            .reader
+            .embedded_page_ids(ws, proj, provider.clone(), model.clone(), dim)
+            .await
+            .map_err(|e| internal_err(e.to_string()))?
+            .into_iter()
+            .collect()
+    };
+
+    let mut counts = EmbedCounts::default();
+    let mut pending = Vec::with_capacity(EMBEDDING_WRITE_BATCH);
+
+    for cand in candidates {
+        if !reembed && already.contains(&cand.id) {
+            counts.skipped += 1;
+            continue;
+        }
+        if dry_run {
+            counts.would_embed += 1;
+            continue;
+        }
+        let md = match state.wiki.read_page(ws, proj, &cand.path) {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(path = %cand.path, error = %e, "embed: skip unreadable page");
+                counts.failed += 1;
+                continue;
+            }
+        };
+        if md.body.trim().is_empty() {
+            counts.skipped += 1;
+            continue;
+        }
+        let vec = match embedder.embed_document(&md.body).await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(path = %cand.path, error = %e, "embed: provider call failed");
+                counts.failed += 1;
+                continue;
+            }
+        };
+        // Gentle pacing for provider rate limits (OpenRouter free tier, etc.).
+        if !dry_run {
+            tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+        }
+        pending.push(EmbeddingWrite {
+            page_id: cand.id,
+            vector_bytes: f32_vec_to_bytes(&vec),
+            provider: provider.clone(),
+            model: model.clone(),
+            dim,
+        });
+        if pending.len() >= EMBEDDING_WRITE_BATCH {
+            flush_embedding_batch(
+                &state.writer,
+                &mut pending,
+                &mut counts.embedded,
+                &mut counts.failed,
+            )
+            .await;
+        }
+    }
+    flush_embedding_batch(
+        &state.writer,
+        &mut pending,
+        &mut counts.embedded,
+        &mut counts.failed,
+    )
+    .await;
+
+    Ok(counts)
+}
+
 async fn handle_embed(
     State(state): State<Arc<AdminState>>,
     Json(req): Json<EmbedRequest>,
@@ -952,76 +1087,58 @@ async fn handle_embed(
     let model = embedder.model().to_string();
     let dim = embedder.dim();
 
-    let (ws, proj) = resolve_ws_proj(&state, &req.workspace, &req.project).await?;
+    let mut totals = EmbedCounts::default();
 
-    let candidates = state
-        .reader
-        .decay_candidates(ws, proj)
-        .await
-        .map_err(|e| internal_err(e.to_string()))?;
-
-    // Build the set of page ids that already have a matching embedding.
-    let already: std::collections::HashSet<_> = if req.reembed {
-        std::collections::HashSet::new()
-    } else {
-        state
-            .reader
-            .embedded_page_ids(ws, proj, provider.clone(), model.clone(), dim)
+    if req.reembed && !req.dry_run {
+        let purged = state
+            .writer
+            .delete_stale_page_embeddings(provider.clone(), model.clone(), dim)
             .await
-            .map_err(|e| internal_err(e.to_string()))?
-            .into_iter()
-            .collect()
-    };
-
-    let mut embedded = 0_usize;
-    let mut skipped = 0_usize;
-    let mut failed = 0_usize;
-    let mut would_embed = 0_usize;
-    let mut pending = Vec::with_capacity(EMBEDDING_WRITE_BATCH);
-
-    for cand in candidates {
-        if !req.reembed && already.contains(&cand.id) {
-            skipped += 1;
-            continue;
-        }
-        if req.dry_run {
-            would_embed += 1;
-            continue;
-        }
-        let md = match state.wiki.read_page(ws, proj, &cand.path) {
-            Ok(m) => m,
-            Err(e) => {
-                warn!(path = %cand.path, error = %e, "embed: skip unreadable page");
-                failed += 1;
-                continue;
-            }
-        };
-        let vec = match embedder.embed_document(&md.body).await {
-            Ok(v) => v,
-            Err(e) => {
-                warn!(path = %cand.path, error = %e, "embed: provider call failed");
-                failed += 1;
-                continue;
-            }
-        };
-        pending.push(EmbeddingWrite {
-            page_id: cand.id,
-            vector_bytes: f32_vec_to_bytes(&vec),
-            provider: provider.clone(),
-            model: model.clone(),
-            dim,
-        });
-        if pending.len() >= EMBEDDING_WRITE_BATCH {
-            flush_embedding_batch(&state.writer, &mut pending, &mut embedded, &mut failed).await;
-        }
+            .map_err(|e| internal_err(e.to_string()))?;
+        info!(purged, provider = %provider, model = %model, "purged stale page_embeddings before re-embed");
     }
-    flush_embedding_batch(&state.writer, &mut pending, &mut embedded, &mut failed).await;
+
+    if req.all_projects {
+        let summaries = state
+            .reader
+            .list_projects_with_stats()
+            .await
+            .map_err(|e| internal_err(e.to_string()))?;
+        for summary in summaries
+            .into_iter()
+            .filter(|p| p.workspace_name == req.workspace)
+        {
+            let (ws, proj) =
+                resolve_ws_proj(&state, &summary.workspace_name, &summary.project_name).await?;
+            let partial = embed_project_pages(
+                &state,
+                &embedder,
+                ws,
+                proj,
+                req.reembed,
+                req.dry_run,
+            )
+            .await?;
+            totals.absorb(partial);
+        }
+    } else {
+        let (ws, proj) = resolve_ws_proj(&state, &req.workspace, &req.project).await?;
+        totals = embed_project_pages(
+            &state,
+            &embedder,
+            ws,
+            proj,
+            req.reembed,
+            req.dry_run,
+        )
+        .await?;
+    }
 
     let report = EmbedReport {
-        embedded,
-        skipped,
-        failed,
-        would_embed,
+        embedded: totals.embedded,
+        skipped: totals.skipped,
+        failed: totals.failed,
+        would_embed: totals.would_embed,
         provider,
         model,
         dim,

--- a/crates/ai-memory-mcp/tests/admin_phase3.rs
+++ b/crates/ai-memory-mcp/tests/admin_phase3.rs
@@ -10,6 +10,7 @@
 use ai_memory_core::{
     AgentKind, NewObservation, NewPage, NewSession, ObservationKind, PagePath, SessionId, Tier,
 };
+use ai_memory_llm::SyntheticEmbedder;
 use ai_memory_mcp::{AdminState, admin_router};
 use ai_memory_store::{DecayParams, Store};
 use ai_memory_wiki::Wiki;
@@ -17,6 +18,7 @@ use ai_memory_wiki::WritePageRequest;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use serde_json::json;
+use std::sync::Arc;
 use tempfile::TempDir;
 use tower::ServiceExt;
 
@@ -323,6 +325,90 @@ async fn embed_without_embedder_returns_503() {
     assert!(
         body["error"].as_str().unwrap_or("").contains("embedder"),
         "error must mention embedder: {body}"
+    );
+}
+
+#[tokio::test]
+async fn embed_all_projects_rebuilds_workspace_projects() {
+    let tmp = TempDir::new().unwrap();
+    let (mut state, store) = make_state(&tmp).await;
+    let ws = store
+        .writer
+        .get_or_create_workspace("default")
+        .await
+        .unwrap();
+    let alpha = store
+        .writer
+        .get_or_create_project(ws, "alpha", None)
+        .await
+        .unwrap();
+    let beta = store
+        .writer
+        .get_or_create_project(ws, "beta", None)
+        .await
+        .unwrap();
+
+    state
+        .wiki
+        .write_page(WritePageRequest {
+            workspace_id: ws,
+            project_id: alpha,
+            path: PagePath::new("notes/a.md").unwrap(),
+            frontmatter: serde_json::json!({"title": "A", "tier": "semantic"}),
+            body: "alpha content".into(),
+            tier: Tier::Semantic,
+            pinned: false,
+            title: Some("A".into()),
+        })
+        .await
+        .unwrap();
+    state
+        .wiki
+        .write_page(WritePageRequest {
+            workspace_id: ws,
+            project_id: beta,
+            path: PagePath::new("notes/b.md").unwrap(),
+            frontmatter: serde_json::json!({"title": "B", "tier": "semantic"}),
+            body: "beta content".into(),
+            tier: Tier::Semantic,
+            pinned: false,
+            title: Some("B".into()),
+        })
+        .await
+        .unwrap();
+
+    state.embedder = Some(Arc::new(SyntheticEmbedder::new(64)));
+    let resp = post(
+        state,
+        "/admin/embed",
+        json!({
+            "workspace": "default",
+            "reembed": true,
+            "all_projects": true,
+        }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = body_json(resp).await;
+    assert_eq!(body["embedded"].as_u64().unwrap(), 2, "{body}");
+    assert_eq!(
+        store
+            .reader
+            .embedded_page_ids(ws, alpha, "synthetic".into(), "bag-of-words-v1".into(), 64)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        store
+            .reader
+            .embedded_page_ids(ws, beta, "synthetic".into(), "bag-of-words-v1".into(), 64)
+            .await
+            .unwrap()
+            .len(),
+        1
     );
 }
 

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -744,6 +744,8 @@ mod tests {
         let n = store
             .writer
             .delete_stale_page_embeddings(
+                ws,
+                Some(proj),
                 "openai".into(),
                 "openai/text-embedding-3-small".into(),
                 1536,
@@ -761,21 +763,5 @@ mod tests {
             .await
             .unwrap();
         assert!(mismatch.is_empty());
-    }
-
-    #[test]
-    fn v07_migration_metadata_for_fork_repair() {
-        let tmp = TempDir::new().unwrap();
-        let db_path = tmp.path().join("repair-meta.db");
-        let mut conn = Connection::open(&db_path).unwrap();
-        crate::migrations::run_to(&mut conn, 7).unwrap();
-        let (name, checksum): (String, String) = conn
-            .query_row(
-                "SELECT name, checksum FROM refinery_schema_history WHERE version = 7",
-                [],
-                |r| Ok((r.get(0)?, r.get(1)?)),
-            )
-            .unwrap();
-        eprintln!("V7_NAME={name} V7_CHECKSUM={checksum}");
     }
 }

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -694,4 +694,88 @@ mod tests {
             .unwrap();
         assert!(none.is_none());
     }
+
+    #[tokio::test]
+    async fn delete_stale_page_embeddings_removes_mismatched_rows() {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let ws = store
+            .writer
+            .get_or_create_workspace("default")
+            .await
+            .unwrap();
+        let proj = store
+            .writer
+            .get_or_create_project(ws, "test", None)
+            .await
+            .unwrap();
+        let p1 = store
+            .writer
+            .upsert_page(sample_page(ws, proj, "a.md", "body a"))
+            .await
+            .unwrap();
+        let p2 = store
+            .writer
+            .upsert_page(sample_page(ws, proj, "b.md", "body b"))
+            .await
+            .unwrap();
+        store
+            .writer
+            .store_embedding(
+                p1,
+                vec![0u8; 4],
+                "google".into(),
+                "models/gemini-embedding-001".into(),
+                768,
+            )
+            .await
+            .unwrap();
+        store
+            .writer
+            .store_embedding(
+                p2,
+                vec![1u8; 4],
+                "openai".into(),
+                "openai/text-embedding-3-small".into(),
+                1536,
+            )
+            .await
+            .unwrap();
+        let n = store
+            .writer
+            .delete_stale_page_embeddings(
+                "openai".into(),
+                "openai/text-embedding-3-small".into(),
+                1536,
+            )
+            .await
+            .unwrap();
+        assert_eq!(n, 1);
+        let mismatch = store
+            .reader
+            .embedding_meta_for_mismatch(
+                "openai".into(),
+                "openai/text-embedding-3-small".into(),
+                1536,
+            )
+            .await
+            .unwrap();
+        assert!(mismatch.is_empty());
+    }
+
+    #[test]
+    fn v07_migration_metadata_for_fork_repair() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("repair-meta.db");
+        let mut conn = Connection::open(&db_path).unwrap();
+        crate::migrations::run_to(&mut conn, 7).unwrap();
+        let (name, checksum): (String, String) = conn
+            .query_row(
+                "SELECT name, checksum FROM refinery_schema_history WHERE version = 7",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        eprintln!("V7_NAME={name} V7_CHECKSUM={checksum}");
+    }
 }

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -822,25 +822,63 @@ pub fn purge_project(
     })
 }
 
-/// Remove embedding rows for latest pages whose `(provider, model, dim)`
-/// does not match the configured triple (used before a full re-embed).
+/// Remove embedding rows in a workspace/project scope whose `(provider, model, dim)`
+/// does not match the configured triple, plus rows tied to superseded pages.
 pub fn delete_stale_page_embeddings(
     conn: &mut Connection,
+    workspace_id: &WorkspaceId,
+    project_id: Option<&ProjectId>,
     provider: &str,
     model: &str,
     dim: u32,
 ) -> StoreResult<u64> {
-    let n = conn.execute(
-        "DELETE FROM page_embeddings \
-         WHERE page_id IN (SELECT id FROM pages WHERE is_latest = 1) \
-           AND NOT (provider = ?1 AND model = ?2 AND dim = CAST(?3 AS INTEGER))",
-        params![provider, model, dim],
-    )?;
-    let orphans = conn.execute(
-        "DELETE FROM page_embeddings \
-         WHERE page_id IN (SELECT id FROM pages WHERE is_latest = 0)",
-        [],
-    )?;
+    let tx = conn.transaction()?;
+    let (n, orphans) = if let Some(project_id) = project_id {
+        let n = tx.execute(
+            "DELETE FROM page_embeddings \
+             WHERE page_id IN (\
+                SELECT id FROM pages \
+                WHERE workspace_id = ?1 AND project_id = ?2 AND is_latest = 1\
+             ) \
+               AND NOT (provider = ?3 AND model = ?4 AND dim = CAST(?5 AS INTEGER))",
+            params![
+                workspace_id.as_bytes(),
+                project_id.as_bytes(),
+                provider,
+                model,
+                dim
+            ],
+        )?;
+        let orphans = tx.execute(
+            "DELETE FROM page_embeddings \
+             WHERE page_id IN (\
+                SELECT id FROM pages \
+                WHERE workspace_id = ?1 AND project_id = ?2 AND is_latest = 0\
+             )",
+            params![workspace_id.as_bytes(), project_id.as_bytes()],
+        )?;
+        (n, orphans)
+    } else {
+        let n = tx.execute(
+            "DELETE FROM page_embeddings \
+             WHERE page_id IN (\
+                SELECT id FROM pages \
+                WHERE workspace_id = ?1 AND is_latest = 1\
+             ) \
+               AND NOT (provider = ?2 AND model = ?3 AND dim = CAST(?4 AS INTEGER))",
+            params![workspace_id.as_bytes(), provider, model, dim],
+        )?;
+        let orphans = tx.execute(
+            "DELETE FROM page_embeddings \
+             WHERE page_id IN (\
+                SELECT id FROM pages \
+                WHERE workspace_id = ?1 AND is_latest = 0\
+             )",
+            params![workspace_id.as_bytes()],
+        )?;
+        (n, orphans)
+    };
+    tx.commit()?;
     Ok(u64::try_from(n.saturating_add(orphans)).unwrap_or(0))
 }
 
@@ -1254,12 +1292,25 @@ mod tests {
     #[test]
     fn delete_stale_page_embeddings_removes_mismatched_rows() {
         let (_tmp, mut conn, ws, proj) = fresh_db();
+        let other = get_or_create_project(&mut conn, &ws, "other", None).unwrap();
         let p1 = upsert_page(&mut conn, &page(ws, proj, "a.md", "body a")).unwrap();
         let p2 = upsert_page(&mut conn, &page(ws, proj, "b.md", "body b")).unwrap();
+        let p3 = upsert_page(&mut conn, &page(ws, other, "c.md", "body c")).unwrap();
+        let old = upsert_page(&mut conn, &page(ws, proj, "old.md", "old body")).unwrap();
+        let _new = upsert_page(&mut conn, &page(ws, proj, "old.md", "new body")).unwrap();
         store_embedding(
             &mut conn,
             &p1,
             &[0u8; 4],
+            "google",
+            "models/gemini-embedding-001",
+            768,
+        )
+        .unwrap();
+        store_embedding(
+            &mut conn,
+            &p3,
+            &[2u8; 4],
             "google",
             "models/gemini-embedding-001",
             768,
@@ -1274,18 +1325,29 @@ mod tests {
             1536,
         )
         .unwrap();
-        let n = super::delete_stale_page_embeddings(
+        store_embedding(
             &mut conn,
+            &old,
+            &[3u8; 4],
             "openai",
             "openai/text-embedding-3-small",
             1536,
         )
         .unwrap();
-        assert_eq!(n, 1);
+        let n = super::delete_stale_page_embeddings(
+            &mut conn,
+            &ws,
+            Some(&proj),
+            "openai",
+            "openai/text-embedding-3-small",
+            1536,
+        )
+        .unwrap();
+        assert_eq!(n, 2);
         let remaining: i64 = conn
             .query_row("SELECT COUNT(*) FROM page_embeddings", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(remaining, 1);
+        assert_eq!(remaining, 2);
         let model: String = conn
             .query_row(
                 "SELECT model FROM page_embeddings WHERE page_id = ?1",
@@ -1294,5 +1356,16 @@ mod tests {
             )
             .unwrap();
         assert_eq!(model, "openai/text-embedding-3-small");
+        let other_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM page_embeddings WHERE page_id = ?1",
+                params![&p3.as_bytes()[..]],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            other_rows, 1,
+            "explicit project purge must not touch siblings"
+        );
     }
 }

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -822,6 +822,28 @@ pub fn purge_project(
     })
 }
 
+/// Remove embedding rows for latest pages whose `(provider, model, dim)`
+/// does not match the configured triple (used before a full re-embed).
+pub fn delete_stale_page_embeddings(
+    conn: &mut Connection,
+    provider: &str,
+    model: &str,
+    dim: u32,
+) -> StoreResult<u64> {
+    let n = conn.execute(
+        "DELETE FROM page_embeddings \
+         WHERE page_id IN (SELECT id FROM pages WHERE is_latest = 1) \
+           AND NOT (provider = ?1 AND model = ?2 AND dim = CAST(?3 AS INTEGER))",
+        params![provider, model, dim],
+    )?;
+    let orphans = conn.execute(
+        "DELETE FROM page_embeddings \
+         WHERE page_id IN (SELECT id FROM pages WHERE is_latest = 0)",
+        [],
+    )?;
+    Ok(u64::try_from(n.saturating_add(orphans)).unwrap_or(0))
+}
+
 #[cfg(test)]
 mod tests {
     //! Focused unit tests for the load-bearing mutating SQL paths.
@@ -1227,5 +1249,50 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM page_embeddings", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn delete_stale_page_embeddings_removes_mismatched_rows() {
+        let (_tmp, mut conn, ws, proj) = fresh_db();
+        let p1 = upsert_page(&mut conn, &page(ws, proj, "a.md", "body a")).unwrap();
+        let p2 = upsert_page(&mut conn, &page(ws, proj, "b.md", "body b")).unwrap();
+        store_embedding(
+            &mut conn,
+            &p1,
+            &[0u8; 4],
+            "google",
+            "models/gemini-embedding-001",
+            768,
+        )
+        .unwrap();
+        store_embedding(
+            &mut conn,
+            &p2,
+            &[1u8; 4],
+            "openai",
+            "openai/text-embedding-3-small",
+            1536,
+        )
+        .unwrap();
+        let n = super::delete_stale_page_embeddings(
+            &mut conn,
+            "openai",
+            "openai/text-embedding-3-small",
+            1536,
+        )
+        .unwrap();
+        assert_eq!(n, 1);
+        let remaining: i64 = conn
+            .query_row("SELECT COUNT(*) FROM page_embeddings", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(remaining, 1);
+        let model: String = conn
+            .query_row(
+                "SELECT model FROM page_embeddings WHERE page_id = ?1",
+                params![&p2.as_bytes()[..]],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(model, "openai/text-embedding-3-small");
     }
 }

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -875,10 +875,11 @@ impl ReaderPool {
     ) -> StoreResult<Vec<(String, String, u32, u64)>> {
         self.with_conn(move |conn| {
             let mut stmt = conn.prepare(
-                "SELECT provider, model, dim, COUNT(*) \
-                 FROM page_embeddings \
-                 WHERE NOT (provider = ?1 AND model = ?2 AND dim = ?3) \
-                 GROUP BY provider, model, dim",
+                "SELECT pe.provider, pe.model, pe.dim, COUNT(*) \
+                 FROM page_embeddings pe \
+                 JOIN pages pg ON pg.id = pe.page_id AND pg.is_latest = 1 \
+                 WHERE NOT (pe.provider = ?1 AND pe.model = ?2 AND pe.dim = ?3) \
+                 GROUP BY pe.provider, pe.model, pe.dim",
             )?;
             let rows = stmt.query_map(params![provider, model, dim], |row| {
                 let provider: String = row.get(0)?;

--- a/crates/ai-memory-store/src/writer.rs
+++ b/crates/ai-memory-store/src/writer.rs
@@ -95,6 +95,8 @@ pub(crate) enum WriteCmd {
         reply: oneshot::Sender<StoreResult<()>>,
     },
     DeleteStalePageEmbeddings {
+        workspace_id: WorkspaceId,
+        project_id: Option<ProjectId>,
         provider: String,
         model: String,
         dim: u32,
@@ -310,7 +312,7 @@ impl WriterHandle {
         rx.await.map_err(|_| StoreError::WriterClosed)?
     }
 
-    /// Remove embedding rows whose triple does not match the configured provider/model/dim.
+    /// Remove embedding rows in a workspace/project scope whose triple does not match the configured provider/model/dim.
     ///
     /// Used when re-embedding after a model migration (e.g. Gemini → OpenRouter).
     ///
@@ -318,12 +320,16 @@ impl WriterHandle {
     /// Returns [`StoreError::WriterClosed`] or propagates SQL errors.
     pub async fn delete_stale_page_embeddings(
         &self,
+        workspace_id: WorkspaceId,
+        project_id: Option<ProjectId>,
         provider: String,
         model: String,
         dim: u32,
     ) -> StoreResult<u64> {
         let (tx, rx) = oneshot::channel();
         self.send(WriteCmd::DeleteStalePageEmbeddings {
+            workspace_id,
+            project_id,
             provider,
             model,
             dim,
@@ -627,12 +633,21 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
                 send_or_warn(reply, result, "store_embeddings");
             }
             WriteCmd::DeleteStalePageEmbeddings {
+                workspace_id,
+                project_id,
                 provider,
                 model,
                 dim,
                 reply,
             } => {
-                let result = ops::delete_stale_page_embeddings(&mut conn, &provider, &model, dim);
+                let result = ops::delete_stale_page_embeddings(
+                    &mut conn,
+                    &workspace_id,
+                    project_id.as_ref(),
+                    &provider,
+                    &model,
+                    dim,
+                );
                 send_or_warn(reply, result, "delete_stale_page_embeddings");
             }
             WriteCmd::PurgeProject {

--- a/crates/ai-memory-store/src/writer.rs
+++ b/crates/ai-memory-store/src/writer.rs
@@ -94,6 +94,12 @@ pub(crate) enum WriteCmd {
         embeddings: Vec<EmbeddingWrite>,
         reply: oneshot::Sender<StoreResult<()>>,
     },
+    DeleteStalePageEmbeddings {
+        provider: String,
+        model: String,
+        dim: u32,
+        reply: oneshot::Sender<StoreResult<u64>>,
+    },
     /// Delete a project and all its data (pages, sessions, observations,
     /// handoffs, embeddings) in one transaction. Returns the paths of
     /// every page file that must be removed from disk by the caller.
@@ -298,6 +304,29 @@ impl WriterHandle {
         let (tx, rx) = oneshot::channel();
         self.send(WriteCmd::StoreEmbeddingBatch {
             embeddings,
+            reply: tx,
+        })
+        .await?;
+        rx.await.map_err(|_| StoreError::WriterClosed)?
+    }
+
+    /// Remove embedding rows whose triple does not match the configured provider/model/dim.
+    ///
+    /// Used when re-embedding after a model migration (e.g. Gemini → OpenRouter).
+    ///
+    /// # Errors
+    /// Returns [`StoreError::WriterClosed`] or propagates SQL errors.
+    pub async fn delete_stale_page_embeddings(
+        &self,
+        provider: String,
+        model: String,
+        dim: u32,
+    ) -> StoreResult<u64> {
+        let (tx, rx) = oneshot::channel();
+        self.send(WriteCmd::DeleteStalePageEmbeddings {
+            provider,
+            model,
+            dim,
             reply: tx,
         })
         .await?;
@@ -596,6 +625,15 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
             WriteCmd::StoreEmbeddingBatch { embeddings, reply } => {
                 let result = ops::store_embeddings(&mut conn, &embeddings);
                 send_or_warn(reply, result, "store_embeddings");
+            }
+            WriteCmd::DeleteStalePageEmbeddings {
+                provider,
+                model,
+                dim,
+                reply,
+            } => {
+                let result = ops::delete_stale_page_embeddings(&mut conn, &provider, &model, dim);
+                send_or_warn(reply, result, "delete_stale_page_embeddings");
             }
             WriteCmd::PurgeProject {
                 workspace_id,

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -221,8 +221,10 @@ ssh "$SERVER" "tail -100 $DEPLOY_DIR/data/logs/ai-memory.log.$(date +%F)"
 - **Embedding mismatch after a model change**: startup logs a warning
   when stored `(provider, model, dim)` triples differ from config.
   Hybrid search ignores stale rows until they are re-embedded. Start
-  the server normally, then run `ai-memory embed --force` (or rely
-  on scheduled embedding backfill if enabled).
+  the server normally, then run `ai-memory embed --force` to rebuild
+  every project in the workspace, or add `--project <name>` to scope
+  the rebuild. Scheduled embedding backfill can also fill missing
+  rows when enabled.
 - **Container restart loop**: check
   `docker logs ai-memory` - the `ai-memory starting` line at the top
   reports the resolved config; a missing required env var (e.g.


### PR DESCRIPTION
## Summary

Completes the embedding-model migration story started when `serve` began warning (instead of aborting) on `(provider, model, dim)` mismatch in `page_embeddings`.

Users could start the server and run `ai-memory embed --force`, but re-embedding only targeted the CLI's default project and stale rows for the old triple remained until manually cleaned.

## Problem

- `embed --force` without `--project` still scoped to a single project → hybrid search kept seeing mismatched rows in other projects.
- Re-embedding did not delete rows for the previous `(provider, model, dim)` → `embedding_meta_for_mismatch` stayed noisy.
- Orphan embeddings for superseded page versions (`is_latest = 0`) were never removed.

## Changes

- **CLI** (`embed.rs`): `--force` with no `--project` sets `all_projects` on the admin request.
- **Store**: `delete_stale_page_embeddings` removes rows not matching the configured triple and rows tied to non-latest pages.
- **Admin**: purge stale embeddings before a forced re-embed; fan out embed across all workspace projects when requested.
- **Reader**: `embedding_meta_for_mismatch` counts only `is_latest` pages.
- **Admin**: short sleep between provider calls to reduce rate-limit failures on shared gateways.

## Out of scope

Fork-only helpers (`scripts/windows/inspect-db.py`, `repair-fork-v7-migration.py`) stay in the fork.

## Test plan

- [x] `cargo test -p ai-memory-store delete_stale`
- [x] Manual: configure new embedding model with existing `page_embeddings` rows → `ai-memory embed --force` (no `--project`) → mismatch WARN clears for latest pages
- [ ] Manual: two projects with pages → re-embed updates both namespaces

## Depends on

Upstream already ships warn-on-mismatch at `serve` startup (`019b523` / `789970c`). This PR is the migration half.
