### PR TITLE
fix: handle empty arrays under bash -u (set -u)

### DIFF
--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -292,8 +292,8 @@ fi
 # binary can derive the *real* host-side project name from it. The
 # `commands::resolve_project_name` helper checks this env var first
 # and falls back to the cwd basename only if it's unset.
-exec "${DOCKER}" run --rm "${TTY_ARGS[@]}" \
-  "${NETWORK_ARGS[@]}" \
+exec "${DOCKER}" run --rm ${TTY_ARGS[@]+"${TTY_ARGS[@]}"} \
+  ${NETWORK_ARGS[@]+"${NETWORK_ARGS[@]}"} \
   -v "${HOME}:${HOME}" \
   -v "${PWD}:/work" \
   -w /work \
@@ -301,5 +301,5 @@ exec "${DOCKER}" run --rm "${TTY_ARGS[@]}" \
   -e AI_MEMORY_HOST_CWD="${PWD}" \
   -u "$(id -u):$(id -g)" \
   "${DATA_ARGS[@]}" \
-  "${ENV_ARGS[@]}" \
+  ${ENV_ARGS[@]+"${ENV_ARGS[@]}"} \
   "${IMAGE}" "$@"


### PR DESCRIPTION
## Summary

On macOS (Darwin), `TTY_ARGS`, `NETWORK_ARGS`, and `ENV_ARGS` remain empty arrays. Expanding an empty array with `${ARRAY[@]}` triggers an **unbound variable** error under `set -u` (part of the script's `set -euo pipefail`).

This causes the wrapper to fail immediately on macOS with:

```
/Users/.../.local/bin/ai-memory: line 295: NETWORK_ARGS[@]: unbound variable
/Users/.../.local/bin/ai-memory: line 295: NETWORK_ARGS[@]: unbound variable
```

## Fix

Use the standard bash safe-expansion idiom: `${ARRAY[@]+"${ARRAY[@]}"}` which expands to nothing when the array is unset/empty, avoiding the unbound variable error.

## Test Plan

- [x] `bash -n bin/ai-memory` passes syntax check
- [x] Verified on macOS (Darwin) — `ai-memory --help` runs without error
- [ ] Verified on Linux — `--network host` still passed when `AI_MEMORY_SERVER_URL` is unset