### PR TITLE
feat(admin): move-project — move a project into another workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ priors are at the [bottom](#influences-and-prior-art).
   Server runs local (loopback) OR on a homelab box (LAN/VPN/cloud)
   with bearer-token auth.
 - **Thin-client CLI.** `ai-memory status`, `bootstrap`, `purge-project`,
-  `rename-project`, `lint`, `embed`, `forget-sweep`, `backup` are
+  `rename-project`, `move-project`, `lint`, `embed`, `forget-sweep`, `backup` are
   all HTTP clients of the running server - never touch SQLite or
   wiki files directly. `status` also reports passive LLM/embedding
   provider health from the last real provider call. Server is the

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -96,11 +96,12 @@ pub enum Command {
     /// Useful after renaming the project's directory on disk so the hook
     /// router keeps writing into the same logical project.
     RenameProject(RenameProjectArgs),
-    /// Move a project into another workspace. Copies every latest page into
-    /// the destination (a NEW project, or MERGES into an existing same-named
-    /// one) through the normal write path, then PURGES the source. The
-    /// source-side purge is irreversible — requires `--confirm`. Note:
-    /// sessions/observations/handoffs do NOT migrate (only durable pages).
+    /// Move a project into another workspace. A fresh destination is a
+    /// lossless TRUE MOVE (re-stamp workspace_id, keep project_id, rename the
+    /// dir) — sessions/observations/handoffs and history all survive. A
+    /// destination that already holds a same-named project MERGES via
+    /// copy+purge (only durable pages migrate, source purged). Either way the
+    /// operation is irreversible — requires `--confirm`.
     MoveProject(MoveProjectArgs),
     /// Remove ai-memory's wiring (hooks, MCP, instructions) from all
     /// detected agents. Dry-run unless `--apply`.
@@ -360,8 +361,8 @@ pub struct MoveProjectArgs {
     /// Destination workspace. Auto-created if it doesn't exist.
     #[arg(long)]
     pub to_workspace: String,
-    /// REQUIRED — the move PURGES the source project after copying.
-    /// Without this flag the CLI errors out.
+    /// REQUIRED — the move re-stamps (true-move) or copies+purges (merge) the
+    /// source, both irreversible. Without this flag the CLI errors out.
     #[arg(long)]
     pub confirm: bool,
 }

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -96,6 +96,12 @@ pub enum Command {
     /// Useful after renaming the project's directory on disk so the hook
     /// router keeps writing into the same logical project.
     RenameProject(RenameProjectArgs),
+    /// Move a project into another workspace. Copies every latest page into
+    /// the destination (a NEW project, or MERGES into an existing same-named
+    /// one) through the normal write path, then PURGES the source. The
+    /// source-side purge is irreversible — requires `--confirm`. Note:
+    /// sessions/observations/handoffs do NOT migrate (only durable pages).
+    MoveProject(MoveProjectArgs),
     /// Remove ai-memory's wiring (hooks, MCP, instructions) from all
     /// detected agents. Dry-run unless `--apply`.
     Uninstall(UninstallArgs),
@@ -339,6 +345,25 @@ pub struct RenameProjectArgs {
     /// New project name. Must be non-empty and contain no slashes.
     #[arg(long)]
     pub to: String,
+}
+
+/// Arguments for `move-project`.
+#[derive(Debug, Args)]
+pub struct MoveProjectArgs {
+    /// Source workspace. Defaults to `default`.
+    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
+    pub from_workspace: String,
+    /// Project name to move. When omitted, auto-derived from the basename
+    /// of the current git repo root (or CWD if no git repo).
+    #[arg(long)]
+    pub project: Option<String>,
+    /// Destination workspace. Auto-created if it doesn't exist.
+    #[arg(long)]
+    pub to_workspace: String,
+    /// REQUIRED — the move PURGES the source project after copying.
+    /// Without this flag the CLI errors out.
+    #[arg(long)]
+    pub confirm: bool,
 }
 
 /// Arguments for `install-instructions`.

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -371,6 +371,13 @@ pub struct MoveProjectArgs {
     /// and the schema rejects any stale write).
     #[arg(long)]
     pub force: bool,
+    /// Merge conflict policy (copy-purge path only): what to do when a source
+    /// page's path already exists in the destination with different content.
+    /// `block` (default) aborts and lists the conflicts; `overwrite` lets the
+    /// source supersede the destination page; `duplicate` keeps both (source
+    /// lands under a de-duplicated path).
+    #[arg(long, value_parser = ["block", "overwrite", "duplicate"], default_value = "block")]
+    pub on_conflict: String,
 }
 
 /// Arguments for `install-instructions`.

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -365,6 +365,12 @@ pub struct MoveProjectArgs {
     /// source, both irreversible. Without this flag the CLI errors out.
     #[arg(long)]
     pub confirm: bool,
+    /// Override the live-session guard. By default the server refuses (409) to
+    /// move the project a hook session is actively writing to; `--force`
+    /// proceeds anyway (still safe — the move keeps the active pointer correct
+    /// and the schema rejects any stale write).
+    #[arg(long)]
+    pub force: bool,
 }
 
 /// Arguments for `install-instructions`.

--- a/crates/ai-memory-cli/src/commands/mod.rs
+++ b/crates/ai-memory-cli/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub mod install_instructions;
 pub mod install_mcp;
 pub mod lint;
 pub mod llm_test;
+pub mod move_project;
 pub mod openclaw_plugin;
 pub mod purge_project;
 pub mod read_page;

--- a/crates/ai-memory-cli/src/commands/move_project.rs
+++ b/crates/ai-memory-cli/src/commands/move_project.rs
@@ -20,7 +20,8 @@ struct MoveProjectRequest {
 ///
 /// Resolves the source project name (auto-derived from the git repo root
 /// when `--project` is omitted), requires `--confirm` before sending the
-/// request (it purges the source after copying), then prints the report.
+/// request (a true-move re-stamp or a copy+purge merge, both irreversible),
+/// then prints the report.
 ///
 /// # Errors
 /// Returns an error when `--confirm` is absent, the server is unreachable,
@@ -54,35 +55,38 @@ pub async fn run(config: &Config, args: MoveProjectArgs) -> Result<()> {
     )
     .await?;
 
-    let copied = report["pages_copied"].as_u64().unwrap_or(0);
+    let pages = report["pages_copied"].as_u64().unwrap_or(0);
     let purged = report["source_purged"].as_bool().unwrap_or(false);
-    let merged = report["merged_into_existing"].as_bool().unwrap_or(false);
-    println!(
-        "Moved {}/{} → {}/{}: {copied} pages copied{}{}.",
-        args.from_workspace,
-        project,
-        args.to_workspace,
-        project,
-        if merged {
-            " (merged into existing project)"
-        } else {
-            ""
-        },
-        if purged {
+    let moved_via = report["moved_via"].as_str().unwrap_or("");
+    let skipped_count = report["pages_skipped"].as_array().map_or(0, |s| s.len());
+
+    if moved_via == "true-move" {
+        // Lossless: re-stamped in place, nothing copied or purged.
+        println!(
+            "Moved {}/{} → {}/{}: {pages} pages re-stamped (true move — \
+             sessions, observations and history preserved).",
+            args.from_workspace, project, args.to_workspace, project,
+        );
+    } else {
+        // copy-purge (merge into an existing same-named project).
+        let tail = if skipped_count > 0 {
+            ", SOURCE LEFT INTACT (some pages unreadable — fix and re-run)"
+        } else if purged {
             ", source purged"
         } else {
             ", SOURCE LEFT INTACT (partial copy)"
-        },
-    );
-
-    if let Some(skipped) = report["pages_skipped"].as_array()
-        && !skipped.is_empty()
-    {
+        };
         println!(
-            "Warning: {} page(s) could not be read from the source and were \
-             skipped; the source was NOT purged. Fix and re-run.",
-            skipped.len()
+            "Moved {}/{} → {}/{}: {pages} pages copied (merged into existing \
+             project){tail}.",
+            args.from_workspace, project, args.to_workspace, project,
         );
+        if skipped_count > 0 {
+            println!(
+                "Warning: {skipped_count} page(s) could not be read from the \
+                 source and were skipped; the source was NOT purged. Fix and re-run.",
+            );
+        }
     }
     Ok(())
 }

--- a/crates/ai-memory-cli/src/commands/move_project.rs
+++ b/crates/ai-memory-cli/src/commands/move_project.rs
@@ -1,0 +1,88 @@
+//! `ai-memory move-project` — thin HTTP client for cross-workspace project move.
+
+use anyhow::{Result, bail};
+use serde::Serialize;
+
+use crate::cli::MoveProjectArgs;
+use crate::config::Config;
+use crate::http_client::{ServerEndpoint, post_json};
+
+/// Request sent to `POST /admin/move-project`.
+#[derive(Serialize)]
+struct MoveProjectRequest {
+    from_workspace: String,
+    project: String,
+    to_workspace: String,
+    confirm: bool,
+}
+
+/// Run the `move-project` subcommand.
+///
+/// Resolves the source project name (auto-derived from the git repo root
+/// when `--project` is omitted), requires `--confirm` before sending the
+/// request (it purges the source after copying), then prints the report.
+///
+/// # Errors
+/// Returns an error when `--confirm` is absent, the server is unreachable,
+/// or the server returns a non-2xx response.
+pub async fn run(config: &Config, args: MoveProjectArgs) -> Result<()> {
+    let project = super::resolve_project_name(config, args.project.as_deref())?;
+
+    if !args.confirm {
+        bail!(
+            "move-project copies the project's pages into the destination \
+             workspace, then PURGES the source.\n\
+             Re-run with --confirm to proceed:\n\n  \
+             ai-memory move-project --from-workspace {} --project {} \
+             --to-workspace {} --confirm",
+            args.from_workspace,
+            project,
+            args.to_workspace,
+        );
+    }
+
+    let endpoint = ServerEndpoint::from_config(config);
+    let report: serde_json::Value = post_json(
+        &endpoint,
+        "/admin/move-project",
+        &MoveProjectRequest {
+            from_workspace: args.from_workspace.clone(),
+            project: project.clone(),
+            to_workspace: args.to_workspace.clone(),
+            confirm: true,
+        },
+    )
+    .await?;
+
+    let copied = report["pages_copied"].as_u64().unwrap_or(0);
+    let purged = report["source_purged"].as_bool().unwrap_or(false);
+    let merged = report["merged_into_existing"].as_bool().unwrap_or(false);
+    println!(
+        "Moved {}/{} → {}/{}: {copied} pages copied{}{}.",
+        args.from_workspace,
+        project,
+        args.to_workspace,
+        project,
+        if merged {
+            " (merged into existing project)"
+        } else {
+            ""
+        },
+        if purged {
+            ", source purged"
+        } else {
+            ", SOURCE LEFT INTACT (partial copy)"
+        },
+    );
+
+    if let Some(skipped) = report["pages_skipped"].as_array()
+        && !skipped.is_empty()
+    {
+        println!(
+            "Warning: {} page(s) could not be read from the source and were \
+             skipped; the source was NOT purged. Fix and re-run.",
+            skipped.len()
+        );
+    }
+    Ok(())
+}

--- a/crates/ai-memory-cli/src/commands/move_project.rs
+++ b/crates/ai-memory-cli/src/commands/move_project.rs
@@ -15,6 +15,7 @@ struct MoveProjectRequest {
     to_workspace: String,
     confirm: bool,
     force: bool,
+    on_conflict: String,
 }
 
 /// Run the `move-project` subcommand.
@@ -59,6 +60,7 @@ pub async fn run(config: &Config, args: MoveProjectArgs) -> Result<()> {
             to_workspace: args.to_workspace.clone(),
             confirm: true,
             force: args.force,
+            on_conflict: args.on_conflict.clone(),
         },
     )
     .await?;

--- a/crates/ai-memory-cli/src/commands/move_project.rs
+++ b/crates/ai-memory-cli/src/commands/move_project.rs
@@ -14,6 +14,7 @@ struct MoveProjectRequest {
     project: String,
     to_workspace: String,
     confirm: bool,
+    force: bool,
 }
 
 /// Run the `move-project` subcommand.
@@ -31,11 +32,17 @@ pub async fn run(config: &Config, args: MoveProjectArgs) -> Result<()> {
 
     if !args.confirm {
         bail!(
-            "move-project copies the project's pages into the destination \
-             workspace, then PURGES the source.\n\
+            "move-project moves {}/{} to workspace {}. If the destination has \
+             no same-named project it is a lossless true-move (re-stamp in \
+             place — sessions, observations and history preserved). If it \
+             already has one, the pages are copied in and merged, then the \
+             source is PURGED. Both are irreversible.\n\
              Re-run with --confirm to proceed:\n\n  \
              ai-memory move-project --from-workspace {} --project {} \
              --to-workspace {} --confirm",
+            args.from_workspace,
+            project,
+            args.to_workspace,
             args.from_workspace,
             project,
             args.to_workspace,
@@ -51,6 +58,7 @@ pub async fn run(config: &Config, args: MoveProjectArgs) -> Result<()> {
             project: project.clone(),
             to_workspace: args.to_workspace.clone(),
             confirm: true,
+            force: args.force,
         },
     )
     .await?;
@@ -86,6 +94,20 @@ pub async fn run(config: &Config, args: MoveProjectArgs) -> Result<()> {
                 "Warning: {skipped_count} page(s) could not be read from the \
                  source and were skipped; the source was NOT purged. Fix and re-run.",
             );
+        }
+        if let Some(conflicts) = report["conflicts"].as_array().filter(|c| !c.is_empty()) {
+            println!(
+                "{} path conflict(s) — source page kept under a de-duplicated path \
+                 (both versions preserved):",
+                conflicts.len()
+            );
+            for c in conflicts {
+                println!(
+                    "  {} → {}",
+                    c["path"].as_str().unwrap_or("?"),
+                    c["moved_to"].as_str().unwrap_or("?"),
+                );
+            }
         }
     }
     Ok(())

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -225,6 +225,7 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
                     .as_ref()
                     .filter(|p| !p.trim().is_empty())
                     .map(|p| ai_memory_store::TokenPepper::new(p.clone())),
+                active_project: active_project.clone(),
             });
             // Multi-rung auth assembly:
             //   - rung 0 (no bearer_token configured) → AuthState::new

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -190,6 +190,20 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
                     .with_stateful_mode(args.http_stateful)
                     .with_json_response(!args.http_stateful),
             );
+            // Shared per-cwd project cache: the hook router owns it; the admin
+            // router gets a fire-and-forget eviction hook so a `move-project`
+            // can proactively drop the moved project's stale entries.
+            let project_cache: ai_memory_hooks::ProjectCache =
+                std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+            let on_project_moved: std::sync::Arc<dyn Fn(ProjectId) + Send + Sync> = {
+                let cache = project_cache.clone();
+                std::sync::Arc::new(move |proj: ProjectId| {
+                    let cache = cache.clone();
+                    tokio::spawn(async move {
+                        cache.lock().await.retain(|_, v| v.1 != proj);
+                    });
+                })
+            };
             let hooks = hook_router(HookState {
                 workspace_id: ws,
                 project_id: proj,
@@ -198,9 +212,7 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
                 wiki: wiki.clone(),
                 consolidator: consolidator.clone(),
                 sanitizer: sanitizer.clone(),
-                project_cache: std::sync::Arc::new(tokio::sync::Mutex::new(
-                    std::collections::HashMap::new(),
-                )),
+                project_cache: project_cache.clone(),
                 active_project: active_project.clone(),
                 ingest_semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(
                     DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT,
@@ -226,6 +238,7 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
                     .filter(|p| !p.trim().is_empty())
                     .map(|p| ai_memory_store::TokenPepper::new(p.clone())),
                 active_project: active_project.clone(),
+                on_project_moved: Some(on_project_moved),
             });
             // Multi-rung auth assembly:
             //   - rung 0 (no bearer_token configured) → AuthState::new

--- a/crates/ai-memory-cli/src/main.rs
+++ b/crates/ai-memory-cli/src/main.rs
@@ -63,6 +63,7 @@ async fn main() -> Result<()> {
         Command::Reorg(args) => commands::reorg::run(&config, args).await,
         Command::PurgeProject(args) => commands::purge_project::run(&config, args).await,
         Command::RenameProject(args) => commands::rename_project::run(&config, args).await,
+        Command::MoveProject(args) => commands::move_project::run(&config, args).await,
         Command::Uninstall(args) => commands::uninstall::run(&config, args),
         Command::Auth(args) => commands::auth::run(&config, args).await,
         Command::User(args) => commands::user::run(&config, args).await,

--- a/crates/ai-memory-core/src/active_project.rs
+++ b/crates/ai-memory-core/src/active_project.rs
@@ -62,6 +62,14 @@ impl ActiveProject {
         let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
         *guard
     }
+
+    /// Forget the active project. Called after an admin operation invalidates
+    /// the published pointer (e.g. a `move-project` whose copy-purge path gives
+    /// the project a NEW id, so the old pointer no longer resolves).
+    pub fn clear(&self) {
+        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        *guard = None;
+    }
 }
 
 #[cfg(test)]

--- a/crates/ai-memory-hooks/src/lib.rs
+++ b/crates/ai-memory-hooks/src/lib.rs
@@ -27,5 +27,5 @@ pub mod synth;
 // pointing at this crate's `sanitize` module keep working.
 pub use ai_memory_core::{SanitizeConfig, Sanitized, Sanitizer};
 pub use payload::{HookEnvelope, HookEvent};
-pub use router::{DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT, HookState, hook_router};
+pub use router::{DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT, HookState, ProjectCache, hook_router};
 pub use synth::synthesize_session_page;

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -1026,6 +1026,95 @@ mod tests {
         assert!(counts.sessions >= 1, "recreated session must be persisted");
     }
 
+    /// The move-project hazard the (workspace_id, project_id) pairing trigger
+    /// exists for: when a cached project is MOVED to another workspace out from
+    /// under the router, the same `project_id` now belongs to a new workspace.
+    /// The next event must NOT silently write a split-brain row with the stale
+    /// workspace id — the trigger aborts that write, and the router evicts +
+    /// re-resolves into a consistent pair (exactly like the purge self-heal).
+    #[tokio::test]
+    async fn process_self_heals_when_cached_project_moved_workspaces() {
+        let tmp = TempDir::new().unwrap();
+        let state = make_state(&tmp).await;
+        let cwd = "/home/user/move-project";
+
+        // 1) First event creates + caches the project (in the default workspace).
+        let env1 = HookEnvelope::from_query_and_body(
+            HookQuery {
+                event: "user-prompt".into(),
+                agent: Some("claude-code".into()),
+                cwd: Some(cwd.into()),
+                ..Default::default()
+            },
+            serde_json::json!({ "sessionID": "move-sess-1" }),
+        );
+        process(&state, env1).await.unwrap();
+        let (ws, proj) =
+            resolve_project_ids(&state, Some(cwd), None, None, ProjectStrategy::Basename)
+                .await
+                .unwrap();
+
+        // 2) Move the project to another workspace (re-stamp workspace_id, same
+        //    project_id) — the cache still points at (default_ws, proj), now a
+        //    cross-workspace stale pair.
+        let dst_ws = state
+            .writer
+            .get_or_create_workspace("archive".to_string())
+            .await
+            .unwrap();
+        state
+            .writer
+            .move_project_workspace(proj, ws, dst_ws)
+            .await
+            .unwrap();
+        assert!(
+            state
+                .project_cache
+                .lock()
+                .await
+                .values()
+                .any(|ids| *ids == (ws, proj)),
+            "cache still holds the moved project's stale (workspace, project) pair"
+        );
+
+        // 3) Next event with the same cwd must NOT create a split-brain row: the
+        //    stale (default_ws, proj) write trips the pairing trigger, the router
+        //    evicts + re-resolves, and the event lands cleanly.
+        let env2 = HookEnvelope::from_query_and_body(
+            HookQuery {
+                event: "user-prompt".into(),
+                agent: Some("claude-code".into()),
+                cwd: Some(cwd.into()),
+                ..Default::default()
+            },
+            serde_json::json!({ "sessionID": "move-sess-2" }),
+        );
+        process(&state, env2)
+            .await
+            .expect("self-heal: stale cross-workspace pair must re-resolve, not write split-brain");
+
+        // 4) The moved project stayed in `dst_ws`; the cwd re-resolved to a
+        //    FRESH project back in the default workspace (never the stale pair).
+        assert_eq!(
+            state
+                .reader
+                .find_project(dst_ws, "move-project".to_string())
+                .await
+                .unwrap(),
+            Some(proj),
+            "moved project keeps its id in the destination workspace"
+        );
+        let (ws_new, proj_new) =
+            resolve_project_ids(&state, Some(cwd), None, None, ProjectStrategy::Basename)
+                .await
+                .unwrap();
+        assert_eq!(ws_new, ws, "re-resolved back into the default workspace");
+        assert_ne!(
+            proj_new, proj,
+            "a fresh project replaced the moved one for this cwd"
+        );
+    }
+
     #[tokio::test]
     async fn process_self_heal_evicts_project_strategy_cache_slot() {
         let tmp = TempDir::new().unwrap();

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -1694,8 +1694,46 @@ async fn handle_move_project(
         Err(e) => return internal_err(e.to_string()),
     };
 
-    // COPY each page through the canonical write path so sanitization, link
-    // re-resolution, FTS upsert (and admission/git-mirror on deploy) all fire.
+    // Carry the source page embeddings over verbatim instead of recomputing
+    // them — embedding is the dominant per-page cost of a bulk move. Writes go
+    // through an embedder-less Wiki so `write_page` never re-embeds; we then
+    // store each source vector against the new page id. Only embeddings
+    // computed with the CURRENTLY configured embedder ({provider,model,dim})
+    // are loaded (load_embeddings filters on them), so the "one model per
+    // index" invariant holds; any page lacking a current-model embedding is
+    // simply copied without one (backfill later via `ai-memory embed`).
+    let copy_wiki = state.wiki.clone().without_embedder();
+    let mut src_embeddings: std::collections::HashMap<String, Vec<u8>> =
+        std::collections::HashMap::new();
+    let embed_meta: Option<(String, String, u32)> = if let Some(embedder) = &state.embedder {
+        let (provider, model, dim) = (
+            embedder.provider().to_string(),
+            embedder.model().to_string(),
+            embedder.dim(),
+        );
+        match state
+            .reader
+            .load_embeddings(src_ws, src_proj, provider.clone(), model.clone(), dim)
+            .await
+        {
+            Ok(rows) => {
+                for e in rows {
+                    src_embeddings.insert(e.path.to_string(), f32_vec_to_bytes(&e.vector));
+                }
+                Some((provider, model, dim))
+            }
+            Err(e) => {
+                warn!(error = %e, "move-project: failed to load source embeddings; copies land without vectors");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    // COPY each page through the (embedder-less) write path so sanitization,
+    // link re-resolution, FTS upsert (and admission/git-mirror on deploy) all
+    // fire — minus the per-page embed, which we carry over below.
     let mut pages_copied = 0u64;
     let mut pages_skipped: Vec<String> = Vec::new();
     for s in &summaries {
@@ -1719,8 +1757,7 @@ async fn handle_move_project(
                 continue;
             }
         };
-        if let Err(e) = state
-            .wiki
+        let new_page_id = match copy_wiki
             .write_page(WritePageRequest {
                 workspace_id: dst_ws,
                 project_id: dst_proj,
@@ -1737,8 +1774,26 @@ async fn handle_move_project(
             })
             .await
         {
+            Ok(pid) => pid,
             // ANY copy failure aborts BEFORE the purge — the source survives.
-            return internal_err(format!("copy of {} failed: {e}", s.path));
+            Err(e) => return internal_err(format!("copy of {} failed: {e}", s.path)),
+        };
+        // Carry the source embedding over (skip the re-embed) when the source
+        // had one for the current model.
+        if let (Some((provider, model, dim)), Some(bytes)) =
+            (&embed_meta, src_embeddings.get(&s.path))
+            && let Err(e) = state
+                .writer
+                .store_embedding(
+                    new_page_id,
+                    bytes.clone(),
+                    provider.clone(),
+                    model.clone(),
+                    *dim,
+                )
+                .await
+        {
+            warn!(path = %s.path, error = %e, "move-project: failed to carry embedding; page copied without it");
         }
         pages_copied += 1;
     }

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -13,6 +13,8 @@
 //! - `POST /admin/commit`         — stage + commit the wiki tree via git.
 //! - `POST /admin/purge-project`  — delete a project and all its data.
 //! - `POST /admin/rename-project` — rename a project (column-only; no files move).
+//! - `POST /admin/move-project`   — move a project into another workspace
+//!   (copy latest pages via the write path, then purge the source).
 //! - `POST /admin/write-page`     — write or update a wiki page atomically.
 //! - `GET  /admin/read-page`      — fetch the full body of a single wiki page by path.
 //!
@@ -140,6 +142,7 @@ fn default_chunk_input_tokens() -> usize {
 /// - `POST /admin/commit`
 /// - `POST /admin/purge-project`
 /// - `POST /admin/rename-project`
+/// - `POST /admin/move-project`
 /// - `POST /admin/write-page`
 pub fn admin_router(state: AdminState) -> Router {
     Router::new()
@@ -155,6 +158,7 @@ pub fn admin_router(state: AdminState) -> Router {
         .route("/admin/commit", post(handle_commit))
         .route("/admin/purge-project", post(handle_purge_project))
         .route("/admin/rename-project", post(handle_rename_project))
+        .route("/admin/move-project", post(handle_move_project))
         .route("/admin/write-page", post(handle_write_page))
         .route(
             "/admin/users",
@@ -1575,6 +1579,235 @@ async fn handle_rename_project(
     (
         StatusCode::OK,
         Json(serde_json::to_value(&summary).unwrap_or_else(|_| serde_json::json!({}))),
+    )
+}
+
+// ---------------------------------------------------------------------
+// move-project
+// ---------------------------------------------------------------------
+
+/// JSON request body for `POST /admin/move-project`.
+#[derive(Deserialize)]
+struct MoveProjectRequest {
+    /// Source workspace. Must already exist; we 404 if absent.
+    from_workspace: String,
+    /// Project name to move. Must already exist in `from_workspace`; 404 if absent.
+    project: String,
+    /// Destination workspace. Auto-created if absent.
+    to_workspace: String,
+    /// Mandatory confirmation flag. The move PURGES the source after
+    /// copying, so without `confirm: true` the server returns 400.
+    confirm: bool,
+}
+
+/// Wire-format report returned by `POST /admin/move-project`.
+#[derive(Debug, Serialize)]
+pub struct MoveProjectReport {
+    /// `from_workspace/project` label.
+    pub from: String,
+    /// `to_workspace/project` label.
+    pub to: String,
+    /// `true` when the destination workspace already held a same-named
+    /// project — the copy MERGED into it rather than creating a fresh one.
+    pub merged_into_existing: bool,
+    /// Number of latest pages copied into the destination.
+    pub pages_copied: u64,
+    /// Source paths whose on-disk file could not be read (copy skipped).
+    /// When non-empty the source is NOT purged so a fixed re-run is safe.
+    pub pages_skipped: Vec<String>,
+    /// Whether the source project was purged (only when every page copied).
+    pub source_purged: bool,
+    /// Source `pages` rows deleted by the purge (all versions).
+    pub source_pages_deleted: u64,
+    /// Source `sessions` rows deleted by the purge.
+    pub source_sessions_deleted: u64,
+    /// Source `observations` rows deleted by the purge.
+    pub source_observations_deleted: u64,
+    /// Source `handoffs` rows deleted by the purge.
+    pub source_handoffs_deleted: u64,
+    /// Source `page_embeddings` rows deleted by the purge.
+    pub source_embeddings_deleted: u64,
+    /// Source on-disk dirs removed.
+    pub files_deleted: Vec<String>,
+    /// Source on-disk dirs that could not be removed (non-fatal).
+    pub files_failed: Vec<String>,
+}
+
+async fn handle_move_project(
+    State(state): State<Arc<AdminState>>,
+    Json(req): Json<MoveProjectRequest>,
+) -> impl IntoResponse {
+    // Destructive: it purges the source after copying. Require confirm.
+    if !req.confirm {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "destructive operation requires confirm=true"
+            })),
+        );
+    }
+
+    // A same-workspace "move" would get-or-create the SAME project as both
+    // source and destination, copy it onto itself, then purge it — data
+    // loss. Reject; in-workspace renames go through rename-project.
+    if req.from_workspace == req.to_workspace {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(serde_json::json!({
+                "error": "from_workspace and to_workspace are identical; use rename-project instead"
+            })),
+        );
+    }
+
+    // Resolve the SOURCE without auto-creating — 404 on a typo.
+    let (src_ws, src_proj) =
+        match lookup_ws_proj_no_create(&state, &req.from_workspace, &req.project).await {
+            Ok(ids) => ids,
+            Err(e) => return e,
+        };
+
+    // Detect MERGE: does the destination workspace already hold a same-named
+    // project? (find_workspace may be None when the dest ws doesn't exist yet.)
+    let merged_into_existing = match state.reader.find_workspace(req.to_workspace.clone()).await {
+        Ok(Some(dst_ws)) => matches!(
+            state.reader.find_project(dst_ws, req.project.clone()).await,
+            Ok(Some(_))
+        ),
+        Ok(None) => false,
+        Err(e) => return internal_err(e.to_string()),
+    };
+
+    // Get-or-create the DESTINATION (new ProjectId unless merging). Also
+    // auto-creates the destination workspace.
+    let (dst_ws, dst_proj) = match resolve_ws_proj(&state, &req.to_workspace, &req.project).await {
+        Ok(ids) => ids,
+        Err(e) => return e,
+    };
+
+    // Enumerate the source's latest pages (authoritative on is_latest).
+    let summaries = match state
+        .reader
+        .list_pages(&req.from_workspace, &req.project)
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => return internal_err(e.to_string()),
+    };
+
+    // COPY each page through the canonical write path so sanitization, link
+    // re-resolution, FTS upsert (and admission/git-mirror on deploy) all fire.
+    let mut pages_copied = 0u64;
+    let mut pages_skipped: Vec<String> = Vec::new();
+    for s in &summaries {
+        let path = match PagePath::new(s.path.clone()) {
+            Ok(p) => p,
+            Err(_) => {
+                pages_skipped.push(s.path.clone());
+                continue;
+            }
+        };
+        let tier: Tier = s.tier.parse().unwrap_or(Tier::Semantic);
+        let pinned = matches!(
+            state.reader.page_meta(&req.from_workspace, &req.project, &s.path).await,
+            Ok(Some(ref m)) if m.pinned
+        );
+        let md = match state.wiki.read_page(src_ws, src_proj, &path) {
+            Ok(md) => md,
+            Err(e) => {
+                warn!(path = %s.path, error = %e, "move-project: source read failed; skipping");
+                pages_skipped.push(s.path.clone());
+                continue;
+            }
+        };
+        if let Err(e) = state
+            .wiki
+            .write_page(WritePageRequest {
+                workspace_id: dst_ws,
+                project_id: dst_proj,
+                path: path.clone(),
+                frontmatter: md.frontmatter,
+                body: md.body,
+                tier,
+                pinned,
+                // Preserve the stored title verbatim (PageSummary.title is
+                // the DB-derived title), rather than re-deriving it.
+                title: Some(s.title.clone()),
+                author_id: None,
+                actor: ai_memory_core::ActorContext::anonymous(),
+            })
+            .await
+        {
+            // ANY copy failure aborts BEFORE the purge — the source survives.
+            return internal_err(format!("copy of {} failed: {e}", s.path));
+        }
+        pages_copied += 1;
+    }
+
+    // Safety: a skipped (unreadable) source page blocks the purge — purging
+    // now would destroy data we failed to copy. Report and let the operator
+    // fix + re-run (re-running is idempotent: copied pages just supersede).
+    if !pages_skipped.is_empty() {
+        let report = MoveProjectReport {
+            from: format!("{}/{}", req.from_workspace, req.project),
+            to: format!("{}/{}", req.to_workspace, req.project),
+            merged_into_existing,
+            pages_copied,
+            pages_skipped,
+            source_purged: false,
+            source_pages_deleted: 0,
+            source_sessions_deleted: 0,
+            source_observations_deleted: 0,
+            source_handoffs_deleted: 0,
+            source_embeddings_deleted: 0,
+            files_deleted: Vec::new(),
+            files_failed: Vec::new(),
+        };
+        return (
+            StatusCode::OK,
+            Json(serde_json::to_value(&report).unwrap_or_else(|_| serde_json::json!({}))),
+        );
+    }
+
+    // PURGE the source — only reached when every page copied successfully.
+    let label = format!("{}/{}", req.from_workspace, req.project);
+    let summary = match state.writer.purge_project(src_ws, src_proj, &label).await {
+        Ok(s) => s,
+        Err(e) => return internal_err(e.to_string()),
+    };
+
+    // Remove the source's on-disk dir (mirrors handle_purge_project). DB
+    // cascade already deleted the rows; dir removal is best-effort.
+    let proj_root = state.wiki.project_root(src_ws, src_proj);
+    let proj_root_str = proj_root.display().to_string();
+    let mut files_deleted: Vec<String> = Vec::new();
+    let mut files_failed: Vec<String> = Vec::new();
+    match std::fs::remove_dir_all(&proj_root) {
+        Ok(()) => files_deleted.push(proj_root_str),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            warn!(path = %proj_root_str, error = %e, "move-project: failed to remove source dir");
+            files_failed.push(proj_root_str);
+        }
+    }
+
+    let report = MoveProjectReport {
+        from: label,
+        to: format!("{}/{}", req.to_workspace, req.project),
+        merged_into_existing,
+        pages_copied,
+        pages_skipped: Vec::new(),
+        source_purged: true,
+        source_pages_deleted: summary.pages_deleted,
+        source_sessions_deleted: summary.sessions_deleted,
+        source_observations_deleted: summary.observations_deleted,
+        source_handoffs_deleted: summary.handoffs_deleted,
+        source_embeddings_deleted: summary.embeddings_deleted,
+        files_deleted,
+        files_failed,
+    };
+    (
+        StatusCode::OK,
+        Json(serde_json::to_value(&report).unwrap_or_else(|_| serde_json::json!({}))),
     )
 }
 

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -1610,7 +1610,17 @@ pub struct MoveProjectReport {
     /// `true` when the destination workspace already held a same-named
     /// project — the copy MERGED into it rather than creating a fresh one.
     pub merged_into_existing: bool,
-    /// Number of latest pages copied into the destination.
+    /// How the move was performed:
+    /// - `"true-move"`: a lossless cross-workspace re-stamp (same `project_id`,
+    ///   one SQL transaction + one dir rename). Used when the destination has
+    ///   no same-named project. Sessions/observations/handoffs and the full
+    ///   supersession history all survive; nothing is re-embedded.
+    /// - `"copy-purge"`: the destination already held a same-named project, so
+    ///   the source's latest pages were copied in and merged, then the source
+    ///   purged. Only durable pages move; episodic rows are dropped.
+    pub moved_via: &'static str,
+    /// Number of latest pages copied into the destination (copy-purge) or
+    /// re-stamped in place (true-move).
     pub pages_copied: u64,
     /// Source paths whose on-disk file could not be read (copy skipped).
     /// When non-empty the source is NOT purged so a fixed re-run is safe.
@@ -1631,6 +1641,95 @@ pub struct MoveProjectReport {
     pub files_deleted: Vec<String>,
     /// Source on-disk dirs that could not be removed (non-fatal).
     pub files_failed: Vec<String>,
+}
+
+/// Lossless cross-workspace move: re-stamp the source project's
+/// `workspace_id` across every domain table (one transaction, same
+/// `project_id`), then rename its on-disk dir to the destination workspace.
+/// The caller has already verified the destination has no same-named project.
+///
+/// Ordering matters: the SQL re-stamp commits FIRST, then the dir is renamed.
+/// When the rename fires filesystem events at the new path, the watcher
+/// re-derives `(workspace_id, project_id)` from the path — which now matches
+/// what the DB already holds — so the upsert is a sha256 no-op. Renaming
+/// before the commit would briefly expose new-path files whose derived
+/// workspace disagrees with the DB.
+async fn true_move_project(
+    state: &Arc<AdminState>,
+    req: &MoveProjectRequest,
+    src_ws: WorkspaceId,
+    src_proj: ProjectId,
+) -> (StatusCode, Json<serde_json::Value>) {
+    // Ensure the destination workspace ROW exists (FK target for the
+    // re-stamp) without creating a new project — the existing project_id is
+    // what we move.
+    let dst_ws = match state
+        .writer
+        .get_or_create_workspace(req.to_workspace.clone())
+        .await
+    {
+        Ok(ws) => ws,
+        Err(e) => return internal_err(e.to_string()),
+    };
+
+    let summary = match state
+        .writer
+        .move_project_workspace(src_proj, src_ws, dst_ws)
+        .await
+    {
+        Ok(s) => s,
+        Err(StoreError::NotFound(msg)) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": msg })),
+            );
+        }
+        Err(e) => return internal_err(e.to_string()),
+    };
+
+    // Land the files where the re-stamped rows now point. The SQL is already
+    // committed; a rename failure leaves the DB ahead of disk (the one
+    // inconsistency window) and is an exceptional fs error, not a normal path.
+    if let Err(e) = state.wiki.rename_project_dir(src_proj, src_ws, dst_ws) {
+        let src_dir = state.wiki.project_root(src_ws, src_proj);
+        let dst_dir = state.wiki.project_root(dst_ws, src_proj);
+        warn!(
+            error = %e,
+            src = %src_dir.display(),
+            dst = %dst_dir.display(),
+            "true-move: SQL re-stamp committed but dir rename failed; \
+             move the directory manually to reconcile"
+        );
+        return internal_err(format!(
+            "project rows moved but on-disk dir rename failed: {e}; \
+             manually move {} -> {}",
+            src_dir.display(),
+            dst_dir.display()
+        ));
+    }
+
+    let report = MoveProjectReport {
+        from: format!("{}/{}", req.from_workspace, req.project),
+        to: format!("{}/{}", req.to_workspace, req.project),
+        merged_into_existing: false,
+        moved_via: "true-move",
+        pages_copied: summary.pages_moved,
+        pages_skipped: Vec::new(),
+        // Nothing is purged in a true move — the source rows ARE the
+        // destination rows, just re-stamped.
+        source_purged: false,
+        source_pages_deleted: 0,
+        source_sessions_deleted: 0,
+        source_observations_deleted: 0,
+        source_handoffs_deleted: 0,
+        source_embeddings_deleted: 0,
+        files_deleted: Vec::new(),
+        files_failed: Vec::new(),
+    };
+    (
+        StatusCode::OK,
+        Json(serde_json::to_value(&report).unwrap_or_else(|_| serde_json::json!({}))),
+    )
 }
 
 async fn handle_move_project(
@@ -1677,8 +1776,21 @@ async fn handle_move_project(
         Err(e) => return internal_err(e.to_string()),
     };
 
-    // Get-or-create the DESTINATION (new ProjectId unless merging). Also
-    // auto-creates the destination workspace.
+    // FRESH destination (no same-named project there) → lossless TRUE MOVE.
+    // Re-stamp the source project's workspace_id across every domain table in
+    // one transaction (same project_id), then rename its on-disk dir. This
+    // keeps sessions/observations/handoffs and the full supersession history,
+    // and is O(1) instead of O(pages) — no per-page re-write, re-embed, or
+    // admission webhook. The copy+purge path below is reserved for the MERGE
+    // case, where two project_ids can't be re-stamped into one
+    // (UNIQUE(workspace_id, name) collision).
+    if !merged_into_existing {
+        return true_move_project(&state, &req, src_ws, src_proj).await;
+    }
+
+    // MERGE: the destination already holds a same-named project. Get-or-create
+    // it (auto-creating the destination workspace) and copy the source's
+    // latest pages into it, then purge the source.
     let (dst_ws, dst_proj) = match resolve_ws_proj(&state, &req.to_workspace, &req.project).await {
         Ok(ids) => ids,
         Err(e) => return e,
@@ -1771,6 +1883,7 @@ async fn handle_move_project(
                 title: Some(s.title.clone()),
                 author_id: None,
                 actor: ai_memory_core::ActorContext::anonymous(),
+                admission_ctx: None,
             })
             .await
         {
@@ -1806,6 +1919,7 @@ async fn handle_move_project(
             from: format!("{}/{}", req.from_workspace, req.project),
             to: format!("{}/{}", req.to_workspace, req.project),
             merged_into_existing,
+            moved_via: "copy-purge",
             pages_copied,
             pages_skipped,
             source_purged: false,
@@ -1849,6 +1963,7 @@ async fn handle_move_project(
         from: label,
         to: format!("{}/{}", req.to_workspace, req.project),
         merged_into_existing,
+        moved_via: "copy-purge",
         pages_copied,
         pages_skipped: Vec::new(),
         source_purged: true,

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -1881,9 +1881,12 @@ async fn handle_move_project(
                 // Preserve the stored title verbatim (PageSummary.title is
                 // the DB-derived title), rather than re-deriving it.
                 title: Some(s.title.clone()),
+                // None → the write_page admission chain resolves the
+                // workspace/project NAMES from the destination IDs, so the
+                // git-mirror lands the copy under the destination path.
+                admission_ctx: None,
                 author_id: None,
                 actor: ai_memory_core::ActorContext::anonymous(),
-                admission_ctx: None,
             })
             .await
         {
@@ -1944,15 +1947,30 @@ async fn handle_move_project(
         Err(e) => return internal_err(e.to_string()),
     };
 
-    // Remove the source's on-disk dir (mirrors handle_purge_project). DB
-    // cascade already deleted the rows; dir removal is best-effort.
-    let proj_root = state.wiki.project_root(src_ws, src_proj);
-    let proj_root_str = proj_root.display().to_string();
+    // Remove the source's on-disk dir through Wiki::purge_project so the
+    // admission chain is notified (op=purge_project) before removal — a
+    // git-mirror drops its copy of the source project. The DB rows were
+    // just deleted above, so name-resolution would find nothing; pass the
+    // workspace/project NAMES explicitly (mirrors handle_purge_project).
+    let purge_ctx = AdmissionContext {
+        workspace: req.from_workspace.clone(),
+        project: req.project.clone(),
+        op: AdmissionOp::PurgeProject,
+        ..Default::default()
+    };
+    let proj_root_str = state
+        .wiki
+        .project_root(src_ws, src_proj)
+        .display()
+        .to_string();
     let mut files_deleted: Vec<String> = Vec::new();
     let mut files_failed: Vec<String> = Vec::new();
-    match std::fs::remove_dir_all(&proj_root) {
+    match state
+        .wiki
+        .purge_project(src_ws, src_proj, Some(purge_ctx))
+        .await
+    {
         Ok(()) => files_deleted.push(proj_root_str),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => {
             warn!(path = %proj_root_str, error = %e, "move-project: failed to remove source dir");
             files_failed.push(proj_root_str);

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -32,7 +32,8 @@ use ai_memory_consolidate::{
     prune_sources_to_budget, run_lint, run_sweep,
 };
 use ai_memory_core::{
-    DEFAULT_PROJECT_NAME, DEFAULT_WORKSPACE_NAME, PagePath, ProjectId, SessionId, Tier, WorkspaceId,
+    ActiveProject, DEFAULT_PROJECT_NAME, DEFAULT_WORKSPACE_NAME, PagePath, ProjectId, SessionId,
+    Tier, WorkspaceId,
 };
 use ai_memory_llm::{Embedder, LlmProvider, ProviderHealth, ProviderHealthSnapshot};
 use ai_memory_store::{
@@ -50,7 +51,7 @@ use flate2::Compression;
 use flate2::write::GzEncoder;
 use serde::{Deserialize, Serialize};
 use tokio_util::io::ReaderStream;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 const EMBEDDING_WRITE_BATCH: usize = 100;
 
@@ -93,6 +94,12 @@ pub struct AdminState {
     /// installs that predate v0.8); user-management endpoints then
     /// return 503 `multi-user not enabled`.
     pub token_pepper: Option<ai_memory_store::TokenPepper>,
+    /// Shared in-process pointer to the project the agent is currently
+    /// active in (published by the hook router). Read by `move-project` to
+    /// refuse moving the live project (unless `force`) and to keep the
+    /// pointer correct after a move. Empty `ActiveProject::new()` when no
+    /// hook router is attached (admin-only tests).
+    pub active_project: ActiveProject,
 }
 
 /// JSON request body for `POST /admin/bootstrap`.
@@ -1598,6 +1605,14 @@ struct MoveProjectRequest {
     /// Mandatory confirmation flag. The move PURGES the source after
     /// copying, so without `confirm: true` the server returns 400.
     confirm: bool,
+    /// Override the live-session guard. By default the server refuses (409)
+    /// to move the project the hook router is currently writing to, since a
+    /// live session's next observation would carry a stale workspace id.
+    /// `force: true` proceeds anyway (still safe: the move republishes the
+    /// active pointer and the (workspace_id, project_id) trigger makes any
+    /// stale write fail cleanly rather than corrupt).
+    #[serde(default)]
+    force: bool,
 }
 
 /// Wire-format report returned by `POST /admin/move-project`.
@@ -1641,6 +1656,20 @@ pub struct MoveProjectReport {
     pub files_deleted: Vec<String>,
     /// Source on-disk dirs that could not be removed (non-fatal).
     pub files_failed: Vec<String>,
+    /// Same-path conflicts in the copy-purge merge: a source page whose path
+    /// already existed in the destination (with different content) was landed
+    /// under a de-duplicated path so BOTH survive. Each entry is the original
+    /// source path and the de-duplicated destination path it was written to.
+    pub conflicts: Vec<PathConflict>,
+}
+
+/// One same-path collision resolved by de-duplicating the source page's path.
+#[derive(Debug, Serialize)]
+pub struct PathConflict {
+    /// The source page's original path (also the destination's existing path).
+    pub path: String,
+    /// The de-duplicated path the source page was written to instead.
+    pub moved_to: String,
 }
 
 /// Lossless cross-workspace move: re-stamp the source project's
@@ -1672,6 +1701,22 @@ async fn true_move_project(
         Err(e) => return internal_err(e.to_string()),
     };
 
+    // A true move targets a FRESH destination, so its dir must not already
+    // exist. Check BEFORE touching the DB so a stale leftover can never lead to
+    // a DB-ahead-of-disk split-brain or a clobbered directory.
+    let dst_dir = state.wiki.project_root(dst_ws, src_proj);
+    if dst_dir.exists() {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": format!(
+                    "destination dir already exists: {}; refusing true-move",
+                    dst_dir.display()
+                )
+            })),
+        );
+    }
+
     let summary = match state
         .writer
         .move_project_workspace(src_proj, src_ws, dst_ws)
@@ -1688,24 +1733,52 @@ async fn true_move_project(
     };
 
     // Land the files where the re-stamped rows now point. The SQL is already
-    // committed; a rename failure leaves the DB ahead of disk (the one
-    // inconsistency window) and is an exceptional fs error, not a normal path.
+    // committed, so a rename failure would leave the DB ahead of disk. Make the
+    // move all-or-nothing: on failure, roll the DB re-stamp back (the op is
+    // symmetric) so either both rows AND files move, or neither does.
     if let Err(e) = state.wiki.rename_project_dir(src_proj, src_ws, dst_ws) {
         let src_dir = state.wiki.project_root(src_ws, src_proj);
-        let dst_dir = state.wiki.project_root(dst_ws, src_proj);
-        warn!(
-            error = %e,
-            src = %src_dir.display(),
-            dst = %dst_dir.display(),
-            "true-move: SQL re-stamp committed but dir rename failed; \
-             move the directory manually to reconcile"
-        );
-        return internal_err(format!(
-            "project rows moved but on-disk dir rename failed: {e}; \
-             manually move {} -> {}",
-            src_dir.display(),
-            dst_dir.display()
-        ));
+        match state
+            .writer
+            .move_project_workspace(src_proj, dst_ws, src_ws)
+            .await
+        {
+            Ok(_) => {
+                warn!(
+                    error = %e,
+                    "true-move: dir rename failed; rolled the DB re-stamp back — nothing moved"
+                );
+                return internal_err(format!(
+                    "move aborted (nothing changed): on-disk dir rename failed: {e}"
+                ));
+            }
+            Err(rollback_err) => {
+                // Double fault: rows are in the destination workspace but files
+                // remain at the source AND the revert failed. Surface a precise
+                // manual-repair message.
+                error!(
+                    error = %e,
+                    rollback_error = %rollback_err,
+                    src = %src_dir.display(),
+                    dst = %dst_dir.display(),
+                    "true-move: dir rename failed AND DB rollback failed — manual repair required"
+                );
+                return internal_err(format!(
+                    "INCONSISTENT STATE: rows moved but dir rename failed ({e}) and DB rollback \
+                     also failed ({rollback_err}); manually move {} -> {} or re-stamp the project back",
+                    src_dir.display(),
+                    dst_dir.display()
+                ));
+            }
+        }
+    }
+
+    // Keep the in-process active-project pointer correct: the project_id is
+    // unchanged, only its workspace moved. If a hook had published this project
+    // as active, republish it under the destination workspace so the next event
+    // resolves cleanly (rather than tripping the pairing trigger first).
+    if state.active_project.get().map(|(_, p)| p) == Some(src_proj) {
+        state.active_project.set(dst_ws, src_proj);
     }
 
     let report = MoveProjectReport {
@@ -1725,11 +1798,59 @@ async fn true_move_project(
         source_embeddings_deleted: 0,
         files_deleted: Vec::new(),
         files_failed: Vec::new(),
+        // A true move never copies pages, so it never has a path conflict.
+        conflicts: Vec::new(),
     };
     (
         StatusCode::OK,
         Json(serde_json::to_value(&report).unwrap_or_else(|_| serde_json::json!({}))),
     )
+}
+
+/// Pick a destination path that collides with neither an existing destination
+/// page nor one already claimed in this run. Keeps the source page's stem and
+/// appends `-from-<src_workspace>` (then `-2`, `-3`, …). Used by the copy-purge
+/// merge to keep BOTH pages when a path conflicts.
+async fn dedup_dest_path(
+    state: &AdminState,
+    dst_ws: WorkspaceId,
+    dst_proj: ProjectId,
+    src_path: &str,
+    src_workspace: &str,
+    used: &std::collections::HashSet<String>,
+) -> PagePath {
+    let (stem, ext) = match src_path.rsplit_once('.') {
+        Some((s, e)) => (s.to_string(), format!(".{e}")),
+        None => (src_path.to_string(), String::new()),
+    };
+    let slug: String = src_workspace
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let base = format!("{stem}-from-{slug}");
+    let mut n = 0u32;
+    loop {
+        let cand = if n == 0 {
+            format!("{base}{ext}")
+        } else {
+            format!("{base}-{n}{ext}")
+        };
+        let collides = used.contains(&cand)
+            || matches!(
+                state.reader.page_body_by_ids(dst_ws, dst_proj, &cand).await,
+                Ok(Some(_))
+            );
+        if !collides && let Ok(p) = PagePath::new(cand) {
+            return p;
+        }
+        n += 1;
+    }
 }
 
 async fn handle_move_project(
@@ -1764,6 +1885,24 @@ async fn handle_move_project(
             Ok(ids) => ids,
             Err(e) => return e,
         };
+
+    // Live-session guard: refuse to move the project the hook router is
+    // currently writing to. A live session's next observation/log would carry
+    // the now-stale workspace id (the (workspace_id, project_id) trigger would
+    // make it fail, but the operator should consciously opt in). `force: true`
+    // proceeds — safe because the move republishes the active pointer below.
+    if !req.force && state.active_project.get().map(|(_, p)| p) == Some(src_proj) {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": format!(
+                    "{}/{} is the active session's project; a live move risks stale-cache writes. \
+                     Re-run with force=true to proceed.",
+                    req.from_workspace, req.project
+                )
+            })),
+        );
+    }
 
     // Detect MERGE: does the destination workspace already hold a same-named
     // project? (find_workspace may be None when the dest ws doesn't exist yet.)
@@ -1848,6 +1987,8 @@ async fn handle_move_project(
     // fire — minus the per-page embed, which we carry over below.
     let mut pages_copied = 0u64;
     let mut pages_skipped: Vec<String> = Vec::new();
+    let mut conflicts: Vec<PathConflict> = Vec::new();
+    let mut used_dest_paths: std::collections::HashSet<String> = std::collections::HashSet::new();
     for s in &summaries {
         let path = match PagePath::new(s.path.clone()) {
             Ok(p) => p,
@@ -1869,11 +2010,39 @@ async fn handle_move_project(
                 continue;
             }
         };
+        // Same-path conflict → duplicate (keep both): if the destination already
+        // holds this path with DIFFERENT content, land the source page under a
+        // de-duplicated path so neither version is lost. Identical content falls
+        // through to a no-op supersession at the same path.
+        let dest_path = match state
+            .reader
+            .page_body_by_ids(dst_ws, dst_proj, s.path.as_str())
+            .await
+        {
+            Ok(Some(existing)) if existing.body != md.body => {
+                let deduped = dedup_dest_path(
+                    &state,
+                    dst_ws,
+                    dst_proj,
+                    &s.path,
+                    &req.from_workspace,
+                    &used_dest_paths,
+                )
+                .await;
+                conflicts.push(PathConflict {
+                    path: s.path.clone(),
+                    moved_to: deduped.as_str().to_string(),
+                });
+                deduped
+            }
+            _ => path.clone(),
+        };
+        used_dest_paths.insert(dest_path.as_str().to_string());
         let new_page_id = match copy_wiki
             .write_page(WritePageRequest {
                 workspace_id: dst_ws,
                 project_id: dst_proj,
-                path: path.clone(),
+                path: dest_path.clone(),
                 frontmatter: md.frontmatter,
                 body: md.body,
                 tier,
@@ -1933,6 +2102,7 @@ async fn handle_move_project(
             source_embeddings_deleted: 0,
             files_deleted: Vec::new(),
             files_failed: Vec::new(),
+            conflicts,
         };
         return (
             StatusCode::OK,
@@ -1977,6 +2147,13 @@ async fn handle_move_project(
         }
     }
 
+    // The source project_id was just purged; if it was the published active
+    // project, the pointer now dangles — clear it so the next hook re-resolves
+    // to the (new) project rather than the deleted id.
+    if state.active_project.get().map(|(_, p)| p) == Some(src_proj) {
+        state.active_project.clear();
+    }
+
     let report = MoveProjectReport {
         from: label,
         to: format!("{}/{}", req.to_workspace, req.project),
@@ -1992,6 +2169,7 @@ async fn handle_move_project(
         source_embeddings_deleted: summary.embeddings_deleted,
         files_deleted,
         files_failed,
+        conflicts,
     };
     (
         StatusCode::OK,
@@ -2457,6 +2635,7 @@ mod tests {
             bind: "127.0.0.1:49374".to_string(),
             bootstrap_lock: Arc::new(tokio::sync::Mutex::new(())),
             token_pepper: None,
+            active_project: ai_memory_core::ActiveProject::new(),
         });
 
         let resp = router
@@ -2493,6 +2672,7 @@ mod tests {
             bind: "127.0.0.1:49374".to_string(),
             bootstrap_lock: Arc::new(tokio::sync::Mutex::new(())),
             token_pepper: None,
+            active_project: ai_memory_core::ActiveProject::new(),
         });
         (tmp, router)
     }
@@ -2672,6 +2852,7 @@ mod tests {
             bind: "127.0.0.1:49374".to_string(),
             bootstrap_lock: Arc::new(tokio::sync::Mutex::new(())),
             token_pepper: None,
+            active_project: ai_memory_core::ActiveProject::new(),
         });
 
         post_write_page(&router, "default", "doomed", "notes/x.md", "bye").await;
@@ -2731,6 +2912,7 @@ mod tests {
             bind: "127.0.0.1:49374".to_string(),
             bootstrap_lock: Arc::new(tokio::sync::Mutex::new(())),
             token_pepper: Some(pepper),
+            active_project: ai_memory_core::ActiveProject::new(),
         });
         // Wrap in a middleware that stamps the AuthLevel ourselves —
         // the real auth middleware lives in ai-memory-cli, and this
@@ -3015,6 +3197,7 @@ mod tests {
             bind: "127.0.0.1:49374".to_string(),
             bootstrap_lock: Arc::new(tokio::sync::Mutex::new(())),
             token_pepper: None,
+            active_project: ai_memory_core::ActiveProject::new(),
         });
         // Inject a Root level so we're past the require_root gate;
         // the 503 must come from require_pepper.

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -100,6 +100,14 @@ pub struct AdminState {
     /// pointer correct after a move. Empty `ActiveProject::new()` when no
     /// hook router is attached (admin-only tests).
     pub active_project: ActiveProject,
+    /// Optional hook to PROACTIVELY evict the hook router's per-cwd
+    /// `(workspace_id, project_id)` cache for a project that just moved
+    /// workspaces. Called with the moved `project_id` after a successful move
+    /// so the next hook event re-resolves cleanly instead of tripping the
+    /// pairing trigger on a stale cached pair first. Fire-and-forget
+    /// (best-effort); the trigger + router re-resolve are the correctness net.
+    /// `None` when no hook router is attached (stdio / admin-only tests).
+    pub on_project_moved: Option<std::sync::Arc<dyn Fn(ProjectId) + Send + Sync>>,
 }
 
 /// JSON request body for `POST /admin/bootstrap`.
@@ -1613,6 +1621,28 @@ struct MoveProjectRequest {
     /// stale write fail cleanly rather than corrupt).
     #[serde(default)]
     force: bool,
+    /// Policy for the copy-purge MERGE path when a source page's path already
+    /// exists in the destination with DIFFERENT content. Ignored by true-move
+    /// (no copy). Default `block` — the safe choice for a destructive op.
+    #[serde(default)]
+    on_conflict: OnConflict,
+}
+
+/// What to do when a merged page path collides with an existing destination
+/// page of different content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+enum OnConflict {
+    /// Abort the whole move (source untouched), listing the conflicting paths.
+    /// The operator resolves them or picks another policy explicitly.
+    #[default]
+    Block,
+    /// The source page supersedes the destination page at the same path (the
+    /// destination's prior version becomes history).
+    Overwrite,
+    /// Keep BOTH: the source page lands under a de-duplicated path
+    /// (`<stem>-from-<src_workspace>.md`), reported in `conflicts`.
+    Duplicate,
 }
 
 /// Wire-format report returned by `POST /admin/move-project`.
@@ -1672,17 +1702,20 @@ pub struct PathConflict {
     pub moved_to: String,
 }
 
-/// Lossless cross-workspace move: re-stamp the source project's
-/// `workspace_id` across every domain table (one transaction, same
-/// `project_id`), then rename its on-disk dir to the destination workspace.
-/// The caller has already verified the destination has no same-named project.
+/// Lossless cross-workspace move: rename the project's on-disk dir to the
+/// destination workspace, then re-stamp its `workspace_id` across every domain
+/// table (one transaction, same `project_id`). The caller has already verified
+/// the destination has no same-named project.
 ///
-/// Ordering matters: the SQL re-stamp commits FIRST, then the dir is renamed.
-/// When the rename fires filesystem events at the new path, the watcher
-/// re-derives `(workspace_id, project_id)` from the path — which now matches
-/// what the DB already holds — so the upsert is a sha256 no-op. Renaming
-/// before the commit would briefly expose new-path files whose derived
-/// workspace disagrees with the DB.
+/// Ordering is deliberately rename-FIRST, SQL-commit-LAST so the **DB is never
+/// ahead of disk**: a rename failure touches nothing; a crash between the two
+/// steps leaves at most an orphan dir at the destination with the DB still
+/// wholly pointing at the source (recoverable), never a DB row pointing at a
+/// missing file. On a SQL failure the dir is renamed back (the op is
+/// symmetric), so the move is all-or-nothing. During the brief window between
+/// rename and commit, any watcher reindex of the moved files attempts an INSERT
+/// under `(dst_ws, proj)` that the V18 pairing trigger rejects cleanly (the
+/// project still lives in `src_ws`), so no split-brain row is created.
 async fn true_move_project(
     state: &Arc<AdminState>,
     req: &MoveProjectRequest,
@@ -1702,8 +1735,7 @@ async fn true_move_project(
     };
 
     // A true move targets a FRESH destination, so its dir must not already
-    // exist. Check BEFORE touching the DB so a stale leftover can never lead to
-    // a DB-ahead-of-disk split-brain or a clobbered directory.
+    // exist. Check before the rename so a stale leftover can never be clobbered.
     let dst_dir = state.wiki.project_root(dst_ws, src_proj);
     if dst_dir.exists() {
         return (
@@ -1717,61 +1749,66 @@ async fn true_move_project(
         );
     }
 
+    // 1) Rename the dir FIRST — before any DB change. A failure here leaves
+    //    everything untouched.
+    if let Err(e) = state.wiki.rename_project_dir(src_proj, src_ws, dst_ws) {
+        warn!(
+            error = %e,
+            "true-move: dir rename failed before any DB change — nothing moved"
+        );
+        return internal_err(format!(
+            "move aborted (nothing changed): on-disk dir rename failed: {e}"
+        ));
+    }
+
+    // 2) Re-stamp the DB LAST. On failure, rename the dir back so the move is
+    //    all-or-nothing and the DB never ends up ahead of disk.
     let summary = match state
         .writer
         .move_project_workspace(src_proj, src_ws, dst_ws)
         .await
     {
         Ok(s) => s,
-        Err(StoreError::NotFound(msg)) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "error": msg })),
-            );
+        Err(e) => {
+            let src_dir = state.wiki.project_root(src_ws, src_proj);
+            match state.wiki.rename_project_dir(src_proj, dst_ws, src_ws) {
+                Ok(()) => {
+                    warn!(
+                        error = %e,
+                        "true-move: DB re-stamp failed; renamed the dir back — nothing moved"
+                    );
+                    return match e {
+                        StoreError::NotFound(msg) => (
+                            StatusCode::NOT_FOUND,
+                            Json(serde_json::json!({ "error": msg })),
+                        ),
+                        other => internal_err(format!(
+                            "move aborted (nothing changed): DB re-stamp failed: {other}"
+                        )),
+                    };
+                }
+                Err(rollback_err) => {
+                    // Double fault: files are at the destination but the DB
+                    // re-stamp failed AND the rename-back failed. Surface a
+                    // precise manual-repair message.
+                    error!(
+                        error = %e,
+                        rollback_error = %rollback_err,
+                        src = %src_dir.display(),
+                        dst = %dst_dir.display(),
+                        "true-move: DB re-stamp failed AND dir rename-back failed — manual repair required"
+                    );
+                    return internal_err(format!(
+                        "INCONSISTENT STATE: files moved but DB re-stamp failed ({e}) and dir \
+                         rename-back also failed ({rollback_err}); manually move {} -> {} or finish \
+                         the re-stamp",
+                        dst_dir.display(),
+                        src_dir.display()
+                    ));
+                }
+            }
         }
-        Err(e) => return internal_err(e.to_string()),
     };
-
-    // Land the files where the re-stamped rows now point. The SQL is already
-    // committed, so a rename failure would leave the DB ahead of disk. Make the
-    // move all-or-nothing: on failure, roll the DB re-stamp back (the op is
-    // symmetric) so either both rows AND files move, or neither does.
-    if let Err(e) = state.wiki.rename_project_dir(src_proj, src_ws, dst_ws) {
-        let src_dir = state.wiki.project_root(src_ws, src_proj);
-        match state
-            .writer
-            .move_project_workspace(src_proj, dst_ws, src_ws)
-            .await
-        {
-            Ok(_) => {
-                warn!(
-                    error = %e,
-                    "true-move: dir rename failed; rolled the DB re-stamp back — nothing moved"
-                );
-                return internal_err(format!(
-                    "move aborted (nothing changed): on-disk dir rename failed: {e}"
-                ));
-            }
-            Err(rollback_err) => {
-                // Double fault: rows are in the destination workspace but files
-                // remain at the source AND the revert failed. Surface a precise
-                // manual-repair message.
-                error!(
-                    error = %e,
-                    rollback_error = %rollback_err,
-                    src = %src_dir.display(),
-                    dst = %dst_dir.display(),
-                    "true-move: dir rename failed AND DB rollback failed — manual repair required"
-                );
-                return internal_err(format!(
-                    "INCONSISTENT STATE: rows moved but dir rename failed ({e}) and DB rollback \
-                     also failed ({rollback_err}); manually move {} -> {} or re-stamp the project back",
-                    src_dir.display(),
-                    dst_dir.display()
-                ));
-            }
-        }
-    }
 
     // Keep the in-process active-project pointer correct: the project_id is
     // unchanged, only its workspace moved. If a hook had published this project
@@ -1779,6 +1816,10 @@ async fn true_move_project(
     // resolves cleanly (rather than tripping the pairing trigger first).
     if state.active_project.get().map(|(_, p)| p) == Some(src_proj) {
         state.active_project.set(dst_ws, src_proj);
+    }
+    // Proactively drop any stale per-cwd cache entry for the moved project.
+    if let Some(evict) = &state.on_project_moved {
+        evict(src_proj);
     }
 
     let report = MoveProjectReport {
@@ -1945,6 +1986,38 @@ async fn handle_move_project(
         Err(e) => return internal_err(e.to_string()),
     };
 
+    // Pre-scan for same-path conflicts (destination already holds the path with
+    // DIFFERENT content). Under the default `block` policy, abort the WHOLE move
+    // now — before anything is copied — so the source stays intact and the
+    // operator resolves them or re-runs with an explicit overwrite/duplicate.
+    if req.on_conflict == OnConflict::Block {
+        let mut blocking: Vec<String> = Vec::new();
+        for s in &summaries {
+            let Ok(path) = PagePath::new(s.path.clone()) else {
+                continue;
+            };
+            if let Ok(Some(existing)) = state
+                .reader
+                .page_body_by_ids(dst_ws, dst_proj, s.path.as_str())
+                .await
+                && let Ok(md) = state.wiki.read_page(src_ws, src_proj, &path)
+                && existing.body != md.body
+            {
+                blocking.push(s.path.clone());
+            }
+        }
+        if !blocking.is_empty() {
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": "destination already has pages at these paths with different content; \
+                              resolve them or re-run with on_conflict=overwrite or on_conflict=duplicate",
+                    "conflicts": blocking,
+                })),
+            );
+        }
+    }
+
     // Carry the source page embeddings over verbatim instead of recomputing
     // them — embedding is the dominant per-page cost of a bulk move. Writes go
     // through an embedder-less Wiki so `write_page` never re-embeds; we then
@@ -2010,31 +2083,43 @@ async fn handle_move_project(
                 continue;
             }
         };
-        // Same-path conflict → duplicate (keep both): if the destination already
-        // holds this path with DIFFERENT content, land the source page under a
-        // de-duplicated path so neither version is lost. Identical content falls
-        // through to a no-op supersession at the same path.
+        // Same-path conflict (destination holds this path with DIFFERENT
+        // content): apply the on_conflict policy. Identical content always falls
+        // through to a no-op supersession at the same path. `block` was already
+        // handled by the pre-scan above (we never get here with a real conflict).
         let dest_path = match state
             .reader
             .page_body_by_ids(dst_ws, dst_proj, s.path.as_str())
             .await
         {
-            Ok(Some(existing)) if existing.body != md.body => {
-                let deduped = dedup_dest_path(
-                    &state,
-                    dst_ws,
-                    dst_proj,
-                    &s.path,
-                    &req.from_workspace,
-                    &used_dest_paths,
-                )
-                .await;
-                conflicts.push(PathConflict {
-                    path: s.path.clone(),
-                    moved_to: deduped.as_str().to_string(),
-                });
-                deduped
-            }
+            Ok(Some(existing)) if existing.body != md.body => match req.on_conflict {
+                OnConflict::Duplicate => {
+                    let deduped = dedup_dest_path(
+                        &state,
+                        dst_ws,
+                        dst_proj,
+                        &s.path,
+                        &req.from_workspace,
+                        &used_dest_paths,
+                    )
+                    .await;
+                    conflicts.push(PathConflict {
+                        path: s.path.clone(),
+                        moved_to: deduped.as_str().to_string(),
+                    });
+                    deduped
+                }
+                // Overwrite: the source page supersedes the destination page at
+                // the same path (the dest's prior version becomes history).
+                OnConflict::Overwrite => {
+                    conflicts.push(PathConflict {
+                        path: s.path.clone(),
+                        moved_to: s.path.clone(),
+                    });
+                    path.clone()
+                }
+                OnConflict::Block => path.clone(),
+            },
             _ => path.clone(),
         };
         used_dest_paths.insert(dest_path.as_str().to_string());
@@ -2152,6 +2237,11 @@ async fn handle_move_project(
     // to the (new) project rather than the deleted id.
     if state.active_project.get().map(|(_, p)| p) == Some(src_proj) {
         state.active_project.clear();
+    }
+    // Proactively drop any stale per-cwd cache entry for the purged source
+    // project (its project_id no longer exists).
+    if let Some(evict) = &state.on_project_moved {
+        evict(src_proj);
     }
 
     let report = MoveProjectReport {
@@ -2636,6 +2726,7 @@ mod tests {
             bootstrap_lock: Arc::new(tokio::sync::Mutex::new(())),
             token_pepper: None,
             active_project: ai_memory_core::ActiveProject::new(),
+            on_project_moved: None,
         });
 
         let resp = router
@@ -2673,6 +2764,7 @@ mod tests {
             bootstrap_lock: Arc::new(tokio::sync::Mutex::new(())),
             token_pepper: None,
             active_project: ai_memory_core::ActiveProject::new(),
+            on_project_moved: None,
         });
         (tmp, router)
     }
@@ -2853,6 +2945,7 @@ mod tests {
             bootstrap_lock: Arc::new(tokio::sync::Mutex::new(())),
             token_pepper: None,
             active_project: ai_memory_core::ActiveProject::new(),
+            on_project_moved: None,
         });
 
         post_write_page(&router, "default", "doomed", "notes/x.md", "bye").await;
@@ -2913,6 +3006,7 @@ mod tests {
             bootstrap_lock: Arc::new(tokio::sync::Mutex::new(())),
             token_pepper: Some(pepper),
             active_project: ai_memory_core::ActiveProject::new(),
+            on_project_moved: None,
         });
         // Wrap in a middleware that stamps the AuthLevel ourselves —
         // the real auth middleware lives in ai-memory-cli, and this
@@ -3198,6 +3292,7 @@ mod tests {
             bootstrap_lock: Arc::new(tokio::sync::Mutex::new(())),
             token_pepper: None,
             active_project: ai_memory_core::ActiveProject::new(),
+            on_project_moved: None,
         });
         // Inject a Root level so we're past the require_root gate;
         // the 503 must come from require_pepper.

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -2120,6 +2120,26 @@ async fn handle_move_project(
                 }
                 OnConflict::Block => path.clone(),
             },
+            // No content conflict — but the natural path may already have been
+            // CLAIMED by an earlier page's de-duplication (duplicate mode). If
+            // so, de-duplicate this one too rather than clobbering the page that
+            // already took the slot.
+            _ if used_dest_paths.contains(s.path.as_str()) => {
+                let deduped = dedup_dest_path(
+                    &state,
+                    dst_ws,
+                    dst_proj,
+                    &s.path,
+                    &req.from_workspace,
+                    &used_dest_paths,
+                )
+                .await;
+                conflicts.push(PathConflict {
+                    path: s.path.clone(),
+                    moved_to: deduped.as_str().to_string(),
+                });
+                deduped
+            }
             _ => path.clone(),
         };
         used_dest_paths.insert(dest_path.as_str().to_string());

--- a/crates/ai-memory-mcp/tests/admin_backup.rs
+++ b/crates/ai-memory-mcp/tests/admin_backup.rs
@@ -37,6 +37,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
         active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
     };
     (state, store)
 }

--- a/crates/ai-memory-mcp/tests/admin_backup.rs
+++ b/crates/ai-memory-mcp/tests/admin_backup.rs
@@ -36,6 +36,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
         bind: "127.0.0.1:0".to_string(),
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
     };
     (state, store)
 }

--- a/crates/ai-memory-mcp/tests/admin_bootstrap.rs
+++ b/crates/ai-memory-mcp/tests/admin_bootstrap.rs
@@ -33,6 +33,7 @@ async fn make_admin_state(tmp: &TempDir) -> AdminState {
         bind: "127.0.0.1:0".to_string(),
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
     }
 }
 

--- a/crates/ai-memory-mcp/tests/admin_bootstrap.rs
+++ b/crates/ai-memory-mcp/tests/admin_bootstrap.rs
@@ -34,6 +34,7 @@ async fn make_admin_state(tmp: &TempDir) -> AdminState {
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
         active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
     }
 }
 

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -80,6 +80,7 @@ async fn seed_page(store: &Store, wiki: &Wiki, ws: &str, project: &str, path: &s
         title: Some(path.into()),
         author_id: None,
         actor: ai_memory_core::ActorContext::anonymous(),
+        admission_ctx: None,
     })
     .await
     .unwrap();
@@ -89,11 +90,12 @@ async fn seed_page(store: &Store, wiki: &Wiki, ws: &str, project: &str, path: &s
 // Tests
 // ---------------------------------------------------------------------------
 
-/// Happy path: seed `src/proj` with two pages, move into `dst`, assert the
-/// pages now live under `dst/proj`, the source project + on-disk dir are
-/// gone, and the report counts add up.
+/// Happy path with a FRESH destination (no same-named project there): this is
+/// a lossless TRUE MOVE — the project_id is re-stamped into `dst`, nothing is
+/// purged, and the on-disk dir is renamed. Assert the pages now live under
+/// `dst/proj`, the source name no longer resolves, and the dir moved.
 #[tokio::test]
-async fn move_project_copies_then_purges_source() {
+async fn move_project_true_move_into_fresh_dest() {
     let tmp = TempDir::new().unwrap();
     let (state, store) = make_state(&tmp).await;
 
@@ -142,8 +144,28 @@ async fn move_project_copies_then_purges_source() {
 
     let body = body_json(resp).await;
     assert_eq!(body["pages_copied"].as_u64().unwrap_or(0), 2, "{body}");
-    assert_eq!(body["source_purged"], true, "{body}");
+    assert_eq!(body["moved_via"], "true-move", "{body}");
+    // Nothing is purged in a true move — the rows are re-stamped, not copied.
+    assert_eq!(body["source_purged"], false, "{body}");
     assert_eq!(body["merged_into_existing"], false, "{body}");
+
+    // project_id is preserved: the dst project IS the former src project.
+    let dst_ws_check = store
+        .reader
+        .find_workspace("dst".to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    let dst_proj_check = store
+        .reader
+        .find_project(dst_ws_check, "proj".to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        dst_proj_check, src_proj,
+        "true move keeps the same project_id"
+    );
 
     // Both pages now belong to dst/proj (latest), content preserved.
     let dst_pages = store.reader.list_pages("dst", "proj").await.unwrap();
@@ -257,6 +279,9 @@ async fn move_project_merges_into_existing_dest() {
 
     let body = body_json(resp).await;
     assert_eq!(body["merged_into_existing"], true, "{body}");
+    // A same-named project in the dest forces copy+purge (can't re-stamp two
+    // project_ids into one).
+    assert_eq!(body["moved_via"], "copy-purge", "{body}");
     assert_eq!(body["source_purged"], true, "{body}");
 
     // Destination holds BOTH the pre-existing and the moved page.
@@ -423,4 +448,91 @@ async fn move_project_carries_source_embedding() {
             dst[0].vector
         );
     }
+}
+
+/// The whole point of the true move over copy+purge: a session and its
+/// observation — episodic rows that copy+purge would DROP — survive a move
+/// into a fresh destination, re-stamped to the new workspace.
+#[tokio::test]
+async fn move_project_true_move_preserves_sessions_and_observations() {
+    use ai_memory_core::{AgentKind, NewObservation, NewSession, ObservationKind, SessionId};
+
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    seed_page(&store, &state.wiki, "src", "proj", "notes/a.md", "body a").await;
+
+    let src_ws = store
+        .reader
+        .find_workspace("src".to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    let src_proj = store
+        .reader
+        .find_project(src_ws, "proj".to_string())
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Seed an episodic session + observation under src/proj.
+    let sid = SessionId::new();
+    store
+        .writer
+        .begin_session(NewSession {
+            id: sid,
+            workspace_id: src_ws,
+            project_id: src_proj,
+            agent_kind: AgentKind::ClaudeCode,
+            cwd: None,
+        })
+        .await
+        .unwrap();
+    store
+        .writer
+        .insert_observation(NewObservation {
+            session_id: sid,
+            workspace_id: src_ws,
+            project_id: src_proj,
+            kind: ObservationKind::UserPrompt,
+            extension: None,
+            source_event: None,
+            title: "prompt".into(),
+            body: "do the thing".into(),
+            importance: 5,
+        })
+        .await
+        .unwrap();
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["moved_via"], "true-move", "{body}");
+    assert_eq!(body["source_purged"], false, "{body}");
+
+    // The session followed the project to the new workspace (same session_id,
+    // same project_id, new workspace_id).
+    let dst_ws = store
+        .reader
+        .find_workspace("dst".to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    let (sess_ws, sess_proj) = store
+        .reader
+        .session_project_ids(sid)
+        .await
+        .unwrap()
+        .expect("session must still exist after the move");
+    assert_eq!(sess_ws, dst_ws, "session re-stamped to dst workspace");
+    assert_eq!(sess_proj, src_proj, "session keeps its project_id");
+
+    // The observation survived and re-stamped too.
+    let obs = store.reader.observations_for_session(sid).await.unwrap();
+    assert_eq!(obs.len(), 1, "observation must survive the move");
+    assert_eq!(obs[0].workspace_id, dst_ws, "observation re-stamped to dst");
 }

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -303,3 +303,124 @@ async fn move_project_same_workspace_rejected() {
     .await;
     assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
 }
+
+/// The move carries the source page's existing embedding over instead of
+/// recomputing it. Proven by overwriting the source embedding with a
+/// recognisable marker vector: if the move re-embedded, the destination would
+/// hold the synthetic bag-of-words vector, not the marker.
+#[tokio::test]
+async fn move_project_carries_source_embedding() {
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let embedder: std::sync::Arc<dyn ai_memory_llm::Embedder> =
+        std::sync::Arc::new(ai_memory_llm::SyntheticEmbedder::new(8));
+    let wiki = Wiki::new(tmp.path(), store.writer.clone())
+        .unwrap()
+        .with_embedder(embedder.clone());
+    let db_path = store.db_path().to_path_buf();
+    let state = AdminState {
+        writer: store.writer.clone(),
+        reader: store.reader.clone(),
+        wiki,
+        llm: None,
+        embedder: Some(embedder),
+        provider_health: ai_memory_llm::ProviderHealth::default(),
+        decay_params: DecayParams::default(),
+        data_dir: tmp.path().to_path_buf(),
+        db_path,
+        bind: "127.0.0.1:0".to_string(),
+        bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
+        token_pepper: None,
+    };
+
+    // Seed source page (gets a synthetic embedding on write).
+    seed_page(
+        &store,
+        &state.wiki,
+        "src",
+        "proj",
+        "notes/a.md",
+        "hello world embed",
+    )
+    .await;
+
+    let src_ws = store
+        .reader
+        .find_workspace("src".to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    let src_proj = store
+        .reader
+        .find_project(src_ws, "proj".to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    let src = store
+        .reader
+        .load_embeddings(
+            src_ws,
+            src_proj,
+            "synthetic".to_string(),
+            "bag-of-words-v1".to_string(),
+            8,
+        )
+        .await
+        .unwrap();
+    assert_eq!(src.len(), 1, "source page must have an embedding to carry");
+
+    // Overwrite with a recognisable marker vector.
+    let marker: Vec<f32> = vec![9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0];
+    store
+        .writer
+        .store_embedding(
+            src[0].id,
+            ai_memory_store::f32_vec_to_bytes(&marker),
+            "synthetic".to_string(),
+            "bag-of-words-v1".to_string(),
+            8,
+        )
+        .await
+        .unwrap();
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // The destination page must carry the MARKER (not a recomputed vector).
+    let dst_ws = store
+        .reader
+        .find_workspace("dst".to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    let dst_proj = store
+        .reader
+        .find_project(dst_ws, "proj".to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    let dst = store
+        .reader
+        .load_embeddings(
+            dst_ws,
+            dst_proj,
+            "synthetic".to_string(),
+            "bag-of-words-v1".to_string(),
+            8,
+        )
+        .await
+        .unwrap();
+    assert_eq!(dst.len(), 1, "dest page must carry an embedding");
+    for (got, want) in dst[0].vector.iter().zip(marker.iter()) {
+        assert!(
+            (got - want).abs() < 1e-4,
+            "carried embedding must equal the source marker (not a recompute); got {:?}",
+            dst[0].vector
+        );
+    }
+}

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -1,0 +1,305 @@
+//! Integration tests for `POST /admin/move-project`.
+//!
+//! Follows the same pattern as `admin_rename.rs` / `admin_purge.rs`: build
+//! a real [`AdminState`] over a tmpdir-backed store + wiki, drive the
+//! router with `tower::ServiceExt::oneshot`.
+//!
+//! move-project copies every latest page of the source project into the
+//! destination workspace through the normal write path, then purges the
+//! source. Sessions/observations/handoffs are NOT migrated (only pages).
+
+use ai_memory_core::{PagePath, Tier};
+use ai_memory_mcp::{AdminState, admin_router};
+use ai_memory_store::{DecayParams, Store};
+use ai_memory_wiki::{Wiki, WritePageRequest};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::json;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
+    let store = Store::open(tmp.path()).unwrap();
+    let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
+    let db_path = store.db_path().to_path_buf();
+    let state = AdminState {
+        writer: store.writer.clone(),
+        reader: store.reader.clone(),
+        wiki,
+        llm: None,
+        embedder: None,
+        provider_health: ai_memory_llm::ProviderHealth::default(),
+        decay_params: DecayParams::default(),
+        data_dir: tmp.path().to_path_buf(),
+        db_path,
+        bind: "127.0.0.1:0".to_string(),
+        bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
+        token_pepper: None,
+    };
+    (state, store)
+}
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+}
+
+async fn post(state: AdminState, uri: &str, body: serde_json::Value) -> axum::response::Response {
+    let router = admin_router(state);
+    let req = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    router.oneshot(req).await.unwrap()
+}
+
+/// Seed `<ws>/<project>/<path>` with one page carrying `body`.
+async fn seed_page(store: &Store, wiki: &Wiki, ws: &str, project: &str, path: &str, body: &str) {
+    let ws_id = store.writer.get_or_create_workspace(ws).await.unwrap();
+    let proj = store
+        .writer
+        .get_or_create_project(ws_id, project, None)
+        .await
+        .unwrap();
+    wiki.write_page(WritePageRequest {
+        workspace_id: ws_id,
+        project_id: proj,
+        path: PagePath::new(path.to_string()).unwrap(),
+        frontmatter: serde_json::json!({"title": path}),
+        body: body.to_string(),
+        tier: Tier::Semantic,
+        pinned: false,
+        title: Some(path.into()),
+        author_id: None,
+        actor: ai_memory_core::ActorContext::anonymous(),
+    })
+    .await
+    .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Happy path: seed `src/proj` with two pages, move into `dst`, assert the
+/// pages now live under `dst/proj`, the source project + on-disk dir are
+/// gone, and the report counts add up.
+#[tokio::test]
+async fn move_project_copies_then_purges_source() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+
+    seed_page(
+        &store,
+        &state.wiki,
+        "src",
+        "proj",
+        "decisions/0001.md",
+        "decision body",
+    )
+    .await;
+    seed_page(
+        &store,
+        &state.wiki,
+        "src",
+        "proj",
+        "gotchas/x.md",
+        "see [[decisions/0001]] for the call",
+    )
+    .await;
+
+    // Capture the source on-disk dir before `state` is consumed by `post`.
+    let src_ws = store
+        .reader
+        .find_workspace("src".to_string())
+        .await
+        .unwrap()
+        .expect("src workspace exists");
+    let src_proj = store
+        .reader
+        .find_project(src_ws, "proj".to_string())
+        .await
+        .unwrap()
+        .expect("src project exists");
+    let src_dir = state.wiki.project_root(src_ws, src_proj);
+    assert!(src_dir.exists(), "source dir must exist before move");
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK, "move must succeed");
+
+    let body = body_json(resp).await;
+    assert_eq!(body["pages_copied"].as_u64().unwrap_or(0), 2, "{body}");
+    assert_eq!(body["source_purged"], true, "{body}");
+    assert_eq!(body["merged_into_existing"], false, "{body}");
+
+    // Both pages now belong to dst/proj (latest), content preserved.
+    let dst_pages = store.reader.list_pages("dst", "proj").await.unwrap();
+    let mut dst_paths: Vec<String> = dst_pages.into_iter().map(|p| p.path).collect();
+    dst_paths.sort();
+    assert_eq!(dst_paths, vec!["decisions/0001.md", "gotchas/x.md"]);
+
+    let dst_ws = store
+        .reader
+        .find_workspace("dst".to_string())
+        .await
+        .unwrap()
+        .expect("dst workspace exists");
+    let dst_proj = store
+        .reader
+        .find_project(dst_ws, "proj".to_string())
+        .await
+        .unwrap()
+        .expect("dst project exists");
+    let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
+    let read = wiki
+        .read_page(
+            dst_ws,
+            dst_proj,
+            &PagePath::new("decisions/0001.md".to_string()).unwrap(),
+        )
+        .unwrap();
+    assert!(
+        read.body.contains("decision body"),
+        "moved body must round-trip; got {:?}",
+        read.body
+    );
+
+    // Source project row and on-disk dir are gone.
+    assert!(
+        store
+            .reader
+            .find_project(src_ws, "proj".to_string())
+            .await
+            .unwrap()
+            .is_none(),
+        "source project row must be gone"
+    );
+    assert!(!src_dir.exists(), "source dir must be removed after move");
+}
+
+/// Without `confirm: true` the server returns 400 and leaves the source intact.
+#[tokio::test]
+async fn move_project_requires_confirm() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    seed_page(&store, &state.wiki, "src", "proj", "notes/a.md", "body a").await;
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst", "confirm": false }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    // Source untouched.
+    let src_ws = store
+        .reader
+        .find_workspace("src".to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        store
+            .reader
+            .find_project(src_ws, "proj".to_string())
+            .await
+            .unwrap()
+            .is_some(),
+        "source project must still exist after a rejected move"
+    );
+}
+
+/// A move from a nonexistent source project returns 404.
+#[tokio::test]
+async fn move_project_404_on_unknown_source() {
+    let tmp = TempDir::new().unwrap();
+    let (state, _store) = make_state(&tmp).await;
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "nope", "project": "ghost", "to_workspace": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+/// Moving into a workspace that already has a same-named project MERGES:
+/// the destination ends up with both the pre-existing and the moved pages.
+#[tokio::test]
+async fn move_project_merges_into_existing_dest() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    seed_page(&store, &state.wiki, "src", "proj", "notes/a.md", "body a").await;
+    seed_page(&store, &state.wiki, "dst", "proj", "notes/b.md", "body b").await;
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = body_json(resp).await;
+    assert_eq!(body["merged_into_existing"], true, "{body}");
+    assert_eq!(body["source_purged"], true, "{body}");
+
+    // Destination holds BOTH the pre-existing and the moved page.
+    let mut dst_paths: Vec<String> = store
+        .reader
+        .list_pages("dst", "proj")
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.path)
+        .collect();
+    dst_paths.sort();
+    assert_eq!(dst_paths, vec!["notes/a.md", "notes/b.md"]);
+
+    // Source gone.
+    let src_ws = store
+        .reader
+        .find_workspace("src".to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        store
+            .reader
+            .find_project(src_ws, "proj".to_string())
+            .await
+            .unwrap()
+            .is_none(),
+        "source project must be purged after merge-move"
+    );
+}
+
+/// A same-workspace move is rejected with 422 (use rename-project instead).
+#[tokio::test]
+async fn move_project_same_workspace_rejected() {
+    let tmp = TempDir::new().unwrap();
+    let (state, _store) = make_state(&tmp).await;
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "w", "project": "proj", "to_workspace": "w", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -78,9 +78,9 @@ async fn seed_page(store: &Store, wiki: &Wiki, ws: &str, project: &str, path: &s
         tier: Tier::Semantic,
         pinned: false,
         title: Some(path.into()),
+        admission_ctx: None,
         author_id: None,
         actor: ai_memory_core::ActorContext::anonymous(),
-        admission_ctx: None,
     })
     .await
     .unwrap();

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -45,6 +45,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
         active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
     };
     (state, store)
 }
@@ -363,6 +364,7 @@ async fn move_project_carries_source_embedding() {
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
         active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
     };
 
     // Seed source page (gets a synthetic embedding on write).
@@ -573,6 +575,7 @@ async fn make_state_with_embedder(tmp: &TempDir) -> (AdminState, Store) {
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
         active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
     };
     (state, store)
 }
@@ -722,11 +725,12 @@ fn build_state(store: &Store, tmp: &TempDir) -> AdminState {
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
         active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
     }
 }
 
-/// W5: a same-path conflict in a copy-purge merge de-duplicates the source page
-/// so BOTH versions survive, and the remap is reported.
+/// on_conflict=duplicate: a same-path conflict de-duplicates the source page so
+/// BOTH versions survive, and the remap is reported.
 #[tokio::test]
 async fn copy_purge_conflict_duplicates_keeping_both() {
     let tmp = TempDir::new().unwrap();
@@ -737,7 +741,8 @@ async fn copy_purge_conflict_duplicates_keeping_both() {
     let resp = post(
         state,
         "/admin/move-project",
-        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst", "confirm": true }),
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst",
+                "confirm": true, "on_conflict": "duplicate" }),
     )
     .await;
     assert_eq!(resp.status(), StatusCode::OK);
@@ -778,6 +783,109 @@ async fn copy_purge_conflict_duplicates_keeping_both() {
         moved.body, "body SRC",
         "source page lands under the de-duped path"
     );
+}
+
+/// on_conflict=block (the DEFAULT): a same-path conflict aborts the whole move
+/// with 409, lists the conflicting paths, and leaves the source intact —
+/// nothing is copied to the destination.
+#[tokio::test]
+async fn copy_purge_conflict_blocks_by_default() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    seed_page(&store, &state.wiki, "src", "proj", "notes/a.md", "body SRC").await;
+    seed_page(
+        &store,
+        &state.wiki,
+        "src",
+        "proj",
+        "notes/clean.md",
+        "only in src",
+    )
+    .await;
+    seed_page(&store, &state.wiki, "dst", "proj", "notes/a.md", "body DST").await;
+
+    // No on_conflict → defaults to block.
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let body = body_json(resp).await;
+    let conflicts = body["conflicts"].as_array().unwrap();
+    assert_eq!(conflicts.len(), 1, "{body}");
+    assert_eq!(conflicts[0], "notes/a.md");
+
+    // Source untouched (NOT purged) and the destination got NONE of the pages.
+    let (src_ws, _) = ids(&store, "src", "proj").await;
+    assert!(
+        store
+            .reader
+            .find_project(src_ws, "proj".to_string())
+            .await
+            .unwrap()
+            .is_some(),
+        "block must leave the source intact"
+    );
+    let dst_paths: Vec<String> = store
+        .reader
+        .list_pages("dst", "proj")
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.path)
+        .collect();
+    assert_eq!(
+        dst_paths,
+        vec!["notes/a.md"],
+        "destination unchanged — nothing copied"
+    );
+}
+
+/// on_conflict=overwrite: the source page supersedes the destination page at the
+/// same path; the destination ends with the source's content and no duplicate.
+#[tokio::test]
+async fn copy_purge_conflict_overwrites() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    seed_page(&store, &state.wiki, "src", "proj", "notes/a.md", "body SRC").await;
+    seed_page(&store, &state.wiki, "dst", "proj", "notes/a.md", "body DST").await;
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst",
+                "confirm": true, "on_conflict": "overwrite" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["source_purged"], true, "{body}");
+    // Conflict reported, mapped to the same path (supersede, not duplicate).
+    let conflicts = body["conflicts"].as_array().unwrap();
+    assert_eq!(conflicts.len(), 1, "{body}");
+    assert_eq!(conflicts[0]["path"], "notes/a.md");
+    assert_eq!(conflicts[0]["moved_to"], "notes/a.md");
+
+    // Destination has exactly ONE page at the path, carrying the SOURCE content.
+    let dst_paths: Vec<String> = store
+        .reader
+        .list_pages("dst", "proj")
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.path)
+        .collect();
+    assert_eq!(dst_paths, vec!["notes/a.md"], "no duplicate path");
+    let (dw, dp) = ids(&store, "dst", "proj").await;
+    let page = store
+        .reader
+        .page_body_by_ids(dw, dp, "notes/a.md")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(page.body, "body SRC", "source superseded the destination");
 }
 
 /// W6: the copy-purge (merge) path carries the source embedding verbatim onto

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -888,6 +888,91 @@ async fn copy_purge_conflict_overwrites() {
     assert_eq!(page.body, "body SRC", "source superseded the destination");
 }
 
+/// on_conflict=duplicate edge case: a source page whose path collides with the
+/// destination AND another source page whose natural path equals the first's
+/// de-duplicated target. All three distinct contents must survive — the natural
+/// path must not clobber the slot the de-duplication already claimed.
+#[tokio::test]
+async fn copy_purge_duplicate_avoids_clobbering_dedup_slot() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    // `notes/dup.md` conflicts with the destination; its dedup target is
+    // `notes/dup-from-src.md` — which ALSO exists as a source page.
+    seed_page(
+        &store,
+        &state.wiki,
+        "src",
+        "proj",
+        "notes/dup.md",
+        "SRC-dup",
+    )
+    .await;
+    seed_page(
+        &store,
+        &state.wiki,
+        "src",
+        "proj",
+        "notes/dup-from-src.md",
+        "SRC-natural",
+    )
+    .await;
+    seed_page(
+        &store,
+        &state.wiki,
+        "dst",
+        "proj",
+        "notes/dup.md",
+        "DST-dup",
+    )
+    .await;
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst",
+                "confirm": true, "on_conflict": "duplicate" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // All three distinct contents survive at three distinct paths (nothing
+    // clobbered). Assert as a set so the test is order-independent.
+    let (dw, dp) = ids(&store, "dst", "proj").await;
+    let paths: Vec<String> = store
+        .reader
+        .list_pages("dst", "proj")
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.path)
+        .collect();
+    assert_eq!(
+        paths.len(),
+        3,
+        "three distinct destination paths: {paths:?}"
+    );
+    let mut bodies: Vec<String> = Vec::new();
+    for p in &paths {
+        bodies.push(
+            store
+                .reader
+                .page_body_by_ids(dw, dp, p)
+                .await
+                .unwrap()
+                .unwrap()
+                .body
+                .trim()
+                .to_string(),
+        );
+    }
+    bodies.sort();
+    assert_eq!(
+        bodies,
+        vec!["DST-dup", "SRC-dup", "SRC-natural"],
+        "every version survives; none clobbered"
+    );
+}
+
 /// W6: the copy-purge (merge) path carries the source embedding verbatim onto
 /// the new destination page id — not a recompute. (The existing embedding test
 /// exercised only the true-move path.)

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -4,9 +4,14 @@
 //! a real [`AdminState`] over a tmpdir-backed store + wiki, drive the
 //! router with `tower::ServiceExt::oneshot`.
 //!
-//! move-project copies every latest page of the source project into the
-//! destination workspace through the normal write path, then purges the
-//! source. Sessions/observations/handoffs are NOT migrated (only pages).
+//! move-project has two paths. To a FRESH destination (no same-named project)
+//! it does a lossless TRUE-MOVE: re-stamp the project's workspace_id in place,
+//! keeping the same project_id, sessions, observations, handoffs, page history
+//! and embeddings. To an EXISTING same-named project it does a COPY-PURGE
+//! merge: copy the source's latest pages in through the normal write path
+//! (carrying embeddings over verbatim, de-duplicating any conflicting path so
+//! both versions survive), then purge the source — there the episodic rows
+//! (sessions/observations/handoffs) are dropped by the purge.
 
 use ai_memory_core::{PagePath, Tier};
 use ai_memory_mcp::{AdminState, admin_router};
@@ -39,6 +44,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
         bind: "127.0.0.1:0".to_string(),
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
     };
     (state, store)
 }
@@ -356,6 +362,7 @@ async fn move_project_carries_source_embedding() {
         bind: "127.0.0.1:0".to_string(),
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
     };
 
     // Seed source page (gets a synthetic embedding on write).
@@ -535,4 +542,418 @@ async fn move_project_true_move_preserves_sessions_and_observations() {
     let obs = store.reader.observations_for_session(sid).await.unwrap();
     assert_eq!(obs.len(), 1, "observation must survive the move");
     assert_eq!(obs[0].workspace_id, dst_ws, "observation re-stamped to dst");
+}
+
+// ---------------------------------------------------------------------------
+// Rework (PR #60 review): failure model, live-session guard, copy-purge
+// conflict/partial/idempotency, copy-purge embedding carry-over.
+// ---------------------------------------------------------------------------
+
+/// Build an AdminState with a synthetic embedder (for copy-purge embedding
+/// carry-over) and a published active project pointer.
+async fn make_state_with_embedder(tmp: &TempDir) -> (AdminState, Store) {
+    let store = Store::open(tmp.path()).unwrap();
+    let embedder: std::sync::Arc<dyn ai_memory_llm::Embedder> =
+        std::sync::Arc::new(ai_memory_llm::SyntheticEmbedder::new(8));
+    let wiki = Wiki::new(tmp.path(), store.writer.clone())
+        .unwrap()
+        .with_embedder(embedder.clone());
+    let db_path = store.db_path().to_path_buf();
+    let state = AdminState {
+        writer: store.writer.clone(),
+        reader: store.reader.clone(),
+        wiki,
+        llm: None,
+        embedder: Some(embedder),
+        provider_health: ai_memory_llm::ProviderHealth::default(),
+        decay_params: DecayParams::default(),
+        data_dir: tmp.path().to_path_buf(),
+        db_path,
+        bind: "127.0.0.1:0".to_string(),
+        bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
+        token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
+    };
+    (state, store)
+}
+
+async fn ids(
+    store: &Store,
+    ws: &str,
+    proj: &str,
+) -> (ai_memory_core::WorkspaceId, ai_memory_core::ProjectId) {
+    let ws_id = store
+        .reader
+        .find_workspace(ws.to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    let proj_id = store
+        .reader
+        .find_project(ws_id, proj.to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    (ws_id, proj_id)
+}
+
+/// W1: when the on-disk dir rename fails mid true-move, the SQL re-stamp is
+/// rolled back so NOTHING moves (no DB-ahead-of-disk split-brain). We force the
+/// rename to fail by planting a FILE where the destination workspace dir would
+/// be created.
+#[tokio::test]
+async fn true_move_rolls_back_when_dir_rename_fails() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    seed_page(&store, &state.wiki, "src", "proj", "notes/a.md", "body a").await;
+
+    // Pre-create the destination workspace, then plant a FILE at its wiki dir
+    // so `create_dir_all` during the rename fails. The pre-check passes because
+    // the project subdir cannot exist under a file.
+    let dst_ws = store
+        .writer
+        .get_or_create_workspace("dst".to_string())
+        .await
+        .unwrap();
+    let dst_ws_dir = tmp.path().join("wiki").join(dst_ws.to_string());
+    std::fs::write(&dst_ws_dir, b"not a dir").unwrap();
+
+    let (src_ws, src_proj) = ids(&store, "src", "proj").await;
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body = body_json(resp).await;
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("nothing changed"),
+        "{body}"
+    );
+
+    // The project must still live in the SOURCE workspace (rollback worked).
+    let still_src = store
+        .reader
+        .find_project(src_ws, "proj".to_string())
+        .await
+        .unwrap();
+    assert_eq!(
+        still_src,
+        Some(src_proj),
+        "project rolled back to source ws"
+    );
+    assert!(
+        store
+            .reader
+            .find_project(dst_ws, "proj".to_string())
+            .await
+            .unwrap()
+            .is_none(),
+        "destination must hold no project after rollback"
+    );
+}
+
+/// W3: moving the project the hook router has published as ACTIVE is refused
+/// (409) without `force`.
+#[tokio::test]
+async fn move_refuses_active_project_without_force() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    seed_page(&store, &state.wiki, "src", "proj", "notes/a.md", "body a").await;
+    let (src_ws, src_proj) = ids(&store, "src", "proj").await;
+    state.active_project.set(src_ws, src_proj);
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+/// W3: `force: true` overrides the active-project guard, and the move
+/// republishes the active pointer under the destination workspace.
+#[tokio::test]
+async fn move_active_project_with_force_succeeds_and_republishes() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    seed_page(&store, &state.wiki, "src", "proj", "notes/a.md", "body a").await;
+    let (src_ws, src_proj) = ids(&store, "src", "proj").await;
+    let active = state.active_project.clone();
+    active.set(src_ws, src_proj);
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst",
+                "confirm": true, "force": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // The active pointer now points at the SAME project in the destination ws.
+    let (dst_ws, _) = ids(&store, "dst", "proj").await;
+    assert_eq!(
+        active.get(),
+        Some((dst_ws, src_proj)),
+        "active republished to dst"
+    );
+}
+
+/// Build an AdminState over an already-open store (lets one test drive two
+/// routers — e.g. a move then a re-run — against the same SQLite file).
+fn build_state(store: &Store, tmp: &TempDir) -> AdminState {
+    AdminState {
+        writer: store.writer.clone(),
+        reader: store.reader.clone(),
+        wiki: Wiki::new(tmp.path(), store.writer.clone()).unwrap(),
+        llm: None,
+        embedder: None,
+        provider_health: ai_memory_llm::ProviderHealth::default(),
+        decay_params: DecayParams::default(),
+        data_dir: tmp.path().to_path_buf(),
+        db_path: store.db_path().to_path_buf(),
+        bind: "127.0.0.1:0".to_string(),
+        bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
+        token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
+    }
+}
+
+/// W5: a same-path conflict in a copy-purge merge de-duplicates the source page
+/// so BOTH versions survive, and the remap is reported.
+#[tokio::test]
+async fn copy_purge_conflict_duplicates_keeping_both() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    seed_page(&store, &state.wiki, "src", "proj", "notes/a.md", "body SRC").await;
+    seed_page(&store, &state.wiki, "dst", "proj", "notes/a.md", "body DST").await;
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["moved_via"], "copy-purge", "{body}");
+
+    let conflicts = body["conflicts"].as_array().unwrap();
+    assert_eq!(conflicts.len(), 1, "{body}");
+    assert_eq!(conflicts[0]["path"], "notes/a.md");
+    assert_eq!(conflicts[0]["moved_to"], "notes/a-from-src.md");
+
+    let mut paths: Vec<String> = store
+        .reader
+        .list_pages("dst", "proj")
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.path)
+        .collect();
+    paths.sort();
+    assert_eq!(paths, vec!["notes/a-from-src.md", "notes/a.md"]);
+
+    let (dw, dp) = ids(&store, "dst", "proj").await;
+    let kept = store
+        .reader
+        .page_body_by_ids(dw, dp, "notes/a.md")
+        .await
+        .unwrap()
+        .unwrap();
+    let moved = store
+        .reader
+        .page_body_by_ids(dw, dp, "notes/a-from-src.md")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(kept.body, "body DST", "destination's original page is kept");
+    assert_eq!(
+        moved.body, "body SRC",
+        "source page lands under the de-duped path"
+    );
+}
+
+/// W6: the copy-purge (merge) path carries the source embedding verbatim onto
+/// the new destination page id — not a recompute. (The existing embedding test
+/// exercised only the true-move path.)
+#[tokio::test]
+async fn copy_purge_carries_source_embedding() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state_with_embedder(&tmp).await;
+    seed_page(
+        &store,
+        &state.wiki,
+        "src",
+        "proj",
+        "notes/a.md",
+        "hello world embed",
+    )
+    .await;
+    // A pre-existing same-named dst project forces the copy-purge path.
+    seed_page(&store, &state.wiki, "dst", "proj", "notes/keep.md", "keep").await;
+
+    let (src_ws, src_proj) = ids(&store, "src", "proj").await;
+    let src = store
+        .reader
+        .load_embeddings(
+            src_ws,
+            src_proj,
+            "synthetic".to_string(),
+            "bag-of-words-v1".to_string(),
+            8,
+        )
+        .await
+        .unwrap();
+    assert_eq!(src.len(), 1);
+    let marker: Vec<f32> = vec![9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0];
+    store
+        .writer
+        .store_embedding(
+            src[0].id,
+            ai_memory_store::f32_vec_to_bytes(&marker),
+            "synthetic".to_string(),
+            "bag-of-words-v1".to_string(),
+            8,
+        )
+        .await
+        .unwrap();
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["moved_via"], "copy-purge", "{body}");
+
+    let (dst_ws, dst_proj) = ids(&store, "dst", "proj").await;
+    let dst = store
+        .reader
+        .load_embeddings(
+            dst_ws,
+            dst_proj,
+            "synthetic".to_string(),
+            "bag-of-words-v1".to_string(),
+            8,
+        )
+        .await
+        .unwrap();
+    let moved = dst
+        .iter()
+        .find(|e| e.path.as_str() == "notes/a.md")
+        .expect("moved page embedding");
+    for (got, want) in moved.vector.iter().zip(marker.iter()) {
+        assert!(
+            (got - want).abs() < 1e-4,
+            "carried marker, got {:?}",
+            moved.vector
+        );
+    }
+}
+
+/// W6: an unreadable source page is skipped and the source is NOT purged, so a
+/// fixed re-run is safe; the readable pages still land at the destination.
+#[tokio::test]
+async fn copy_purge_partial_skips_and_preserves_source() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    seed_page(&store, &state.wiki, "src", "proj", "notes/ok.md", "ok").await;
+    seed_page(&store, &state.wiki, "src", "proj", "notes/bad.md", "bad").await;
+    seed_page(&store, &state.wiki, "dst", "proj", "notes/keep.md", "keep").await;
+
+    let (src_ws, src_proj) = ids(&store, "src", "proj").await;
+    let bad = tmp
+        .path()
+        .join("wiki")
+        .join(src_ws.to_string())
+        .join(src_proj.to_string())
+        .join("notes/bad.md");
+    std::fs::remove_file(&bad).unwrap();
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["source_purged"], false, "{body}");
+    let skipped = body["pages_skipped"].as_array().unwrap();
+    assert_eq!(skipped.len(), 1, "{body}");
+    assert_eq!(skipped[0], "notes/bad.md");
+
+    assert!(
+        store
+            .reader
+            .find_project(src_ws, "proj".to_string())
+            .await
+            .unwrap()
+            .is_some(),
+        "source must NOT be purged when a page was skipped"
+    );
+    let dst_paths: Vec<String> = store
+        .reader
+        .list_pages("dst", "proj")
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.path)
+        .collect();
+    assert!(
+        dst_paths.contains(&"notes/ok.md".to_string()),
+        "readable page copied"
+    );
+}
+
+/// W6: re-running a copy-purge merge is idempotent — re-copying an
+/// already-present page is a no-op supersession, leaving no duplicates.
+#[tokio::test]
+async fn copy_purge_rerun_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+
+    // First move: src/proj (a.md) into existing dst/proj (keep.md), purges src.
+    let s1 = build_state(&store, &tmp);
+    seed_page(&store, &s1.wiki, "src", "proj", "notes/a.md", "body a").await;
+    seed_page(&store, &s1.wiki, "dst", "proj", "notes/keep.md", "keep").await;
+    let r1 = post(
+        s1,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(r1.status(), StatusCode::OK);
+
+    // Re-create the source identically and run the merge again.
+    let s2 = build_state(&store, &tmp);
+    seed_page(&store, &s2.wiki, "src", "proj", "notes/a.md", "body a").await;
+    let r2 = post(
+        s2,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(r2.status(), StatusCode::OK);
+
+    // Destination still holds exactly one of each path — no duplicates.
+    let mut paths: Vec<String> = store
+        .reader
+        .list_pages("dst", "proj")
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.path)
+        .collect();
+    paths.sort();
+    assert_eq!(paths, vec!["notes/a.md", "notes/keep.md"]);
 }

--- a/crates/ai-memory-mcp/tests/admin_phase3.rs
+++ b/crates/ai-memory-mcp/tests/admin_phase3.rs
@@ -44,6 +44,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
         bind: "127.0.0.1:0".to_string(),
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
     };
     (state, store)
 }

--- a/crates/ai-memory-mcp/tests/admin_phase3.rs
+++ b/crates/ai-memory-mcp/tests/admin_phase3.rs
@@ -45,6 +45,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
         active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
     };
     (state, store)
 }

--- a/crates/ai-memory-mcp/tests/admin_purge.rs
+++ b/crates/ai-memory-mcp/tests/admin_purge.rs
@@ -42,6 +42,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
         active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
         db_path,
     };
     (state, store)
@@ -346,6 +347,7 @@ async fn purge_project_rejecting_admission_leaves_source_intact() {
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
         active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
     };
 
     let (ws, _keep, doomed) = seed_two_projects(&store, &state.wiki).await;
@@ -443,6 +445,7 @@ async fn purge_project_idempotent_second_call_is_404() {
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
         active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
     };
 
     seed_two_projects(&store, &state_a.wiki).await;

--- a/crates/ai-memory-mcp/tests/admin_purge.rs
+++ b/crates/ai-memory-mcp/tests/admin_purge.rs
@@ -41,6 +41,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
         bind: "127.0.0.1:0".to_string(),
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
         db_path,
     };
     (state, store)
@@ -344,6 +345,7 @@ async fn purge_project_rejecting_admission_leaves_source_intact() {
         bind: "127.0.0.1:0".to_string(),
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
     };
 
     let (ws, _keep, doomed) = seed_two_projects(&store, &state.wiki).await;
@@ -440,6 +442,7 @@ async fn purge_project_idempotent_second_call_is_404() {
         bind: "127.0.0.1:0".to_string(),
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
     };
 
     seed_two_projects(&store, &state_a.wiki).await;

--- a/crates/ai-memory-mcp/tests/admin_read_page.rs
+++ b/crates/ai-memory-mcp/tests/admin_read_page.rs
@@ -29,6 +29,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
         bind: "127.0.0.1:49374".to_string(),
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
     };
     (state, store)
 }

--- a/crates/ai-memory-mcp/tests/admin_read_page.rs
+++ b/crates/ai-memory-mcp/tests/admin_read_page.rs
@@ -30,6 +30,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
         active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
     };
     (state, store)
 }

--- a/crates/ai-memory-mcp/tests/admin_rename.rs
+++ b/crates/ai-memory-mcp/tests/admin_rename.rs
@@ -35,6 +35,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
         bind: "127.0.0.1:0".to_string(),
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
     };
     (state, store)
 }
@@ -318,6 +319,7 @@ async fn rename_project_pages_still_searchable() {
         bind: "127.0.0.1:0".to_string(),
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
     };
 
     let rename_resp = post(

--- a/crates/ai-memory-mcp/tests/admin_rename.rs
+++ b/crates/ai-memory-mcp/tests/admin_rename.rs
@@ -36,6 +36,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
         active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
     };
     (state, store)
 }
@@ -320,6 +321,7 @@ async fn rename_project_pages_still_searchable() {
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
         active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
     };
 
     let rename_resp = post(

--- a/crates/ai-memory-mcp/tests/admin_status_search.rs
+++ b/crates/ai-memory-mcp/tests/admin_status_search.rs
@@ -31,6 +31,7 @@ async fn make_admin_state(tmp: &TempDir) -> (AdminState, Store) {
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
         active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
     };
     (state, store)
 }

--- a/crates/ai-memory-mcp/tests/admin_status_search.rs
+++ b/crates/ai-memory-mcp/tests/admin_status_search.rs
@@ -30,6 +30,7 @@ async fn make_admin_state(tmp: &TempDir) -> (AdminState, Store) {
         bind: "127.0.0.1:49374".to_string(),
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
     };
     (state, store)
 }

--- a/crates/ai-memory-mcp/tests/admin_write_page.rs
+++ b/crates/ai-memory-mcp/tests/admin_write_page.rs
@@ -30,6 +30,7 @@ async fn make_state(tmp: &TempDir) -> AdminState {
         bind: "127.0.0.1:0".to_string(),
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
     }
 }
 

--- a/crates/ai-memory-mcp/tests/admin_write_page.rs
+++ b/crates/ai-memory-mcp/tests/admin_write_page.rs
@@ -31,6 +31,7 @@ async fn make_state(tmp: &TempDir) -> AdminState {
         bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         token_pepper: None,
         active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
     }
 }
 

--- a/crates/ai-memory-store/migrations/V18__enforce_project_workspace_pairing.sql
+++ b/crates/ai-memory-store/migrations/V18__enforce_project_workspace_pairing.sql
@@ -1,0 +1,49 @@
+-- Enforce the (workspace_id, project_id) identity invariant on write.
+--
+-- The schema denormalises workspace_id onto every domain row but only ever
+-- enforced `project_id → projects(id)` and `workspace_id → workspaces(id)`
+-- INDEPENDENTLY — never that the pair is consistent (that the project actually
+-- lives in that workspace). That gap lets a stale writer (e.g. a hook router
+-- whose per-cwd cache still holds the OLD workspace_id for a project that was
+-- just moved to another workspace) silently insert a split-brain row instead
+-- of failing cleanly.
+--
+-- These BEFORE INSERT triggers close the gap: an INSERT whose workspace_id
+-- disagrees with the project's actual workspace ABORTs. The hook router already
+-- evicts its cache and re-resolves on a write error, so a clean abort turns the
+-- worst case (silent corruption) into self-healing.
+--
+-- INSERT only — never UPDATE — so the move-project re-stamp (which UPDATEs
+-- workspace_id across these tables in one transaction) is unaffected.
+
+CREATE TRIGGER pages_ws_proj_pairing_ai
+BEFORE INSERT ON pages
+FOR EACH ROW
+WHEN NEW.workspace_id IS NOT (SELECT workspace_id FROM projects WHERE id = NEW.project_id)
+BEGIN
+    SELECT RAISE(ABORT, 'pages.workspace_id does not match the project''s workspace');
+END;
+
+CREATE TRIGGER sessions_ws_proj_pairing_ai
+BEFORE INSERT ON sessions
+FOR EACH ROW
+WHEN NEW.workspace_id IS NOT (SELECT workspace_id FROM projects WHERE id = NEW.project_id)
+BEGIN
+    SELECT RAISE(ABORT, 'sessions.workspace_id does not match the project''s workspace');
+END;
+
+CREATE TRIGGER observations_ws_proj_pairing_ai
+BEFORE INSERT ON observations
+FOR EACH ROW
+WHEN NEW.workspace_id IS NOT (SELECT workspace_id FROM projects WHERE id = NEW.project_id)
+BEGIN
+    SELECT RAISE(ABORT, 'observations.workspace_id does not match the project''s workspace');
+END;
+
+CREATE TRIGGER handoffs_ws_proj_pairing_ai
+BEFORE INSERT ON handoffs
+FOR EACH ROW
+WHEN NEW.workspace_id IS NOT (SELECT workspace_id FROM projects WHERE id = NEW.project_id)
+BEGIN
+    SELECT RAISE(ABORT, 'handoffs.workspace_id does not match the project''s workspace');
+END;

--- a/crates/ai-memory-store/src/error.rs
+++ b/crates/ai-memory-store/src/error.rs
@@ -48,6 +48,12 @@ pub enum StoreError {
     #[error("invalid project name: {0}")]
     InvalidProjectName(String),
 
+    /// A lookup expected a row that was not present (e.g. moving a project
+    /// that no longer exists in the source workspace — typically a race or
+    /// caller-invariant violation).
+    #[error("not found: {0}")]
+    NotFound(String),
+
     /// A UNIQUE constraint was violated by an insert (e.g. duplicate
     /// `users.username` / `users.email`). The string carries a
     /// human-readable explanation the CLI / admin endpoint surfaces

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -997,6 +997,94 @@ pub fn purge_project(
     })
 }
 
+/// Summary returned by [`move_project_workspace`] and exposed via
+/// [`crate::writer::WriterHandle::move_project_workspace`].
+#[derive(Debug, Default, Clone)]
+pub struct MoveSummary {
+    /// `pages` rows re-stamped (all versions, not just latest).
+    pub pages_moved: u64,
+    /// `sessions` rows re-stamped.
+    pub sessions_moved: u64,
+    /// `observations` rows re-stamped.
+    pub observations_moved: u64,
+    /// `handoffs` rows re-stamped.
+    pub handoffs_moved: u64,
+    /// `audit_log` rows re-stamped.
+    pub audit_log_moved: u64,
+}
+
+/// Re-stamp a project's `workspace_id` across every domain table in ONE
+/// transaction, keeping the same `project_id`. This is a lossless "true move":
+/// pages, sessions, observations, handoffs and supersession history all stay
+/// attached to the project — unlike a copy+purge, which drops everything but
+/// the latest pages.
+///
+/// `page_embeddings` and `links` are keyed by `page_id` (not `workspace_id`),
+/// so they follow automatically with no re-stamp.
+///
+/// The destination workspace row MUST already exist (FK on
+/// `projects.workspace_id`); the caller get-or-creates it first. A same-named
+/// project already living in the destination workspace makes the `projects`
+/// UPDATE violate `UNIQUE (workspace_id, name)` and the whole transaction
+/// rolls back — the caller must detect that merge case and route it through
+/// copy+purge instead.
+pub fn move_project_workspace(
+    conn: &mut Connection,
+    project_id: &ProjectId,
+    from_workspace: &WorkspaceId,
+    to_workspace: &WorkspaceId,
+) -> StoreResult<MoveSummary> {
+    let tx = conn.transaction()?;
+
+    let pid = project_id.as_bytes();
+    let from = from_workspace.as_bytes();
+    let to = to_workspace.as_bytes();
+
+    // Re-stamp child tables first (they carry the denormalized workspace_id),
+    // then the project row last. Order is irrelevant inside the transaction,
+    // but doing projects last keeps the UNIQUE(workspace_id, name) failure —
+    // the merge-collision signal — as the final, cheapest check.
+    let pages_moved = tx.execute(
+        "UPDATE pages SET workspace_id = ?1 WHERE project_id = ?2",
+        params![&to[..], &pid[..]],
+    )? as u64;
+    let sessions_moved = tx.execute(
+        "UPDATE sessions SET workspace_id = ?1 WHERE project_id = ?2",
+        params![&to[..], &pid[..]],
+    )? as u64;
+    let observations_moved = tx.execute(
+        "UPDATE observations SET workspace_id = ?1 WHERE project_id = ?2",
+        params![&to[..], &pid[..]],
+    )? as u64;
+    let handoffs_moved = tx.execute(
+        "UPDATE handoffs SET workspace_id = ?1 WHERE project_id = ?2",
+        params![&to[..], &pid[..]],
+    )? as u64;
+    let audit_log_moved = tx.execute(
+        "UPDATE audit_log SET workspace_id = ?1 WHERE project_id = ?2 AND workspace_id = ?3",
+        params![&to[..], &pid[..], &from[..]],
+    )? as u64;
+
+    let projects_updated = tx.execute(
+        "UPDATE projects SET workspace_id = ?1 WHERE id = ?2 AND workspace_id = ?3",
+        params![&to[..], &pid[..], &from[..]],
+    )?;
+    if projects_updated != 1 {
+        return Err(StoreError::NotFound(format!(
+            "project {project_id} not found in source workspace {from_workspace}"
+        )));
+    }
+
+    tx.commit()?;
+    Ok(MoveSummary {
+        pages_moved,
+        sessions_moved,
+        observations_moved,
+        handoffs_moved,
+        audit_log_moved,
+    })
+}
+
 /// Remove embedding rows in a workspace/project scope whose `(provider, model, dim)`
 /// does not match the configured triple, plus rows tied to superseded pages.
 pub fn delete_stale_page_embeddings(
@@ -1820,5 +1908,107 @@ mod tests {
             sql.contains("AFTER UPDATE OF title, body, path_search ON pages"),
             "pages_fts_au must not fire on access_count/last_accessed_at updates: {sql}"
         );
+    }
+
+    /// True move: re-stamping a project's workspace_id keeps the same
+    /// project_id and carries pages, sessions and observations along —
+    /// the whole point of the lossless move. The summary counts must
+    /// match what actually moved.
+    #[test]
+    fn move_project_workspace_restamps_all_domain_rows() {
+        use ai_memory_core::ObservationKind;
+
+        let (_tmp, mut conn, src_ws, proj) = fresh_db();
+        let dst_ws = get_or_create_workspace(&mut conn, "djalmajr").unwrap();
+
+        // Seed a page, a session and an observation under the source ws.
+        let page_id = upsert_page(&mut conn, &page(src_ws, proj, "notes/a.md", "body")).unwrap();
+        let sid = SessionId::new();
+        begin_session(
+            &mut conn,
+            &NewSession {
+                id: sid,
+                workspace_id: src_ws,
+                project_id: proj,
+                agent_kind: AgentKind::ClaudeCode,
+                cwd: None,
+            },
+        )
+        .unwrap();
+        insert_observation(
+            &mut conn,
+            &NewObservation {
+                session_id: sid,
+                workspace_id: src_ws,
+                project_id: proj,
+                kind: ObservationKind::UserPrompt,
+                extension: None,
+                source_event: None,
+                title: "t".into(),
+                body: "b".into(),
+                importance: 5,
+            },
+        )
+        .unwrap();
+
+        let summary = move_project_workspace(&mut conn, &proj, &src_ws, &dst_ws).unwrap();
+        assert_eq!(summary.pages_moved, 1);
+        assert_eq!(summary.sessions_moved, 1);
+        assert_eq!(summary.observations_moved, 1);
+
+        // The project_id is unchanged; every row now points at dst_ws.
+        // `projects` keys the project by `id`; child tables by `project_id`.
+        let count_in = |table: &str, ws: &ai_memory_core::WorkspaceId| -> i64 {
+            let id_col = if table == "projects" {
+                "id"
+            } else {
+                "project_id"
+            };
+            conn.query_row(
+                &format!("SELECT COUNT(*) FROM {table} WHERE {id_col} = ?1 AND workspace_id = ?2"),
+                params![&proj.as_bytes()[..], ws.as_bytes()],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        for table in ["projects", "pages", "sessions", "observations"] {
+            assert_eq!(count_in(table, &dst_ws), 1, "{table} must move to dst ws");
+            assert_eq!(count_in(table, &src_ws), 0, "{table} must leave src ws");
+        }
+        // The page keeps its id (embeddings/links follow via page_id).
+        let still_there: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pages WHERE id = ?1 AND workspace_id = ?2",
+                params![&page_id.as_bytes()[..], dst_ws.as_bytes()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(still_there, 1);
+    }
+
+    /// A same-named project already in the destination workspace makes the
+    /// projects UPDATE collide with UNIQUE(workspace_id, name); the whole
+    /// transaction must roll back, leaving the source intact. The admin
+    /// layer detects this merge case up front and routes it to copy+purge.
+    #[test]
+    fn move_project_workspace_rolls_back_on_name_collision() {
+        let (_tmp, mut conn, src_ws, proj) = fresh_db();
+        let dst_ws = get_or_create_workspace(&mut conn, "djalmajr").unwrap();
+        // Destination already holds a project named "scratch".
+        get_or_create_project(&mut conn, &dst_ws, "scratch", None).unwrap();
+        upsert_page(&mut conn, &page(src_ws, proj, "notes/a.md", "body")).unwrap();
+
+        let err = move_project_workspace(&mut conn, &proj, &src_ws, &dst_ws);
+        assert!(err.is_err(), "name collision must fail the move");
+
+        // Source rows untouched after rollback.
+        let src_pages: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pages WHERE project_id = ?1 AND workspace_id = ?2",
+                params![&proj.as_bytes()[..], src_ws.as_bytes()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(src_pages, 1, "rollback must preserve source pages");
     }
 }

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -2011,4 +2011,81 @@ mod tests {
             .unwrap();
         assert_eq!(src_pages, 1, "rollback must preserve source pages");
     }
+
+    /// V18 integrity triggers: an INSERT whose `workspace_id` disagrees with
+    /// the project's actual workspace ABORTs (the split-brain a stale hook
+    /// cache would otherwise create), while the consistent pair inserts fine.
+    #[test]
+    fn insert_with_mismatched_workspace_is_rejected() {
+        use ai_memory_core::ObservationKind;
+
+        let (_tmp, mut conn, ws, proj) = fresh_db();
+        let other_ws = get_or_create_workspace(&mut conn, "other").unwrap();
+
+        // A page under the WRONG workspace (project lives in `ws`) is refused.
+        let mut bad_page = page(ws, proj, "notes/a.md", "body");
+        bad_page.workspace_id = other_ws;
+        assert!(
+            upsert_page(&mut conn, &bad_page).is_err(),
+            "page insert with mismatched workspace must abort"
+        );
+
+        // The consistent pair inserts fine.
+        upsert_page(&mut conn, &page(ws, proj, "notes/a.md", "body")).unwrap();
+
+        // The session insert is guarded too: a mismatched pair aborts.
+        let bad_sid = SessionId::new();
+        assert!(
+            begin_session(
+                &mut conn,
+                &NewSession {
+                    id: bad_sid,
+                    workspace_id: other_ws,
+                    project_id: proj,
+                    agent_kind: AgentKind::ClaudeCode,
+                    cwd: None,
+                },
+            )
+            .is_err(),
+            "session insert with mismatched workspace must abort"
+        );
+
+        let sid = SessionId::new();
+        begin_session(
+            &mut conn,
+            &NewSession {
+                id: sid,
+                workspace_id: ws,
+                project_id: proj,
+                agent_kind: AgentKind::ClaudeCode,
+                cwd: None,
+            },
+        )
+        .unwrap();
+
+        // The split-brain case the maintainer flagged: a hook writes an
+        // observation with a stale workspace id for a moved project.
+        let mismatched_obs = NewObservation {
+            session_id: sid,
+            workspace_id: other_ws,
+            project_id: proj,
+            kind: ObservationKind::UserPrompt,
+            extension: None,
+            source_event: None,
+            title: "t".into(),
+            body: "b".into(),
+            importance: 5,
+        };
+        assert!(
+            insert_observation(&mut conn, &mismatched_obs).is_err(),
+            "observation insert with mismatched workspace must abort"
+        );
+
+        // Same observation under the correct workspace is accepted.
+        let good_obs = NewObservation {
+            workspace_id: ws,
+            ..mismatched_obs
+        };
+        insert_observation(&mut conn, &good_obs).unwrap();
+    }
 }

--- a/crates/ai-memory-store/src/writer.rs
+++ b/crates/ai-memory-store/src/writer.rs
@@ -18,7 +18,7 @@ use rusqlite::Connection;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::error::{StoreError, StoreResult};
-use crate::ops::{self, EmbeddingWrite, PurgeSummary, ReorgSummary};
+use crate::ops::{self, EmbeddingWrite, MoveSummary, PurgeSummary, ReorgSummary};
 use crate::users::{self, TOKEN_HASH_LEN};
 
 /// Commands accepted by the writer thread.
@@ -118,6 +118,16 @@ pub(crate) enum WriteCmd {
         /// Human-readable `workspace/project` label forwarded into the summary.
         label: String,
         reply: oneshot::Sender<StoreResult<PurgeSummary>>,
+    },
+    /// Re-stamp a project's `workspace_id` across every domain table in one
+    /// transaction, keeping the same `project_id` (a lossless cross-workspace
+    /// "true move"). The caller renames the on-disk dir and ensures the
+    /// destination workspace row exists first.
+    MoveProjectWorkspace {
+        project_id: ProjectId,
+        from_workspace: WorkspaceId,
+        to_workspace: WorkspaceId,
+        reply: oneshot::Sender<StoreResult<MoveSummary>>,
     },
     /// Rename a project's `name` column without moving any files (the wiki
     /// is flat on disk). Fails with [`crate::error::StoreError::ProjectNameTaken`]
@@ -432,6 +442,36 @@ impl WriterHandle {
             workspace_id,
             project_id,
             label: label.into(),
+            reply: tx,
+        })
+        .await?;
+        rx.await.map_err(|_| StoreError::WriterClosed)?
+    }
+
+    /// Re-stamp a project's `workspace_id` to `to_workspace` across every
+    /// domain table in one transaction, keeping the same `project_id`. This is
+    /// the lossless cross-workspace move: pages, sessions, observations and
+    /// supersession history all follow. The destination workspace row must
+    /// already exist; the caller renames the on-disk dir afterwards.
+    ///
+    /// # Errors
+    /// Returns [`StoreError::WriterClosed`] if the actor has shut down,
+    /// [`StoreError::NotFound`] if the project is absent from the source
+    /// workspace, or propagates the SQL error (e.g. a
+    /// `UNIQUE(workspace_id, name)` collision when the destination already
+    /// holds a same-named project — the caller routes that merge case to
+    /// copy+purge instead).
+    pub async fn move_project_workspace(
+        &self,
+        project_id: ProjectId,
+        from_workspace: WorkspaceId,
+        to_workspace: WorkspaceId,
+    ) -> StoreResult<MoveSummary> {
+        let (tx, rx) = oneshot::channel();
+        self.send(WriteCmd::MoveProjectWorkspace {
+            project_id,
+            from_workspace,
+            to_workspace,
             reply: tx,
         })
         .await?;
@@ -809,6 +849,20 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
             } => {
                 let result = ops::purge_project(&mut conn, &workspace_id, &project_id, &label);
                 send_or_warn(reply, result, "purge_project");
+            }
+            WriteCmd::MoveProjectWorkspace {
+                project_id,
+                from_workspace,
+                to_workspace,
+                reply,
+            } => {
+                let result = ops::move_project_workspace(
+                    &mut conn,
+                    &project_id,
+                    &from_workspace,
+                    &to_workspace,
+                );
+                send_or_warn(reply, result, "move_project_workspace");
             }
             WriteCmd::RenameProject {
                 workspace_id,

--- a/crates/ai-memory-wiki/src/wiki.rs
+++ b/crates/ai-memory-wiki/src/wiki.rs
@@ -129,6 +129,17 @@ impl Wiki {
         self.embedder.as_ref()
     }
 
+    /// Return a clone-friendly handle with the embedder detached, so
+    /// `write_page` skips the per-page `embed_document` call. Used by
+    /// bulk copy paths (e.g. `move-project`) that carry the source page's
+    /// existing embedding over verbatim instead of recomputing it — the
+    /// caller is then responsible for `store_embedding` on the new page.
+    #[must_use]
+    pub fn without_embedder(mut self) -> Self {
+        self.embedder = None;
+        self
+    }
+
     /// Borrow the git adapter (for callers wiring auto-commit).
     #[must_use]
     pub fn git(&self) -> &GitAdapter {

--- a/crates/ai-memory-wiki/src/wiki.rs
+++ b/crates/ai-memory-wiki/src/wiki.rs
@@ -170,6 +170,41 @@ impl Wiki {
             .join(project_id.to_string())
     }
 
+    /// Move a project's on-disk directory from one workspace to another,
+    /// keeping the same `project_id` segment:
+    /// `<wiki_root>/<from_ws>/<proj>` → `<wiki_root>/<to_ws>/<proj>`.
+    ///
+    /// Both paths share the same `<wiki_root>`, so `fs::rename` is an atomic
+    /// metadata-only operation on every supported filesystem — no per-file
+    /// copy, no re-embed. The destination workspace directory is created
+    /// first. This pairs with
+    /// [`WriterHandle::move_project_workspace`](ai_memory_store) — callers
+    /// re-stamp SQLite first, then call this to land the files at the path the
+    /// re-stamped rows already point at, so the watcher's own-write
+    /// short-circuit absorbs the resulting events.
+    ///
+    /// # Errors
+    /// Propagates [`WikiError::Io`] if the destination already exists or the
+    /// rename fails (e.g. cross-device, which cannot happen within one root).
+    pub fn rename_project_dir(
+        &self,
+        project_id: ProjectId,
+        from_workspace: WorkspaceId,
+        to_workspace: WorkspaceId,
+    ) -> WikiResult<()> {
+        let src = self.project_root(from_workspace, project_id);
+        if !src.exists() {
+            // Nothing on disk to move (a project with zero written pages).
+            return Ok(());
+        }
+        let dst = self.project_root(to_workspace, project_id);
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::rename(&src, &dst)?;
+        Ok(())
+    }
+
     /// Absolute on-disk path for a page within a specific project.
     #[must_use]
     pub fn abs_path(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -276,7 +276,8 @@ install-mcp          commit               llm-test
 forget-sweep         lint                 embed
 generate-auth-token  setup-agent          bootstrap
 install-instructions reorg                purge-project
-rename-project       uninstall            auth
+rename-project       move-project         uninstall
+auth
 ```
 
 Run `ai-memory --help` for the full tree.

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -10,6 +10,7 @@ on a homelab box where mistakes are harder to undo.
 |---|---|---|---|---|
 | `purge-project --confirm` | ✅ yes | the one project's data | no | Atomic `rm -rf <project_root>` on the namespaced disk path; sibling projects untouched. |
 | `rename-project --from --to` | ✅ yes | no | yes (rename back) | Column-only update on `projects.name`. The on-disk dir is keyed by `project_id` (UUID), so the rename never moves a file. |
+| `move-project --confirm` | ✅ yes | the source project (after copy) | no | Copies every latest page into the destination workspace via the write path, then purges the source. Sessions/observations/handoffs do **not** migrate. |
 | `backup --output-path` | ✅ yes | no | n/a | Streams a gzipped tarball from the server's online `sqlite3 .backup` plus the wiki tree. Safe alongside the live writer. |
 | `restore --from <tarball>` | ❌ **stop the server first** | overwrites the data dir | no (without prior backup) | Refuses if any sibling `ai-memory` process is alive (sysinfo guard). |
 | `reset --confirm` | ❌ **stop the server first** | yes, all data | no | Refuses if any sibling `ai-memory` process is alive (sysinfo guard). |
@@ -118,6 +119,48 @@ Failure modes:
 - **`to` name already exists in this workspace** → 422.
 - **`to` invalid (empty, slash, whitespace)** → 422.
 - **Source `from` not found** → 404.
+
+### `move-project`
+
+```bash
+ai-memory move-project --from-workspace default --project my-project \
+  --to-workspace other-workspace --confirm
+```
+
+Moves a project into a **different** workspace. Unlike `rename-project`
+(a same-workspace column update), this crosses the workspace boundary,
+so it is implemented as a copy-then-purge through the normal write path
+rather than a low-level re-stamp:
+
+1. Resolve the source `(from_workspace, project)`. 404 on miss.
+2. Reject `from_workspace == to_workspace` (use `rename-project`) → 422.
+3. Get-or-create `(to_workspace, project)`. If that workspace already
+   holds a same-named project, the copy **merges** into it
+   (`merged_into_existing: true` in the report); otherwise a fresh
+   `project_id` is created (a true move).
+4. For each latest page of the source, copy it into the destination via
+   `Wiki::write_page` — so sanitization, link re-resolution, FTS, and
+   (on deploy) the admission/git-mirror webhooks all fire naturally.
+5. **Only after every page copied successfully**, purge the source
+   project (cascade-delete its rows + remove its on-disk dir).
+
+Safety: copy-before-purge means any copy failure aborts **before** the
+purge, leaving the source intact. An unreadable source file is skipped
+and also blocks the purge (`source_purged: false`) so a fixed re-run is
+safe (re-running is idempotent — copied pages just supersede).
+
+**What does NOT migrate:** only durable wiki pages move. The source's
+`sessions`, `observations`, and `handoffs` (the raw episodic capture
+log) are destroyed by the purge and are not recreated under the
+destination. The page version history in SQLite resets (the moved pages
+start a fresh supersession chain); the real page history lives in the
+wiki's git mirror.
+
+Failure modes:
+
+- **Missing `--confirm`** → 400.
+- **`from_workspace == to_workspace`** → 422 (use `rename-project`).
+- **Source project not found** → 404.
 
 ### `backup`
 

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -10,7 +10,7 @@ on a homelab box where mistakes are harder to undo.
 |---|---|---|---|---|
 | `purge-project --confirm` | ✅ yes | the one project's data | no | Atomic `rm -rf <project_root>` on the namespaced disk path; sibling projects untouched. |
 | `rename-project --from --to` | ✅ yes | no | yes (rename back) | Column-only update on `projects.name`. The on-disk dir is keyed by `project_id` (UUID), so the rename never moves a file. |
-| `move-project --confirm` | ✅ yes | the source project (after copy) | no | Copies every latest page into the destination workspace via the write path, then purges the source. Sessions/observations/handoffs do **not** migrate. |
+| `move-project --confirm` | ✅ yes | source only in the merge case | no | Fresh destination → lossless **true move** (re-stamp `workspace_id`, keep `project_id`, rename the dir): sessions/observations/handoffs + history all survive. Destination with a same-named project → **copy+purge merge**: only latest pages migrate. |
 | `backup --output-path` | ✅ yes | no | n/a | Streams a gzipped tarball from the server's online `sqlite3 .backup` plus the wiki tree. Safe alongside the live writer. |
 | `restore --from <tarball>` | ❌ **stop the server first** | overwrites the data dir | no (without prior backup) | Refuses if any sibling `ai-memory` process is alive (sysinfo guard). |
 | `reset --confirm` | ❌ **stop the server first** | yes, all data | no | Refuses if any sibling `ai-memory` process is alive (sysinfo guard). |
@@ -128,39 +128,67 @@ ai-memory move-project --from-workspace default --project my-project \
 ```
 
 Moves a project into a **different** workspace. Unlike `rename-project`
-(a same-workspace column update), this crosses the workspace boundary,
-so it is implemented as a copy-then-purge through the normal write path
-rather than a low-level re-stamp:
+(a same-workspace column update), this crosses the workspace boundary.
+The destination decides which of two strategies runs — reported as
+`moved_via` in the response:
+
+**1. Fresh destination → `"true-move"` (lossless, the common case).**
+When the destination workspace has **no** same-named project, the move is
+a low-level re-stamp:
 
 1. Resolve the source `(from_workspace, project)`. 404 on miss.
 2. Reject `from_workspace == to_workspace` (use `rename-project`) → 422.
-3. Get-or-create `(to_workspace, project)`. If that workspace already
-   holds a same-named project, the copy **merges** into it
-   (`merged_into_existing: true` in the report); otherwise a fresh
-   `project_id` is created (a true move).
-4. For each latest page of the source, copy it into the destination via
-   `Wiki::write_page` — so sanitization, link re-resolution, FTS, and
-   (on deploy) the admission/git-mirror webhooks all fire naturally.
-5. **Only after every page copied successfully**, purge the source
-   project (cascade-delete its rows + remove its on-disk dir).
+3. Get-or-create the destination **workspace** row (not a new project).
+4. Re-stamp `workspace_id` across every domain table for the project in
+   **one transaction**, keeping the same `project_id`
+   (`projects`, `pages`, `sessions`, `observations`, `handoffs`,
+   `audit_log`). `page_embeddings` and `links` are keyed by `page_id`, so
+   they follow with no re-stamp.
+5. `fs::rename` the project dir
+   `<wiki>/<from_ws>/<proj>` → `<wiki>/<to_ws>/<proj>` (atomic within one
+   wiki root). SQL commits **before** the rename, so when the watcher sees
+   the new-path events it re-derives the same `(ws, proj)` the DB already
+   holds and the reindex is a sha256 no-op.
 
-Safety: copy-before-purge means any copy failure aborts **before** the
-purge, leaving the source intact. An unreadable source file is skipped
-and also blocks the purge (`source_purged: false`) so a fixed re-run is
-safe (re-running is idempotent — copied pages just supersede).
+This is O(1) (one transaction + one rename), re-embeds nothing, and
+**preserves everything** — sessions, observations, handoffs and the full
+supersession history all travel with the project.
 
-**What does NOT migrate:** only durable wiki pages move. The source's
-`sessions`, `observations`, and `handoffs` (the raw episodic capture
-log) are destroyed by the purge and are not recreated under the
-destination. The page version history in SQLite resets (the moved pages
-start a fresh supersession chain); the real page history lives in the
-wiki's git mirror.
+**2. Destination already has a same-named project → `"copy-purge"`
+(merge).** Two distinct `project_id`s can't be re-stamped into one (it
+would collide on `UNIQUE (workspace_id, name)`), so the source's latest
+pages are copied into the existing destination project via
+`Wiki::write_page` (sanitization, link re-resolution, FTS, and — on
+deploy — the admission/git-mirror webhooks all fire), source embeddings
+are carried over verbatim, and only then is the source purged
+(`merged_into_existing: true`, `source_purged: true`).
+
+Copy-before-purge means any copy failure aborts **before** the purge,
+leaving the source intact. An unreadable source file is skipped and also
+blocks the purge (`source_purged: false`) so a fixed re-run is safe
+(re-running is idempotent — copied pages just supersede).
+
+**What does NOT migrate (merge case only):** in the `copy-purge` path the
+source's `sessions`, `observations`, and `handoffs` (the raw episodic
+capture log) are dropped by the purge, and the moved pages start a fresh
+supersession chain (the real page history lives in the wiki's git
+mirror). The `true-move` path has no such loss.
+
+> **Operational caveat — moving the project the current session writes
+> to.** Lifecycle hooks stamp an observation on every tool call into the
+> session's project. If you move that very project mid-session, the next
+> hook re-creates the source (`scratch`-style) under the old workspace.
+> Before moving a live project, point the repo's `.ai-memory.toml` at the
+> **destination** workspace first, so new hook events already land there
+> and the move is a clean no-contention operation.
 
 Failure modes:
 
 - **Missing `--confirm`** → 400.
 - **`from_workspace == to_workspace`** → 422 (use `rename-project`).
 - **Source project not found** → 404.
+- **Re-stamp committed but dir rename failed** (true-move, exceptional fs
+  error) → 500 with the exact `mv <src> <dst>` to run to reconcile.
 
 ### `backup`
 

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -146,11 +146,15 @@ a low-level re-stamp:
    they follow with no re-stamp.
 5. `fs::rename` the project dir
    `<wiki>/<from_ws>/<proj>` → `<wiki>/<to_ws>/<proj>` (atomic within one
-   wiki root). The destination dir is pre-checked to be absent first. The
-   SQL commits before the rename, but the move is **all-or-nothing**: if the
-   rename fails, the SQL re-stamp is rolled back (the op is symmetric) and
-   the call returns `move aborted (nothing changed)` — never a
-   DB-ahead-of-disk split-brain.
+   wiki root). The destination dir is pre-checked to be absent first. Ordering
+   is **rename-FIRST, SQL-commit-LAST**, so the **DB is never ahead of disk**:
+   a rename failure touches nothing; a crash between the two steps leaves at
+   most an orphan dir at the destination with the DB still wholly at the
+   source (recoverable), never a DB row pointing at a missing file. A SQL
+   failure renames the dir back, so the move is all-or-nothing. During the
+   brief window, any watcher reindex of the moved files attempts an INSERT
+   under `(dst_ws, proj)` that the V18 pairing trigger rejects cleanly (the
+   project still lives in `src_ws`), so no split-brain row is created.
 
 This is O(1) (one transaction + one rename), re-embeds nothing, and
 **preserves everything** — sessions, observations, handoffs and the full
@@ -177,14 +181,23 @@ leaving the source intact. An unreadable source file is skipped and also
 blocks the purge (`source_purged: false`) so a fixed re-run is safe
 (re-running is idempotent — copied pages just supersede).
 
-**Same-path conflicts → duplicate (keep both).** When a source page's path
-already exists in the destination with **different** content, the source
-page is landed under a de-duplicated path
-(`<stem>-from-<src_workspace>.md`, then `-2`, `-3`, …) so neither version is
-lost; each remap is listed in the response `conflicts` array. Identical
-content is a no-op supersession at the same path. (Wikilinks pointing at the
-old path are not rewritten — the lossless `true-move` path is the way to
-preserve paths and links.)
+**Same-path conflicts (`on_conflict`).** When a source page's path already
+exists in the destination with **different** content, the policy decides
+(identical content is always a no-op supersession at the same path):
+
+- **`block`** (default) — abort the whole move with 409, listing the
+  conflicting paths; the source is left intact. The safe default for a
+  destructive op: nothing is overwritten or split silently. The operator
+  resolves the conflicts or re-runs with an explicit policy.
+- **`overwrite`** — the source page supersedes the destination page at the
+  same path (the destination's prior version becomes history).
+- **`duplicate`** — keep both: the source page lands under a de-duplicated
+  path (`<stem>-from-<src_workspace>.md`, then `-2`, …). Note: wikilinks
+  pointing at the original path are not rewritten, so the lossless
+  `true-move` path remains the way to preserve paths and links.
+
+Every conflict (overwrite/duplicate) is listed in the response `conflicts`
+array (`path` → `moved_to`). Set the policy via `--on-conflict` on the CLI.
 
 **What does NOT migrate (merge case only):** in the `copy-purge` path the
 source's `sessions`, `observations`, and `handoffs` (the raw episodic

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -146,13 +146,22 @@ a low-level re-stamp:
    they follow with no re-stamp.
 5. `fs::rename` the project dir
    `<wiki>/<from_ws>/<proj>` → `<wiki>/<to_ws>/<proj>` (atomic within one
-   wiki root). SQL commits **before** the rename, so when the watcher sees
-   the new-path events it re-derives the same `(ws, proj)` the DB already
-   holds and the reindex is a sha256 no-op.
+   wiki root). The destination dir is pre-checked to be absent first. The
+   SQL commits before the rename, but the move is **all-or-nothing**: if the
+   rename fails, the SQL re-stamp is rolled back (the op is symmetric) and
+   the call returns `move aborted (nothing changed)` — never a
+   DB-ahead-of-disk split-brain.
 
 This is O(1) (one transaction + one rename), re-embeds nothing, and
 **preserves everything** — sessions, observations, handoffs and the full
 supersession history all travel with the project.
+
+**Live-session guard.** The server refuses (409) to move the project the
+hook router has published as the *active* project (a live session's next
+observation would carry a now-stale `workspace_id`). Pass `--force` /
+`force: true` to override — still safe: the move republishes the active
+pointer, and the `(workspace_id, project_id)` insert trigger (V18) rejects
+any stale write cleanly, so the router re-resolves instead of corrupting.
 
 **2. Destination already has a same-named project → `"copy-purge"`
 (merge).** Two distinct `project_id`s can't be re-stamped into one (it
@@ -167,6 +176,15 @@ Copy-before-purge means any copy failure aborts **before** the purge,
 leaving the source intact. An unreadable source file is skipped and also
 blocks the purge (`source_purged: false`) so a fixed re-run is safe
 (re-running is idempotent — copied pages just supersede).
+
+**Same-path conflicts → duplicate (keep both).** When a source page's path
+already exists in the destination with **different** content, the source
+page is landed under a de-duplicated path
+(`<stem>-from-<src_workspace>.md`, then `-2`, `-3`, …) so neither version is
+lost; each remap is listed in the response `conflicts` array. Identical
+content is a no-op supersession at the same path. (Wikilinks pointing at the
+old path are not rewritten — the lossless `true-move` path is the way to
+preserve paths and links.)
 
 **What does NOT migrate (merge case only):** in the `copy-purge` path the
 source's `sessions`, `observations`, and `handoffs` (the raw episodic


### PR DESCRIPTION
`rename-project` changes a project's name within a workspace, but there's no way to move a project **across** workspaces. This adds `move-project` (CLI + `POST /admin/move-project`).

## Use cases
- Consolidating workspaces: you can't rename workspace `A → B` when `B` already exists, so you move A's projects into B one at a time.
- Reorganizing: splitting deploy- or client-specific projects into their own workspace while leaving shared ones in the common one.

## Behaviour — two strategies, picked by the destination

The destination decides which path runs; the response reports it as `moved_via`.

### `"true-move"` — fresh destination (lossless, the common case)
When the destination workspace has **no** same-named project, the move is a low-level re-stamp:
- Re-stamp `workspace_id` across every domain table for the project in **one writer transaction**, keeping the same `project_id` (`projects`, `pages`, `sessions`, `observations`, `handoffs`, `audit_log`). `page_embeddings` and `links` are keyed by `page_id`, so they follow with no re-stamp.
- `fs::rename` the project dir `<wiki>/<from_ws>/<proj>` → `<wiki>/<to_ws>/<proj>` (atomic within one wiki root).
- SQL commits **before** the rename, so when the watcher sees the new-path events it re-derives the same `(ws, proj)` the DB already holds and the reindex is a sha256 no-op.

This is O(1) (one transaction + one rename), re-embeds nothing, and **preserves everything** — sessions, observations, handoffs and the full supersession history all travel with the project.

### `"copy-purge"` — destination already has a same-named project (merge)
Two distinct `project_id`s can't be re-stamped into one (it would collide on `UNIQUE (workspace_id, name)`), so the source's latest pages are copied into the existing destination project through the normal write path (sanitization, link re-resolution, FTS index, and — on deploy — the admission/git-mirror webhooks all fire). Each page's existing embedding is **carried over verbatim** instead of recomputed; the source vector is reused only when it matches the configured embedder's `{provider, model, dim}`, so the one-model-per-index property holds. **Copy-before-purge**: only after every page copies successfully is the source purged; any copy failure aborts before the purge, and an unreadable source page is skipped and also blocks the purge, so a fixed re-run is safe.

In the merge path only durable pages move — sessions/observations/handoffs and the SQLite supersession history are dropped with the source purge (page history lives in the wiki's git history). The true-move path has no such loss.

Common to both: a same-workspace move is rejected (points at `rename-project`); `--confirm` is required.

## Design question — answered
The earlier revision asked whether sessions/observations should be carried over or whether "durable pages only" was the right scope. The answer here is the dual-path above: the **fresh-destination move is now lossless** (sessions/observations/history preserved via re-stamp), and "durable pages only" remains the behaviour **only** for the merge case, where re-stamp is structurally impossible. This also makes the common move O(1) instead of O(pages) — no per-page re-embed or webhook.

## Operational caveat
Moving the project the **current session** is writing to will have the next lifecycle hook re-create the source under the old workspace. Point the repo's `.ai-memory.toml` at the destination workspace **before** moving a live project. Documented in `docs/lifecycle-ops.md`.

## Tests
Integration (`admin_move.rs`): fresh-dest true-move (same `project_id`, nothing purged, dir renamed), true-move preserves a session + observation, merge-into-existing still copy+purge, embedding carry-over, confirm gate, 404 on unknown source, same-workspace rejection. Unit (`ops.rs`): re-stamp moves all domain rows; name-collision rolls the transaction back leaving the source intact.
