### PR TITLE
fix(hooks): resolve Windows backslash paths to basename on Linux server

### DIFF
--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -350,10 +350,16 @@ async fn resolve_project_ids(
     }
 
     fn basename(path: &std::path::Path) -> Option<String> {
-        path.file_name()
-            .and_then(|s| s.to_str())
-            .map(str::to_string)
-            .filter(|s| !s.is_empty())
+        // Split on both `/` and `\` so Windows paths sent to a Linux
+        // server still resolve to the final component.
+        let s = path.to_str()?;
+        let name = s
+            .rsplit(['/', '\\'])
+            .find(|seg| !seg.is_empty())?;
+        if name.is_empty() {
+            return None;
+        }
+        Some(name.to_string())
     }
 
     let ws = state
@@ -1703,6 +1709,43 @@ mod tests {
         assert_ne!(
             proj, proj2,
             "different bare repo basenames → different projects"
+        );
+    }
+
+    /// Windows-style backslash paths sent to a Linux server must
+    /// still resolve to `basename(cwd)`, not the full path string.
+    #[tokio::test]
+    async fn windows_backslash_path_resolves_to_basename() {
+        let tmp = TempDir::new().unwrap();
+        let state = make_state(&tmp).await;
+
+        let (_, proj_a) = resolve_project_ids(
+            &state,
+            Some(r"E:\source\ai-memory"),
+            None,
+            None,
+            ProjectStrategy::Basename,
+        )
+        .await
+        .unwrap();
+
+        let (_, proj_b) = resolve_project_ids(
+            &state,
+            Some(r"C:\Users\dev\projects\ai-memory"),
+            None,
+            None,
+            ProjectStrategy::Basename,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            proj_a, proj_b,
+            "different Windows paths with same basename must resolve to same project"
+        );
+        assert_ne!(
+            proj_a, state.project_id,
+            "Windows path must not fall back to the server-default project"
         );
     }
 }

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -353,9 +353,7 @@ async fn resolve_project_ids(
         // Split on both `/` and `\` so Windows paths sent to a Linux
         // server still resolve to the final component.
         let s = path.to_str()?;
-        let name = s
-            .rsplit(['/', '\\'])
-            .find(|seg| !seg.is_empty())?;
+        let name = s.rsplit(['/', '\\']).find(|seg| !seg.is_empty())?;
         if name.is_empty() {
             return None;
         }


### PR DESCRIPTION
## Summary

- **Bug:** `std::path::Path::file_name()` on Linux treats `\` as a literal character, so Windows `cwd` values like `E:\source\ai-memory` sent via hooks were stored as the full path string instead of resolving to `ai-memory`. This caused duplicate projects in the database — one from bootstrap (correct basename) and one from hooks (full Windows path).
- **Fix:** Replace `Path::file_name()` with a manual `rsplit(['/', '\\'])` in the `basename()` helper inside `resolve_project_ids`, so both Unix and Windows path separators are handled regardless of the server's platform.
- **Test:** Added `windows_backslash_path_resolves_to_basename` that verifies two different Windows paths with the same final component resolve to the same project.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p ai-memory-hooks -- windows_backslash` — new test passes
- [x] All 52 existing router tests still pass
- [ ] After merge + server redeploy: verify Windows hooks no longer create duplicate full-path projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)