### PR TITLE
feat(openai-compat): opt-in strict mode via response_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `openai-compat` LLM providers can now opt into strict JSON Schema structured
+  output with `AI_MEMORY_LLM_COMPAT_STRICT=true`. Strict mode sends
+  `response_format=json_schema` first for compatible Ollama, vLLM, LM Studio,
+  llama.cpp, and gateway endpoints, while the tolerant JSON-object parser
+  remains the default and the fallback for strict raw-call failures ([#70]).
 - The read-only web browser now renders `[[wiki links]]` as clickable internal
   links to the target page. Supports `[[path]]`, `[[path|label]]`,
   `[[project:path]]`, and `[[workspace/project:path]]`, resolved against the

--- a/README.md
+++ b/README.md
@@ -441,8 +441,9 @@ also set `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` on the server.
 > `openai-compat`, if consolidation fails on large sessions** with
 > `did not contain a JSON object` or `serde: unknown variant`, set
 > `AI_MEMORY_LLM_COMPAT_STRICT=true`. It sends `response_format=json_schema`
-> (strict) so the engine constrains output to the schema, with a fallback to
-> the default tolerant parser when the engine ignores it. Off by default.
+> (strict) so capable engines constrain output to the schema. If the strict
+> raw call fails, ai-memory falls back to the default tolerant parser. Off by
+> default.
 
 Embeddings are optional and separate from the LLM provider. Set
 `AI_MEMORY_EMBEDDING_PROVIDER=openai`, `voyage`, `google`, or `gemini` when

--- a/README.md
+++ b/README.md
@@ -429,6 +429,14 @@ also set `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` on the server.
 > model is plenty and is much easier on subscription rate limits. Save the
 > high-effort thinking models for your coding agent.
 
+> [!TIP]
+> **On a local engine (Ollama, vLLM, LM Studio, llama.cpp) with
+> `openai-compat`, if consolidation fails on large sessions** with
+> `did not contain a JSON object` or `serde: unknown variant`, set
+> `AI_MEMORY_LLM_COMPAT_STRICT=true`. It sends `response_format=json_schema`
+> (strict) so the engine constrains output to the schema, with a fallback to
+> the default tolerant parser when the engine ignores it. Off by default.
+
 Embeddings are optional and separate from the LLM provider. Set
 `AI_MEMORY_EMBEDDING_PROVIDER=openai`, `voyage`, `google`, or `gemini` when
 you want vector reranking in addition to FTS5 + graph-neighbor retrieval.

--- a/crates/ai-memory-cli/src/commands/llm_test.rs
+++ b/crates/ai-memory-cli/src/commands/llm_test.rs
@@ -23,6 +23,7 @@ pub async fn run(config: &Config, args: LlmTestArgs) -> Result<()> {
         model: args.model,
         auth: config.provider_auth(provider, api_key_override),
         base_url: args.base_url.or_else(|| config.llm_test_base_url()),
+        compat_strict: config.llm_compat_strict,
     };
     let client = build_provider(provider_config).context("building LLM provider")?;
     info!(

--- a/crates/ai-memory-cli/src/config.rs
+++ b/crates/ai-memory-cli/src/config.rs
@@ -65,9 +65,8 @@ pub struct Config {
     /// parser stays the default for older local engines that ignore
     /// `response_format`. Modern engines (recent Ollama, vLLM, LM Studio,
     /// llama.cpp) honour structured output; this lets the operator opt in.
-    /// When the strict call fails, the provider falls back to the tolerant
-    /// parser, so enabling it never regresses below the default. Set with
-    /// `AI_MEMORY_LLM_COMPAT_STRICT=true`.
+    /// If the strict raw call fails, the provider falls back to the tolerant
+    /// parser. Set with `AI_MEMORY_LLM_COMPAT_STRICT=true`.
     pub llm_compat_strict: bool,
     /// Opt-in: run LLM consolidation on SessionEnd (in addition to the
     /// always-written heuristic session page), when an LLM provider is
@@ -815,6 +814,7 @@ mod tests {
             provider.auth.require_api_key().unwrap().expose_secret(),
             "sk-test-key"
         );
+        assert!(!provider.compat_strict);
     }
 
     #[test]
@@ -852,6 +852,27 @@ mod tests {
             }
         );
         assert!(auth.optional_api_key().is_none());
+    }
+
+    #[test]
+    fn openai_compat_provider_threads_strict_flag() {
+        let cfg = Config {
+            llm_provider: Some("openai-compat".into()),
+            llm_model: Some("qwen3:32b".into()),
+            llm_base_url: Some("http://localhost:11434/v1".into()),
+            llm_compat_strict: true,
+            ..Config::default()
+        };
+
+        let provider = cfg.llm_provider_config().unwrap().unwrap();
+
+        assert_eq!(provider.provider, ProviderChoice::OpenAiCompat);
+        assert_eq!(provider.model, "qwen3:32b");
+        assert_eq!(
+            provider.base_url.as_deref(),
+            Some("http://localhost:11434/v1")
+        );
+        assert!(provider.compat_strict);
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/config.rs
+++ b/crates/ai-memory-cli/src/config.rs
@@ -59,6 +59,16 @@ pub struct Config {
     pub llm_model: Option<String>,
     /// Optional LLM base URL override.
     pub llm_base_url: Option<String>,
+    /// Opt-in: send `response_format=json_schema` (strict) to the
+    /// `openai-compat` provider instead of asking for prose JSON and
+    /// extracting the first balanced object. Off by default — the tolerant
+    /// parser stays the default for older local engines that ignore
+    /// `response_format`. Modern engines (recent Ollama, vLLM, LM Studio,
+    /// llama.cpp) honour structured output; this lets the operator opt in.
+    /// When the strict call fails, the provider falls back to the tolerant
+    /// parser, so enabling it never regresses below the default. Set with
+    /// `AI_MEMORY_LLM_COMPAT_STRICT=true`.
+    pub llm_compat_strict: bool,
     /// Opt-in: run LLM consolidation on SessionEnd (in addition to the
     /// always-written heuristic session page), when an LLM provider is
     /// configured. Off by default — SessionEnd stays cheap and
@@ -275,6 +285,7 @@ impl Default for Config {
             llm_provider: None,
             llm_model: None,
             llm_base_url: None,
+            llm_compat_strict: false,
             consolidate_on_session_end: false,
             embedding_provider: None,
             embedding_model: None,
@@ -446,6 +457,7 @@ impl Config {
                 .llm_base_url
                 .clone()
                 .or_else(|| self.runtime_env.llm_base_url.clone()),
+            compat_strict: self.llm_compat_strict,
         }))
     }
 

--- a/crates/ai-memory-llm/src/factory.rs
+++ b/crates/ai-memory-llm/src/factory.rs
@@ -87,6 +87,11 @@ pub struct ProviderConfig {
     pub auth: ProviderAuth,
     /// Base URL override (required for OpenAI-compat).
     pub base_url: Option<String>,
+    /// Opt-in strict mode for the `openai-compat` provider: send
+    /// `response_format=json_schema` instead of the tolerant prose-JSON
+    /// parser. Ignored by every other provider. Sourced once from
+    /// `AI_MEMORY_LLM_COMPAT_STRICT` by `Config::load`.
+    pub compat_strict: bool,
 }
 
 /// Embedding providers available to ai-memory.
@@ -200,11 +205,10 @@ pub fn build_provider(config: ProviderConfig) -> LlmResult<Arc<dyn LlmProvider>>
             let base = config
                 .base_url
                 .ok_or_else(|| LlmError::NotConfigured("LLM_BASE_URL".into()))?;
-            Ok(Arc::new(OpenAiCompatProvider::new(
-                base,
-                config.auth.optional_api_key(),
-                config.model,
-            )?))
+            Ok(Arc::new(
+                OpenAiCompatProvider::new(base, config.auth.optional_api_key(), config.model)?
+                    .with_strict(config.compat_strict),
+            ))
         }
         ProviderChoice::OpenAiOAuth => {
             let path = config.auth.require_openai_oauth_token_file()?.to_path_buf();
@@ -276,6 +280,7 @@ mod tests {
             model: "gpt-4o-mini".into(),
             auth: ProviderAuth::required_api_key_from_env("OPENAI_API_KEY", None),
             base_url: None,
+            compat_strict: false,
         };
 
         let err = match build_provider(cfg) {

--- a/crates/ai-memory-llm/src/openai_compat.rs
+++ b/crates/ai-memory-llm/src/openai_compat.rs
@@ -2,9 +2,10 @@
 //!
 //! Uses the same wire format as [`crate::openai::OpenAiProvider`] but
 //! with a configurable base URL (and no key required for most local
-//! deployments). Structured output falls back to "parse first JSON
-//! object out of the text" because most local engines lack reliable
-//! `response_format` honour.
+//! deployments). Structured output defaults to "parse first JSON object
+//! out of the text" because many local engines lack reliable
+//! `response_format` honour; operators can opt into strict
+//! `response_format=json_schema` for engines that support it.
 
 use std::sync::LazyLock;
 
@@ -126,10 +127,9 @@ impl LlmProvider for OpenAiCompatProvider {
         // response_format. The dialect stays Compat, so the api.openai.com
         // token/temperature quirks do NOT leak into the local engine.
         //
-        // If the strict call fails (engine that ignores the schema, truncated
-        // JSON, etc.) we fall through to the tolerant parser below instead of
-        // propagating the error — so enabling the flag never regresses below
-        // the default behaviour.
+        // If the strict raw call fails (engine that rejects the schema,
+        // truncated JSON, etc.) we fall through to the tolerant parser below
+        // instead of propagating that raw-call error.
         if self.strict {
             let mut strict_schema = schema.clone();
             enforce_strict_object_schemas(&mut strict_schema);

--- a/crates/ai-memory-llm/src/openai_compat.rs
+++ b/crates/ai-memory-llm/src/openai_compat.rs
@@ -14,7 +14,7 @@ use secrecy::SecretString;
 use tracing::debug;
 
 use crate::error::{LlmError, LlmResult};
-use crate::openai::{OpenAiProvider, RequestDialect};
+use crate::openai::{OpenAiProvider, RequestDialect, enforce_strict_object_schemas};
 use crate::provider::LlmProvider;
 use crate::text::{suffix_within_bytes, truncate_with_ellipsis};
 use crate::types::{ChatRequest, ChatResponse};
@@ -56,6 +56,10 @@ pub(crate) fn strip_reasoning_blocks(s: &str) -> String {
 pub struct OpenAiCompatProvider {
     inner: OpenAiProvider,
     name_tag: &'static str,
+    /// When `true`, structured output sends a strict `response_format`
+    /// instead of the tolerant parser. Set by the factory from
+    /// `ProviderConfig::compat_strict` (sourced once by `Config::load`).
+    strict: bool,
 }
 
 impl OpenAiCompatProvider {
@@ -81,7 +85,17 @@ impl OpenAiCompatProvider {
         Ok(Self {
             inner,
             name_tag: "openai-compat",
+            strict: false,
         })
+    }
+
+    /// Set strict mode. The factory calls this with
+    /// `ProviderConfig::compat_strict`; `new` defaults it off so the
+    /// tolerant parser stays the zero-config behaviour.
+    #[must_use]
+    pub fn with_strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
     }
 }
 
@@ -102,11 +116,40 @@ impl LlmProvider for OpenAiCompatProvider {
     async fn complete_structured_raw(
         &self,
         request: ChatRequest,
-        _schema: serde_json::Value,
+        schema: serde_json::Value,
     ) -> LlmResult<serde_json::Value> {
-        // Most local engines don't honour `response_format`. We
-        // ask the model to emit a JSON object and fall back to
-        // extracting the first balanced `{…}` from the text.
+        // Strict mode (opt-in; see `strict` field): modern local engines
+        // honour `response_format=json_schema`. Normalise the schema
+        // to the strict subset (additionalProperties:false, full required, no
+        // oneOf / no $ref siblings) — the same rewrite the Official dialect
+        // applies — and delegate to the inner provider, which sends the
+        // response_format. The dialect stays Compat, so the api.openai.com
+        // token/temperature quirks do NOT leak into the local engine.
+        //
+        // If the strict call fails (engine that ignores the schema, truncated
+        // JSON, etc.) we fall through to the tolerant parser below instead of
+        // propagating the error — so enabling the flag never regresses below
+        // the default behaviour.
+        if self.strict {
+            let mut strict_schema = schema.clone();
+            enforce_strict_object_schemas(&mut strict_schema);
+            match self
+                .inner
+                .complete_structured_raw(request.clone(), strict_schema)
+                .await
+            {
+                Ok(v) if v.is_object() => return Ok(v),
+                Ok(_) => {
+                    debug!("compat strict: non-object response, falling back to tolerant parser");
+                }
+                Err(err) => {
+                    debug!(error = %err, "compat strict failed, falling back to tolerant parser");
+                }
+            }
+        }
+        // Default (and strict fallback): most older local engines don't
+        // honour `response_format`. Ask for JSON and extract the first
+        // balanced `{…}` object from the text.
         let res = self.inner.complete(request).await?;
         // Reasoning models (DeepSeek, Qwen, MiniMax M2.7, …) prepend
         // `<think>…</think>` before the JSON. Strip those blocks (and any
@@ -185,6 +228,17 @@ fn first_json_object(s: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `new` defaults strict off; `with_strict` is the only way to turn it
+    /// on, mirroring how the factory threads `ProviderConfig::compat_strict`.
+    #[test]
+    fn strict_defaults_off_and_can_be_overridden() {
+        let p = OpenAiCompatProvider::new("http://localhost:11434/v1", None, "mistral-nemo")
+            .expect("provider builds");
+        assert!(!p.strict);
+        let p = p.with_strict(true);
+        assert!(p.strict);
+    }
 
     #[test]
     fn first_json_object_finds_balanced_object() {

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -170,12 +170,14 @@ alternatives:
 > responses with the strict-JSON consolidation prompt. If you must use one, turn
 > reasoning off.
 
-ai-memory's consolidator uses OpenAI's `json_schema` strict mode for
+ai-memory's hosted OpenAI-family providers use `json_schema` strict mode for
 structured output. The OpenAI provider normalizes schemars output into
-OpenAI's supported subset (`additionalProperties: false`, complete
-`required`, generated enum `anyOf`, and plain `$ref` nodes). Most modern
-models honour this, but if you switch to a niche local model, run a quick
-`ai-memory llm-test` (with a structured prompt) before trusting it.
+OpenAI's supported subset (`additionalProperties: false`, complete `required`,
+generated enum `anyOf`, and plain `$ref` nodes). For `openai-compat` local or
+gateway endpoints, the tolerant parser stays the default; set
+`AI_MEMORY_LLM_COMPAT_STRICT=true` only after confirming the endpoint honours
+OpenAI-style `response_format=json_schema`. If you switch to a niche local
+model, run a quick `ai-memory llm-test` before trusting it.
 
 ## Backups
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -806,6 +806,18 @@ required. For OpenRouter (Kimi, DeepSeek, etc.):
 -e LLM_API_KEY=sk-or-v1-...
 ```
 
+Modern Ollama, vLLM, LM Studio, llama.cpp, and gateway endpoints may honour
+OpenAI-style `response_format=json_schema`. If the tolerant default parser fails
+with errors such as `did not contain a JSON object` or `serde: unknown variant`,
+try strict compat mode:
+
+```bash
+-e AI_MEMORY_LLM_COMPAT_STRICT=true
+```
+
+Strict mode is opt-in. ai-memory sends the schema-constrained request first and
+falls back to the tolerant parser only when that raw strict call fails.
+
 ---
 
 ## Subcommand reference

--- a/docs/llm-provider-comparison.md
+++ b/docs/llm-provider-comparison.md
@@ -162,10 +162,13 @@ synonym, never code fences". Local instruction-tuned models -
 especially when there's no `response_format: json_schema`
 support to enforce - will drift to whatever feels natural.
 
-Compounding this: openai-compat providers (Ollama, OpenRouter
-passthrough) do **not** expose strict-mode JSON-schema
-validation. The schema is descriptive, not coercive. So the
-prompt has to do the load-bearing work.
+Compounding this at the time of the run: openai-compat providers
+(Ollama, OpenRouter passthrough) were using ai-memory's tolerant
+parser path, so the schema was descriptive, not coercive. ai-memory
+now has opt-in `AI_MEMORY_LLM_COMPAT_STRICT=true` for compatible
+engines that honour OpenAI-style `response_format=json_schema`, but
+the prompt still has to do the load-bearing work when strict mode is
+off or the strict raw call falls back.
 
 ## The fix
 

--- a/evals/src/main.rs
+++ b/evals/src/main.rs
@@ -368,6 +368,9 @@ impl From<ResolvedConfig> for ProviderConfig {
             model: r.model,
             auth: r.auth,
             base_url: r.base_url,
+            // The eval harness benchmarks the default tolerant path; strict
+            // mode is an operator opt-in not modeled by these comparisons.
+            compat_strict: false,
         }
     }
 }


### PR DESCRIPTION
Closes #69

## What changes
Adds the **`AI_MEMORY_LLM_COMPAT_STRICT`** flag (default **off** — current
behaviour is 100% preserved). When `true`, `openai-compat`'s
`complete_structured_raw`:

1. normalizes the schema to the strict subset via
   `enforce_strict_object_schemas` (the same function PR #31 added for the
   Official path: `additionalProperties:false`, full `required`,
   `oneOf`→`anyOf`, strip of `$ref` siblings);
2. delegates to the inner provider, which sends `response_format=json_schema`
   (`strict:true`);
3. **fallback**: if the strict call fails (engine ignores the schema,
   truncated JSON, non-object response), it falls through to the original
   tolerant parser. Turning the flag on **never** regresses below the default.

The `RequestDialect` stays `Compat` — the `api.openai.com`
`max_completion_tokens`/temperature quirks do **not** leak into the local
engine. The flag is read **once** by `Config::load` and threaded through
`ProviderConfig::compat_strict`; no `std::env::var` in the provider (respects
the project's config-read-path invariant).

## Why not fix it in the `openai` provider
The `openai` provider already sends strict, but the `ProviderChoice::OpenAi`
arm in `factory.rs` does not call `.with_base_url()` — it ignores
`AI_MEMORY_LLM_BASE_URL` and always goes to `api.openai.com` (401 when pointed
at Ollama). Fixing `openai-compat` (which already honours base_url) is less
invasive and changes no one's default. *(Correlated factory bug, possible
second commit.)*

## Relationship to the maintainer's prior work
- **Issue #5 / v0.1.3** (`strip_reasoning_blocks`): covers the reasoning-block
  sub-case. Strict **complements** it, does not replace it — for reasoning
  models the recommendation is to keep the flag OFF (see below).
- **Issue #30 / PR #31** (`enforce_strict_object_schemas`): the compat strict
  path **reuses** that function, no duplication. The #31 closing comment said
  "compat providers remain unchanged"; this PR changes that in an opt-in way,
  with a fallback, and without altering the default.

---

## EVIDENCE AND TESTS

### Decisive A/B — maintainer's path (strict OFF) vs strict ON

Two identical containers over the **same** data directory, differing only in
`AI_MEMORY_LLM_COMPAT_STRICT`. `memory_consolidate dry_run` via MCP on the
three largest real sessions, single- and multi-page. Same binary (v0.8.1, with
windowing + strip already in effect), same sessions — only the flag changes.

| Session (obs) | Mode | strict OFF (maintainer) | strict ON (patch) |
|---|---|---|---|
| A (3544) | single | ❌ did not contain a JSON object | ✅ OK |
| A (3544) | multi  | ✅ OK | ✅ OK |
| B (1651) | single | ❌ did not contain a JSON object | ✅ OK |
| B (1651) | multi  | ❌ `serde: unknown variant 'state'` | ✅ OK |
| C (1238) | single | ❌ did not contain a JSON object | ✅ OK |
| C (1238) | multi  | ❌ `serde: unknown variant 'state'` | ✅ OK |

**Score: tolerant 1/6 · strict 6/6.** Since both containers are v0.8.1, the
windowing and `strip_reasoning_blocks` were already active when the six cells
failed — none of them constrains *generation* the way
`response_format=json_schema` does.

### Granular validation against raw Ollama (C1–C7)

Before the end-to-end A/B, we validated that Ollama actually honours strict
`response_format`, mapping where it complies and where it doesn't.

**Setup**

```bash
OLLAMA=http://127.0.0.1:11434
python3 -m venv /tmp/strictvenv && /tmp/strictvenv/bin/pip install jsonschema
```

Evaluation helper `check_strict.py` (validates syntax + schema with
`jsonschema`; supports `--schema enum`):

```python
#!/usr/bin/env python3
import json, sys
import jsonschema

PAGES_SCHEMA = {
    "type": "object", "additionalProperties": False,
    "properties": {"pages": {"type": "array", "items": {
        "type": "object", "additionalProperties": False,
        "properties": {"path": {"type": "string"}, "title": {"type": "string"},
                       "body": {"type": "string"}},
        "required": ["path", "title", "body"]}}},
    "required": ["pages"],
}
ENUM_SCHEMA = {
    "type": "object", "additionalProperties": False,
    "properties": {
        "tier": {"anyOf": [{"const": "working"}, {"const": "episodic"}, {"const": "semantic"}]},
        "title": {"type": "string"},
        "note": {"type": ["string", "null"]}},
    "required": ["tier", "title", "note"],
}
which = sys.argv[2] if len(sys.argv) > 2 and sys.argv[1] == "--schema" else "pages"
SCHEMA = ENUM_SCHEMA if which == "enum" else PAGES_SCHEMA
r = json.load(sys.stdin)
if "choices" not in r:
    print("FAIL: envelope has no choices:", str(r)[:300]); sys.exit(1)
msg = r["choices"][0]["message"]
print("finish_reason:", r["choices"][0].get("finish_reason"))
print("has reasoning field:", bool(msg.get("reasoning")))
content = msg.get("content", "")
print("content[:80]:", repr(content[:80]))
try:
    data = json.loads(content)
except Exception as e:
    print("FAIL syntax:", e); sys.exit(1)
print("OK syntax: valid JSON")
try:
    jsonschema.validate(data, SCHEMA)
    print("OK schema: adherent")
except jsonschema.ValidationError as e:
    print("FAIL schema:", e.message); sys.exit(1)
if which == "enum":
    print("tier:", data.get("tier"), "| note is null:", data.get("note") is None)
else:
    print("n_pages:", len(data.get("pages", [])))
```

Base payload `req.json` (adjust `model`/`content`):

```json
{
  "model": "mistral-nemo",
  "stream": false,
  "options": { "num_ctx": 16384 },
  "messages": [
    {"role": "system", "content": "Summarize the sources into wiki pages. Output JSON only."},
    {"role": "user", "content": "<<CONTENT>>"}
  ],
  "response_format": {
    "type": "json_schema",
    "json_schema": {
      "name": "pages", "strict": true,
      "schema": {
        "type": "object", "additionalProperties": false,
        "properties": {"pages": {"type": "array", "items": {
          "type": "object", "additionalProperties": false,
          "properties": {"path": {"type": "string"}, "title": {"type": "string"},
                         "body": {"type": "string"}},
          "required": ["path", "title", "body"]}}},
        "required": ["pages"]
      }
    }
  }
}
```

**Scenarios and criteria**

- **C1 — baseline (small prompt, simple schema).** Expects `OK syntax` +
  `OK schema`. Run on mistral-nemo and qwen3:14b.
- **C2 — LARGE prompt (~20k tokens, real bootstrap-chunk size).** The one that
  broke without strict. Compare WITH and WITHOUT `response_format` to isolate
  strict's value.
- **C3 — reasoning model (qwen3:14b) with strict.** Check whether `reasoning`
  comes in a separate field and `content` stays clean/adherent.
- **C4 — schema stress (closed enum `anyOf`/`const` + nullable).** Loop;
  confirm it never invents a `tier` outside the enum.
- **C5 — repetition 20× (non-determinism).** Criterion: FAIL=0.
- **C6 — `num_ctx=2048` (negative control).** Force truncation.
- **C7 — end-to-end through the binary** (`memory_consolidate` via MCP on a
  real large session).

**Results (Ollama 0.24.0 — 2026-06-01)**

| Model | C1 base | C2 large | C3 reasoning | C4 enum | C5 (20×) | Notes |
|---|:--:|:--:|:--:|:--:|:--:|---|
| mistral-nemo | ✅ | ✅ | n/a | ✅ 10/10 | ✅ 20/20 | solid; `n_pages` varies 0–6 but the form is always adherent |
| qwen2.5:32b | skipped | skipped | n/a | skipped | skipped | out of scope (runs on CPU, slow) |
| qwen3:14b | ✅ | ✅* | ✅ | skipped | skipped | reasoning in a separate field; content always clean JSON. *C2 returned `pages:[]` (form ok, empty content) |

- **C2 A/B (mistral-nemo):** WITH strict → adherent JSON; **WITHOUT strict →
  the model regurgitates raw Go code, `FAIL syntax`** (= the "did not contain
  a JSON object" of the tolerant path). Central argument.
- **C6 (num_ctx=2048):** even truncated, the strict output stays **valid +
  adherent JSON** → the tolerant path's schema failures were the absence of
  `response_format`, not `num_ctx`. Strict isolates the two problems.
- **C7 (end-to-end, `ai-memory:strict` + `memory_consolidate`):** a 698-obs
  session (which was failing) → ✅ single-page and ✅ multi_page (schemas with
  `$ref`/`oneOf`) with no error; container logs free of `did not contain a
  JSON object`.

### Validated conclusions
1. **Strict fixes the real failure** (A/B C2 + end-to-end A/B 6/6 vs 1/6).
2. **Strict guarantees form, not content** — qwen3:14b returned a
   valid-but-empty `pages:[]`; this justifies keeping mistral-nemo as the
   default and keeping the fallback.
3. **num_ctx ≠ strict** — negative control C6 confirms it.
4. **Closed enums honoured** — C4: 10/10 inside the enum.
5. **Robustness** — C5: 20/20 with no failure.
6. **Reasoning did not need the fallback here** — qwen3:14b emitted clean
   `content`; the fallback is still justified for engines that contaminate
   `content`.

### Reasoning models: keep the flag OFF
The strict path reads only `message.content` and parses it directly — it does
**not** run `strip_reasoning_blocks`. Reasoning models (MiniMax M2,
DeepSeek-R1, Qwen "thinking") that emit `<think>…</think>` **inside** `content`
are already handled by the default tolerant path (issue #5). Turning strict on
for them just wastes one doomed strict call before falling back to that same
tolerant path. It does not regress (the fallback guarantees that), but it is
unnecessary. Strict is for NON-reasoning engines (mistral-nemo) where the
problem is missing structure. **Off is the right default for reasoning
models.**

### Honest gaps
- Only **Ollama 0.24.0** tested. LM Studio / llama.cpp / vLLM **not** exercised
  (expected to work via the same `response_format`, not validated).
- `qwen2.5:32b` out of scope (CPU cost — 20GB doesn't fit the 16GB GPU).
- The nullable union's `null` branch was *accepted* by the schema, but the
  model never *chose* to emit `null` — we did not prove `null` generation
  itself.

---

## DESIGN DECISIONS (why this shape)

Five choices, each the most surgical option that fits the existing code:

1. **A `with_strict(bool)` builder** on the provider, not a `new()` parameter —
   mirrors the nine existing `with_*` builders in the LLM layer
   (`with_base_url`, `with_dialect`, …).
2. **Threaded through `Config` → `ProviderConfig`**, not read from the env in
   the provider — the config-read-path invariant forbids `std::env::var`
   outside `Config::load`. Same shape as the existing
   `consolidate_on_session_end` flag.
3. **Reuses `enforce_strict_object_schemas`** from the Official path (the
   function PR #31 added) — no duplicated schema normalisation.
4. **A `bool` on the compat wrapper, not a new `RequestDialect::CompatStrict`
   variant** — the dialect controls request *shape* (token field,
   temperature); strict here needs schema normalisation + the Compat request
   shape + the **fall-back to the tolerant parser**, which lives in the
   wrapper, not in the inner provider. A dialect variant could not express the
   fallback.
5. **The strict attempt clones `request`/`schema`** so the originals survive
   for the fallback. The trait takes them by value; avoiding the clone would
   mean changing the trait signature across all five providers — not worth it
   for a background job.

---

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all green; 2 new strict tests)
- [x] End-to-end A/B (tolerant 1/6 vs strict 6/6) and C1–C7 against Ollama 0.24.0
- [ ] Validate LM Studio / llama.cpp / vLLM (future)

## Quick reproduction
```bash
# rebuild the fork image
docker build -f docker/Dockerfile -t ai-memory:strict .

# two containers, same data dir, only the flag differs → A/B
#   container A: AI_MEMORY_LLM_COMPAT_STRICT=true  (port 49374)
#   container B: AI_MEMORY_LLM_COMPAT_STRICT=false (port 49375)
# memory_consolidate dry_run via MCP on the same large sessions in both.

# Raw Ollama (C1–C7): venv + check_strict.py + req.json above.
```
