### PR TITLE
feat(serve): host the HTTP surface under a configurable base path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `ai-memory serve --transport http` can host the entire HTTP surface under a
+  configurable subpath with `--base-path` / `AI_MEMORY_BASE_PATH`; `/mcp`,
+  `/hook`, `/admin/*`, `/api/v1`, and the web UI all move under that prefix.
+  The web UI mount can also be changed with `--web-slug`, and custom
+  `--web-ui-dir` SPAs receive injected `<base href>` plus
+  `ai-memory-base-path` metadata for same-origin API calls behind reverse
+  proxies ([#65]).
 - `ai-memory move-project` can move projects across workspaces via the admin
   API. Fresh destinations use a lossless true move that keeps the same
   `project_id`, sessions, observations, handoffs, embeddings, and page history;
@@ -24,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before removal ([#55]).
 
 ### Fixed
+- Custom `--web-ui-dir` frontends no longer serve raw `/index.html` without
+  base-path injection; direct index requests and SPA fallback routes now return
+  the injected shell, while static assets remain untouched ([#65]).
 - `move-project` true moves now run through a wiki mutation gate: normal
   page writes/reindexes validate the `(workspace_id, project_id)` pair before
   touching disk, while true moves hold the exclusive side across the directory

--- a/README.md
+++ b/README.md
@@ -369,6 +369,13 @@ Useful entry points:
   screenshots and e2e tests — lives at
   [djalmajr/ai-memory-ui](https://github.com/djalmajr/ai-memory-ui).
 
+  When a reverse proxy hosts ai-memory under a URL subpath, set
+  `--base-path` (or `AI_MEMORY_BASE_PATH`) so every HTTP surface moves
+  together. Example: `--base-path /wiki` serves MCP at `/wiki/mcp`, hooks at
+  `/wiki/hook`, the API at `/wiki/api/v1`, and the default browser at
+  `/wiki/web`. Set `--web-slug /` if you want the browser or custom SPA at
+  `/wiki` itself.
+
 Install the routing snippet once so agents proactively call the right
 MCP tool for those prompts:
 

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -902,6 +902,23 @@ pub struct ServeArgs {
     /// --enable-web is set.
     #[arg(long)]
     pub web_ui_dir: Option<PathBuf>,
+    /// Base path the whole HTTP surface is served under. Empty (default)
+    /// keeps every route at the host root — byte-identical to previous
+    /// behaviour. Set e.g. `/wiki` to host ai-memory under a URL subpath
+    /// behind a reverse proxy that preserves the prefix; then `/mcp`,
+    /// `/api/v1`, `/hook` and the web UI all live under it (`/wiki/mcp`,
+    /// `/wiki/api/v1`, …). The value is normalised to `/<core>` (leading
+    /// slash, no trailing); `/` and `` both mean root.
+    #[arg(long, env = "AI_MEMORY_BASE_PATH", default_value = "")]
+    pub base_path: String,
+    /// Slug the web UI is mounted at, WITHIN `--base-path`. Default `/web`
+    /// (the read-only `/api/v1` API always stays at `<base>/api/v1`). Set
+    /// `/` to serve the UI at the base root itself (e.g. `/wiki` instead of
+    /// `/wiki/web`). The server injects a normalised `<base href>` into the
+    /// served HTML so the built-in UI and a custom `--web-ui-dir` SPA both
+    /// resolve their assets under the prefix without a rebuild.
+    #[arg(long, env = "AI_MEMORY_WEB_SLUG", default_value = "/web")]
+    pub web_slug: String,
     /// Run the HTTP transport in stateful (session) mode: the server
     /// issues an `Mcp-Session-Id` on `initialize` and requires it on
     /// every later request, with SSE-framed responses. Off by default —

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -1,5 +1,6 @@
 //! `ai-memory serve` — MCP server with optional filesystem watcher.
 
+use std::convert::Infallible;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -24,6 +25,7 @@ use rmcp::transport::streamable_http_server::{
     StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
 };
 use tokio_util::sync::CancellationToken;
+use tower::service_fn;
 use tower_http::cors::CorsLayer;
 use tower_http::services::ServeDir;
 use tracing::info;
@@ -297,7 +299,7 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
                 &args.web_slug,
                 &base_href,
                 &base_path,
-            );
+            )?;
             let router = apply_http_layers(router, auth_state, config.allowed_hosts.clone());
             // Host the entire surface under the configured base path. Empty
             // base = root (unchanged). The auth/host layers are already
@@ -885,9 +887,9 @@ fn mount_web_router(
     web_slug: &str,
     base_href: &str,
     base_path: &str,
-) -> axum::Router {
+) -> Result<axum::Router> {
     if !enable_web {
-        return router;
+        return Ok(router);
     }
     // Register the web surfaces BEFORE applying the bearer middleware. In
     // axum 0.8, `.layer()` only attaches to routes registered before the
@@ -928,24 +930,16 @@ fn mount_web_router(
     // URLs resolve under `{base_path}{web_slug}`.
     if let Some(dir) = web_ui_dir {
         let dir = dir.to_path_buf();
-        let raw = std::fs::read_to_string(dir.join("index.html")).unwrap_or_default();
+        let raw = std::fs::read_to_string(dir.join("index.html"))
+            .with_context(|| format!("reading custom web UI index at {}", dir.display()))?;
         let injected = inject_base_path_meta(&inject_base_href(&raw, base_href), base_path);
         info!(mount, base_href, base_path, "custom web UI mounted");
-        // Assets are served as files; any unmatched path (SPA client route)
-        // falls back to the injected index. `append_index_html_on_directories`
-        // is off so the directory index also flows through the injecting
-        // fallback rather than serving the raw on-disk index.html.
-        let spa = ServeDir::new(dir)
-            .append_index_html_on_directories(false)
-            .fallback(axum::routing::get(move || {
-                let body = injected.clone();
-                async move { axum::response::Html(body) }
-            }));
-        return if slug.is_empty() {
-            router.fallback_service(spa)
+        let spa = custom_spa_router(dir, injected);
+        return Ok(if slug.is_empty() {
+            router.merge(spa)
         } else {
-            router.nest_service(&slug, spa)
-        };
+            router.nest(&slug, spa)
+        });
     }
 
     // The built-in server-rendered browser emits RELATIVE asset/link URLs
@@ -958,7 +952,7 @@ fn mount_web_router(
     );
     info!(mount, base_href, "read-only wiki browser mounted");
     if slug.is_empty() {
-        router.merge(web_router)
+        Ok(router.merge(web_router))
     } else {
         // Strip-trailing-slash redirect. The target must carry the full
         // external prefix (`{base_path}{slug}`), because the surrounding
@@ -972,7 +966,7 @@ fn mount_web_router(
                 trimmed.to_string()
             }
         };
-        router
+        Ok(router
             .route(
                 &format!("{slug}/"),
                 axum::routing::get(move || {
@@ -980,8 +974,44 @@ fn mount_web_router(
                     async move { axum::response::Redirect::permanent(&to) }
                 }),
             )
-            .nest(&slug, web_router)
+            .nest(&slug, web_router))
     }
+}
+
+fn custom_spa_router(dir: std::path::PathBuf, injected_index: String) -> axum::Router {
+    let index = Arc::new(injected_index);
+    let root_index = index.clone();
+    let direct_index = index.clone();
+    let fallback_index = index.clone();
+
+    // Assets are served as files; any missing asset path falls back to the
+    // injected index for SPA client routes. Direct `/index.html` is routed
+    // explicitly so it cannot bypass injection by being served from disk.
+    let assets = ServeDir::new(dir)
+        .append_index_html_on_directories(false)
+        .fallback(service_fn(move |_req: Request<Body>| {
+            let body = fallback_index.clone();
+            async move {
+                Ok::<_, Infallible>(axum::response::Html((*body).clone()).into_response())
+            }
+        }));
+
+    axum::Router::new()
+        .route(
+            "/",
+            axum::routing::get(move || {
+                let body = root_index.clone();
+                async move { axum::response::Html((*body).clone()) }
+            }),
+        )
+        .route(
+            "/index.html",
+            axum::routing::get(move || {
+                let body = direct_index.clone();
+                async move { axum::response::Html((*body).clone()) }
+            }),
+        )
+        .route_service("/{*path}", assets)
 }
 
 /// Response middleware: inject `<base href>` into `text/html` responses from
@@ -1168,7 +1198,8 @@ mod tests {
             "/web",
             "/web/",
             "",
-        );
+        )
+        .unwrap();
         let router = apply_http_layers(
             router,
             Arc::new(AuthState::new(Some("secret".to_string()))),
@@ -1210,7 +1241,8 @@ mod tests {
             web_slug,
             &base_href,
             &base,
-        );
+        )
+        .unwrap();
         let router = if base.is_empty() {
             router
         } else {
@@ -1347,6 +1379,167 @@ mod tests {
                 .contains(r#"<base href="/web/">"#),
             "default mount should inject the root-relative base href"
         );
+    }
+
+    #[tokio::test]
+    async fn custom_spa_index_routes_are_injected_under_base_path() {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
+        let ui = TempDir::new().unwrap();
+        std::fs::write(
+            ui.path().join("index.html"),
+            "<!doctype html><html><head><title>spa</title></head><body>shell</body></html>",
+        )
+        .unwrap();
+        std::fs::write(ui.path().join("app.js"), "console.log('asset');").unwrap();
+
+        let base = normalize_prefix("/wiki");
+        let base_href = web_base_href("/wiki", "/web");
+        let router = mount_web_router(
+            axum::Router::new(),
+            true,
+            store.reader.clone(),
+            wiki,
+            Some(ui.path()),
+            &[],
+            "/web",
+            &base_href,
+            &base,
+        )
+        .unwrap();
+        let router = axum::Router::new().nest(&base, router);
+
+        for uri in [
+            "/wiki/web",
+            "/wiki/web/index.html",
+            "/wiki/web/client/route",
+        ] {
+            let resp = router
+                .clone()
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "{uri}");
+            let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let html = std::str::from_utf8(&body).unwrap();
+            assert!(
+                html.contains(r#"<base href="/wiki/web/">"#),
+                "{uri} must receive injected base href: {html}"
+            );
+            assert!(
+                html.contains(r#"<meta name="ai-memory-base-path" content="/wiki">"#),
+                "{uri} must receive injected API base-path meta: {html}"
+            );
+            assert!(html.contains("shell"), "{uri} returns the SPA shell");
+        }
+
+        let asset = router
+            .oneshot(
+                Request::builder()
+                    .uri("/wiki/web/app.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(asset.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(asset.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let js = std::str::from_utf8(&body).unwrap();
+        assert_eq!(js, "console.log('asset');");
+    }
+
+    #[tokio::test]
+    async fn custom_spa_root_slug_does_not_shadow_api_routes() {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
+        let ui = TempDir::new().unwrap();
+        std::fs::write(
+            ui.path().join("index.html"),
+            "<!doctype html><html><head><title>spa</title></head><body>root shell</body></html>",
+        )
+        .unwrap();
+        std::fs::write(ui.path().join("app.js"), "console.log('root asset');").unwrap();
+
+        let base = normalize_prefix("/wiki");
+        let base_href = web_base_href("/wiki", "/");
+        let router = mount_web_router(
+            axum::Router::new(),
+            true,
+            store.reader.clone(),
+            wiki,
+            Some(ui.path()),
+            &[],
+            "/",
+            &base_href,
+            &base,
+        )
+        .unwrap();
+        let router = axum::Router::new().nest(&base, router);
+
+        for uri in ["/wiki", "/wiki/index.html", "/wiki/client/route"] {
+            let resp = router
+                .clone()
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "{uri}");
+            let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let html = std::str::from_utf8(&body).unwrap();
+            assert!(
+                html.contains(r#"<base href="/wiki/">"#),
+                "{uri} must receive injected base href: {html}"
+            );
+            assert!(
+                html.contains(r#"<meta name="ai-memory-base-path" content="/wiki">"#),
+                "{uri} must receive injected API base-path meta: {html}"
+            );
+            assert!(html.contains("root shell"), "{uri} returns the SPA shell");
+        }
+
+        let api = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/wiki/api/v1/projects")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(api.status(), StatusCode::OK);
+        let content_type = api
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or_default();
+        assert!(
+            content_type.starts_with("application/json"),
+            "API route must not be shadowed by the root SPA: {content_type}"
+        );
+
+        let asset = router
+            .oneshot(
+                Request::builder()
+                    .uri("/wiki/app.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(asset.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(asset.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let js = std::str::from_utf8(&body).unwrap();
+        assert_eq!(js, "console.log('root asset');");
     }
 
     #[tokio::test]
@@ -1492,7 +1685,8 @@ mod tests {
             "/web",
             "/web/",
             "",
-        );
+        )
+        .unwrap();
         // No auth layer so we can reach /api/v1 directly.
         let resp = router
             .oneshot(
@@ -1544,7 +1738,8 @@ mod tests {
             "/web",
             "/web/",
             "",
-        );
+        )
+        .unwrap();
         let resp = router
             .oneshot(
                 Request::builder()
@@ -1585,7 +1780,8 @@ mod tests {
             "/web",
             "/web/",
             "",
-        );
+        )
+        .unwrap();
         // /web is a non-api route; sending an Origin header must not trigger CORS.
         let resp = router
             .oneshot(

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -954,10 +954,7 @@ fn mount_web_router(
     // anchoring the custom SPA gets via its injected index. Default (`/web/`)
     // is byte-equivalent to the previous absolute `/web/…` links.
     let web_router = ai_memory_web::router(reader, wiki).layer(
-        axum::middleware::from_fn_with_state(
-            Arc::new(base_href.to_string()),
-            inject_web_base_href,
-        ),
+        axum::middleware::from_fn_with_state(Arc::new(base_href.to_string()), inject_web_base_href),
     );
     info!(mount, base_href, "read-only wiki browser mounted");
     if slug.is_empty() {
@@ -1009,7 +1006,10 @@ async fn inject_web_base_href(
     let bytes = match axum::body::to_bytes(body, usize::MAX).await {
         Ok(b) => b,
         Err(_) => {
-            return (StatusCode::INTERNAL_SERVER_ERROR, "response body read error\n")
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "response body read error\n",
+            )
                 .into_response();
         }
     };
@@ -1187,6 +1187,166 @@ mod tests {
             .unwrap();
 
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// Assemble the web/API surface under `base_path` + `web_slug` exactly the
+    /// way the `serve` handler does (mount, then `nest(&base_path, …)`), with
+    /// no auth/host layers so tests probe routing + injection in isolation.
+    /// Returns the `TempDir` guard too — the caller must keep it alive for the
+    /// router's lifetime (the store's SQLite + wiki files live under it).
+    fn based_web_router(base_path: &str, web_slug: &str) -> (TempDir, axum::Router) {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
+        let base = normalize_prefix(base_path);
+        let base_href = web_base_href(base_path, web_slug);
+        let router = mount_web_router(
+            axum::Router::new(),
+            true,
+            store.reader.clone(),
+            wiki,
+            None,
+            &[],
+            web_slug,
+            &base_href,
+            &base,
+        );
+        let router = if base.is_empty() {
+            router
+        } else {
+            axum::Router::new().nest(&base, router)
+        };
+        (tmp, router)
+    }
+
+    #[tokio::test]
+    async fn base_path_nests_all_surfaces_and_root_404s() {
+        let (_tmp, router) = based_web_router("/wiki", "/web");
+
+        // The web UI is reachable UNDER the prefix…
+        let under = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/wiki/web")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(under.status(), StatusCode::OK);
+
+        // …and the API too.
+        let api = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/wiki/api/v1/projects")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(api.status(), StatusCode::OK);
+
+        // The same paths at the host ROOT must 404 — nothing leaks outside the
+        // prefix (the whole point of base-path hosting behind a shared proxy).
+        for uri in ["/web", "/api/v1/projects"] {
+            let root = router
+                .clone()
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(
+                root.status(),
+                StatusCode::NOT_FOUND,
+                "{uri} must 404 at root"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn inject_web_base_href_targets_html_only() {
+        let (_tmp, router) = based_web_router("/wiki", "/web");
+
+        // HTML response carries the injected <base href> under the prefix.
+        let html_resp = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/wiki/web")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(html_resp.status(), StatusCode::OK);
+        let html = axum::body::to_bytes(html_resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = std::str::from_utf8(&html).unwrap();
+        assert!(
+            html.contains(r#"<base href="/wiki/web/">"#),
+            "expected injected base href, got: {html}"
+        );
+
+        // A non-HTML asset passes through untouched (no <base> smuggled in).
+        let css_resp = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/wiki/web/static/tailwind.css")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(css_resp.status(), StatusCode::OK);
+        let css = axum::body::to_bytes(css_resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(
+            !std::str::from_utf8(&css).unwrap().contains("<base href"),
+            "non-HTML asset must not receive a <base href> injection"
+        );
+    }
+
+    #[tokio::test]
+    async fn trailing_slash_redirect_carries_the_prefix() {
+        let (_tmp, router) = based_web_router("/wiki", "/web");
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/wiki/web/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::PERMANENT_REDIRECT);
+        // Location must include the external prefix — the surrounding base nest
+        // does NOT rewrite Location headers, so a bare `/web` would drop `/wiki`.
+        assert_eq!(resp.headers().get(header::LOCATION).unwrap(), "/wiki/web",);
+    }
+
+    #[tokio::test]
+    async fn no_base_path_is_byte_equivalent_at_root() {
+        let (_tmp, router) = based_web_router("", "/web");
+        let resp = router
+            .clone()
+            .oneshot(Request::builder().uri("/web").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(
+            std::str::from_utf8(&body)
+                .unwrap()
+                .contains(r#"<base href="/web/">"#),
+            "default mount should inject the root-relative base href"
+        );
     }
 
     #[tokio::test]

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -948,21 +948,79 @@ fn mount_web_router(
         };
     }
 
-    let web_router = ai_memory_web::router(reader, wiki);
-    info!(mount, "read-only wiki browser mounted");
+    // The built-in server-rendered browser emits RELATIVE asset/link URLs
+    // (`static/…`, `w/…`, `search`, `.`). Inject a `<base href>` into every
+    // HTML response so they resolve under `{base_path}{web_slug}/` — the same
+    // anchoring the custom SPA gets via its injected index. Default (`/web/`)
+    // is byte-equivalent to the previous absolute `/web/…` links.
+    let web_router = ai_memory_web::router(reader, wiki).layer(
+        axum::middleware::from_fn_with_state(
+            Arc::new(base_href.to_string()),
+            inject_web_base_href,
+        ),
+    );
+    info!(mount, base_href, "read-only wiki browser mounted");
     if slug.is_empty() {
         router.merge(web_router)
     } else {
-        let redirect_to = slug.clone();
+        // Strip-trailing-slash redirect. The target must carry the full
+        // external prefix (`{base_path}{slug}`), because the surrounding
+        // `nest(&base_path, …)` does NOT rewrite Location headers. Derive it
+        // from base_href (which already folds in base_path + slug).
+        let canonical = {
+            let trimmed = base_href.trim_end_matches('/');
+            if trimmed.is_empty() {
+                "/".to_string()
+            } else {
+                trimmed.to_string()
+            }
+        };
         router
             .route(
                 &format!("{slug}/"),
                 axum::routing::get(move || {
-                    let to = redirect_to.clone();
+                    let to = canonical.clone();
                     async move { axum::response::Redirect::permanent(&to) }
                 }),
             )
             .nest(&slug, web_router)
+    }
+}
+
+/// Response middleware: inject `<base href>` into `text/html` responses from
+/// the built-in server-rendered web browser, so its relative URLs resolve
+/// under the configured `{base_path}{web_slug}` prefix. Non-HTML responses
+/// (static assets, redirects) pass through untouched.
+async fn inject_web_base_href(
+    State(base_href): State<Arc<String>>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    let resp = next.run(req).await;
+    let is_html = resp
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ct| ct.starts_with("text/html"));
+    if !is_html {
+        return resp;
+    }
+    let (mut parts, body) = resp.into_parts();
+    let bytes = match axum::body::to_bytes(body, usize::MAX).await {
+        Ok(b) => b,
+        Err(_) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, "response body read error\n")
+                .into_response();
+        }
+    };
+    match std::str::from_utf8(&bytes) {
+        Ok(html) => {
+            let injected = inject_base_href(html, &base_href);
+            // Stale length from the pre-injection body; let hyper recompute.
+            parts.headers.remove(header::CONTENT_LENGTH);
+            Response::from_parts(parts, Body::from(injected))
+        }
+        Err(_) => Response::from_parts(parts, Body::from(bytes)),
     }
 }
 

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -25,7 +25,7 @@ use rmcp::transport::streamable_http_server::{
 };
 use tokio_util::sync::CancellationToken;
 use tower_http::cors::CorsLayer;
-use tower_http::services::{ServeDir, ServeFile};
+use tower_http::services::ServeDir;
 use tracing::info;
 
 use crate::auth::{AuthState, require_bearer};
@@ -279,6 +279,14 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
                 .merge(hooks)
                 .layer(DefaultBodyLimit::max(MAX_BODY_BYTES))
                 .merge(admin.layer(DefaultBodyLimit::max(BOOTSTRAP_MAX_BODY_BYTES)));
+            let base_path = normalize_prefix(&args.base_path);
+            if base_path.is_empty() && !args.base_path.trim_matches('/').trim().is_empty() {
+                tracing::warn!(
+                    raw = %args.base_path,
+                    "AI_MEMORY_BASE_PATH is not a safe path prefix; serving at root instead",
+                );
+            }
+            let base_href = web_base_href(&args.base_path, &args.web_slug);
             let router = mount_web_router(
                 router,
                 args.enable_web,
@@ -286,8 +294,18 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
                 wiki.clone(),
                 args.web_ui_dir.as_deref(),
                 &cors_origins,
+                &args.web_slug,
+                &base_href,
             );
             let router = apply_http_layers(router, auth_state, config.allowed_hosts.clone());
+            // Host the entire surface under the configured base path. Empty
+            // base = root (unchanged). The auth/host layers are already
+            // attached to `router`, so they run for every nested route.
+            let router = if base_path.is_empty() {
+                router
+            } else {
+                axum::Router::new().nest(&base_path, router)
+            };
             let listener = tokio::net::TcpListener::bind(&bind)
                 .await
                 .with_context(|| format!("binding {bind}"))?;
@@ -712,6 +730,123 @@ fn llm_retry_hint(provider: &str, model: &str, base_url: Option<&str>) -> String
     command
 }
 
+/// Normalise an operator-supplied path prefix into either `""` (root) or
+/// `/<core>` — exactly one leading slash, no trailing slash, internal
+/// empty/`//` segments collapsed. Segments are restricted to a safe path
+/// charset; anything outside it falls back to root so a malformed env var
+/// can never inject markup or a protocol-relative `//` into served HTML.
+pub(crate) fn normalize_prefix(raw: &str) -> String {
+    let segs: Vec<&str> = raw.trim().split('/').filter(|s| !s.is_empty()).collect();
+    if segs.is_empty() {
+        return String::new();
+    }
+    let safe = segs.iter().all(|s| {
+        s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '~'))
+    });
+    if !safe {
+        return String::new();
+    }
+    format!("/{}", segs.join("/"))
+}
+
+/// Build the `<base href>` value (always trailing-slash-terminated, never
+/// the protocol-relative `//`) for the web UI mounted at `base_path` +
+/// `web_slug`.
+pub(crate) fn web_base_href(base_path: &str, web_slug: &str) -> String {
+    let combined = format!(
+        "{}{}",
+        normalize_prefix(base_path),
+        normalize_prefix(web_slug)
+    );
+    if combined.is_empty() {
+        "/".to_string()
+    } else {
+        format!("{combined}/")
+    }
+}
+
+/// Escape a string for safe inclusion inside a double-quoted HTML attribute.
+fn escape_attr(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// Inject `<base href="{href}">` immediately after the first `<head…>` tag
+/// (or prepend it when there is no head) so the served SPA's relative
+/// asset/router URLs resolve under the configured prefix.
+pub(crate) fn inject_base_href(html: &str, href: &str) -> String {
+    let tag = format!("<base href=\"{}\">", escape_attr(href));
+    if let Some(start) = html.find("<head")
+        && let Some(gt) = html[start..].find('>')
+    {
+        let pos = start + gt + 1;
+        let mut out = String::with_capacity(html.len() + tag.len());
+        out.push_str(&html[..pos]);
+        out.push_str(&tag);
+        out.push_str(&html[pos..]);
+        return out;
+    }
+    format!("{tag}{html}")
+}
+
+#[cfg(test)]
+mod web_base_tests {
+    use super::{inject_base_href, normalize_prefix, web_base_href};
+
+    #[test]
+    fn normalize_prefix_edge_cases() {
+        assert_eq!(normalize_prefix(""), "");
+        assert_eq!(normalize_prefix("/"), "");
+        assert_eq!(normalize_prefix("//"), "");
+        assert_eq!(normalize_prefix("  /  "), "");
+        assert_eq!(normalize_prefix("wiki"), "/wiki");
+        assert_eq!(normalize_prefix("/wiki"), "/wiki");
+        assert_eq!(normalize_prefix("/wiki/"), "/wiki");
+        assert_eq!(normalize_prefix("//wiki//"), "/wiki");
+        assert_eq!(normalize_prefix("/wiki/sub"), "/wiki/sub");
+        // Unsafe chars fall back to root — never inject markup or `//`.
+        assert_eq!(normalize_prefix("/wi\"ki"), "");
+        assert_eq!(normalize_prefix("/wiki space"), "");
+        assert_eq!(normalize_prefix("/<script>"), "");
+    }
+
+    #[test]
+    fn web_base_href_never_protocol_relative() {
+        assert_eq!(web_base_href("", "/web"), "/web/");
+        assert_eq!(web_base_href("/wiki", "/web"), "/wiki/web/");
+        assert_eq!(web_base_href("/wiki", "/"), "/wiki/");
+        assert_eq!(web_base_href("", "/"), "/");
+        assert_eq!(web_base_href("/", "/"), "/");
+        assert_eq!(web_base_href("/wiki/", "web"), "/wiki/web/");
+        for (b, s) in [("", "/"), ("/", "/"), ("//", "//")] {
+            assert!(!web_base_href(b, s).starts_with("//"));
+        }
+    }
+
+    #[test]
+    fn inject_base_href_after_head() {
+        let html = "<!doctype html><html><head><meta charset=\"utf-8\"></head><body></body></html>";
+        let out = inject_base_href(html, "/wiki/web/");
+        assert!(out.contains("<head><base href=\"/wiki/web/\"><meta"));
+    }
+
+    #[test]
+    fn inject_base_href_no_head_prepends() {
+        let out = inject_base_href("<html></html>", "/x/");
+        assert!(out.starts_with("<base href=\"/x/\"><html>"));
+    }
+
+    #[test]
+    fn inject_base_href_escapes_attr() {
+        let out = inject_base_href("<head></head>", "/a\"b/");
+        assert!(out.contains("<base href=\"/a&quot;b/\">"));
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn mount_web_router(
     router: axum::Router,
     enable_web: bool,
@@ -719,6 +854,8 @@ fn mount_web_router(
     wiki: Wiki,
     web_ui_dir: Option<&Path>,
     cors_origins: &[String],
+    web_slug: &str,
+    base_href: &str,
 ) -> axum::Router {
     if !enable_web {
         return router;
@@ -751,25 +888,55 @@ fn mount_web_router(
     };
     let router = router.nest("/api/v1", api);
 
+    // Where the UI is mounted WITHIN the (already-applied) base path.
+    // Empty slug => the UI is the root of the base path itself.
+    let slug = normalize_prefix(web_slug);
+    let mount = if slug.is_empty() { "/" } else { slug.as_str() };
+
     // Custom SPA via --web-ui-dir (SPA fallback to index.html), otherwise
-    // the built-in server-side wiki browser.
+    // the built-in server-side wiki browser. In both cases the served
+    // index carries an injected `<base href>` so relative asset/router
+    // URLs resolve under `{base_path}{web_slug}`.
     if let Some(dir) = web_ui_dir {
         let dir = dir.to_path_buf();
-        let index = dir.join("index.html");
-        info!(dir = %dir.display(), "custom web UI mounted at /web");
-        // ServeDir already answers /web and /web/ (SPA fallback to index.html);
-        // an explicit /web/ route here would conflict with the nest_service.
-        return router.nest_service("/web", ServeDir::new(dir).fallback(ServeFile::new(index)));
+        let injected = inject_base_href(
+            &std::fs::read_to_string(dir.join("index.html")).unwrap_or_default(),
+            base_href,
+        );
+        info!(mount, base_href, "custom web UI mounted");
+        // Assets are served as files; any unmatched path (SPA client route)
+        // falls back to the injected index. `append_index_html_on_directories`
+        // is off so the directory index also flows through the injecting
+        // fallback rather than serving the raw on-disk index.html.
+        let spa = ServeDir::new(dir)
+            .append_index_html_on_directories(false)
+            .fallback(axum::routing::get(move || {
+                let body = injected.clone();
+                async move { axum::response::Html(body) }
+            }));
+        return if slug.is_empty() {
+            router.fallback_service(spa)
+        } else {
+            router.nest_service(&slug, spa)
+        };
     }
 
     let web_router = ai_memory_web::router(reader, wiki);
-    info!("read-only wiki browser mounted at /web");
-    router
-        .route(
-            "/web/",
-            axum::routing::get(|| async { axum::response::Redirect::permanent("/web") }),
-        )
-        .nest("/web", web_router)
+    info!(mount, "read-only wiki browser mounted");
+    if slug.is_empty() {
+        router.merge(web_router)
+    } else {
+        let redirect_to = slug.clone();
+        router
+            .route(
+                &format!("{slug}/"),
+                axum::routing::get(move || {
+                    let to = redirect_to.clone();
+                    async move { axum::response::Redirect::permanent(&to) }
+                }),
+            )
+            .nest(&slug, web_router)
+    }
 }
 
 fn apply_http_layers(
@@ -913,6 +1080,8 @@ mod tests {
             wiki,
             None,
             &[],
+            "/web",
+            "/web/",
         );
         let router = apply_http_layers(
             router,
@@ -1074,6 +1243,8 @@ mod tests {
             wiki,
             None,
             &cors_origins,
+            "/web",
+            "/web/",
         );
         // No auth layer so we can reach /api/v1 directly.
         let resp = router
@@ -1123,6 +1294,8 @@ mod tests {
             wiki,
             None,
             &cors_origins,
+            "/web",
+            "/web/",
         );
         let resp = router
             .oneshot(
@@ -1161,6 +1334,8 @@ mod tests {
             wiki,
             None,
             &cors_origins,
+            "/web",
+            "/web/",
         );
         // /web is a non-api route; sending an Origin header must not trigger CORS.
         let resp = router

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -296,6 +296,7 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
                 &cors_origins,
                 &args.web_slug,
                 &base_href,
+                &base_path,
             );
             let router = apply_http_layers(router, auth_state, config.allowed_hosts.clone());
             // Host the entire surface under the configured base path. Empty
@@ -774,27 +775,45 @@ fn escape_attr(s: &str) -> String {
         .replace('>', "&gt;")
 }
 
-/// Inject `<base href="{href}">` immediately after the first `<head…>` tag
-/// (or prepend it when there is no head) so the served SPA's relative
-/// asset/router URLs resolve under the configured prefix.
-pub(crate) fn inject_base_href(html: &str, href: &str) -> String {
-    let tag = format!("<base href=\"{}\">", escape_attr(href));
+/// Insert `snippet` immediately after the first `<head…>` tag (or prepend
+/// it when there is no head).
+fn inject_into_head(html: &str, snippet: &str) -> String {
     if let Some(start) = html.find("<head")
         && let Some(gt) = html[start..].find('>')
     {
         let pos = start + gt + 1;
-        let mut out = String::with_capacity(html.len() + tag.len());
+        let mut out = String::with_capacity(html.len() + snippet.len());
         out.push_str(&html[..pos]);
-        out.push_str(&tag);
+        out.push_str(snippet);
         out.push_str(&html[pos..]);
         return out;
     }
-    format!("{tag}{html}")
+    format!("{snippet}{html}")
+}
+
+/// Inject `<base href="{href}">` so the served SPA's relative asset/router
+/// URLs resolve under the configured prefix.
+pub(crate) fn inject_base_href(html: &str, href: &str) -> String {
+    inject_into_head(html, &format!("<base href=\"{}\">", escape_attr(href)))
+}
+
+/// Inject `<meta name="ai-memory-base-path" content="{base_path}">` so the
+/// SPA can build API URLs as `{base_path}/api/v1`. The `<base href>` alone is
+/// ambiguous for this because it also folds in the web slug (e.g. `/web`),
+/// whereas `/api/v1` hangs off the base path, not the web mount.
+pub(crate) fn inject_base_path_meta(html: &str, base_path: &str) -> String {
+    inject_into_head(
+        html,
+        &format!(
+            "<meta name=\"ai-memory-base-path\" content=\"{}\">",
+            escape_attr(base_path)
+        ),
+    )
 }
 
 #[cfg(test)]
 mod web_base_tests {
-    use super::{inject_base_href, normalize_prefix, web_base_href};
+    use super::{inject_base_href, inject_base_path_meta, normalize_prefix, web_base_href};
 
     #[test]
     fn normalize_prefix_edge_cases() {
@@ -844,6 +863,15 @@ mod web_base_tests {
         let out = inject_base_href("<head></head>", "/a\"b/");
         assert!(out.contains("<base href=\"/a&quot;b/\">"));
     }
+
+    #[test]
+    fn inject_base_path_meta_emits_meta() {
+        let out = inject_base_path_meta("<head></head>", "/wiki");
+        assert!(out.contains("<meta name=\"ai-memory-base-path\" content=\"/wiki\">"));
+        // Empty base path => empty content (SPA falls back to root).
+        let empty = inject_base_path_meta("<head></head>", "");
+        assert!(empty.contains("content=\"\""));
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -856,6 +884,7 @@ fn mount_web_router(
     cors_origins: &[String],
     web_slug: &str,
     base_href: &str,
+    base_path: &str,
 ) -> axum::Router {
     if !enable_web {
         return router;
@@ -899,11 +928,9 @@ fn mount_web_router(
     // URLs resolve under `{base_path}{web_slug}`.
     if let Some(dir) = web_ui_dir {
         let dir = dir.to_path_buf();
-        let injected = inject_base_href(
-            &std::fs::read_to_string(dir.join("index.html")).unwrap_or_default(),
-            base_href,
-        );
-        info!(mount, base_href, "custom web UI mounted");
+        let raw = std::fs::read_to_string(dir.join("index.html")).unwrap_or_default();
+        let injected = inject_base_path_meta(&inject_base_href(&raw, base_href), base_path);
+        info!(mount, base_href, base_path, "custom web UI mounted");
         // Assets are served as files; any unmatched path (SPA client route)
         // falls back to the injected index. `append_index_html_on_directories`
         // is off so the directory index also flows through the injecting
@@ -1082,6 +1109,7 @@ mod tests {
             &[],
             "/web",
             "/web/",
+            "",
         );
         let router = apply_http_layers(
             router,
@@ -1245,6 +1273,7 @@ mod tests {
             &cors_origins,
             "/web",
             "/web/",
+            "",
         );
         // No auth layer so we can reach /api/v1 directly.
         let resp = router
@@ -1296,6 +1325,7 @@ mod tests {
             &cors_origins,
             "/web",
             "/web/",
+            "",
         );
         let resp = router
             .oneshot(
@@ -1336,6 +1366,7 @@ mod tests {
             &cors_origins,
             "/web",
             "/web/",
+            "",
         );
         // /web is a non-api route; sending an Origin header must not trigger CORS.
         let resp = router

--- a/crates/ai-memory-web/src/templates.rs
+++ b/crates/ai-memory-web/src/templates.rs
@@ -15,7 +15,11 @@ use askama::Template;
 /// subpath (`/wiki/web/…`), without the templates knowing the prefix.
 #[must_use]
 pub(crate) fn project_href(workspace: &str, project: &str) -> String {
-    format!("w/{}/{}", encode_segment(workspace), encode_segment(project))
+    format!(
+        "w/{}/{}",
+        encode_segment(workspace),
+        encode_segment(project)
+    )
 }
 
 /// Build a `/web` page URL with workspace/project/path percent-encoded.

--- a/crates/ai-memory-web/src/templates.rs
+++ b/crates/ai-memory-web/src/templates.rs
@@ -6,14 +6,16 @@ use askama::Template;
 // URL helpers
 // ---------------------------------------------------------------------------
 
-/// Build a `/web` project URL with path segments percent-encoded.
+/// Build a project URL with path segments percent-encoded.
+///
+/// The URL is **relative** (`w/{ws}/{proj}`, no leading slash) so it
+/// resolves against the page's injected `<base href>` — which the server
+/// sets to `{base_path}{web_slug}/`. That keeps every link correct whether
+/// the browser is served at the host root (`/web/…`) or under a reverse-proxy
+/// subpath (`/wiki/web/…`), without the templates knowing the prefix.
 #[must_use]
 pub(crate) fn project_href(workspace: &str, project: &str) -> String {
-    format!(
-        "/web/w/{}/{}",
-        encode_segment(workspace),
-        encode_segment(project)
-    )
+    format!("w/{}/{}", encode_segment(workspace), encode_segment(project))
 }
 
 /// Build a `/web` page URL with workspace/project/path percent-encoded.
@@ -102,7 +104,7 @@ pub(crate) struct ProjectCard {
     pub page_count: u64,
     /// Humanised timestamp (e.g. "3 hours ago"), or empty string.
     pub last_updated_relative: String,
-    /// Link target (`/web/w/{ws}/{proj}`).
+    /// Link target (`w/{ws}/{proj}`, relative to `<base href>`).
     pub href: String,
 }
 
@@ -249,13 +251,15 @@ mod tests {
 
     #[test]
     fn href_helpers_percent_encode_segments() {
+        // Relative (no leading slash) so they resolve against the injected
+        // `<base href>` — see `project_href` docs.
         assert_eq!(
             project_href("default space", "proj#one"),
-            "/web/w/default%20space/proj%23one"
+            "w/default%20space/proj%23one"
         );
         assert_eq!(
             page_href("default", "scratch", "notes/a b%25.md"),
-            "/web/w/default/scratch/p/notes/a%20b%2525.md"
+            "w/default/scratch/p/notes/a%20b%2525.md"
         );
     }
 }

--- a/crates/ai-memory-web/templates/base.html
+++ b/crates/ai-memory-web/templates/base.html
@@ -4,20 +4,20 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}ai-memory{% endblock %}</title>
-  <link rel="stylesheet" href="/web/static/tailwind.css">
+  <link rel="stylesheet" href="static/tailwind.css">
 </head>
 <body class="min-h-full bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100">
   <header class="border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 sticky top-0 z-10">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center gap-4 h-14">
-      <a href="/web/" class="flex items-center gap-2 shrink-0">
+      <a href="." class="flex items-center gap-2 shrink-0">
         <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="/web/static/logo-dark.png">
-          <img src="/web/static/logo.png" alt="ai-memory logo" class="h-7 w-auto">
+          <source media="(prefers-color-scheme: dark)" srcset="static/logo-dark.png">
+          <img src="static/logo.png" alt="ai-memory logo" class="h-7 w-auto">
         </picture>
         <span class="font-semibold text-slate-800 dark:text-slate-100 text-sm hidden sm:inline">ai-memory</span>
       </a>
       <div class="flex-1"></div>
-      <form action="/web/search" method="get" class="flex items-center">
+      <form action="search" method="get" class="flex items-center">
         <input
           name="q"
           type="search"

--- a/crates/ai-memory-web/templates/not_found.html
+++ b/crates/ai-memory-web/templates/not_found.html
@@ -7,7 +7,7 @@
   <p class="text-6xl font-bold text-slate-200 dark:text-slate-800">404</p>
   <h1 class="mt-4 text-2xl font-semibold text-slate-700 dark:text-slate-300">Page not found</h1>
   <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">The page you're looking for doesn't exist or has been superseded.</p>
-  <a href="/web/" class="mt-6 inline-block rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700">
+  <a href="." class="mt-6 inline-block rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700">
     Back to home
   </a>
 </div>

--- a/crates/ai-memory-web/templates/page.html
+++ b/crates/ai-memory-web/templates/page.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <nav class="mb-6 flex items-center gap-1 text-sm text-slate-500 dark:text-slate-400">
-  <a href="/web/" class="hover:text-blue-600 dark:hover:text-blue-400">home</a>
+  <a href="." class="hover:text-blue-600 dark:hover:text-blue-400">home</a>
   <span>/</span>
   <a href="{{ project_href }}" class="hover:text-blue-600 dark:hover:text-blue-400">{{ workspace }}/{{ project }}</a>
   <span>/</span>

--- a/crates/ai-memory-web/templates/project.html
+++ b/crates/ai-memory-web/templates/project.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <nav class="mb-6 flex items-center gap-1 text-sm text-slate-500 dark:text-slate-400">
-  <a href="/web/" class="hover:text-blue-600 dark:hover:text-blue-400">home</a>
+  <a href="." class="hover:text-blue-600 dark:hover:text-blue-400">home</a>
   <span>/</span>
   <span class="text-slate-400 dark:text-slate-500">{{ workspace }}</span>
   <span>/</span>

--- a/crates/ai-memory-web/templates/search.html
+++ b/crates/ai-memory-web/templates/search.html
@@ -13,7 +13,7 @@
   </h1>
 </div>
 
-<form action="/web/search" method="get" class="mb-8 flex gap-2">
+<form action="search" method="get" class="mb-8 flex gap-2">
   <input
     name="q"
     type="search"

--- a/crates/ai-memory-web/tests/routes.rs
+++ b/crates/ai-memory-web/tests/routes.rs
@@ -369,9 +369,11 @@ async fn web_links_percent_encode_route_segments() {
         .await
         .unwrap();
     let text = std::str::from_utf8(&body).unwrap();
+    // Links are now relative (no leading `/web/`) so they resolve against the
+    // `<base href>` the server injects per the configured prefix.
     assert!(
-        text.contains("/web/w/default/scratch%20%231/p/notes/a%20b%2525.md"),
-        "expected encoded href in project response: {text}"
+        text.contains("\"w/default/scratch%20%231/p/notes/a%20b%2525.md\""),
+        "expected encoded relative href in project response: {text}"
     );
 }
 

--- a/docs/frontend-api.md
+++ b/docs/frontend-api.md
@@ -12,7 +12,7 @@
 | | What you can do | What you can't do |
 |---|---|---|
 | `/api/v1/*` | Browse workspaces, projects, pages; read full page markdown + frontmatter + back-links; FTS5 search (global or scoped, single or multi-project); aggregate "overview" snapshots; drill into stale / duplicate / orphan pages. | Write, delete, rename, lint, consolidate, run sweeps, manage handoffs. The `/api/v1` surface is **read-only by construction** — the handlers contain zero writer calls. Writes still go through `/admin/*` (used by the CLI) or MCP tools. |
-| `--web-ui-dir` | Host any SPA at `/web`, same-origin with the API, behind the same auth. The default built-in `/web` browser stays the fallback when the flag is absent. | Host the SPA on a *different* origin without a reverse proxy — there's no CORS layer yet (see §9). |
+| `--web-ui-dir` | Host any SPA at `/web` (or `--web-slug`), same-origin with the API, behind the same auth. The default built-in `/web` browser stays the fallback when the flag is absent. | Host the SPA on a *different* origin without a reverse proxy — use same-origin hosting or configure CORS deliberately (see §9). |
 
 ## 2. Auth model
 
@@ -341,7 +341,7 @@ across all projects in the workspace:
   on every request. If your UI polls aggressively, consider client-side
   debouncing; server-side caching is a planned iteration.
 
-## 6. Custom UI hosting (`--web-ui-dir`)
+## 6. Custom UI hosting and base paths
 
 ```bash
 ai-memory serve \
@@ -364,6 +364,26 @@ The static directory is served at `/web` via `tower-http::ServeDir`:
 - **Pre-startup validation:** the directory must exist *and* contain
   `index.html`, or `ai-memory serve` exits with a clear error before
   binding. Requires `--enable-web` to also be set.
+- **Base-path injection:** ai-memory injects `<base href="...">` and
+  `<meta name="ai-memory-base-path" content="...">` into the SPA shell. This
+  covers direct `/web`, `/web/index.html`, and client-router fallback paths;
+  static assets are served unchanged.
+
+When a reverse proxy keeps ai-memory under a URL subpath, set
+`--base-path` (or `AI_MEMORY_BASE_PATH`) so every HTTP surface moves together:
+
+```bash
+ai-memory serve \
+    --transport http \
+    --bind 127.0.0.1:49374 \
+    --enable-web \
+    --base-path /wiki
+```
+
+With `--base-path /wiki`, the API lives at `/wiki/api/v1`, MCP at
+`/wiki/mcp`, hooks at `/wiki/hook`, admin routes at `/wiki/admin/*`, and the
+default web UI at `/wiki/web`. Set `--web-slug /` to mount the web UI or custom
+SPA at the base root (`/wiki`) instead of `/wiki/web`.
 
 When `--web-ui-dir` is **absent**, the built-in server-side `/web`
 browser is the default (read-only HTML rendering, FTS5 search,
@@ -372,8 +392,12 @@ project tree). No regression.
 ## 7. Worked example: minimal SPA fetch
 
 ```js
-// Resolve the API base from the SPA's own origin (same-origin model).
-const API = `${location.origin}/api/v1`;
+// Resolve the API base from the SPA shell injected by ai-memory. The meta tag
+// is empty at host root and e.g. "/wiki" behind a subpath reverse proxy.
+const basePath = document
+  .querySelector('meta[name="ai-memory-base-path"]')
+  ?.getAttribute("content") ?? "";
+const API = `${location.origin}${basePath}/api/v1`;
 const TOKEN = localStorage.getItem("ai-memory-token"); // your storage choice
 
 async function apiGet(path, params) {

--- a/docs/https-via-proxy.md
+++ b/docs/https-via-proxy.md
@@ -127,6 +127,38 @@ The `AI_MEMORY_ALLOWED_HOSTS` must include the public hostname or
 ai-memory's DNS-rebinding guard will refuse Caddy's forwarded
 requests.
 
+### Hosting under a subpath
+
+If ai-memory shares a hostname with other apps, keep the prefix when proxying
+and tell ai-memory about it:
+
+```bash
+AI_MEMORY_BASE_PATH=/wiki
+```
+
+```caddyfile
+memory.example.com {
+    handle /wiki/* {
+        reverse_proxy ai-memory:49374
+    }
+}
+```
+
+Do **not** use `handle_path /wiki/*` for this deployment: it strips `/wiki`
+before forwarding, while ai-memory intentionally serves all routes under the
+configured prefix. With the example above, clients use:
+
+```bash
+ai-memory install-mcp   --client claude-code --apply \
+    --server-url "https://memory.example.com/wiki/mcp" --auth-token "$AI_MEMORY_AUTH_TOKEN"
+ai-memory install-hooks --agent  claude-code --apply \
+    --server-url "https://memory.example.com/wiki" --auth-token "$AI_MEMORY_AUTH_TOKEN"
+```
+
+The built-in browser is then at `https://memory.example.com/wiki/web`; add
+`AI_MEMORY_WEB_SLUG=/` if you want the browser or custom `--web-ui-dir` SPA at
+`https://memory.example.com/wiki` itself.
+
 ### MCP client config (Claude Code shown — others follow the same shape)
 
 ```bash


### PR DESCRIPTION
## Why

ai-memory currently mounts every route at the host root (`/mcp`, `/api/v1`, `/hook`, `/web`). That's perfect when it owns a hostname, but homelab/reverse-proxy setups often want to host it under a **URL subpath** of an existing host — e.g. `https://admin.home/wiki` alongside other services on `admin.home`. Without prefix awareness the SPA's absolute `/api/v1` calls and `/web` asset URLs collide with whatever else lives at that host's root.

## What

Adds an **opt-in** `--base-path` / `AI_MEMORY_BASE_PATH` to `serve`:

- **Empty (default) → byte-identical to today.** Every route stays at root; no behavior change for existing deploys.
- Set e.g. `/wiki` → the whole HTTP surface nests under it: `/wiki/mcp`, `/wiki/api/v1`, `/wiki/hook`, and the web UI.
- The value is normalized to `/<core>` (leading slash, no trailing, collapsed slashes, safe charset); `/` and `` both mean root.
- The bundled web UI is made subpath-aware by injecting `<base href>` + a `<meta name="ai-memory-base-path">` into the served `index.html`, so the SPA builds its asset and `/api/v1` URLs under the prefix. (The companion SPA change reads that meta; the server-rendered fallback links are noted as a follow-up.)
- Also exposes `--web-slug` / `AI_MEMORY_WEB_SLUG` (default `/web`) so the UI mount point under the base is configurable.

Behind a reverse proxy you point the prefix at the engine and **preserve** it (no strip) — the engine now owns the prefix end-to-end.

## Compatibility

The feature is entirely opt-in and the default path is unchanged — verified that an unset `AI_MEMORY_BASE_PATH` renders the identical route tree as before. Diff is confined to `serve` (`cli.rs` + `commands/serve.rs`); no store/migration/MCP-protocol changes.

## Tests

- New `web_base_tests` module covering prefix normalization (root fallback, trailing/duplicate slash collapse, unsafe-char rejection), `<base href>` derivation, and head injection.
- Existing serve tests updated for the new mount signature; full suite green.

## Notes / follow-ups

- Both frontends are now subpath-aware: the custom SPA (injected `<base href>` + meta) and the built-in server-rendered browser (relative URLs + injected `<base href>` on every HTML response).
- Validated live in a homelab behind nginx-ingress at `https://<host>/wiki` (MCP + browser UI both reachable under the prefix).

