### PR TITLE
fix(hooks): non-blocking stdin read in PowerShell hook helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Windows PowerShell hooks no longer hang or stall the agent.** The shared
+  `hooks/lib/ai-memory-hook.ps1` read stdin via `[Console]::In.ReadToEnd()`,
+  which blocks indefinitely when the agent does not close the stdin pipe
+  (observed on Claude Code `PreCompact`); because the `Invoke-WebRequest`
+  timeout only starts after the read returns, a stuck read meant the hook
+  never POSTed anything. Stdin is now read asynchronously, guarded by
+  `[Console]::IsInputRedirected` with a 2s cap, so the hook can never freeze.
+  HTTP timeouts were also raised from 1s to 3s (POST) / 2s (handoff GET) to
+  tolerate remote servers over higher-latency links. The full raw payload is
+  still forwarded (parity with `_lib.sh`), so observation title/body stay
+  intact. Affects every agent still on the PowerShell hook runner
+  (Codex, Cursor, Gemini CLI, Antigravity, OpenCode on Windows).
+
 ## [0.6.1] - 2026-05-28
 
 ### Added

--- a/hooks/lib/ai-memory-hook.ps1
+++ b/hooks/lib/ai-memory-hook.ps1
@@ -61,6 +61,25 @@ function Get-AiMemoryMarkerQuery {
     return $qs
 }
 
+function Read-AiMemoryStdin {
+    try {
+        if (-not [Console]::IsInputRedirected) { return "" }
+        $StdinStream = [Console]::OpenStandardInput()
+        $StdinReader = [System.IO.StreamReader]::new($StdinStream, [System.Text.Encoding]::UTF8, $false, 4096)
+        $ReadTask = $StdinReader.ReadToEndAsync()
+        if ($ReadTask.Wait(2000)) {
+            $result = $ReadTask.Result
+            $StdinReader.Dispose()
+            $StdinStream.Dispose()
+            return $result
+        }
+        $StdinReader.Dispose()
+        $StdinStream.Dispose()
+    } catch {
+    }
+    return ""
+}
+
 function Invoke-AiMemoryHook {
     param(
         [Parameter(Mandatory = $true)] [string] $Event,
@@ -70,7 +89,7 @@ function Invoke-AiMemoryHook {
     )
 
     $Server = if ($env:AI_MEMORY_HOOK_URL) { $env:AI_MEMORY_HOOK_URL } else { "http://127.0.0.1:49374" }
-    $Payload = [Console]::In.ReadToEnd()
+    $Payload = Read-AiMemoryStdin
     $Cwd = Get-AiMemoryCwd -Payload $Payload
     $QS = Get-AiMemoryMarkerQuery -Cwd $Cwd
     $Headers = @{}
@@ -82,7 +101,7 @@ function Invoke-AiMemoryHook {
     try {
         Invoke-WebRequest `
             -UseBasicParsing `
-            -TimeoutSec 1 `
+            -TimeoutSec 3 `
             -Method Post `
             -Uri "$Server/hook?event=$Event&agent=$Agent$QS" `
             -Headers $Headers `
@@ -95,7 +114,7 @@ function Invoke-AiMemoryHook {
         try {
             $Response = Invoke-WebRequest `
                 -UseBasicParsing `
-                -TimeoutSec 1 `
+                -TimeoutSec 2 `
                 -Uri "$Server/handoff?agent=$Agent$QS" `
                 -Headers $Headers
             if ($null -ne $Response -and $Response.Content) {


### PR DESCRIPTION
## Problem

On Windows, `hooks/lib/ai-memory-hook.ps1` reads the hook payload with
`[Console]::In.ReadToEnd()`. When the invoking agent does not close the
stdin pipe, that call **blocks indefinitely**. Because the
`Invoke-WebRequest` timeout only starts counting *after* the read returns,
a stuck read means the hook never POSTs anything — the lifecycle event is
silently lost. This was observed on Claude Code `PreCompact` (a long
compaction event whose observations never reached the server).

## Fix

- **Non-blocking stdin.** New `Read-AiMemoryStdin` helper reads stdin
  asynchronously, guarded by `[Console]::IsInputRedirected`, with a 2s
  cap. The hook can no longer freeze the agent, and returns an empty
  payload cleanly when no stdin is redirected.
- **Timeouts for remote servers.** `1s → 3s` (POST) and `1s → 2s`
  (handoff GET). The previous 1s budget assumes a loopback server and is
  too tight for a remote `aimemory.*` deployment over TLS.
- **Payload stays raw.** The body is still the unmodified stdin (parity
  with `_lib.sh`'s `--data-binary @-`), so the server keeps deriving
  observation title/body from `prompt` / `tool_name` / `tool_response`.

## Scope

This affects every agent still on the PowerShell hook runner (Codex,
Cursor, Gemini CLI, Antigravity, and OpenCode on Windows). Claude Code on
Windows already moved to the `bash -c` + `.sh` runner in #45, so it is not
affected — but the shared `.ps1` helper still had the latent hang.

## Testing

Built `v0.6.1` and ran `ai-memory serve --transport http` against an
isolated temp data dir, then fired the fixed `.ps1` hooks via
`powershell.exe` with stdin redirected (matching how Claude Code invokes
them):

- `UserPromptSubmit` → observation stored with the prompt text intact in
  both title and body.
- `PostToolUse` → observation stored with the tool name as title and the
  tool output in the body.
- Empty-stdin + dead URL probe → hook completes in ~2.5s (no infinite
  hang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)