### PR TITLE
fix(wiki): implement inode tracking on Windows via NTFS file index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,9 @@ notify = "8"
 notify-debouncer-full = "0.6"
 sysinfo = "0.32"
 
+# Windows NTFS file-index (inode equivalent) for own-write detection.
+winapi-util = "0.1"
+
 # MCP server SDK.
 rmcp = { version = "1.7", features = ["server", "macros", "transport-io", "transport-streamable-http-server", "schemars"] }
 schemars = "1"

--- a/crates/ai-memory-wiki/Cargo.toml
+++ b/crates/ai-memory-wiki/Cargo.toml
@@ -26,6 +26,9 @@ notify-debouncer-full.workspace = true
 git2.workspace = true
 async-trait.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+winapi-util = { workspace = true }
+
 [dev-dependencies]
 
 [lints]

--- a/crates/ai-memory-wiki/src/atomic.rs
+++ b/crates/ai-memory-wiki/src/atomic.rs
@@ -50,7 +50,14 @@ fn inode_of(path: &Path) -> std::io::Result<u64> {
     Ok(std::fs::metadata(path)?.ino())
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn inode_of(path: &Path) -> std::io::Result<u64> {
+    let file = std::fs::File::open(path)?;
+    let info = winapi_util::file::information(&file)?;
+    Ok(info.file_index())
+}
+
+#[cfg(not(any(unix, windows)))]
 fn inode_of(_path: &Path) -> std::io::Result<u64> {
     Ok(0)
 }
@@ -67,7 +74,7 @@ mod tests {
         let ino = write_atomic(&target, b"hello").unwrap();
         assert!(target.is_file());
         assert_eq!(std::fs::read(&target).unwrap(), b"hello");
-        if cfg!(unix) {
+        if cfg!(unix) || cfg!(windows) {
             assert_ne!(ino, 0);
         }
     }


### PR DESCRIPTION
## Summary

- The watcher's own-write detection relies on `inode_of()` to skip files it just wrote. The `#[cfg(not(unix))]` fallback returned `0`, disabling this on Windows — every atomic write triggered a spurious reindex.
- Add a `#[cfg(windows)]` implementation using `winapi-util::file::information().file_index()` (the NTFS equivalent of a Unix inode). The crate is a lightweight, pure-Rust wrapper around `GetFileInformationByHandle`.
- `winapi-util` is a `cfg(windows)`-only dependency — zero cost on Linux/macOS builds.
- The `#[cfg(not(any(unix, windows)))]` fallback still returns `0` for other platforms.
- Test assertion updated to expect a non-zero inode on Windows too.

## Test plan

- [x] `cargo fmt --all -- --check` — pass
- [x] `cargo clippy -p ai-memory-wiki -- -D warnings` — pass
- [x] `cargo test -p ai-memory-wiki -- atomic` — 4/4 pass on Windows (including `writes_atomically_and_creates_parents` now asserting `ino != 0`)
- [x] Verified `file_index()` returns distinct non-zero values for different files on NTFS

Ref: #11 (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)