### PR TITLE
feat(search): relevance-ranked recall — OR-join queries + accent-insensitive FTS

### DIFF
--- a/crates/ai-memory-store/migrations/V13__fts_remove_diacritics.sql
+++ b/crates/ai-memory-store/migrations/V13__fts_remove_diacritics.sql
@@ -1,0 +1,70 @@
+-- Accent-insensitive full-text search (Portuguese-friendly).
+--
+-- The FTS5 tables were created with `unicode61 tokenchars '/_-'`, which keeps
+-- diacritics: a query for "descricao" never matches stored "descrição". The
+-- tokenizer is fixed at CREATE time, so the only way to change it is to drop
+-- and recreate the FTS table (+ its sync triggers) and rebuild from the
+-- content table. `remove_diacritics 2` folds diacritics across the full
+-- Unicode range, so "descricao"/"descrição", "sessao"/"sessão", etc. unify.
+--
+-- Both FTS tables are contentless (`content='pages'` / `content='observations'`),
+-- so the source rows are untouched; only the derived index is rebuilt.
+
+-- ── pages_fts ────────────────────────────────────────────────────────────
+DROP TRIGGER pages_fts_ai;
+DROP TRIGGER pages_fts_ad;
+DROP TRIGGER pages_fts_au;
+DROP TABLE pages_fts;
+
+CREATE VIRTUAL TABLE pages_fts USING fts5(
+    title, body,
+    content='pages',
+    content_rowid='rowid',
+    tokenize="unicode61 remove_diacritics 2 tokenchars '/_-'"
+);
+INSERT INTO pages_fts(pages_fts) VALUES('rebuild');
+
+CREATE TRIGGER pages_fts_ai AFTER INSERT ON pages BEGIN
+    INSERT INTO pages_fts(rowid, title, body)
+        VALUES (new.rowid, new.title, new.body);
+END;
+CREATE TRIGGER pages_fts_ad AFTER DELETE ON pages BEGIN
+    INSERT INTO pages_fts(pages_fts, rowid, title, body)
+        VALUES ('delete', old.rowid, old.title, old.body);
+END;
+-- Matches the V08 narrowing: only re-index on title/body updates.
+CREATE TRIGGER pages_fts_au AFTER UPDATE OF title, body ON pages BEGIN
+    INSERT INTO pages_fts(pages_fts, rowid, title, body)
+        VALUES ('delete', old.rowid, old.title, old.body);
+    INSERT INTO pages_fts(rowid, title, body)
+        VALUES (new.rowid, new.title, new.body);
+END;
+
+-- ── observations_fts ──────────────────────────────────────────────────────
+DROP TRIGGER observations_fts_ai;
+DROP TRIGGER observations_fts_ad;
+DROP TRIGGER observations_fts_au;
+DROP TABLE observations_fts;
+
+CREATE VIRTUAL TABLE observations_fts USING fts5(
+    title, body,
+    content='observations',
+    content_rowid='rowid',
+    tokenize="unicode61 remove_diacritics 2 tokenchars '/_-'"
+);
+INSERT INTO observations_fts(observations_fts) VALUES('rebuild');
+
+CREATE TRIGGER observations_fts_ai AFTER INSERT ON observations BEGIN
+    INSERT INTO observations_fts(rowid, title, body)
+        VALUES (new.rowid, new.title, new.body);
+END;
+CREATE TRIGGER observations_fts_ad AFTER DELETE ON observations BEGIN
+    INSERT INTO observations_fts(observations_fts, rowid, title, body)
+        VALUES ('delete', old.rowid, old.title, old.body);
+END;
+CREATE TRIGGER observations_fts_au AFTER UPDATE ON observations BEGIN
+    INSERT INTO observations_fts(observations_fts, rowid, title, body)
+        VALUES ('delete', old.rowid, old.title, old.body);
+    INSERT INTO observations_fts(rowid, title, body)
+        VALUES (new.rowid, new.title, new.body);
+END;

--- a/crates/ai-memory-store/src/fts_query.rs
+++ b/crates/ai-memory-store/src/fts_query.rs
@@ -10,13 +10,31 @@
 ///
 /// Returns an empty string when `raw` is empty/whitespace-only; callers
 /// should skip the SQL query in that case.
+///
+/// Bare multi-word queries are joined with **`OR`**, not the FTS5 default
+/// (`AND`). A natural-language query like "cross project search strategy"
+/// otherwise requires every word to co-occur in one page — near-zero recall
+/// for anything but single keywords. With `OR` + bm25 ranking (callers
+/// `ORDER BY rank`), the best-matching pages still surface first. When the
+/// caller supplies explicit FTS5 syntax (`OR` / `AND` / `NOT` / `NEAR` /
+/// quoted phrases / parens) we preserve it verbatim instead.
 #[must_use]
 pub fn prepare_fts5_query(raw: &str) -> String {
+    let explicit_syntax = raw.contains('"')
+        || raw.contains('(')
+        || raw.contains(')')
+        || raw
+            .split_whitespace()
+            .any(|t| matches!(t, "OR" | "AND" | "NOT" | "NEAR"));
     let tokens: Vec<String> = raw
         .split_whitespace()
         .flat_map(prepare_fts5_token)
         .collect();
-    tokens.join(" ")
+    if tokens.is_empty() {
+        return String::new();
+    }
+    let separator = if explicit_syntax { " " } else { " OR " };
+    tokens.join(separator)
 }
 
 fn prepare_fts5_token(token: &str) -> Vec<String> {
@@ -58,8 +76,33 @@ mod tests {
 
     #[test]
     fn colon_is_not_column_syntax() {
+        // Bare multi-word → OR-joined (no explicit operator present).
         let q = prepare_fts5_query("pick: handoff ai-memory");
-        assert_eq!(q, "\"pick\" handoff \"ai-memory\"");
+        assert_eq!(q, "\"pick\" OR handoff OR \"ai-memory\"");
+    }
+
+    #[test]
+    fn bare_multi_word_is_or_joined() {
+        // The recall fix: every word no longer has to co-occur.
+        assert_eq!(
+            prepare_fts5_query("cross project search strategy"),
+            "cross OR project OR search OR strategy"
+        );
+    }
+
+    #[test]
+    fn portuguese_accented_terms_or_join_and_keep_accents() {
+        // PT natural-language query: tokens preserved (accents intact),
+        // joined with OR so a page matching any term is found.
+        assert_eq!(
+            prepare_fts5_query("descrição testes commits"),
+            "descrição OR testes OR commits"
+        );
+    }
+
+    #[test]
+    fn single_word_has_no_or() {
+        assert_eq!(prepare_fts5_query("handoff"), "handoff");
     }
 
     #[test]

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -415,6 +415,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn search_is_accent_insensitive() {
+        // V13: an accent-free query matches accented stored text (PT-friendly).
+        let tmp = TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let ws = store
+            .writer
+            .get_or_create_workspace("default")
+            .await
+            .unwrap();
+        let proj = store
+            .writer
+            .get_or_create_project(ws, "scratch", None)
+            .await
+            .unwrap();
+        store
+            .writer
+            .upsert_page(sample_page(
+                ws,
+                proj,
+                "notes/decisao.md",
+                "a descrição da sessão e a consolidação dos commits",
+            ))
+            .await
+            .unwrap();
+
+        let hits = store
+            .reader
+            .search_pages("descricao sessao".into(), 10)
+            .await
+            .unwrap();
+        assert!(
+            !hits.is_empty(),
+            "accent-free query must match accented stored text"
+        );
+    }
+
+    #[tokio::test]
     async fn search_boolean_or_still_works() {
         let tmp = TempDir::new().unwrap();
         let store = Store::open(tmp.path()).unwrap();


### PR DESCRIPTION
## The problem
`prepare_fts5_query` joins query tokens with a space, which FTS5 reads as **AND**: every word must co-occur in one page. For a recall system that's a sharp recall cliff, and it fails silently — the caller gets zero rows and concludes "never recorded."

Concrete failures with the current behavior:

- **Natural-language queries return nothing.** An agent asking *"have we discussed cross project search strategy"* runs `MATCH 'cross project search strategy'` → AND → **0 hits**, even when a page matches 3 of the 4 words. Single-keyword queries work, which masks the bug; multi-word queries (how agents actually phrase recall) silently miss.
- **Portuguese / accents.** `"descricao da sessao"` never matches stored `"descrição da sessão"` — the `unicode61` tokenizer keeps diacritics, so an accent-free query (common when typing fast or from logs) finds nothing.

Both were hit in real usage: multi-term recall queries that *should* have matched returned empty, and the failure was invisible.

## The change
1. **OR-join bare tokens** (with bm25 ranking the callers already apply via `ORDER BY rank`). A query for N words now matches pages containing *any* of them, ranked by relevance — pages matching more (and rarer) terms rank first, so the top results are still the "AND-ish" matches; OR just adds a relevant tail instead of returning nothing. Explicit FTS5 syntax (`OR`/`AND`/`NOT`/`NEAR`, quoted phrases, parens) is detected and preserved verbatim — so exact-match is still available as an escape hatch.
2. **Accent-insensitive FTS** — rebuild the FTS tables (+ sync triggers) with `unicode61 remove_diacritics 2`, so `"descricao"` matches `"descrição"`. Contentless FTS, so source rows are untouched. (Migration version is provisional — renumber to the next free upstream version on merge.)

## Why OR is the right default (not AND)
For retrieval, recall + ranking beats precision-by-exclusion: bm25 already orders by relevance, so OR doesn't flood — it ranks. AND-default optimizes for "all words present," which is the surprising choice for a search box; every mainstream engine defaults to OR + ranking. Callers who want strict AND keep it via explicit operators / quotes.

## Verification
- `cargo fmt` / `clippy -D warnings` — clean
- `cargo test --workspace` — green except the ambient `commands::reset::tests::*`
- New: `bare_multi_word_is_or_joined`, `portuguese_accented_terms_or_join_and_keep_accents`, `single_word_has_no_or`, `search_is_accent_insensitive`