### PR TITLE
fix(hooks): use bash -c wrapping for Claude Code hooks on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Claude Code hook installs on native Windows now render Git Bash-compatible
+  `bash -c` commands that keep the POSIX `.sh` hook scripts and convert
+  drive-letter paths to Git Bash paths, matching Claude Code's actual hook
+  runner instead of emitting PowerShell commands ([#45]).
 
 ## [0.5.1] - 2026-05-27
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 | Linux | Supported | Primary Docker/server target and CI platform. Published Docker images support `linux/amd64` and `linux/arm64`. Native Arch/AUR packages include system and user systemd units. |
 | macOS | Supported | Workspace tests run in CI; native source builds are supported. Docker images run natively on Apple Silicon via the `linux/arm64` manifest. |
 | Windows via WSL2 | Supported | Use the Linux install path inside WSL2 when the agent runs there. |
-| Native Windows | Experimental | PowerShell wrapper and `.ps1` hooks are available; real agent harness feedback still needed. See [`docs/windows.md`](docs/windows.md). |
+| Native Windows | Experimental | PowerShell wrapper is available. Claude Code uses Git Bash `.sh` hooks on native Windows; other script-hook agents use the current PowerShell defaults pending harness feedback. See [`docs/windows.md`](docs/windows.md). |
 | Claude Code | Supported | MCP config + lifecycle hooks. |
 | Codex | Supported | MCP config + lifecycle hooks. |
 | OpenCode | Supported | Remote MCP config + generated TypeScript plugin. |
@@ -236,9 +236,10 @@ use `--mcp-url` if you installed MCP with a custom endpoint, and
 
 ### Install Notes
 
-- **Windows:** use the Linux path inside WSL2, or the native PowerShell
-  wrapper and `.ps1` hooks for native Windows agents. Do not mix path
-  worlds. See [`docs/windows.md`](docs/windows.md).
+- **Windows:** use the Linux path inside WSL2, or the native Windows wrapper
+  from PowerShell/cmd. Native Claude Code uses Git Bash `.sh` hooks; other
+  script-hook agents use PowerShell defaults. Do not mix path worlds. See
+  [`docs/windows.md`](docs/windows.md).
 - **Docker compose:** `docker compose -f docker/docker-compose.yml up -d`
   is supported; agent setup is the same as step 3 above.
 - **Remote server:** set `AI_MEMORY_SERVER_URL=http://<server-ip>:49374`

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -25,8 +25,8 @@ use crate::commands::install_mcp;
 use crate::commands::openclaw_plugin;
 use crate::commands::render_shared::{
     CURSOR_PROFILE, GEMINI_PROFILE, build_antigravity_payload, build_claude_code_payload,
-    build_codex_payload, build_profile_payload, hook_script_for_current_platform,
-    ts_string_literal,
+    build_codex_payload, build_profile_payload, hook_script_for_claude_code,
+    hook_script_for_current_platform, ts_string_literal,
 };
 use crate::config::{Config, DEFAULT_SERVER_URL};
 
@@ -1481,7 +1481,7 @@ fn render_claude_code(hooks_dir: &Path, server_url: &str, auth_token: Option<&st
     // that exists only on the host's filesystem — bailing would
     // sabotage the docker-only flow `setup-agent` enables.
     for (_, script) in super::render_shared::CLAUDE_CODE_EVENTS {
-        let script = hook_script_for_current_platform(script);
+        let script = hook_script_for_claude_code(script);
         let abs = hooks_dir.join(script.as_ref());
         if !abs.exists() {
             eprintln!(

--- a/crates/ai-memory-cli/src/commands/render_shared.rs
+++ b/crates/ai-memory-cli/src/commands/render_shared.rs
@@ -97,12 +97,13 @@ pub(crate) fn build_claude_code_payload(
     server_url: &str,
     auth_token: Option<&str>,
 ) -> serde_json::Value {
-    build_hook_payload(
+    build_hook_payload_for_platform(
         &CLAUDE_CODE_EVENTS,
         emit_root,
         server_url,
         auth_token,
         HookShape::Nested,
+        HookCommandPlatform::for_bash_runner(),
     )
 }
 
@@ -328,6 +329,11 @@ fn build_hook_payload(
 pub(crate) enum HookCommandPlatform {
     Posix,
     Windows,
+    /// Claude Code on Windows invokes hooks through bash (Git for
+    /// Windows), not PowerShell. Commands use POSIX `.sh` scripts
+    /// wrapped in `bash -c '...'` with drive-letter paths converted
+    /// to Git Bash format (`C:\x` → `/c/x`).
+    WindowsBash,
 }
 
 impl HookCommandPlatform {
@@ -337,7 +343,23 @@ impl HookCommandPlatform {
             Ok(v) if v.eq_ignore_ascii_case("posix") || v.eq_ignore_ascii_case("unix") => {
                 Self::Posix
             }
+            Ok(v) if v.eq_ignore_ascii_case("windows-bash") => Self::WindowsBash,
             _ if cfg!(windows) => Self::Windows,
+            _ => Self::Posix,
+        }
+    }
+
+    /// Platform for agents known to use bash as their hook runner on
+    /// Windows (currently Claude Code). Returns `WindowsBash` on
+    /// Windows unless overridden by `AI_MEMORY_HOOK_PLATFORM`.
+    fn for_bash_runner() -> Self {
+        match std::env::var("AI_MEMORY_HOOK_PLATFORM") {
+            Ok(v) if v.eq_ignore_ascii_case("windows") => Self::Windows,
+            Ok(v) if v.eq_ignore_ascii_case("posix") || v.eq_ignore_ascii_case("unix") => {
+                Self::Posix
+            }
+            Ok(v) if v.eq_ignore_ascii_case("windows-bash") => Self::WindowsBash,
+            _ if cfg!(windows) => Self::WindowsBash,
             _ => Self::Posix,
         }
     }
@@ -405,7 +427,7 @@ fn build_hook_payload_for_platform(
 
 fn script_for_platform(script: &str, platform: HookCommandPlatform) -> Cow<'_, str> {
     match platform {
-        HookCommandPlatform::Posix => Cow::Borrowed(script),
+        HookCommandPlatform::Posix | HookCommandPlatform::WindowsBash => Cow::Borrowed(script),
         HookCommandPlatform::Windows => match script.strip_suffix(".sh") {
             Some(stem) => Cow::Owned(format!("{stem}.ps1")),
             None => Cow::Borrowed(script),
@@ -415,6 +437,10 @@ fn script_for_platform(script: &str, platform: HookCommandPlatform) -> Cow<'_, s
 
 pub(crate) fn hook_script_for_current_platform(script: &str) -> Cow<'_, str> {
     script_for_platform(script, HookCommandPlatform::current())
+}
+
+pub(crate) fn hook_script_for_claude_code(script: &str) -> Cow<'_, str> {
+    script_for_platform(script, HookCommandPlatform::for_bash_runner())
 }
 
 fn hook_command(
@@ -444,6 +470,31 @@ fn hook_command(
                 powershell_quote(&script.to_string_lossy())
             )
         }
+        HookCommandPlatform::WindowsBash => {
+            let bash_path = to_git_bash_path(&script.to_string_lossy());
+            let mut inner = format!("AI_MEMORY_HOOK_URL={} ", shell_quote(server_url));
+            if let Some(t) = auth_token {
+                inner.push_str(&format!("AI_MEMORY_AUTH_TOKEN={} ", shell_quote(t)));
+            }
+            inner.push_str(&shell_quote(&bash_path));
+            format!("bash -c {}", shell_quote(&inner))
+        }
+    }
+}
+
+/// Convert a Windows path to Git Bash (MSYS2) format.
+/// `C:\Users\alice\hooks\x.sh` → `/c/Users/alice/hooks/x.sh`
+fn to_git_bash_path(path: &str) -> String {
+    let s = path.replace('\\', "/");
+    if s.len() >= 3
+        && s.as_bytes()[0].is_ascii_alphabetic()
+        && s.as_bytes()[1] == b':'
+        && s.as_bytes()[2] == b'/'
+    {
+        let drive = (s.as_bytes()[0] as char).to_ascii_lowercase();
+        format!("/{drive}{}", &s[2..])
+    } else {
+        s
     }
 }
 
@@ -846,5 +897,124 @@ mod tests {
                 "missing Antigravity event {expected}"
             );
         }
+    }
+
+    #[test]
+    fn to_git_bash_path_converts_drive_letter_and_backslashes() {
+        assert_eq!(
+            to_git_bash_path(r"C:\Users\alice\hooks\x.sh"),
+            "/c/Users/alice/hooks/x.sh"
+        );
+        assert_eq!(to_git_bash_path(r"D:\Projects\repo"), "/d/Projects/repo");
+    }
+
+    #[test]
+    fn to_git_bash_path_preserves_posix_paths() {
+        assert_eq!(
+            to_git_bash_path("/already/posix/path"),
+            "/already/posix/path"
+        );
+    }
+
+    #[test]
+    fn to_git_bash_path_handles_forward_slash_windows_paths() {
+        assert_eq!(
+            to_git_bash_path("C:/Users/alice/hooks/x.sh"),
+            "/c/Users/alice/hooks/x.sh"
+        );
+    }
+
+    #[test]
+    fn windows_bash_hook_command_wraps_in_bash_c_with_git_bash_paths() {
+        let cmd = hook_command(
+            &PathBuf::from(
+                r"C:\Users\alice\.local\share\ai-memory\hooks\claude-code\session-start.sh",
+            ),
+            "https://my-server.example.com",
+            Some("tok123"),
+            HookCommandPlatform::WindowsBash,
+        );
+        assert!(
+            cmd.starts_with("bash -c "),
+            "command must be bash-wrapped: {cmd}"
+        );
+        assert!(
+            cmd.contains("/c/Users/alice/"),
+            "Windows path must be converted to Git Bash format: {cmd}"
+        );
+        assert!(
+            cmd.contains("session-start.sh"),
+            "must use .sh script: {cmd}"
+        );
+        assert!(
+            cmd.contains("AI_MEMORY_HOOK_URL=https://my-server.example.com"),
+            "must inline hook URL: {cmd}"
+        );
+        assert!(
+            cmd.contains("AI_MEMORY_AUTH_TOKEN=tok123"),
+            "must inline auth token: {cmd}"
+        );
+    }
+
+    #[test]
+    fn windows_bash_hook_command_omits_token_when_absent() {
+        let cmd = hook_command(
+            &PathBuf::from(r"C:\Users\alice\hooks\session-start.sh"),
+            "http://localhost:49374",
+            None,
+            HookCommandPlatform::WindowsBash,
+        );
+        assert!(cmd.starts_with("bash -c "));
+        assert!(
+            !cmd.contains("AI_MEMORY_AUTH_TOKEN"),
+            "no token expected: {cmd}"
+        );
+    }
+
+    #[test]
+    fn windows_bash_script_for_platform_keeps_sh_extension() {
+        let s = script_for_platform("session-start.sh", HookCommandPlatform::WindowsBash);
+        assert_eq!(s, "session-start.sh");
+    }
+
+    #[test]
+    fn windows_bash_payload_uses_bash_c_and_sh_hooks() {
+        let root = PathBuf::from(r"C:\Users\alice\.local\share\ai-memory\hooks\claude-code");
+        let v = build_hook_payload_for_platform(
+            &CLAUDE_CODE_EVENTS,
+            &root,
+            "https://my-server.example.com",
+            Some("tok123"),
+            HookShape::Nested,
+            HookCommandPlatform::WindowsBash,
+        );
+        let cmd = v
+            .pointer("/hooks/SessionStart/0/hooks/0/command")
+            .and_then(|s| s.as_str())
+            .unwrap();
+        assert!(
+            cmd.starts_with("bash -c "),
+            "command must be bash-wrapped: {cmd}"
+        );
+        assert!(
+            cmd.contains("/c/Users/alice/"),
+            "path must be in Git Bash format: {cmd}"
+        );
+        assert!(
+            cmd.contains("session-start.sh"),
+            "must use .sh script: {cmd}"
+        );
+        assert!(
+            !cmd.contains("session-start.ps1"),
+            "must not use .ps1: {cmd}"
+        );
+        assert!(
+            cmd.contains("AI_MEMORY_HOOK_URL="),
+            "must inline URL: {cmd}"
+        );
+        assert!(
+            cmd.contains("AI_MEMORY_AUTH_TOKEN=tok123"),
+            "must inline token: {cmd}"
+        );
     }
 }

--- a/docs/install.md
+++ b/docs/install.md
@@ -410,6 +410,9 @@ Cursor, Gemini CLI, Antigravity CLI, and OpenClaw have lifecycle capture paths t
 > Gemini CLI, and Antigravity CLI use shell/PowerShell hook scripts: (1) `docker cp` the
 > bundled scripts to your home dir, (2) `docker run --rm install-hooks`
 > to render the config snippet.
+> On native Windows, Claude Code is the exception to the PowerShell default:
+> it runs hooks through Git Bash, so ai-memory renders `bash -c` commands for
+> the `.sh` scripts.
 > OpenClaw, OpenCode, and OMP are different: they use generated
 > TypeScript plugin/extension files, so no shell-script extraction is
 > needed for those clients.
@@ -609,8 +612,9 @@ server's environment.
 
 On Windows, see [`docs/windows.md`](windows.md). The short version: run
 the install commands from the same environment that launches the agent.
-WSL2-launched agents need WSL paths and POSIX `.sh` hooks; native Windows
-agents need Windows paths and PowerShell `.ps1` hooks.
+WSL2-launched agents need WSL paths and POSIX `.sh` hooks. Native Claude Code
+uses Git Bash `.sh` hooks with Windows paths converted to `/c/...`; other
+native Windows script-hook agents use PowerShell `.ps1` defaults.
 
 When run from source, `install-hooks` finds the bundled scripts in
 the repo's `hooks/` automatically:

--- a/docs/mcp-install.md
+++ b/docs/mcp-install.md
@@ -23,7 +23,9 @@ Claude Code, OpenAI Codex, Cursor, Gemini CLI, Antigravity CLI, OpenClaw, OpenCo
 OMP have automatic capture integrations (shell/PowerShell hooks for
 Claude Code / Codex / Cursor / Gemini CLI / Antigravity CLI, TypeScript plugin/extension
 files for OpenClaw / OpenCode / OMP) and are covered in the
-[main README](../README.md#quick-start).
+[main README](../README.md#quick-start). On native Windows, Claude Code uses
+Git Bash `.sh` hooks rather than the PowerShell default used by other
+script-hook agents.
 
 Claude Desktop is **MCP-only** here: it exposes long-term memory to its
 LLM via ai-memory's MCP tools (`memory_query`, `memory_recent`,

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -16,7 +16,11 @@ launches Claude Code, Codex, Cursor, Gemini CLI, or another agent.
 
 The difference matters because hook configs contain executable paths.
 WSL2 agents need Linux paths and POSIX `.sh` hooks. Native Windows
-agents need Windows paths and PowerShell `.ps1` hooks.
+agents need Windows paths, but the hook runner is agent-specific:
+Claude Code invokes hooks through Git Bash, so ai-memory renders
+`bash -c` commands that call `.sh` scripts with Git Bash paths
+(`/c/Users/...`). Other native Windows script-hook agents keep the
+PowerShell `.ps1` default until their harness behavior is verified.
 
 ## Scenario A: Everything Inside WSL2
 
@@ -93,12 +97,14 @@ ai-memory install-hooks --agent claude-code --apply
 ```
 
 In this mode, the PowerShell wrapper runs the Linux container but tells
-the CLI to render Windows hook commands:
+the CLI to render hook commands for the native Windows agent:
 
 - Config files are written through the mounted Windows home directory.
 - Hook scripts are staged under `$HOME\.local\share\ai-memory\hooks\`.
-- Hook commands explicitly call `powershell.exe`.
-- Hook commands point at `.ps1` scripts.
+- Claude Code hook commands call `bash -c` and point at `.sh` scripts using
+  Git Bash paths such as `/c/Users/alice/...`.
+- Other native Windows script-hook agents currently call `powershell.exe` and
+  point at `.ps1` scripts.
 
 Use the matching `--client` / `--agent` values for other clients, for
 example `codex`, `cursor`, or `gemini-cli`.
@@ -130,17 +136,20 @@ target\debug\ai-memory.exe install-mcp --client claude-code --apply
 target\debug\ai-memory.exe install-hooks --agent claude-code --apply
 ```
 
-Native Windows builds automatically render `.ps1` lifecycle hooks. The
-hook bundle ships matching `.sh` and `.ps1` event scripts, and tests
-enforce one-to-one event/agent parity between them.
+Native Windows builds render agent-specific lifecycle hooks. Claude Code uses
+Git Bash-compatible `.sh` commands on native Windows; other script-hook agents
+use the PowerShell `.ps1` default. The hook bundle ships matching `.sh` and
+`.ps1` event scripts, and tests enforce one-to-one event/agent parity between
+them.
 
 ## Current Harness Caveats
 
 Windows hook support is new and needs real-world testing against native
 Windows agent builds.
 
-- Claude Code may be used natively on Windows or from inside WSL2. Test
-  which process launches the hooks before assuming path format.
+- Claude Code may be used natively on Windows or from inside WSL2. Native
+  Claude Code invokes hooks through Git Bash; WSL2 Claude Code uses normal
+  WSL paths.
 - Codex, OpenCode, Cursor, Gemini CLI, and OpenClaw may each choose different
   Windows config locations or shell execution behavior. ai-memory uses
   the current best-known defaults, but they need validation on real
@@ -166,8 +175,9 @@ For native Windows:
 
 1. Run all install commands from PowerShell or `cmd.exe` using
    `ai-memory` / `ai-memory.ps1`.
-2. Confirm generated hook commands reference `.ps1` files under your
-   Windows home directory.
+2. Confirm generated hook commands match the agent: Claude Code should use
+   `bash -c` plus `.sh` files with `/c/...` Git Bash paths; other script-hook
+   agents should use `.ps1` files under your Windows home directory.
 3. Launch the native Windows agent.
 4. Call `memory_status` from the agent.
 5. Send a prompt, then run `ai-memory status` or `ai-memory recent`.


### PR DESCRIPTION
## Summary

- Add `WindowsBash` platform variant to `HookCommandPlatform` that generates `bash -c 'VAR=val /c/path/script.sh'` commands with Git Bash path conversion (`C:\x` → `/c/x`)
- Wire `build_claude_code_payload()` to use `WindowsBash` on Windows (via `for_bash_runner()`), keeping `.sh` scripts instead of `.ps1`
- Other agents (Codex, Cursor, Gemini, Antigravity) retain the existing PowerShell behaviour on Windows
- `AI_MEMORY_HOOK_PLATFORM=windows-bash` available as explicit override for any agent

## Context

This is the third and final PR from the split requested in #11. Claude Code on Windows invokes hooks through bash (Git for Windows), not PowerShell. The current `powershell.exe -NoProfile -Command "$env:VAR='val'"` commands fail because Git Bash receives the string and tries to parse `$env:` as POSIX syntax ([details in issue comment](https://github.com/akitaonrails/ai-memory/issues/11#issuecomment-4543920075)).

## Test plan

- [x] 7 new unit tests for `to_git_bash_path()`, `hook_command(WindowsBash)`, and full payload generation
- [x] All 19 `render_shared` tests pass
- [x] All 160 `ai-memory-cli` unit tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] 7 pre-existing `uninstall.rs` test failures on Windows confirmed on clean `main` (not caused by this PR)
- [x] Verified manually on native Windows 11 with Claude Code CLI — `install-hooks --apply` generates correct `bash -c` commands, hook scripts execute successfully via Git Bash, server receives events with auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #11