### PR TITLE
feat(links): cross-project wiki links + dependency graph

### DIFF
--- a/crates/ai-memory-consolidate/src/lint.rs
+++ b/crates/ai-memory-consolidate/src/lint.rs
@@ -107,6 +107,38 @@ pub async fn run_lint(
     let candidates = reader.decay_candidates(workspace_id, project_id).await?;
     let mut findings = rule_based_findings(&candidates);
 
+    // Dangling cross-project links: a `[[project:path]]` dependency that does
+    // not resolve. A broken inter-project edge is high-signal — surface it
+    // even on the zero-LLM path.
+    for dangling in reader
+        .dangling_cross_project_links(workspace_id, project_id)
+        .await?
+    {
+        let target = match &dangling.workspace {
+            Some(ws) => format!("{ws}/{}:{}", dangling.project, dangling.path),
+            None => format!("{}:{}", dangling.project, dangling.path),
+        };
+        let message = if dangling.project_exists {
+            format!(
+                "Page {} links to {} but that page does not exist in project `{}` \
+                 (missing, renamed, or deleted) — a broken cross-project dependency",
+                dangling.from_path, target, dangling.project,
+            )
+        } else {
+            format!(
+                "Page {} links to {} but project `{}` does not exist (typo or wrong name)",
+                dangling.from_path, target, dangling.project,
+            )
+        };
+        findings.push(LintFinding {
+            kind: "broken_link".into(),
+            severity: "warning".into(),
+            message,
+            pages: vec![dangling.from_path],
+            detail: None,
+        });
+    }
+
     if use_llm && let Some(provider) = llm {
         match contradiction_pass(
             provider.clone(),

--- a/crates/ai-memory-core/src/ids.rs
+++ b/crates/ai-memory-core/src/ids.rs
@@ -89,7 +89,7 @@ id_newtype!(pub HandoffId, "Identifier for a cross-agent handoff record.");
 /// Always uses `/` as the separator (POSIX-style), normalised on construction.
 /// Never starts with a slash; never contains `..` or `.` components. This
 /// invariant lets the store treat paths as flat keys without re-validating.
-#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct PagePath(String);
 

--- a/crates/ai-memory-core/src/lib.rs
+++ b/crates/ai-memory-core/src/lib.rs
@@ -27,6 +27,6 @@ pub use ids::{
     AgentKind, HandoffId, ObservationId, PageId, PagePath, ProjectId, SessionId, WorkspaceId,
 };
 pub use observation::{NewObservation, NewSession, Observation, ObservationKind};
-pub use page::{NewPage, Page, Tier};
+pub use page::{LinkTarget, NewPage, Page, Tier};
 pub use routing_snippet::{MARKER_END, MARKER_START, SNIPPET_BODY, full_block};
 pub use sanitize::{SanitizeConfig, Sanitized, Sanitizer};

--- a/crates/ai-memory-core/src/page.rs
+++ b/crates/ai-memory-core/src/page.rs
@@ -52,9 +52,53 @@ pub struct NewPage {
     pub pinned: bool,
     /// Outgoing links discovered in the page body.
     ///
-    /// The store resolves these against the latest page rows in the same
-    /// project and keeps unresolved forward links as `to_page_id = NULL`.
-    pub links: Vec<PagePath>,
+    /// The store resolves these against the latest page rows in the target
+    /// project (the source's own project for bare links, or the named
+    /// project for a cross-project `[[project:path]]` link) and keeps
+    /// unresolved forward links as `to_page_id = NULL`.
+    pub links: Vec<LinkTarget>,
+}
+
+/// A link target discovered in a page body.
+///
+/// A bare `[[path]]` / `[label](path)` resolves within the source page's
+/// own project (`workspace`/`project` both `None`). A `[[project:path]]`
+/// link names a sibling project in the same workspace; a
+/// `[[workspace/project:path]]` link crosses workspaces. Making
+/// cross-project dependencies explicit edges is what turns the per-project
+/// wikis into one graph.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct LinkTarget {
+    /// Cross-workspace qualifier. `None` = same workspace as the source.
+    pub workspace: Option<String>,
+    /// Cross-project qualifier. `None` = same project as the source.
+    pub project: Option<String>,
+    /// Wiki path within the target project (root-relative).
+    pub path: PagePath,
+}
+
+impl LinkTarget {
+    /// A link resolving within the source page's own project.
+    #[must_use]
+    pub fn local(path: PagePath) -> Self {
+        Self {
+            workspace: None,
+            project: None,
+            path,
+        }
+    }
+
+    /// Whether this link names a different project than its source.
+    #[must_use]
+    pub fn is_cross_project(&self) -> bool {
+        self.project.is_some()
+    }
+}
+
+impl From<PagePath> for LinkTarget {
+    fn from(path: PagePath) -> Self {
+        Self::local(path)
+    }
 }
 
 /// Materialised view of a page row.

--- a/crates/ai-memory-store/migrations/V12__cross_project_links.sql
+++ b/crates/ai-memory-store/migrations/V12__cross_project_links.sql
@@ -1,0 +1,35 @@
+-- Cross-project links.
+--
+-- A `[[project:path]]` / `[[workspace/project:path]]` wikilink carries an
+-- explicit scope; `to_workspace` / `to_project` are NULL for the common case
+-- (a link within the source page's own project). The scope joins the PRIMARY
+-- KEY so one page can link to the same `to_path` in two different projects
+-- without colliding. `to_page_id` stays a global PageId, so a resolved
+-- cross-project link already surfaces as a backlink on its target with no
+-- query change — the per-project wikis become one graph.
+--
+-- SQLite cannot alter a PRIMARY KEY in place, so rebuild the table. No other
+-- table references `links`, so the drop/rename is safe with FKs enabled.
+
+CREATE TABLE links_new (
+    from_page_id  BLOB NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    to_page_id    BLOB REFERENCES pages(id) ON DELETE SET NULL,
+    to_workspace  TEXT,                                  -- NULL = source page's workspace
+    to_project    TEXT,                                  -- NULL = source page's project
+    to_path       TEXT NOT NULL,                         -- root-relative path in the target project
+    link_type     TEXT NOT NULL DEFAULT 'references',
+    PRIMARY KEY (from_page_id, to_workspace, to_project, to_path, link_type)
+);
+
+INSERT INTO links_new (from_page_id, to_page_id, to_workspace, to_project, to_path, link_type)
+    SELECT from_page_id, to_page_id, NULL, NULL, to_path, link_type FROM links;
+
+DROP TABLE links;
+ALTER TABLE links_new RENAME TO links;
+
+-- Recreate the indexes the dropped table carried (V01/V07/V08) ...
+CREATE INDEX idx_links_to ON links(to_page_id) WHERE to_page_id IS NOT NULL;
+CREATE INDEX idx_links_unresolved_path ON links(to_path) WHERE to_page_id IS NULL;
+CREATE INDEX idx_links_to_path ON links(to_path);
+-- ... plus one for scoped (cross-project) resolution + refresh.
+CREATE INDEX idx_links_scope ON links(to_project, to_path);

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -93,8 +93,8 @@ impl Store {
 mod tests {
     use super::*;
     use ai_memory_core::{
-        AgentKind, NewObservation, NewPage, NewSession, ObservationId, ObservationKind, PagePath,
-        ProjectId, SessionId, Tier, WorkspaceId,
+        AgentKind, LinkTarget, NewObservation, NewPage, NewSession, ObservationId, ObservationKind,
+        PagePath, ProjectId, SessionId, Tier, WorkspaceId,
     };
     use rusqlite::{Connection, params};
     use tempfile::TempDir;
@@ -111,6 +111,76 @@ mod tests {
             pinned: false,
             links: Vec::new(),
         }
+    }
+
+    #[tokio::test]
+    async fn cross_project_links_surface_in_graph_briefing_and_lint() {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let ws = store
+            .writer
+            .get_or_create_workspace("default")
+            .await
+            .unwrap();
+        let app = store
+            .writer
+            .get_or_create_project(ws, "app", None)
+            .await
+            .unwrap();
+        let infra = store
+            .writer
+            .get_or_create_project(ws, "infra", None)
+            .await
+            .unwrap();
+
+        // Target page in `infra`, then a page in `app` that depends on it
+        // plus a dangling link to a non-existent project.
+        store
+            .writer
+            .upsert_page(sample_page(ws, infra, "runbooks/02.md", "the runbook"))
+            .await
+            .unwrap();
+        let mut dep = sample_page(ws, app, "concepts/dep.md", "needs infra + a typo");
+        dep.links = vec![
+            LinkTarget {
+                workspace: None,
+                project: Some("infra".into()),
+                path: PagePath::new("runbooks/02.md").unwrap(),
+            },
+            LinkTarget {
+                workspace: None,
+                project: Some("nope".into()),
+                path: PagePath::new("ghost.md").unwrap(),
+            },
+        ];
+        store.writer.upsert_page(dep).await.unwrap();
+
+        // Graph: exactly one resolved cross-project edge, app -> infra.
+        let edges = store.reader.cross_project_edges(None).await.unwrap();
+        assert_eq!(edges.len(), 1, "one resolved cross-project edge");
+        assert_eq!(edges[0].from_project, "app");
+        assert_eq!(edges[0].to_project, "infra");
+
+        // Briefing degree: app depends on 1 project; infra has 1 dependent.
+        let app_brief = store.reader.briefing_for_project(ws, app, 5).await.unwrap();
+        assert_eq!(app_brief.cross_project_dependencies, 1);
+        assert_eq!(app_brief.cross_project_dependents, 0);
+        let infra_brief = store
+            .reader
+            .briefing_for_project(ws, infra, 5)
+            .await
+            .unwrap();
+        assert_eq!(infra_brief.cross_project_dependents, 1);
+
+        // Lint: the dangling link to project `nope` is reported as unknown.
+        let dangling = store
+            .reader
+            .dangling_cross_project_links(ws, app)
+            .await
+            .unwrap();
+        assert_eq!(dangling.len(), 1, "only the unresolved `nope` link");
+        assert_eq!(dangling[0].project, "nope");
+        assert!(!dangling[0].project_exists);
     }
 
     #[tokio::test]

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -498,7 +498,7 @@ mod tests {
             .await
             .unwrap();
         let mut source = sample_page(ws, proj, "source.md", "needle source content");
-        source.links = vec![PagePath::new("target.md").unwrap()];
+        source.links = vec![PagePath::new("target.md").unwrap().into()];
         store.writer.upsert_page(source).await.unwrap();
 
         let hits = store

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -7,8 +7,8 @@
 use std::collections::BTreeSet;
 
 use ai_memory_core::{
-    AgentKind, HandoffId, NewHandoff, NewObservation, NewPage, NewSession, ObservationId,
-    ObservationKind, PageId, PagePath, ProjectId, SessionId, WorkspaceId,
+    AgentKind, HandoffId, LinkTarget, NewHandoff, NewObservation, NewPage, NewSession,
+    ObservationId, ObservationKind, PageId, ProjectId, SessionId, WorkspaceId,
 };
 
 /// Summary returned by [`reorg_sessions`] and exposed via
@@ -294,35 +294,84 @@ fn replace_links_in_tx(
     )?;
 
     let mut seen = BTreeSet::new();
-    for to_path in &page.links {
-        if !seen.insert(to_path.as_str().to_string()) {
+    for link in &page.links {
+        let key = (
+            link.workspace.clone(),
+            link.project.clone(),
+            link.path.as_str().to_string(),
+        );
+        if !seen.insert(key) {
             continue;
         }
-        let to_page_id = latest_page_id_for_path(tx, page, to_path)?;
+        let to_page_id = latest_page_id_for_link(tx, page, link)?;
         let to_page_blob = to_page_id.as_ref().map(|id| &id.as_bytes()[..]);
         tx.execute(
-            "INSERT INTO links (from_page_id, to_page_id, to_path, link_type) \
-             VALUES (?1, ?2, ?3, 'references')",
-            params![from_page_id.as_bytes(), to_page_blob, to_path.as_str()],
+            "INSERT INTO links \
+                 (from_page_id, to_page_id, to_workspace, to_project, to_path, link_type) \
+             VALUES (?1, ?2, ?3, ?4, ?5, 'references')",
+            params![
+                from_page_id.as_bytes(),
+                to_page_blob,
+                link.workspace,
+                link.project,
+                link.path.as_str(),
+            ],
         )?;
     }
     Ok(())
 }
 
-fn latest_page_id_for_path(
+/// Resolve a link target to the latest page id it points at, or `None` if the
+/// target workspace / project / page does not exist yet (an unresolved forward
+/// link). A bare link resolves within the source page's own project; a
+/// `[[project:path]]` / `[[workspace/project:path]]` link resolves against the
+/// named project (same workspace when only the project is given).
+fn latest_page_id_for_link(
     tx: &rusqlite::Transaction<'_>,
     page: &NewPage,
-    to_path: &PagePath,
+    link: &LinkTarget,
 ) -> StoreResult<Option<PageId>> {
+    let (workspace_blob, project_blob): (Vec<u8>, Vec<u8>) = match &link.project {
+        None => (
+            page.workspace_id.as_bytes().to_vec(),
+            page.project_id.as_bytes().to_vec(),
+        ),
+        Some(project_name) => {
+            let workspace_blob: Vec<u8> = match &link.workspace {
+                None => page.workspace_id.as_bytes().to_vec(),
+                Some(workspace_name) => {
+                    let found: Option<Vec<u8>> = tx
+                        .query_row(
+                            "SELECT id FROM workspaces WHERE name = ?1",
+                            params![workspace_name],
+                            |row| row.get(0),
+                        )
+                        .optional()?;
+                    match found {
+                        Some(id) => id,
+                        None => return Ok(None),
+                    }
+                }
+            };
+            let project_blob: Option<Vec<u8>> = tx
+                .query_row(
+                    "SELECT id FROM projects WHERE workspace_id = ?1 AND name = ?2",
+                    params![workspace_blob, project_name],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            match project_blob {
+                Some(id) => (workspace_blob, id),
+                None => return Ok(None),
+            }
+        }
+    };
+
     let bytes: Option<Vec<u8>> = tx
         .query_row(
             "SELECT id FROM pages \
              WHERE workspace_id = ?1 AND project_id = ?2 AND path = ?3 AND is_latest = 1",
-            params![
-                page.workspace_id.as_bytes(),
-                page.project_id.as_bytes(),
-                to_path.as_str(),
-            ],
+            params![workspace_blob, project_blob, link.path.as_str()],
             |row| row.get(0),
         )
         .optional()?;
@@ -336,10 +385,13 @@ fn refresh_incoming_links_for_path(
     page: &NewPage,
     latest_page_id: &PageId,
 ) -> StoreResult<()> {
+    // (1) Bare (same-project) links: from_page lives in this page's project and
+    // the target carries no scope. Repoints all matches (not only unresolved):
+    // a new page version changes the latest id, so resolved links must follow.
     tx.execute(
         "UPDATE links \
          SET to_page_id = ?1 \
-         WHERE to_path = ?2 \
+         WHERE to_project IS NULL AND to_path = ?2 \
            AND EXISTS ( \
                SELECT 1 FROM pages from_page \
                WHERE from_page.id = links.from_page_id \
@@ -353,6 +405,48 @@ fn refresh_incoming_links_for_path(
             page.project_id.as_bytes(),
         ],
     )?;
+
+    // (2) Cross-project links naming this page's project by name. `to_workspace`
+    // may be explicit (cross-workspace) or NULL (same workspace as the source).
+    let project_name: Option<String> = tx
+        .query_row(
+            "SELECT name FROM projects WHERE id = ?1",
+            params![page.project_id.as_bytes()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let workspace_name: Option<String> = tx
+        .query_row(
+            "SELECT name FROM workspaces WHERE id = ?1",
+            params![page.workspace_id.as_bytes()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if let (Some(project_name), Some(workspace_name)) = (project_name, workspace_name) {
+        tx.execute(
+            "UPDATE links \
+             SET to_page_id = ?1 \
+             WHERE to_project = ?2 AND to_path = ?3 \
+               AND ( \
+                   to_workspace = ?4 \
+                   OR ( \
+                       to_workspace IS NULL \
+                       AND EXISTS ( \
+                           SELECT 1 FROM pages from_page \
+                           WHERE from_page.id = links.from_page_id \
+                             AND from_page.workspace_id = ?5 \
+                       ) \
+                   ) \
+               )",
+            params![
+                latest_page_id.as_bytes(),
+                project_name,
+                page.path.as_str(),
+                workspace_name,
+                page.workspace_id.as_bytes(),
+            ],
+        )?;
+    }
     Ok(())
 }
 
@@ -916,7 +1010,7 @@ mod tests {
     //! deserve direct coverage so a regression surfaces with a
     //! one-line diff instead of a cascading e2e failure.
     use super::*;
-    use ai_memory_core::{NewHandoff, NewPage, NewSession, PagePath, Tier};
+    use ai_memory_core::{LinkTarget, NewHandoff, NewPage, NewSession, PagePath, Tier};
     use rusqlite::Connection;
     use tempfile::TempDir;
 
@@ -1075,7 +1169,7 @@ mod tests {
     fn upsert_page_persists_and_resolves_links() {
         let (_tmp, mut conn, ws, proj) = fresh_db();
         let mut source = page(ws, proj, "concepts/source.md", "see target");
-        source.links = vec![PagePath::new("decisions/target.md").unwrap()];
+        source.links = vec![PagePath::new("decisions/target.md").unwrap().into()];
         let source_id = upsert_page(&mut conn, &source).unwrap();
 
         let unresolved: i64 = conn
@@ -1102,6 +1196,53 @@ mod tests {
             )
             .unwrap();
         assert_eq!(resolved.as_deref(), Some(&target_id.as_bytes()[..]));
+    }
+
+    /// A `[[infra:runbooks/02.md]]` link from one project resolves to a page
+    /// in a sibling project once that page exists — the cross-project edge.
+    #[test]
+    fn upsert_page_resolves_cross_project_link() {
+        let (_tmp, mut conn, ws, scratch) = fresh_db();
+        let infra = get_or_create_project(&mut conn, &ws, "infra", None).unwrap();
+
+        let mut source = page(ws, scratch, "concepts/dep.md", "depends on infra runbook");
+        source.links = vec![LinkTarget {
+            workspace: None,
+            project: Some("infra".into()),
+            path: PagePath::new("runbooks/02.md").unwrap(),
+        }];
+        let source_id = upsert_page(&mut conn, &source).unwrap();
+
+        // Persisted with the scope, unresolved until the target project's page exists.
+        let (to_project, resolved): (Option<String>, Option<Vec<u8>>) = conn
+            .query_row(
+                "SELECT to_project, to_page_id FROM links \
+                 WHERE from_page_id = ?1 AND to_path = ?2",
+                params![source_id.as_bytes(), "runbooks/02.md"],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(to_project.as_deref(), Some("infra"));
+        assert!(
+            resolved.is_none(),
+            "cross-project link is unresolved before the target exists"
+        );
+
+        // Create the target in `infra` → the forward link repoints across projects.
+        let target_id =
+            upsert_page(&mut conn, &page(ws, infra, "runbooks/02.md", "the runbook")).unwrap();
+        let resolved: Option<Vec<u8>> = conn
+            .query_row(
+                "SELECT to_page_id FROM links WHERE from_page_id = ?1 AND to_path = ?2",
+                params![source_id.as_bytes(), "runbooks/02.md"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            resolved.as_deref(),
+            Some(&target_id.as_bytes()[..]),
+            "link must resolve across projects once the target lands"
+        );
     }
 
     /// Handoff state machine: insert → Open; accept_handoff → Accepted

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -172,6 +172,13 @@ pub struct BriefingSnapshot {
     pub slots: Vec<BriefingPage>,
     /// Top-N most-recently-updated `is_latest = 1` pages.
     pub recent_pages: Vec<BriefingPage>,
+    /// Distinct other projects whose pages link INTO this project (who
+    /// depends on us). Project-scoped briefings only; `0` for
+    /// workspace/global snapshots.
+    pub cross_project_dependents: u64,
+    /// Distinct other projects this project's pages link OUT to (what we
+    /// depend on). Project-scoped briefings only; `0` otherwise.
+    pub cross_project_dependencies: u64,
 }
 
 /// Trimmed page view for the briefing — path, title, kind, updated_at
@@ -263,6 +270,43 @@ pub struct PageMeta {
     pub updated_at: String,
     /// Path of the page this one supersedes, if any.
     pub supersedes: Option<String>,
+}
+
+/// One resolved cross-project edge (a link whose endpoints live in
+/// different projects). The `/api/v1/graph` endpoint returns these; the UI
+/// builds nodes from the endpoints and can aggregate to a project graph.
+#[derive(Debug, Clone, Serialize)]
+pub struct CrossProjectEdge {
+    /// Source page workspace.
+    pub from_workspace: String,
+    /// Source page project.
+    pub from_project: String,
+    /// Source page path.
+    pub from_path: String,
+    /// Target page workspace.
+    pub to_workspace: String,
+    /// Target page project.
+    pub to_project: String,
+    /// Target page path.
+    pub to_path: String,
+}
+
+/// An unresolved cross-project link — a declared dependency on another
+/// project's page that does not resolve. Surfaced by `memory_lint`.
+#[derive(Debug, Clone, Serialize)]
+pub struct DanglingCrossLink {
+    /// Path of the page that authored the link (in the queried project).
+    pub from_path: String,
+    /// Target workspace name (`None` = the source page's own workspace).
+    pub workspace: Option<String>,
+    /// Target project name.
+    pub project: String,
+    /// Target page path within that project.
+    pub path: String,
+    /// Whether the named target project exists at all. `false` →
+    /// likely a typo / wrong name; `true` → the page is missing or was
+    /// renamed/deleted in an existing project (a broken dependency).
+    pub project_exists: bool,
 }
 
 /// A page related to another through the link graph — used by the
@@ -1416,6 +1460,8 @@ impl ReaderPool {
                 rules,
                 slots,
                 recent_pages,
+                cross_project_dependents: 0,
+                cross_project_dependencies: 0,
             })
         })
         .await
@@ -1547,6 +1593,8 @@ impl ReaderPool {
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()?;
 
+            let (cross_project_dependents, cross_project_dependencies) =
+                cross_project_degree(conn, workspace_id, project_id)?;
             Ok(BriefingSnapshot {
                 counts,
                 activity_7d,
@@ -1556,6 +1604,8 @@ impl ReaderPool {
                 rules,
                 slots,
                 recent_pages,
+                cross_project_dependents,
+                cross_project_dependencies,
             })
         })
         .await
@@ -1747,6 +1797,8 @@ impl ReaderPool {
                 rules,
                 slots,
                 recent_pages,
+                cross_project_dependents: 0,
+                cross_project_dependencies: 0,
             })
         })
         .await
@@ -2161,6 +2213,111 @@ impl ReaderPool {
                 links: collect(outgoing)?,
                 backlinks: collect(incoming)?,
             })
+        })
+        .await
+    }
+
+    /// List unresolved cross-project links authored by pages in this project
+    /// — declared dependencies on another project's page that don't resolve.
+    /// Each row says whether the named target project exists, so the lint can
+    /// tell a typo'd project name from a missing / renamed target page.
+    ///
+    /// # Errors
+    /// Propagates any SQL or pool error.
+    pub async fn dangling_cross_project_links(
+        &self,
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+    ) -> StoreResult<Vec<DanglingCrossLink>> {
+        self.with_conn(move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT fp.path, l.to_workspace, l.to_project, l.to_path, \
+                        EXISTS ( \
+                            SELECT 1 FROM projects pr \
+                            JOIN workspaces ws ON ws.id = pr.workspace_id \
+                            WHERE pr.name = l.to_project \
+                              AND ws.name = COALESCE( \
+                                  l.to_workspace, \
+                                  (SELECT name FROM workspaces WHERE id = ?1) \
+                              ) \
+                        ) AS project_exists \
+                 FROM links l \
+                 JOIN pages fp ON fp.id = l.from_page_id \
+                     AND fp.workspace_id = ?1 AND fp.project_id = ?2 AND fp.is_latest = 1 \
+                 WHERE l.to_page_id IS NULL AND l.to_project IS NOT NULL \
+                 ORDER BY fp.path, l.to_project, l.to_path",
+            )?;
+            let rows = stmt.query_map(
+                params![workspace_id.as_bytes(), project_id.as_bytes()],
+                |row| {
+                    let exists: i64 = row.get(4)?;
+                    Ok(DanglingCrossLink {
+                        from_path: row.get(0)?,
+                        workspace: row.get(1)?,
+                        project: row.get(2)?,
+                        path: row.get(3)?,
+                        project_exists: exists != 0,
+                    })
+                },
+            )?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r?);
+            }
+            Ok(out)
+        })
+        .await
+    }
+
+    /// Resolved cross-project edges (links whose endpoints are in different
+    /// projects). When `scope` is `Some((ws, proj))`, only edges that touch
+    /// that project (as source or target) are returned; `None` returns the
+    /// whole cross-project graph. Powers `/api/v1/graph`.
+    ///
+    /// # Errors
+    /// Propagates any SQL or pool error.
+    pub async fn cross_project_edges(
+        &self,
+        scope: Option<(WorkspaceId, ProjectId)>,
+    ) -> StoreResult<Vec<CrossProjectEdge>> {
+        self.with_conn(move |conn| {
+            let base = "SELECT fw.name, fpr.name, fp.path, tw.name, tpr.name, tp.path \
+                 FROM links l \
+                 JOIN pages fp ON fp.id = l.from_page_id AND fp.is_latest = 1 \
+                 JOIN pages tp ON tp.id = l.to_page_id AND tp.is_latest = 1 \
+                 JOIN projects fpr ON fpr.id = fp.project_id \
+                 JOIN workspaces fw ON fw.id = fp.workspace_id \
+                 JOIN projects tpr ON tpr.id = tp.project_id \
+                 JOIN workspaces tw ON tw.id = tp.workspace_id \
+                 WHERE fp.project_id != tp.project_id";
+            let map_row = |row: &rusqlite::Row<'_>| {
+                Ok(CrossProjectEdge {
+                    from_workspace: row.get(0)?,
+                    from_project: row.get(1)?,
+                    from_path: row.get(2)?,
+                    to_workspace: row.get(3)?,
+                    to_project: row.get(4)?,
+                    to_path: row.get(5)?,
+                })
+            };
+            let mut out = Vec::new();
+            if let Some((_ws, proj)) = scope {
+                let sql =
+                    format!("{base} AND (fp.project_id = ?1 OR tp.project_id = ?1) ORDER BY fw.name, fpr.name, fp.path");
+                let mut stmt = conn.prepare(&sql)?;
+                let rows = stmt.query_map(params![proj.as_bytes()], map_row)?;
+                for r in rows {
+                    out.push(r?);
+                }
+            } else {
+                let sql = format!("{base} ORDER BY fw.name, fpr.name, fp.path");
+                let mut stmt = conn.prepare(&sql)?;
+                let rows = stmt.query_map([], map_row)?;
+                for r in rows {
+                    out.push(r?);
+                }
+            }
+            Ok(out)
         })
         .await
     }
@@ -2972,6 +3129,46 @@ fn count_project(
         )
         .optional()?;
     Ok(u64::try_from(n.unwrap_or(0)).unwrap_or(0))
+}
+
+/// Cross-project link degree for a project: `(dependents, dependencies)`.
+/// `dependents` = distinct other projects whose pages link into this one;
+/// `dependencies` = distinct other projects this one links out to. Counts
+/// resolved links only (`to_page_id` is set); project ids are globally
+/// unique, so a bare `!= project_id` excludes self across all workspaces.
+fn cross_project_degree(
+    conn: &Connection,
+    workspace_id: WorkspaceId,
+    project_id: ProjectId,
+) -> StoreResult<(u64, u64)> {
+    let dependents: Option<i64> = conn
+        .query_row(
+            "SELECT COUNT(DISTINCT fp.project_id) \
+             FROM links l \
+             JOIN pages tp ON tp.id = l.to_page_id \
+                 AND tp.workspace_id = ?1 AND tp.project_id = ?2 AND tp.is_latest = 1 \
+             JOIN pages fp ON fp.id = l.from_page_id AND fp.is_latest = 1 \
+             WHERE fp.project_id != ?2",
+            params![workspace_id.as_bytes(), project_id.as_bytes()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let dependencies: Option<i64> = conn
+        .query_row(
+            "SELECT COUNT(DISTINCT tp.project_id) \
+             FROM links l \
+             JOIN pages fp ON fp.id = l.from_page_id \
+                 AND fp.workspace_id = ?1 AND fp.project_id = ?2 AND fp.is_latest = 1 \
+             JOIN pages tp ON tp.id = l.to_page_id AND tp.is_latest = 1 \
+             WHERE tp.project_id != ?2",
+            params![workspace_id.as_bytes(), project_id.as_bytes()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok((
+        u64::try_from(dependents.unwrap_or(0)).unwrap_or(0),
+        u64::try_from(dependencies.unwrap_or(0)).unwrap_or(0),
+    ))
 }
 
 fn count_workspace(conn: &Connection, sql: &str, workspace_id: WorkspaceId) -> StoreResult<u64> {

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -276,6 +276,11 @@ pub struct RelatedPage {
     pub title: String,
     /// Semantic kind of the related page.
     pub kind: String,
+    /// Workspace the related page lives in. Lets a backlink from another
+    /// project be labelled / navigated (the cross-project dependency signal).
+    pub workspace: String,
+    /// Project the related page lives in.
+    pub project: String,
 }
 
 /// Resolved outgoing links and incoming back-links for one page.
@@ -2108,11 +2113,14 @@ impl ReaderPool {
                                     WHEN pg.path LIKE 'gotchas/%' THEN 'gotcha' \
                                     ELSE 'fact' \
                                 END \
-                            ) \
+                            ), \
+                            ws.name, pr.name \
                      FROM links l \
                      JOIN pages pg ON pg.id = l.to_page_id \
+                     JOIN projects pr ON pr.id = pg.project_id \
+                     JOIN workspaces ws ON ws.id = pg.workspace_id \
                      WHERE l.from_page_id = ?1 AND pg.is_latest = 1 \
-                     ORDER BY pg.path";
+                     ORDER BY ws.name, pr.name, pg.path";
             let incoming = "SELECT DISTINCT pg.path, pg.title, \
                             COALESCE( \
                                 json_extract(pg.frontmatter_json, '$.kind'), \
@@ -2122,11 +2130,14 @@ impl ReaderPool {
                                     WHEN pg.path LIKE 'gotchas/%' THEN 'gotcha' \
                                     ELSE 'fact' \
                                 END \
-                            ) \
+                            ), \
+                            ws.name, pr.name \
                      FROM links l \
                      JOIN pages pg ON pg.id = l.from_page_id \
+                     JOIN projects pr ON pr.id = pg.project_id \
+                     JOIN workspaces ws ON ws.id = pg.workspace_id \
                      WHERE l.to_page_id = ?1 AND pg.is_latest = 1 \
-                     ORDER BY pg.path";
+                     ORDER BY ws.name, pr.name, pg.path";
 
             let collect = |sql: &str| -> StoreResult<Vec<RelatedPage>> {
                 let mut stmt = conn.prepare(sql)?;
@@ -2135,6 +2146,8 @@ impl ReaderPool {
                         path: row.get(0)?,
                         title: row.get(1)?,
                         kind: row.get(2)?,
+                        workspace: row.get(3)?,
+                        project: row.get(4)?,
                     })
                 })?;
                 let mut out = Vec::new();

--- a/crates/ai-memory-web/src/routes/api.rs
+++ b/crates/ai-memory-web/src/routes/api.rs
@@ -54,6 +54,7 @@ pub(crate) fn build(state: Arc<WebState>) -> Router {
             "/workspaces/{workspace}/projects/{project}/overview",
             axum::routing::get(project_overview_handler),
         )
+        .route("/graph", axum::routing::get(graph_handler))
         .with_state(state)
 }
 
@@ -87,6 +88,23 @@ async fn workspaces_handler(State(state): State<Arc<WebState>>) -> Result<Respon
         .map_err(internal_error)?;
     Ok(with_cache(
         Json(workspaces).into_response(),
+        LIST_CACHE_MAX_AGE,
+    ))
+}
+
+/// Cross-project dependency graph: every resolved link whose endpoints are
+/// in different projects, each carrying both endpoints' workspace/project/
+/// path. The UI builds nodes from the endpoints (and may aggregate to a
+/// project-level dependency graph). Global for now; project scoping is a
+/// follow-up query param.
+async fn graph_handler(State(state): State<Arc<WebState>>) -> Result<Response, Response> {
+    let edges = state
+        .reader
+        .cross_project_edges(None)
+        .await
+        .map_err(internal_error)?;
+    Ok(with_cache(
+        Json(serde_json::json!({ "edges": edges })).into_response(),
         LIST_CACHE_MAX_AGE,
     ))
 }

--- a/crates/ai-memory-wiki/src/markdown.rs
+++ b/crates/ai-memory-wiki/src/markdown.rs
@@ -8,7 +8,7 @@
 
 use std::collections::BTreeSet;
 
-use ai_memory_core::PagePath;
+use ai_memory_core::{LinkTarget, PagePath};
 use serde::{Deserialize, Serialize};
 
 use crate::error::WikiResult;
@@ -102,15 +102,21 @@ pub fn derive_title(frontmatter: &serde_json::Value, body: &str, path: &PagePath
     stem.strip_suffix(".md").unwrap_or(stem).to_string()
 }
 
+/// A normalised link key: `(workspace, project, path)`. `workspace` and
+/// `project` are `None` for a link that resolves within the source page's
+/// own project. Collected in a `BTreeSet` so output is deduped + stable.
+type LinkKey = (Option<String>, Option<String>, String);
+
 /// Extract internal wiki links from a markdown body.
 ///
-/// Supports `[[wiki links]]`, `[[wiki links|labels]]`, and ordinary
-/// markdown links such as `[label](../decisions/foo.md#anchor)`. External
-/// URLs, anchors, images, and non-markdown assets are ignored. Returned
-/// paths are normalised to wiki-root-relative [`PagePath`] values.
+/// Supports `[[wiki links]]`, `[[wiki links|labels]]`, cross-project
+/// `[[project:path]]` / `[[workspace/project:path]]` wikilinks, and
+/// ordinary markdown links such as `[label](../decisions/foo.md#anchor)`.
+/// External URLs, anchors, images, and non-markdown assets are ignored.
+/// Returned values are normalised to wiki-root-relative [`LinkTarget`]s.
 #[must_use]
-pub fn extract_links(body: &str, page_path: &PagePath) -> Vec<PagePath> {
-    let mut out = BTreeSet::new();
+pub fn extract_links(body: &str, page_path: &PagePath) -> Vec<LinkTarget> {
+    let mut out: BTreeSet<LinkKey> = BTreeSet::new();
     let mut in_fence = false;
 
     for line in body.lines() {
@@ -127,11 +133,54 @@ pub fn extract_links(body: &str, page_path: &PagePath) -> Vec<PagePath> {
     }
 
     out.into_iter()
-        .filter_map(|path| PagePath::new(path).ok())
+        .filter_map(|(workspace, project, path)| {
+            PagePath::new(path).ok().map(|path| LinkTarget {
+                workspace,
+                project,
+                path,
+            })
+        })
         .collect()
 }
 
-fn extract_wikilinks(line: &str, page_path: &PagePath, out: &mut BTreeSet<String>) {
+/// Split an optional `[workspace/]project:` scope qualifier off the front
+/// of a wikilink target. Returns `(workspace, project, path_part)`. URL and
+/// scheme-prefixed targets carry no scope (the `:` belongs to the scheme);
+/// [`normalize_link_target`] rejects those downstream.
+fn split_scope(target: &str) -> LinkKey {
+    let lower = target.to_ascii_lowercase();
+    if target.contains("://")
+        || lower.starts_with("mailto:")
+        || lower.starts_with("data:")
+        || lower.starts_with("javascript:")
+        || lower.starts_with("tel:")
+    {
+        return (None, None, target.to_string());
+    }
+    if let Some((scope, rest)) = target.split_once(':') {
+        let scope = scope.trim();
+        let scope_ok = !scope.is_empty()
+            && scope
+                .chars()
+                .all(|c| c.is_alphanumeric() || matches!(c, '-' | '_' | '/' | '.'));
+        if scope_ok {
+            let (workspace, project) = match scope.split_once('/') {
+                Some((ws, proj)) => (Some(ws.trim().to_string()), proj.trim()),
+                None => (None, scope),
+            };
+            if !project.is_empty() {
+                return (
+                    workspace,
+                    Some(project.to_string()),
+                    rest.trim().to_string(),
+                );
+            }
+        }
+    }
+    (None, None, target.to_string())
+}
+
+fn extract_wikilinks(line: &str, page_path: &PagePath, out: &mut BTreeSet<LinkKey>) {
     let mut rest = line;
     while let Some(start) = rest.find("[[") {
         let after_start = &rest[start + 2..];
@@ -139,14 +188,18 @@ fn extract_wikilinks(line: &str, page_path: &PagePath, out: &mut BTreeSet<String
             break;
         };
         let raw = &after_start[..end];
-        if let Some(path) = normalize_link_target(raw, page_path, true) {
-            out.insert(path);
+        // Strip the `|label` first, then peel any cross-project scope so the
+        // remaining path normalises the same way a bare wikilink does.
+        let unlabelled = raw.split_once('|').map_or(raw, |(target, _)| target).trim();
+        let (workspace, project, path_part) = split_scope(unlabelled);
+        if let Some(path) = normalize_link_target(&path_part, page_path, true) {
+            out.insert((workspace, project, path));
         }
         rest = &after_start[end + 2..];
     }
 }
 
-fn extract_markdown_links(line: &str, page_path: &PagePath, out: &mut BTreeSet<String>) {
+fn extract_markdown_links(line: &str, page_path: &PagePath, out: &mut BTreeSet<LinkKey>) {
     let mut start_at = 0;
     while let Some(rel_start) = line[start_at..].find('[') {
         let start = start_at + rel_start;
@@ -170,7 +223,7 @@ fn extract_markdown_links(line: &str, page_path: &PagePath, out: &mut BTreeSet<S
         let target_end = target_start + rel_end;
         let raw = &line[target_start..target_end];
         if let Some(path) = normalize_link_target(raw, page_path, false) {
-            out.insert(path);
+            out.insert((None, None, path));
         }
         start_at = target_end + 1;
     }
@@ -249,6 +302,48 @@ fn resolve_relative(page_path: &PagePath, target: &str, root_relative: bool) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn page() -> PagePath {
+        PagePath::new("notes/here.md").unwrap()
+    }
+
+    #[test]
+    fn extract_links_bare_wikilink_is_local() {
+        let links = extract_links("see [[decisions/0001.md]] and [[other]]", &page());
+        assert!(links.iter().all(|l| !l.is_cross_project()));
+        assert!(
+            links
+                .iter()
+                .any(|l| l.path.as_str() == "decisions/0001.md" && l.project.is_none())
+        );
+        // bare name gets `.md` appended, still local
+        assert!(links.iter().any(|l| l.path.as_str() == "other.md"));
+    }
+
+    #[test]
+    fn extract_links_cross_project_wikilink() {
+        let links = extract_links("dep on [[infra:runbooks/02.md]]", &page());
+        let l = links.iter().find(|l| l.is_cross_project()).expect("xproj");
+        assert_eq!(l.workspace, None);
+        assert_eq!(l.project.as_deref(), Some("infra"));
+        assert_eq!(l.path.as_str(), "runbooks/02.md");
+    }
+
+    #[test]
+    fn extract_links_cross_workspace_wikilink_with_label() {
+        let links = extract_links("[[zommehq/zomme:decisions/adr-1.md|the ADR]]", &page());
+        let l = links.iter().find(|l| l.is_cross_project()).expect("xws");
+        assert_eq!(l.workspace.as_deref(), Some("zommehq"));
+        assert_eq!(l.project.as_deref(), Some("zomme"));
+        assert_eq!(l.path.as_str(), "decisions/adr-1.md");
+    }
+
+    #[test]
+    fn extract_links_url_wikilink_is_not_a_scope() {
+        // `https://...` must not be parsed as project "https".
+        let links = extract_links("[[https://example.com]] [[mailto:a@b.com]]", &page());
+        assert!(links.is_empty(), "URLs/schemes are not links: {links:?}");
+    }
 
     #[test]
     fn parses_frontmatter_and_body() {
@@ -350,7 +445,7 @@ mod tests {
                     [gotcha](../gotchas/hooks.md#details). Also \
                     [external](https://example.com) and ![image](../img/logo.png).";
         let links = extract_links(body, &path);
-        let paths: Vec<&str> = links.iter().map(PagePath::as_str).collect();
+        let paths: Vec<&str> = links.iter().map(|l| l.path.as_str()).collect();
         assert_eq!(
             paths,
             vec!["decisions/0001-single-sqlite-file.md", "gotchas/hooks.md"]
@@ -362,7 +457,7 @@ mod tests {
         let path = PagePath::new("notes/a.md").unwrap();
         let body = "```\n[[notes/ignored]]\n```\n[[notes/kept]]\n";
         let links = extract_links(body, &path);
-        let paths: Vec<&str> = links.iter().map(PagePath::as_str).collect();
+        let paths: Vec<&str> = links.iter().map(|l| l.path.as_str()).collect();
         assert_eq!(paths, vec!["notes/kept.md"]);
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,7 +160,7 @@ backpressure, or single-writer SQLite actor.
 | `pages_fts` | FTS5 virtual table over `(title, body)`, auto-synced by triggers. |
 | `sessions`, `observations` | Hook capture, full audit log. |
 | `observations_fts` | FTS5 virtual table over raw observation `(title, body)`, used only as bounded fallback. |
-| `links` | Wikilink / markdown cross-references with `to_page_id` nullable for unresolved forward links. |
+| `links` | Wikilink / markdown cross-references. `to_page_id` (a global PageId) is nullable for unresolved forward links. `to_workspace` / `to_project` carry a cross-project scope (NULL = the source page's own project). |
 | `handoffs` | Typed cross-agent handoff records (open / accepted / expired). |
 | `page_embeddings` | Optional vector rows for latest pages, with `(provider, model, dim)` denormalised so hybrid search can ignore stale vectors after an embedding config change and report missing-embedding diagnostics. |
 | `audit_log` | Every mutation, addressable by `at DESC`. |
@@ -184,6 +184,32 @@ focus and pending items. Use `invariant` for high-resistance project
 context, identity, rules, or user preferences; consolidation should not
 rewrite an existing invariant slot unless new observations directly
 contradict specific existing content.
+
+## Cross-project links
+
+Pages normally link within their own project (`[[decisions/0001.md]]`,
+`[label](../gotchas/x.md)`). A wikilink can also name another project so
+that dependencies between projects become explicit edges in the graph:
+
+* `[[project:path.md]]` — a sibling project in the same workspace.
+* `[[workspace/project:path.md]]` — a project in another workspace.
+
+The parser (`ai-memory-wiki::extract_links`) yields a `LinkTarget
+{ workspace, project, path }`; the store resolves it against the named
+project's latest page and records the scope in `links.to_workspace` /
+`links.to_project` (NULL = the source's own project, the common case).
+Resolution is deferred-safe: a link to a page that does not exist yet
+stays `to_page_id = NULL` and is repointed by
+`refresh_incoming_links_for_path` when that page later lands — across
+projects, not only within one.
+
+Because `to_page_id` is a global id and `ReaderPool::page_links` joins by
+id without a project filter, a resolved cross-project link surfaces as a
+backlink on its target for free; `RelatedPage` carries the source's
+`workspace` / `project` so the dependency is labelled and navigable. This
+is what turns the per-project wikis into one dependency graph (see also
+the `memory_lint` dangling-ref check, the briefing dependents counts, and
+the `/api/v1/graph` endpoint).
 
 ## Crate layout
 


### PR DESCRIPTION
## What
Wiki links can name another project, turning the per-project wikis into one dependency graph:

- `[[project:path.md]]` — a sibling project in the same workspace
- `[[workspace/project:path.md]]` — a project in another workspace

Bare links are unchanged (resolve within the source's own project). On top of the link primitive:
- **lint** reports dangling cross-project refs (typo'd project vs missing/renamed target page)
- **briefing** exposes `cross_project_dependents` / `cross_project_dependencies` per project
- **`GET /api/v1/graph`** returns the resolved cross-project edges for a graph view

## Why
Projects depend on each other (an app on shared infra/ops notes), but there was no way to make that explicit. Once it's an edge, the dependency is visible (graph, briefing) and breakage is catchable (lint).

## Design
- `links.to_page_id` is already a global id and `page_links` joins by id without a project filter — so a resolved cross-project link surfaces as a backlink for free. This wires authoring + resolution + display: `LinkTarget { workspace, project, path }`, a scope-aware resolver, deferred re-resolution across projects when a target lands later, and `RelatedPage` carrying the source's workspace/project.
- Migration rebuilds `links` with `to_workspace`/`to_project` in the PK. The migration version is provisional (V12 in our tree) — renumber to the next free upstream version on merge.

## Verification
- `cargo fmt` / `clippy -D warnings` — clean
- `cargo test --workspace` — green except the ambient `commands::reset::tests::*` (alive-process abort; same on upstream/main)
- New tests cover parsing (bare / cross-project / cross-workspace / URL), cross-project resolution, and graph+briefing+lint off one fixture