### PR TITLE
fix(release): add linux/arm64 platform to docker manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ name: release
 on:
   push:
     tags:
-      - 'v*.*.*''
+      - 'v*.*.*'
 
 env:
   CARGO_TERM_COLOR: always
@@ -146,7 +146,7 @@ jobs:
 
       - uses: docker/setup-qemu-action@v4
         with:
-          platforms: linux/arm64
+          platforms: arm64
 
       - uses: docker/setup-buildx-action@v3
 
@@ -171,7 +171,8 @@ jobs:
 
       - name: Smoke test the published image
         run: |
-          docker pull --platform linux/amd64 "${{ secrets.DOCKERHUB_USERNAME }}/ai-memory:${{ needs.validate-version.outputs.version }}"
+          docker pull --platform linux/amd64 \
+            "${{ secrets.DOCKERHUB_USERNAME }}/ai-memory:${{ needs.validate-version.outputs.version }}"
           docker run --rm --platform linux/amd64 \
             "${{ secrets.DOCKERHUB_USERNAME }}/ai-memory:${{ needs.validate-version.outputs.version }}" \
             --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ name: release
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - 'v*.*.*''
 
 env:
   CARGO_TERM_COLOR: always
@@ -144,6 +144,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: docker/setup-qemu-action@v4
+        with:
+          platforms: linux/arm64
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
@@ -157,6 +161,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/ai-memory:latest
@@ -166,8 +171,8 @@ jobs:
 
       - name: Smoke test the published image
         run: |
-          docker pull "${{ secrets.DOCKERHUB_USERNAME }}/ai-memory:${{ needs.validate-version.outputs.version }}"
-          docker run --rm \
+          docker pull --platform linux/amd64 "${{ secrets.DOCKERHUB_USERNAME }}/ai-memory:${{ needs.validate-version.outputs.version }}"
+          docker run --rm --platform linux/amd64 \
             "${{ secrets.DOCKERHUB_USERNAME }}/ai-memory:${{ needs.validate-version.outputs.version }}" \
             --version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Docker release images now publish both `linux/amd64` and `linux/arm64`
+  manifests, so Apple Silicon and ARM64 Linux hosts can pull the image without
+  forcing x86 emulation ([#41]).
 
 ## [0.4.0] - 2026-05-27
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 
 | Area | Status | Notes |
 |---|---|---|
-| Linux | Supported | Primary Docker/server target and CI platform. Native Arch/AUR packages include system and user systemd units. |
-| macOS | Supported | Workspace tests run in CI; native source builds are supported. |
+| Linux | Supported | Primary Docker/server target and CI platform. Published Docker images support `linux/amd64` and `linux/arm64`. Native Arch/AUR packages include system and user systemd units. |
+| macOS | Supported | Workspace tests run in CI; native source builds are supported. Docker images run natively on Apple Silicon via the `linux/arm64` manifest. |
 | Windows via WSL2 | Supported | Use the Linux install path inside WSL2 when the agent runs there. |
 | Native Windows | Experimental | PowerShell wrapper and `.ps1` hooks are available; real agent harness feedback still needed. See [`docs/windows.md`](docs/windows.md). |
 | Claude Code | Supported | MCP config + lifecycle hooks. |
@@ -158,6 +158,10 @@ packaged unit. Full user-service, system-service, auth, and provider setup is in
 
 You need: Docker + an agent CLI (Claude Code, Codex, OpenCode, OMP, Cursor,
 Antigravity CLI, or anything else that speaks MCP).
+
+The published Docker image includes `linux/amd64` and `linux/arm64` variants,
+so Apple Silicon Macs and ARM64 Linux hosts can pull `akitaonrails/ai-memory`
+without `--platform linux/amd64` emulation.
 
 The default quick-start has **no authentication** - the server binds
 to loopback only, so on a single-user laptop nothing else can reach

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -13,6 +13,9 @@ system service, or XDG user paths for the user service. The Docker deployment
 below remains `/data` inside the container and `/var/opt/docker/...` on the
 host.
 
+Published Docker images include `linux/amd64` and `linux/arm64` manifests, so
+homelab hosts on x86_64 and ARM64 can pull the same tag natively.
+
 ## What gets committed vs. what stays local
 
 The repo ships **templates only**. The real files with your homelab

--- a/docs/install.md
+++ b/docs/install.md
@@ -27,6 +27,9 @@ path (docker + Claude Code). This page covers everything else:
 > and replace `homelab` with `localhost` if the server runs on the
 > same machine as the agent CLI.
 
+The Docker image is published for `linux/amd64` and `linux/arm64`; Apple
+Silicon Macs and ARM64 Linux hosts should not need `--platform linux/amd64`.
+
 ---
 
 ## Server on a different machine


### PR DESCRIPTION
## Summary

- Adds `docker/setup-qemu-action@v3` to enable ARM64 emulation on the `ubuntu-latest` runner
- Adds `platforms: linux/amd64,linux/arm64` to the `build-push-action` step so both architectures are published to Docker Hub
- Pins the smoke test to `--platform linux/amd64` since the runner cannot natively execute the ARM64 image

Fixes #41 — `docker pull akitaonrails/ai-memory:latest` returned `no matching manifest for linux/arm64/v8` on Apple Silicon Macs and other ARM64 hosts.

## Test plan

- [ ] Verify the release workflow completes without error on the next tag push
- [ ] Confirm `docker pull akitaonrails/ai-memory:latest` works on an ARM64 host without `--platform linux/amd64`
- [ ] Confirm the existing `linux/amd64` image is unaffected