### PR TITLE
fix(test): make Claude Code hook render tests portable across platforms

### DIFF
--- a/crates/ai-memory-cli/src/commands/render_shared.rs
+++ b/crates/ai-memory-cli/src/commands/render_shared.rs
@@ -496,7 +496,14 @@ mod tests {
     #[test]
     fn claude_code_payload_embeds_auth_token_when_provided() {
         let root = PathBuf::from("/host/hooks/claude-code");
-        let v = build_claude_code_payload(&root, "http://localhost:49374", Some("tok"));
+        let v = build_hook_payload_for_platform(
+            &CLAUDE_CODE_EVENTS,
+            &root,
+            "http://localhost:49374",
+            Some("tok"),
+            HookShape::Nested,
+            HookCommandPlatform::Posix,
+        );
         // Env vars are inlined into the command string so CC's
         // hook runner sees them regardless of whether it honours
         // a separate `env` field. Assert the token landed in the
@@ -678,17 +685,22 @@ mod tests {
         let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("hooks")
             .join("claude-code");
-        let v = build_claude_code_payload(&root, "http://localhost:49374", None);
+        let v = build_hook_payload_for_platform(
+            &CLAUDE_CODE_EVENTS,
+            &root,
+            "http://localhost:49374",
+            None,
+            HookShape::Nested,
+            HookCommandPlatform::Posix,
+        );
         let cmd = v
             .pointer("/hooks/SessionStart/0/hooks/0/command")
             .and_then(|s| s.as_str())
             .unwrap();
-        // The command now has the env prefix + the absolute path,
-        // joined by a single space.
         let expected = root.join("session-start.sh").to_string_lossy().to_string();
         assert!(
-            cmd.ends_with(&expected),
-            "command should end with the absolute script path: {cmd}"
+            cmd.contains(&expected),
+            "command should contain the absolute script path: {cmd}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Two tests in `render_shared::tests` (`claude_code_payload_embeds_auth_token_when_provided` and `claude_code_payload_emits_absolute_paths`) called `build_claude_code_payload()` which delegates to `HookCommandPlatform::current()`, then asserted POSIX-style inline env-var syntax. On Windows, `current()` returns `Windows` and produces PowerShell output, breaking the assertions.
- Fix: call `build_hook_payload_for_platform()` with an explicit `HookCommandPlatform::Posix`, since these tests verify the POSIX rendering path. The Windows path is already covered by `windows_payload_uses_powershell_and_ps1_hooks`.
- Switch `ends_with` to `contains` in the absolute-path assertion, since Windows paths contain backslashes that trigger `shell_quote` wrapping.

**Scope:** Claude Code tests only — per issue #11 feedback, other agents (Cursor, Antigravity) are left as-is until their Windows hook runner behavior is verified.

## Test plan

- [x] `cargo fmt --all -- --check` — pass
- [x] `cargo clippy -p ai-memory-cli -- -D warnings` — pass
- [x] `cargo test -p ai-memory-cli -- render_shared::tests::claude_code` — 5/5 pass on Windows
- [x] Existing `windows_payload_uses_powershell_and_ps1_hooks` and `posix_hook_command_quotes_script_path_and_shell_metachars` still pass

Ref: #11 (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)