### PR TITLE
fix(cli): write-page and read-page resolve project identically (ghost write)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,7 +262,7 @@ match the intent to the tool. They do not need to name the tool.
 
 | User says / situation | Tool |
 |---|---|
-| "have we discussed X?" / "search memory for Y" / before proposing architecture | `memory_query` |
+| "have we discussed X?" / "search memory for Y" / before proposing architecture | `memory_query` (current project; `scopes` for named siblings; `global=true` to search every project) |
 | "what's been going on" / "show recent activity" (light) | `memory_recent` |
 | "is ai-memory healthy?" / "how big is the wiki?" | `memory_status` |
 | "give me the stats" / structured snapshot for the agent to consume | `memory_briefing` |
@@ -272,6 +272,7 @@ match the intent to the tool. They do not need to name the tool.
 | "save context for the next session" / wrapping up | `memory_handoff_begin` (single-use handoff; terse summary; put detail in `open_questions` + `next_steps` bullets) |
 | "consolidate this session" / "compile what we learned" (also runs on PreCompact; at session end only if `AI_MEMORY_CONSOLIDATE_ON_SESSION_END` is set) | `memory_consolidate` |
 | "remember this permanently" / "save a note" / "add an annotation" / durable project knowledge | `memory_write_page` (write a wiki page; do **not** use handoff for permanent notes) |
+| "read the page about X" / "show me the full content of Y" / "open the page on Z" | `memory_read_page` (full body; pass a query to search or `path` for a direct lookup) |
 | "audit the wiki" / "find contradictions" / "what rules should we add?" | `memory_lint` |
 | "prune old pages" / "memory cleanup" | `memory_forget_sweep` |
 
@@ -279,6 +280,22 @@ match the intent to the tool. They do not need to name the tool.
 going on" use case — it returns a prose digest whose verbosity
 scales automatically to how long it's been since the last activity
 (< 1 h → one line; > 30 days → full catchup).
+
+### When the current project comes up empty — broaden the search
+
+`memory_query` searches only the **current** project; there is **no
+global "search everything" mode**. If a search comes back empty or
+thin, the knowledge may live in a **sibling project** — shared `infra`,
+`ops`, or a related app. Re-run `memory_query` with explicit `scopes`
+naming those projects, e.g. `scopes: [{ "workspace": "default",
+"project": "infra" }]`. Don't conclude "we never recorded it" after a
+single project misses.
+
+`memory_query` returns **snippets, not full page bodies** — an empty or
+short snippet does **not** mean the page is empty (a large page can
+match outside the snippet window). To read the whole page, use
+`memory_read_page` (by `path`, or pass a `query` to fetch the top hit's
+full body).
 
 ### When you write a project rule, write it here
 

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -788,8 +788,12 @@ pub struct WritePageArgs {
     #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
     pub workspace: String,
     /// Project name within the workspace (auto-created if absent).
-    #[arg(long, default_value_t = crate::config::DEFAULT_PROJECT.to_string())]
-    pub project: String,
+    /// When omitted, auto-derived from the current project — the SAME
+    /// heuristic `read-page`/`search` use, so a write and the read-back
+    /// that follows it always resolve to the same project (no "wrote to
+    /// `scratch`, read from `<cwd>`" divergence).
+    #[arg(long)]
+    pub project: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/ai-memory-cli/src/commands/write_page.rs
+++ b/crates/ai-memory-cli/src/commands/write_page.rs
@@ -50,10 +50,14 @@ pub async fn run(config: &Config, args: WritePageArgs) -> Result<()> {
         args.body
     };
 
-    // `project` has a non-empty default ("scratch"); pass it directly so the
-    // explicit --project flag always wins. The auto-detect path is only useful
-    // for commands whose project arg is truly optional (no default).
-    let project = args.project.clone();
+    // Resolve the project the SAME way `read-page`/`search` do: an explicit
+    // `--project` wins, otherwise auto-detect from the current dir. Previously
+    // `write-page` hard-defaulted to "scratch" while `read-page` auto-detected,
+    // so a write+read-back pair from any dir not named "scratch" silently
+    // targeted two different projects — the write landed in `default/scratch`
+    // and the read 404'd ("ghost write"). Sharing one resolver removes the
+    // divergence at the source.
+    let project = super::resolve_project_name(config, args.project.as_deref())?;
 
     let endpoint = ServerEndpoint::from_config(config);
     let resp: WritePageResponseBody = post_json(


### PR DESCRIPTION
## Problem

`write-page` and `read-page` resolved the target `(workspace, project)` through **different** code paths, so a write followed by a read-back could silently target two different projects — the classic "ghost write": the write returns a `page_id`, but the read-back reports the page does not exist.

- `read-page` / `search` use `resolve_project_name` — an explicit `--project` wins, otherwise the project is auto-detected from the current directory.
- `write-page` instead hard-defaulted `--project` to `"scratch"` (a clap default that masked "no value given") and **bypassed** the cwd auto-detect.

So from any directory not literally named `scratch`, with no explicit `--project`:
- the write landed in `default/scratch`,
- the read-back looked in `default/<cwd>` → `404 No such file`.

## Reproduction

In a local container (`serve` + CLI against it):

- **Before:** 60/60 ghosts. The write reported `under default/scratch`; the read 404'd against `default/<cwd>`; the file existed on disk under `scratch`.
- **After:** 0/30 ghosts; both write and read-back resolve to `default/<cwd>`.

## Fix

Make `WritePageArgs.project` an `Option<String>` (no default) and route it through the same `resolve_project_name` resolver the read path uses. Explicit `--project` still wins; with none, the write and the read-back that follows it now always resolve to the same project.

## Tests

All `ai-memory-cli` tests pass (178). No store/migration/protocol changes — the fix is confined to CLI project resolution.