### PR TITLE
fix: skip -u flag on macOS to prevent UID mismatch crash

### DIFF
--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -248,6 +248,7 @@ done
 # 127.0.0.1 would mean "this helper container", so thin-client commands like
 # `status` and `bootstrap` could not reach the default server.
 NETWORK_ARGS=()
+USER_ARGS=()
 case "$(uname -s 2>/dev/null || true)" in
   Linux)
     if [ -z "${AI_MEMORY_SERVER_URL:-}" ]; then
@@ -258,6 +259,19 @@ case "$(uname -s 2>/dev/null || true)" in
     if [ -z "${AI_MEMORY_SERVER_URL:-}" ]; then
       ENV_ARGS+=(-e "AI_MEMORY_SERVER_URL=http://host.docker.internal:49374")
     fi
+    # On macOS, Docker Desktop handles file-sharing permissions via its
+    # gRPC/SSH layer.  Passing -u <host-uid>:<host-gid> causes a UID
+    # mismatch: the data volume is typically owned by the container's
+    # internal uid 1000 (the ai-memory user), but the host UID on macOS
+    # is usually 501/502.  The one-shot wrapper container then cannot
+    # create log files or write to the data dir, crashing with
+    # "Permission denied" in the rolling file appender.
+    # Omitting -u lets the container run as its default (uid 1000)
+    # which matches the volume owner.
+    USER_ARGS=()
+    ;;
+  *)
+    USER_ARGS=(-u "$(id -u):$(id -g)")
     ;;
 esac
 
@@ -292,14 +306,14 @@ fi
 # binary can derive the *real* host-side project name from it. The
 # `commands::resolve_project_name` helper checks this env var first
 # and falls back to the cwd basename only if it's unset.
-exec "${DOCKER}" run --rm "${TTY_ARGS[@]}" \
-  "${NETWORK_ARGS[@]}" \
+exec "${DOCKER}" run --rm ${TTY_ARGS[@]+"${TTY_ARGS[@]}"} \
+  ${NETWORK_ARGS[@]+"${NETWORK_ARGS[@]}"} \
   -v "${HOME}:${HOME}" \
   -v "${PWD}:/work" \
   -w /work \
   -e HOME="${HOME}" \
   -e AI_MEMORY_HOST_CWD="${PWD}" \
-  -u "$(id -u):$(id -g)" \
+  "${USER_ARGS[@]}" \
   "${DATA_ARGS[@]}" \
-  "${ENV_ARGS[@]}" \
+  ${ENV_ARGS[@]+"${ENV_ARGS[@]}"} \
   "${IMAGE}" "$@"


### PR DESCRIPTION
## Summary

On macOS, the wrapper script passes `-u $(id -u):$(id -g)` to one-shot containers. This causes a **UID mismatch**: the data volume is owned by uid 1000 (the container's internal `ai-memory` user), but the host UID on macOS is typically 501/502.

The one-shot container then crashes with:

```
thread 'main' panicked at .../rolling.rs:156:14:
initializing rolling file appender failed: InitError {
  context: "failed to create log file",
  source: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
}
```

This affects all thin-client commands: `status`, `install-mcp`, `install-hooks`, `search`, `write-page`, etc.

## Fix

- Only pass `-u` on non-macOS platforms. On macOS, omitting `-u` lets the container run as its default uid 1000 which matches the volume owner. Docker Desktop's file sharing layer handles permissions correctly without explicit UID mapping.
- Initialize `USER_ARGS=()` before the platform case to satisfy `set -u`.
- Fix empty array expansions for `TTY_ARGS`, `NETWORK_ARGS`, and `ENV_ARGS` under `set -u` (same class of bug as #50).

## Test Plan

- [x] `bash -n bin/ai-memory` — syntax check passes
- [x] Verified on macOS: `ai-memory status`, `ai-memory install-mcp --client claude-code` run without permission errors
- [ ] Verified on Linux: `-u $(id -u):$(id -g)` still passed to containers

Supersedes #50 (includes the empty-array fix from that PR).