### PR TITLE
feat(auto-scope): per-session / per-actor ActiveProject isolation modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pointer by `session_id` to isolate concurrent agent runs of the same
   operator; opt-in `per_actor` keys by `(user, session_id)` to isolate
   across operators as well, pairing with multi-user mode where `user`
-  comes from the `users` row that owns the bearer token. Per-key entries
-  carry an insertion timestamp and are TTL-evicted (default 1 hour) and
+  comes from the `users` row that owns the bearer token. `per_actor`
+  also keeps a user-only fallback slot so authenticated MCP requests
+  from clients that cannot forward a session id do not inherit another
+  user's latest project; same-user session isolation still requires a
+  client/bridge that sends `X-Memory-Actor-Session-Id` or
+  `Mcp-Session-Id` on MCP tool calls. Per-key entries carry an insertion
+  timestamp and are TTL-evicted (default 1 hour) and
   capped (default 4096) so adversarial / runaway clients cannot grow the
   map without bound. Both opt-in modes still publish to the single slot
   in parallel, so any caller without actor context falls back gracefully

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New `[auto_scope]` config block (`mode`, `session_ttl_secs`,
+  `max_entries`) selects how the hook-published "currently active project"
+  pointer is shared across concurrent MCP callers. The default `single` mode
+  preserves the historical process-wide slot. Opt-in `per_session` keys the
+  pointer by `session_id` to isolate concurrent agent runs of the same
+  operator; opt-in `per_actor` keys by `(user, session_id)` to isolate
+  across operators as well, pairing with multi-user mode where `user`
+  comes from the `users` row that owns the bearer token. Per-key entries
+  carry an insertion timestamp and are TTL-evicted (default 1 hour) and
+  capped (default 4096) so adversarial / runaway clients cannot grow the
+  map without bound. Both opt-in modes still publish to the single slot
+  in parallel, so any caller without actor context falls back gracefully
+  to the most recent project rather than an empty pointer. All MCP read
+  tools (`memory_query`, `memory_recent`, `memory_read_page`,
+  `memory_status`, `memory_briefing`, `memory_explore`, `memory_lint`,
+  `memory_forget_sweep`, `memory_handoff_*`) now thread the request's
+  `ActorContext` into scope resolution, so opt-in isolation takes effect
+  for the full read surface.
 
 ## [0.10.0] - 2026-06-04
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,7 @@ version = "0.10.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
+ "ai-memory-hooks",
  "ai-memory-llm",
  "ai-memory-store",
  "ai-memory-wiki",

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ priors are at the [bottom](#influences-and-prior-art).
   Gemini CLI, Antigravity CLI, OpenClaw, and Oh My Pi / OMP
   (`pi` / `omp` aliases).
   Server runs local (loopback) OR on a homelab box (LAN/VPN/cloud)
-  with bearer-token auth.
+  with bearer-token auth. Shared servers can opt into
+  [`[auto_scope]` modes](docs/auto-scope.md) for per-user or
+  session-aware current-project routing.
 - **Thin-client CLI.** `ai-memory status`, `bootstrap`, `purge-project`,
   `rename-project`, `move-project`, `lint`, `embed`, `forget-sweep`, `backup` are
   all HTTP clients of the running server - never touch SQLite or
@@ -492,6 +494,7 @@ diagram, crate breakdown, schema notes, and invariants.
 | [`docs/install.md`](docs/install.md) | **Installation cookbook.** Every agent CLI, every alternative (curl, source build, no-docker, no-auth), and the server-on-a-different-machine (homelab/LAN) walkthrough. Read after the Quick start if your setup doesn't match the happy path. |
 | [`docs/usage.md`](docs/usage.md) | Handoffs, proactive memory queries, routing snippet, web UI, raw-wiki inspection, and rules-vs-facts workflow. |
 | [`docs/marker-file.md`](docs/marker-file.md) | `.ai-memory.toml` workspace/project routing for multi-client trees, mono-repos, worktrees, and work/personal separation. |
+| [`docs/auto-scope.md`](docs/auto-scope.md) | `[auto_scope]` modes for shared servers: default single-slot routing, session-aware isolation, and multi-user `per_actor` behavior. |
 | [`docs/windows.md`](docs/windows.md) | Windows install modes: full WSL2, native Windows with Docker Desktop, native source builds, and current hook/MCP harness caveats. |
 | [`docs/mcp-install.md`](docs/mcp-install.md) | Per-client MCP and lifecycle notes (Cursor, Claude Desktop, Gemini CLI, Antigravity CLI, OpenClaw, OMP). |
 | [`docs/deploy.md`](docs/deploy.md) | Homelab deploy: bin/deploy, bearer-token auth, pointers to the TLS guide. |

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -126,7 +126,21 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
     // answers for the project the agent is actually in, not the static
     // `--project` (issue #2). In stdio mode no hook router is built, so
     // this stays empty and the baked-in default is used.
-    let active_project = ActiveProject::new();
+    // Construct ActiveProject with the configured `[auto_scope]` mode +
+    // TTL/cap. `single` (default) preserves the legacy behaviour; the
+    // opt-in modes (`per_session`, `per_actor`) keyed-isolate concurrent
+    // sessions / operators on shared installs.
+    let active_project = ActiveProject::with_config(
+        config.auto_scope.mode,
+        std::time::Duration::from_secs(config.auto_scope.session_ttl_secs),
+        config.auto_scope.max_entries,
+    );
+    tracing::info!(
+        mode = ?config.auto_scope.mode,
+        session_ttl_secs = config.auto_scope.session_ttl_secs,
+        max_entries = config.auto_scope.max_entries,
+        "active-project isolation mode"
+    );
     let mut server = AiMemoryServer::new(store.reader.clone(), store.writer.clone(), ws, proj)
         .with_wiki(wiki.clone())
         .with_decay_params(config.decay)

--- a/crates/ai-memory-cli/src/config.rs
+++ b/crates/ai-memory-cli/src/config.rs
@@ -101,6 +101,12 @@ pub struct Config {
     /// `AI_MEMORY_AUTH_TOKEN` env var or `[auth].bearer_token` in
     /// config.toml.
     pub auth: AuthSettings,
+    /// `[auto_scope]` — opt-in isolation of the hook-published "current
+    /// project" pointer used by MCP tools that omit `workspace`/`project`.
+    /// Default `single` mode preserves the legacy global slot; `per_session`
+    /// and `per_actor` are for shared installs. See [`AutoScopeSettings`]
+    /// and [`ai_memory_core::ActiveProjectMode`].
+    pub auto_scope: AutoScopeSettings,
     /// `Host`-header allowlist for the HTTP server. Requests whose
     /// `Host` header doesn't match this list are rejected before they
     /// reach MCP, hook, admin, or web routes (DNS-rebinding defence).
@@ -274,6 +280,39 @@ pub struct AuthSettings {
     pub token_pepper: Option<String>,
 }
 
+/// `[auto_scope]` — controls how the hook-published "currently active
+/// project" pointer is shared across concurrent callers. The legacy default
+/// is `single` (process-wide slot, last-write-wins). Opt-in modes isolate
+/// concurrent agent runs and/or operators.
+///
+/// Set under `[auto_scope]` in `config.toml` or via the
+/// `AI_MEMORY_AUTO_SCOPE__MODE`, `AI_MEMORY_AUTO_SCOPE__SESSION_TTL_SECS`,
+/// and `AI_MEMORY_AUTO_SCOPE__MAX_ENTRIES` env vars.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AutoScopeSettings {
+    /// `single` (default), `per_session`, or `per_actor`. See
+    /// [`ai_memory_core::ActiveProjectMode`] for full semantics.
+    pub mode: ai_memory_core::ActiveProjectMode,
+    /// TTL (seconds) for per-key entries in `per_session`/`per_actor`
+    /// modes. Default is 1 hour. Set to 0 to fall back to the default.
+    pub session_ttl_secs: u64,
+    /// Hard upper bound on the per-key map size, evicting the oldest
+    /// insertions first. Default 4096; lower for very small installs,
+    /// raise for shared engines with many concurrent agents.
+    pub max_entries: usize,
+}
+
+impl Default for AutoScopeSettings {
+    fn default() -> Self {
+        Self {
+            mode: ai_memory_core::ActiveProjectMode::default(),
+            session_ttl_secs: ai_memory_core::DEFAULT_PER_KEY_TTL.as_secs(),
+            max_entries: ai_memory_core::DEFAULT_MAX_ENTRIES,
+        }
+    }
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -294,6 +333,7 @@ impl Default for Config {
             maintenance: MaintenanceSettings::default(),
             sanitize: ai_memory_core::SanitizeConfig::default(),
             auth: AuthSettings::default(),
+            auto_scope: AutoScopeSettings::default(),
             allowed_hosts: vec!["localhost".into(), "127.0.0.1".into(), "::1".into()],
             cors_allow_origins: Vec::new(),
             admission_webhooks: Vec::new(),

--- a/crates/ai-memory-cli/tests/autoscope_env.rs
+++ b/crates/ai-memory-cli/tests/autoscope_env.rs
@@ -1,0 +1,322 @@
+//! Subprocess smoke tests for `[auto_scope]` env-var configuration.
+//!
+//! These tests assert the wiring between figment's `AI_MEMORY_*` env-var
+//! parser and the `[auto_scope]` config block. The chart values.yaml will
+//! ship the same env vars (`AI_MEMORY_AUTO_SCOPE__MODE`, …), so a regression
+//! here would silently downgrade prod from `per_session`/`per_actor` to
+//! the legacy `single` slot — and we'd only catch it by smoke-running
+//! against a multi-actor scenario in prod.
+//!
+//! Each test spawns the `ai-memory` binary with one env-var combination,
+//! waits for the startup log line that records the resolved mode, and
+//! kills the child. Invalid values trip a clear-error exit, which is
+//! also asserted so figment's parse-failure path stays loud.
+
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_ai-memory")
+}
+
+/// Spawn the binary with the given env vars and stream stderr until either
+/// `needle` appears in a line or `timeout` elapses. Always kills the child
+/// before returning. Returns `(matched_line_or_none, all_stderr_captured)`.
+fn spawn_and_wait_for_log(
+    envs: &[(&str, &str)],
+    needle: &str,
+    timeout: Duration,
+) -> (Option<String>, String) {
+    let tmp = TempDir::new().expect("tempdir for serve");
+    // `--bind 127.0.0.1:0` asks the OS for any free port — we never
+    // actually want to talk to the listener, only to confirm the engine
+    // starts up far enough to log the `[auto_scope]` mode.
+    let mut cmd = Command::new(bin());
+    cmd.args([
+        "serve",
+        "--transport",
+        "http",
+        "--bind",
+        "127.0.0.1:0",
+        "--data-dir",
+    ])
+    .arg(tmp.path())
+    .env("AI_MEMORY_DATA_DIR", tmp.path())
+    // Force tracing to spit at least info-level so the
+    // "active-project isolation mode" line is rendered to stderr.
+    .env("RUST_LOG", "info")
+    .stdout(Stdio::null())
+    .stderr(Stdio::piped());
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let mut child = cmd.spawn().expect("spawn ai-memory serve");
+
+    // Pump stderr in a background thread so we can apply a wall-clock
+    // timeout on the *match*, not on the underlying read syscalls.
+    let stderr = child.stderr.take().expect("stderr piped");
+    let (tx, rx) = mpsc::channel::<String>();
+    let pump = std::thread::spawn(move || {
+        let mut all = String::new();
+        let reader = BufReader::new(stderr);
+        for line in reader.lines() {
+            let Ok(line) = line else { break };
+            all.push_str(&line);
+            all.push('\n');
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+        all
+    });
+
+    let deadline = Instant::now() + timeout;
+    let mut matched: Option<String> = None;
+    while Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match rx.recv_timeout(remaining) {
+            Ok(line) => {
+                if line.contains(needle) {
+                    matched = Some(line);
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    // Pump thread terminates once stderr closes (post-kill); collect what
+    // it captured.
+    let all_stderr = pump.join().unwrap_or_default();
+    (matched, all_stderr)
+}
+
+/// Spawn the binary and let it run to completion, capturing exit status
+/// + stderr. Used for the invalid-mode test where startup fails before
+/// reaching the log line we'd otherwise wait for.
+fn spawn_and_wait_for_exit(envs: &[(&str, &str)], timeout: Duration) -> (bool, String) {
+    let tmp = TempDir::new().expect("tempdir for serve");
+    let mut cmd = Command::new(bin());
+    cmd.args([
+        "serve",
+        "--transport",
+        "http",
+        "--bind",
+        "127.0.0.1:0",
+        "--data-dir",
+    ])
+    .arg(tmp.path())
+    .env("AI_MEMORY_DATA_DIR", tmp.path())
+    .env("RUST_LOG", "info")
+    .stdout(Stdio::null())
+    .stderr(Stdio::piped());
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let mut child = cmd.spawn().expect("spawn ai-memory serve");
+
+    // Poll for exit with a wall-clock cap. If the binary stays alive
+    // past the timeout, that's *also* a failure for "invalid value
+    // must fail fast" — kill it so the test doesn't hang and report
+    // false success.
+    let deadline = Instant::now() + timeout;
+    let exited_cleanly = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status.success(),
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break true; // still running == didn't fail fast
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(_) => break true,
+        }
+    };
+
+    let mut stderr_buf = String::new();
+    if let Some(mut s) = child.stderr.take() {
+        use std::io::Read;
+        let _ = s.read_to_string(&mut stderr_buf);
+    }
+    (exited_cleanly, stderr_buf)
+}
+
+const STARTUP_NEEDLE: &str = "active-project isolation mode";
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(8);
+
+#[test]
+fn default_mode_is_single() {
+    let (line, all) = spawn_and_wait_for_log(&[], STARTUP_NEEDLE, STARTUP_TIMEOUT);
+    let line = line.unwrap_or_else(|| panic!("startup log line not found.\nstderr:\n{all}"));
+    assert!(
+        line.contains("Single"),
+        "default mode must log `Single`. Got: {line}\nfull stderr:\n{all}"
+    );
+}
+
+#[test]
+fn per_session_mode_via_env() {
+    let (line, all) = spawn_and_wait_for_log(
+        &[("AI_MEMORY_AUTO_SCOPE__MODE", "per_session")],
+        STARTUP_NEEDLE,
+        STARTUP_TIMEOUT,
+    );
+    let line = line.unwrap_or_else(|| {
+        panic!("startup log line not found for per_session.\nstderr:\n{all}")
+    });
+    assert!(
+        line.contains("PerSession"),
+        "expected `PerSession` in startup line, got: {line}\nfull stderr:\n{all}"
+    );
+}
+
+#[test]
+fn per_actor_mode_via_env() {
+    let (line, all) = spawn_and_wait_for_log(
+        &[("AI_MEMORY_AUTO_SCOPE__MODE", "per_actor")],
+        STARTUP_NEEDLE,
+        STARTUP_TIMEOUT,
+    );
+    let line = line.unwrap_or_else(|| {
+        panic!("startup log line not found for per_actor.\nstderr:\n{all}")
+    });
+    assert!(
+        line.contains("PerActor"),
+        "expected `PerActor` in startup line, got: {line}\nfull stderr:\n{all}"
+    );
+}
+
+#[test]
+fn ttl_and_max_entries_via_env() {
+    // Confirms the full struct round-trips through figment's `__`
+    // separator convention — not just `mode`. A typo in any of the
+    // three field-names downstream would surface here.
+    let (line, all) = spawn_and_wait_for_log(
+        &[
+            ("AI_MEMORY_AUTO_SCOPE__MODE", "per_session"),
+            ("AI_MEMORY_AUTO_SCOPE__SESSION_TTL_SECS", "120"),
+            ("AI_MEMORY_AUTO_SCOPE__MAX_ENTRIES", "64"),
+        ],
+        STARTUP_NEEDLE,
+        STARTUP_TIMEOUT,
+    );
+    let line = line.unwrap_or_else(|| panic!("startup log not found.\nstderr:\n{all}"));
+    assert!(
+        line.contains("PerSession") && line.contains("120") && line.contains("64"),
+        "all three fields must be reflected in the startup log.\nGot: {line}\nfull stderr:\n{all}"
+    );
+}
+
+#[test]
+fn invalid_mode_value_fails_fast() {
+    // figment + serde's `rename_all = "snake_case"` rejects unknown
+    // enum variants. The process must NOT keep running silently with a
+    // surprise fallback — that's exactly the silent-misconfig bug we
+    // want to catch in CI long before it reaches prod.
+    let (exited_ok, all) = spawn_and_wait_for_exit(
+        &[("AI_MEMORY_AUTO_SCOPE__MODE", "per_universe")],
+        Duration::from_secs(5),
+    );
+    assert!(
+        !exited_ok,
+        "invalid `mode` must NOT result in a successful startup.\nstderr:\n{all}"
+    );
+}
+
+// ─── Boundary-value cases for the numeric fields ──────────────────────
+//
+// figment coerces strings → integers and the `PerActorMap` constructor
+// gracefully clamps the degenerate-zero cases so an operator who copy-
+// pastes a placeholder doesn't get a server that immediately evicts
+// every entry (`ttl=0`) or refuses to store anything (`max_entries=0`).
+// These pin that behaviour so a future refactor either keeps the clamp
+// or makes the failure loud.
+
+#[test]
+fn max_entries_zero_clamps_and_starts() {
+    // `0` is a footgun — without clamping, every insertion would be
+    // immediately evicted and per_actor would silently degrade to the
+    // single slot. `PerActorMap::new` clamps to 1; the engine must
+    // still start.
+    let (line, all) = spawn_and_wait_for_log(
+        &[
+            ("AI_MEMORY_AUTO_SCOPE__MODE", "per_session"),
+            ("AI_MEMORY_AUTO_SCOPE__MAX_ENTRIES", "0"),
+        ],
+        STARTUP_NEEDLE,
+        STARTUP_TIMEOUT,
+    );
+    let line = line.unwrap_or_else(|| {
+        panic!("startup log line not found with max_entries=0.\nstderr:\n{all}")
+    });
+    // The startup log shows the configured value (0), not the
+    // post-clamp internal value — that's a separate observability
+    // concern. Asserting `PerSession` is enough proof that startup
+    // succeeded; the clamp itself is exercised by the unit tests on
+    // `PerActorMap::new`.
+    assert!(
+        line.contains("PerSession"),
+        "max_entries=0 should still start in per_session mode: {line}\nfull stderr:\n{all}"
+    );
+}
+
+#[test]
+fn session_ttl_zero_clamps_and_starts() {
+    // Same logic as max_entries=0: zero TTL = entries expire on
+    // insertion = per_actor silently degrades. `PerActorMap::new` falls
+    // back to DEFAULT_PER_KEY_TTL when ttl.is_zero(). Engine must
+    // still start.
+    let (line, all) = spawn_and_wait_for_log(
+        &[
+            ("AI_MEMORY_AUTO_SCOPE__MODE", "per_actor"),
+            ("AI_MEMORY_AUTO_SCOPE__SESSION_TTL_SECS", "0"),
+        ],
+        STARTUP_NEEDLE,
+        STARTUP_TIMEOUT,
+    );
+    let line = line.unwrap_or_else(|| {
+        panic!("startup log line not found with ttl=0.\nstderr:\n{all}")
+    });
+    assert!(
+        line.contains("PerActor"),
+        "session_ttl_secs=0 should still start in per_actor mode: {line}\nfull stderr:\n{all}"
+    );
+}
+
+#[test]
+fn empty_mode_string_fails_fast() {
+    // `""` is not a valid serde enum variant. Just like
+    // `per_universe`, this must abort startup — never quietly default
+    // to single.
+    let (exited_ok, all) = spawn_and_wait_for_exit(
+        &[("AI_MEMORY_AUTO_SCOPE__MODE", "")],
+        Duration::from_secs(5),
+    );
+    assert!(
+        !exited_ok,
+        "empty `mode` must NOT result in a successful startup.\nstderr:\n{all}"
+    );
+}
+
+#[test]
+fn pascalcase_mode_fails_fast() {
+    // The serde rename is `snake_case`. `PerSession` (the rust enum
+    // variant name) is NOT a valid wire value; the operator must use
+    // `per_session`. Pin this so a refactor doesn't quietly accept
+    // both forms (which would mask a future case-sensitivity bug).
+    let (exited_ok, all) = spawn_and_wait_for_exit(
+        &[("AI_MEMORY_AUTO_SCOPE__MODE", "PerSession")],
+        Duration::from_secs(5),
+    );
+    assert!(
+        !exited_ok,
+        "PascalCase `mode` must NOT result in a successful startup.\nstderr:\n{all}"
+    );
+}

--- a/crates/ai-memory-cli/tests/autoscope_env.rs
+++ b/crates/ai-memory-cli/tests/autoscope_env.rs
@@ -96,8 +96,8 @@ fn spawn_and_wait_for_log(
     (matched, all_stderr)
 }
 
-/// Spawn the binary and let it run to completion, capturing exit status
-/// + stderr. Used for the invalid-mode test where startup fails before
+/// Spawn the binary and let it run to completion, capturing both exit status
+/// and stderr. Used for the invalid-mode test where startup fails before
 /// reaching the log line we'd otherwise wait for.
 fn spawn_and_wait_for_exit(envs: &[(&str, &str)], timeout: Duration) -> (bool, String) {
     let tmp = TempDir::new().expect("tempdir for serve");
@@ -168,9 +168,8 @@ fn per_session_mode_via_env() {
         STARTUP_NEEDLE,
         STARTUP_TIMEOUT,
     );
-    let line = line.unwrap_or_else(|| {
-        panic!("startup log line not found for per_session.\nstderr:\n{all}")
-    });
+    let line = line
+        .unwrap_or_else(|| panic!("startup log line not found for per_session.\nstderr:\n{all}"));
     assert!(
         line.contains("PerSession"),
         "expected `PerSession` in startup line, got: {line}\nfull stderr:\n{all}"
@@ -184,9 +183,8 @@ fn per_actor_mode_via_env() {
         STARTUP_NEEDLE,
         STARTUP_TIMEOUT,
     );
-    let line = line.unwrap_or_else(|| {
-        panic!("startup log line not found for per_actor.\nstderr:\n{all}")
-    });
+    let line =
+        line.unwrap_or_else(|| panic!("startup log line not found for per_actor.\nstderr:\n{all}"));
     assert!(
         line.contains("PerActor"),
         "expected `PerActor` in startup line, got: {line}\nfull stderr:\n{all}"
@@ -281,9 +279,8 @@ fn session_ttl_zero_clamps_and_starts() {
         STARTUP_NEEDLE,
         STARTUP_TIMEOUT,
     );
-    let line = line.unwrap_or_else(|| {
-        panic!("startup log line not found with ttl=0.\nstderr:\n{all}")
-    });
+    let line =
+        line.unwrap_or_else(|| panic!("startup log line not found with ttl=0.\nstderr:\n{all}"));
     assert!(
         line.contains("PerActor"),
         "session_ttl_secs=0 should still start in per_actor mode: {line}\nfull stderr:\n{all}"

--- a/crates/ai-memory-core/src/active_project.rs
+++ b/crates/ai-memory-core/src/active_project.rs
@@ -168,6 +168,16 @@ impl PerActorMap {
         self.purge_expired(now);
         self.entries.get(key).map(|(ws, proj, _)| (*ws, *proj))
     }
+
+    /// Test-only: live row count in the backing HashMap. Counts all
+    /// rows, including ones whose TTL has elapsed (those are dropped
+    /// by `purge_expired` on the next read/write). The randomised cap
+    /// test uses this to verify `enforce_cap` keeps the storage bounded
+    /// at every step regardless of when expiry sweeps run.
+    #[cfg(test)]
+    fn raw_len(&self) -> usize {
+        self.entries.len()
+    }
 }
 
 /// Cheap, cloneable handle to the shared "currently active project" pointer.
@@ -332,6 +342,19 @@ impl ActiveProject {
         }
         let mut guard = self.per_actor.write().unwrap_or_else(|e| e.into_inner());
         guard.get(&scoped, Instant::now())
+    }
+
+    /// Test-only: live count of keyed entries in the per-actor backing
+    /// store, after any pending TTL expiry. Used by the randomised
+    /// invariant tests to pin `count <= max_entries` after every
+    /// operation. Counts both still-fresh and stale entries because
+    /// pre-expiry sweeping is a `get`-time concern; this helper
+    /// inspects raw storage so the cap test catches a cap violation
+    /// regardless of when expiry sweeps run.
+    #[cfg(test)]
+    fn keyed_entry_count_for_test(&self) -> usize {
+        let guard = self.per_actor.read().unwrap_or_else(|e| e.into_inner());
+        guard.raw_len()
     }
 }
 
@@ -535,5 +558,254 @@ mod tests {
         // the keyed entry expired).
         ap.clear();
         assert!(ap.get_for(&k).is_none());
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Randomised invariant tests.
+    //
+    // Each `prop_*` test runs a long sequence of operations driven by a
+    // tiny xorshift RNG with a fixed seed (printed on failure for
+    // repro). We assert universal invariants that must hold AFTER every
+    // operation — not just at one cherry-picked moment — so a bug in
+    // eviction order or TTL expiry that the fixed scenarios miss
+    // surfaces here.
+    //
+    // No external dep: workspace deliberately curates its dev-deps and
+    // adding `proptest` for one module is more cost than signal. The
+    // randomized fuzzing below covers the same ground for the
+    // invariants we care about; if a future regression motivates true
+    // shrinking, swap in proptest then.
+    // ────────────────────────────────────────────────────────────────────
+
+    /// Minimal xorshift64* — deterministic, ~4 cycles/step, no deps.
+    struct Rng(u64);
+    impl Rng {
+        fn new(seed: u64) -> Self {
+            // Avoid the all-zero degenerate state.
+            Self(if seed == 0 { 0x9e37_79b9_7f4a_7c15 } else { seed })
+        }
+        fn next(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x
+        }
+        fn pick<T: Copy>(&mut self, slice: &[T]) -> T {
+            slice[(self.next() as usize) % slice.len()]
+        }
+    }
+
+    /// One operation in the randomised harness.
+    #[derive(Debug, Clone, Copy)]
+    enum Op {
+        Set(usize),    // set_for(actor_pool[idx], ws, fresh proj)
+        Get(usize),    // get_for(actor_pool[idx])
+        ClearAll,      // clear() — single + keyed
+        SetSingle,     // set(ws, fresh proj) — legacy single-slot path
+        GetSingle,     // get() — legacy single-slot path
+    }
+
+    fn run_seeded<F: FnMut(usize, &Op, &ActiveProject)>(
+        ap: &ActiveProject,
+        seed: u64,
+        steps: usize,
+        actor_pool_size: usize,
+        ws: WorkspaceId,
+        mut on_step: F,
+    ) {
+        let mut rng = Rng::new(seed);
+        let actors: Vec<ActorKey> = (0..actor_pool_size)
+            .map(|i| ActorKey {
+                user: Some(format!("user-{i}")),
+                session_id: Some(format!("sess-{i}")),
+            })
+            .collect();
+
+        let op_table = [Op::Set(0), Op::Get(0), Op::ClearAll, Op::SetSingle, Op::GetSingle];
+
+        for step in 0..steps {
+            let mut op = rng.pick(&op_table);
+            if let Op::Set(_) = op {
+                op = Op::Set((rng.next() as usize) % actor_pool_size);
+            } else if let Op::Get(_) = op {
+                op = Op::Get((rng.next() as usize) % actor_pool_size);
+            }
+
+            match op {
+                Op::Set(i) => {
+                    let proj = ProjectId::new();
+                    ap.set_for(&actors[i], ws, proj);
+                }
+                Op::Get(i) => {
+                    let _ = ap.get_for(&actors[i]);
+                }
+                Op::ClearAll => ap.clear(),
+                Op::SetSingle => {
+                    let proj = ProjectId::new();
+                    ap.set(ws, proj);
+                }
+                Op::GetSingle => {
+                    let _ = ap.get();
+                }
+            }
+
+            on_step(step, &op, ap);
+        }
+    }
+
+    /// Property: at every moment, the count of `keyed` entries must be
+    /// `<= max_entries`. The LRU evictor is the only thing keeping the
+    /// map bounded; a race that lets it grow past the cap would surface
+    /// here within a few thousand random ops.
+    #[test]
+    fn prop_keyed_entries_never_exceed_max() {
+        let ws = WorkspaceId::new();
+        for seed in [1, 42, 1337, 0xdead_beef, 0xfeed_face] {
+            let cap = 8;
+            let ap = ActiveProject::with_config(
+                ActiveProjectMode::PerActor,
+                DEFAULT_PER_KEY_TTL,
+                cap,
+            );
+            // Pool larger than cap so eviction is exercised continuously.
+            run_seeded(&ap, seed, 2_000, cap * 4, ws, |step, op, ap| {
+                let count = ap.keyed_entry_count_for_test();
+                assert!(
+                    count <= cap,
+                    "seed={seed:#x} step={step}: cap violated, count={count} > {cap} after {op:?}"
+                );
+            });
+        }
+    }
+
+    /// Property: an entry's projection through `set_for(k, _, p)` must
+    /// be observable by `keyed_only_get(k) == Some(_, p)` until either
+    /// (a) another `set_for(k, _, p')` overrides it, (b) eviction
+    /// kicks it out (only possible if cap was exceeded between writes),
+    /// or (c) the TTL passes.
+    ///
+    /// This is the "fresh write is durable" contract — the foundation
+    /// every read tool depends on.
+    #[test]
+    fn prop_fresh_write_round_trips_until_overwrite_or_evict() {
+        let ws = WorkspaceId::new();
+        for seed in [1, 99, 12_345, 0xc0ffee_u64] {
+            let cap = 16;
+            let pool_size = cap * 2;
+            let ap = ActiveProject::with_config(
+                ActiveProjectMode::PerActor,
+                Duration::from_secs(60), // long TTL — eviction stays cap-driven
+                cap,
+            );
+            let mut rng = Rng::new(seed);
+            let actors: Vec<ActorKey> = (0..pool_size)
+                .map(|i| ActorKey {
+                    user: Some(format!("user-{i}")),
+                    session_id: Some(format!("sess-{i}")),
+                })
+                .collect();
+
+            // Walk: each step picks an actor, writes a fresh project id,
+            // immediately reads back, asserts the read sees THAT id.
+            // Whether other actors' entries were evicted is fine; the
+            // write we JUST did MUST be readable.
+            for step in 0..1_000 {
+                let i = (rng.next() as usize) % pool_size;
+                let proj = ProjectId::new();
+                ap.set_for(&actors[i], ws, proj);
+                let got = ap.keyed_only_get(&actors[i]);
+                assert_eq!(
+                    got,
+                    Some((ws, proj)),
+                    "seed={seed:#x} step={step}: fresh write for actor {i} not readable; got {got:?}"
+                );
+            }
+        }
+    }
+
+    /// Property: `clear()` must wipe BOTH the single slot and every
+    /// keyed entry. Operators rely on this for tests / admin-driven
+    /// reset; a partial clear would leak stale routing.
+    #[test]
+    fn prop_clear_wipes_all_slots() {
+        let ws = WorkspaceId::new();
+        for seed in [1_u64, 7, 314_159, 271_828, 161_803] {
+            let ap = ActiveProject::with_config(
+                ActiveProjectMode::PerActor,
+                DEFAULT_PER_KEY_TTL,
+                64,
+            );
+            run_seeded(&ap, seed, 500, 8, ws, |_step, _op, _ap| {});
+            // After arbitrary ops, clear and assert emptiness from every
+            // angle. Use a fresh actor key not seen in the run.
+            ap.clear();
+            assert!(ap.get().is_none(), "seed={seed:#x}: single slot not cleared");
+            assert!(
+                ap.keyed_only_get(&ActorKey {
+                    user: Some("post-clear-probe".into()),
+                    session_id: Some("post-clear".into()),
+                })
+                .is_none(),
+                "seed={seed:#x}: keyed lookup after clear must be None"
+            );
+            assert_eq!(
+                ap.keyed_entry_count_for_test(),
+                0,
+                "seed={seed:#x}: keyed_entry_count after clear must be 0"
+            );
+        }
+    }
+
+    /// Property: TTL is monotonic in time — once an entry has expired
+    /// (the per-key TTL has elapsed since its last `set_for`), no
+    /// `get_for` lookup should ever see it again via the *keyed* path.
+    /// The single-slot fallback is allowed (graceful degradation).
+    #[test]
+    fn prop_expired_entry_is_not_resurrected_via_keyed_path() {
+        let ws = WorkspaceId::new();
+        for seed in [1_u64, 11, 222, 3_333] {
+            let ttl = Duration::from_millis(40);
+            let ap = ActiveProject::with_config(ActiveProjectMode::PerActor, ttl, 32);
+            let mut rng = Rng::new(seed);
+            let actors: Vec<ActorKey> = (0..8)
+                .map(|i| ActorKey {
+                    user: Some(format!("u-{i}")),
+                    session_id: Some(format!("s-{i}")),
+                })
+                .collect();
+
+            // Pre-populate every actor; record the write time relative
+            // to the run start.
+            for actor in &actors {
+                ap.set_for(actor, ws, ProjectId::new());
+            }
+
+            // Wait for TTL plus a margin so every pre-populated entry
+            // is logically expired.
+            std::thread::sleep(ttl + Duration::from_millis(30));
+
+            // Now hit each actor with `keyed_only_get`. None of them
+            // should resurrect: even though `get_for` would fall back
+            // to the single slot, `keyed_only_get` must return None.
+            for (idx, actor) in actors.iter().enumerate() {
+                assert!(
+                    ap.keyed_only_get(actor).is_none(),
+                    "seed={seed:#x} idx={idx}: expired keyed entry resurrected"
+                );
+            }
+
+            // Cross-check that fresh writes still work after expiry —
+            // the map shouldn't go into an unrecoverable state.
+            let i = (rng.next() as usize) % actors.len();
+            let proj = ProjectId::new();
+            ap.set_for(&actors[i], ws, proj);
+            assert_eq!(
+                ap.keyed_only_get(&actors[i]),
+                Some((ws, proj)),
+                "seed={seed:#x}: fresh post-expiry write must round-trip"
+            );
+        }
     }
 }

--- a/crates/ai-memory-core/src/active_project.rs
+++ b/crates/ai-memory-core/src/active_project.rs
@@ -28,17 +28,22 @@
 //! - `PerSession` keys by `session_id` — isolates concurrent agent runs of
 //!   the same operator (one person with several Claude Code / Codex windows
 //!   in different repos at once).
-//! - `PerActor` keys by `(user, session_id)` — isolates across operators as
-//!   well as across sessions, for corporate installs with multiple authed
-//!   users sharing one engine. Pairs with multi-user mode (rung 2): `user`
-//!   comes from the `users` row that owns the bearer token.
+//! - `PerActor` keys by `(user, session_id)` when both coordinates are present
+//!   and also keeps a user-only fallback slot. That isolates across operators
+//!   even when a client cannot forward a per-session key, while preserving
+//!   per-session isolation for clients/bridges that do forward one. Pairs with
+//!   multi-user mode (rung 2): `user` comes from the `users` row that owns the
+//!   bearer token.
 //!
 //! When the caller has no actor identity at all (anonymous request without a
 //! session, or a code path the migration has not threaded yet), every mode
-//! falls back to the single slot — never a silent error, never a wrong-actor
-//! lookup. The single slot is also what the historical `set` / `get` /
-//! `clear` API touches, so existing callers compile unchanged and admin ops
-//! like `move-project` still invalidate the pointer correctly.
+//! falls back to the single slot for backward compatibility. That is a legacy
+//! convenience, not isolation; session-aware clients should forward a session
+//! key, and shared authenticated installs should use `PerActor` so user-scoped
+//! fallback applies before the global slot. The single slot is also what the
+//! historical `set` / `get` / `clear` API touches, so existing callers compile
+//! unchanged and admin ops like `move-project` still invalidate the pointer
+//! correctly.
 //!
 //! ## Memory bound
 //!
@@ -242,6 +247,11 @@ impl ActiveProject {
     ///   *and* the single slot is updated as well, so callers that have no
     ///   actor identity (anonymous probes, legacy code paths) still see the
     ///   latest project rather than an empty pointer.
+    /// - In `PerActor`, a user-only fallback entry is also set when `user` is
+    ///   present. Real MCP clients often cannot attach the hook payload's
+    ///   session id to every tool call; the user-only slot still prevents an
+    ///   authenticated Alice request from falling through to Bob's latest
+    ///   project in the global slot.
     pub fn set_for(&self, actor: &ActorKey, workspace_id: WorkspaceId, project_id: ProjectId) {
         self.write_single(workspace_id, project_id);
         if self.mode == ActiveProjectMode::Single || actor.is_empty() {
@@ -252,6 +262,20 @@ impl ActiveProject {
             return;
         }
         let mut guard = self.per_actor.write().unwrap_or_else(|e| e.into_inner());
+        if self.mode == ActiveProjectMode::PerActor
+            && actor.user.is_some()
+            && actor.session_id.is_some()
+        {
+            guard.insert(
+                ActorKey {
+                    user: actor.user.clone(),
+                    session_id: None,
+                },
+                workspace_id,
+                project_id,
+                Instant::now(),
+            );
+        }
         guard.insert(scoped, workspace_id, project_id, Instant::now());
     }
 
@@ -268,6 +292,18 @@ impl ActiveProject {
                 let mut guard = self.per_actor.write().unwrap_or_else(|e| e.into_inner());
                 if let Some(found) = guard.get(&scoped, Instant::now()) {
                     return Some(found);
+                }
+                if self.mode == ActiveProjectMode::PerActor
+                    && scoped.user.is_some()
+                    && scoped.session_id.is_some()
+                {
+                    let user_only = ActorKey {
+                        user: scoped.user.clone(),
+                        session_id: None,
+                    };
+                    if let Some(found) = guard.get(&user_only, Instant::now()) {
+                        return Some(found);
+                    }
                 }
             }
         }
@@ -493,6 +529,48 @@ mod tests {
         assert_eq!(ap.get_for(&alice_a), Some((ws, p1)));
         assert_eq!(ap.get_for(&alice_b), Some((ws, p2)));
         assert_eq!(ap.get_for(&bob_a), Some((ws, p3)));
+    }
+
+    #[test]
+    fn per_actor_user_only_lookup_stays_with_that_user() {
+        let ap = ActiveProject::with_mode(ActiveProjectMode::PerActor);
+        let alice_a = key_actor("alice", "sA");
+        let bob_a = key_actor("bob", "sA");
+        let ws = WorkspaceId::new();
+        let p_alice = ProjectId::new();
+        let p_bob = ProjectId::new();
+        ap.set_for(&alice_a, ws, p_alice);
+        ap.set_for(&bob_a, ws, p_bob);
+
+        assert_eq!(
+            ap.get_for(&ActorKey {
+                user: Some("alice".into()),
+                session_id: None,
+            }),
+            Some((ws, p_alice)),
+            "missing session id must not fall through to Bob's global slot"
+        );
+    }
+
+    #[test]
+    fn per_actor_unknown_session_falls_back_to_user_slot() {
+        let ap = ActiveProject::with_mode(ActiveProjectMode::PerActor);
+        let alice_a = key_actor("alice", "hook-session");
+        let bob_a = key_actor("bob", "hook-session");
+        let ws = WorkspaceId::new();
+        let p_alice = ProjectId::new();
+        let p_bob = ProjectId::new();
+        ap.set_for(&alice_a, ws, p_alice);
+        ap.set_for(&bob_a, ws, p_bob);
+
+        assert_eq!(
+            ap.get_for(&ActorKey {
+                user: Some("alice".into()),
+                session_id: Some("different-mcp-session".into()),
+            }),
+            Some((ws, p_alice)),
+            "mismatched session id should degrade to Alice's latest slot, not the global slot"
+        );
     }
 
     #[test]

--- a/crates/ai-memory-core/src/active_project.rs
+++ b/crates/ai-memory-core/src/active_project.rs
@@ -582,7 +582,11 @@ mod tests {
     impl Rng {
         fn new(seed: u64) -> Self {
             // Avoid the all-zero degenerate state.
-            Self(if seed == 0 { 0x9e37_79b9_7f4a_7c15 } else { seed })
+            Self(if seed == 0 {
+                0x9e37_79b9_7f4a_7c15
+            } else {
+                seed
+            })
         }
         fn next(&mut self) -> u64 {
             let mut x = self.0;
@@ -600,11 +604,11 @@ mod tests {
     /// One operation in the randomised harness.
     #[derive(Debug, Clone, Copy)]
     enum Op {
-        Set(usize),    // set_for(actor_pool[idx], ws, fresh proj)
-        Get(usize),    // get_for(actor_pool[idx])
-        ClearAll,      // clear() — single + keyed
-        SetSingle,     // set(ws, fresh proj) — legacy single-slot path
-        GetSingle,     // get() — legacy single-slot path
+        Set(usize), // set_for(actor_pool[idx], ws, fresh proj)
+        Get(usize), // get_for(actor_pool[idx])
+        ClearAll,   // clear() — single + keyed
+        SetSingle,  // set(ws, fresh proj) — legacy single-slot path
+        GetSingle,  // get() — legacy single-slot path
     }
 
     fn run_seeded<F: FnMut(usize, &Op, &ActiveProject)>(
@@ -623,7 +627,13 @@ mod tests {
             })
             .collect();
 
-        let op_table = [Op::Set(0), Op::Get(0), Op::ClearAll, Op::SetSingle, Op::GetSingle];
+        let op_table = [
+            Op::Set(0),
+            Op::Get(0),
+            Op::ClearAll,
+            Op::SetSingle,
+            Op::GetSingle,
+        ];
 
         for step in 0..steps {
             let mut op = rng.pick(&op_table);
@@ -664,11 +674,8 @@ mod tests {
         let ws = WorkspaceId::new();
         for seed in [1, 42, 1337, 0xdead_beef, 0xfeed_face] {
             let cap = 8;
-            let ap = ActiveProject::with_config(
-                ActiveProjectMode::PerActor,
-                DEFAULT_PER_KEY_TTL,
-                cap,
-            );
+            let ap =
+                ActiveProject::with_config(ActiveProjectMode::PerActor, DEFAULT_PER_KEY_TTL, cap);
             // Pool larger than cap so eviction is exercised continuously.
             run_seeded(&ap, seed, 2_000, cap * 4, ws, |step, op, ap| {
                 let count = ap.keyed_entry_count_for_test();
@@ -732,16 +739,16 @@ mod tests {
     fn prop_clear_wipes_all_slots() {
         let ws = WorkspaceId::new();
         for seed in [1_u64, 7, 314_159, 271_828, 161_803] {
-            let ap = ActiveProject::with_config(
-                ActiveProjectMode::PerActor,
-                DEFAULT_PER_KEY_TTL,
-                64,
-            );
+            let ap =
+                ActiveProject::with_config(ActiveProjectMode::PerActor, DEFAULT_PER_KEY_TTL, 64);
             run_seeded(&ap, seed, 500, 8, ws, |_step, _op, _ap| {});
             // After arbitrary ops, clear and assert emptiness from every
             // angle. Use a fresh actor key not seen in the run.
             ap.clear();
-            assert!(ap.get().is_none(), "seed={seed:#x}: single slot not cleared");
+            assert!(
+                ap.get().is_none(),
+                "seed={seed:#x}: single slot not cleared"
+            );
             assert!(
                 ap.keyed_only_get(&ActorKey {
                     user: Some("post-clear-probe".into()),

--- a/crates/ai-memory-core/src/active_project.rs
+++ b/crates/ai-memory-core/src/active_project.rs
@@ -15,60 +15,323 @@
 //! defaults to `scratch` and made the read tools return empty memory even
 //! when the hooks were correctly populating a real project).
 //!
-//! The pointer reflects the most recently resolved cwd-based project. For the
-//! common single-user, one-project-at-a-time workflow this is exactly right.
-//! For the rarer case of one shared server fielding several projects
-//! concurrently, the MCP tools also accept an explicit `project` argument that
-//! takes precedence over this pointer.
+//! ## Isolation modes
 //!
-//! The lock is held only for the microseconds it takes to copy a small tuple;
-//! callers never `.await` while holding it, so a plain `std::sync::RwLock` is
-//! the right primitive (no async lock needed).
+//! The default `Single` mode keeps the historical behaviour — one process-
+//! wide slot, last-write-wins. That is right for a single operator running
+//! one project at a time, but collapses parallel sessions on shared installs:
+//! a hook firing from `~/repo-A` overwrites the slot a concurrent
+//! `memory_query` (with no explicit project) in `~/repo-B` was about to read.
+//!
+//! Opt-in modes keep a per-key map alongside the single slot:
+//!
+//! - `PerSession` keys by `session_id` — isolates concurrent agent runs of
+//!   the same operator (one person with several Claude Code / Codex windows
+//!   in different repos at once).
+//! - `PerActor` keys by `(user, session_id)` — isolates across operators as
+//!   well as across sessions, for corporate installs with multiple authed
+//!   users sharing one engine. Pairs with multi-user mode (rung 2): `user`
+//!   comes from the `users` row that owns the bearer token.
+//!
+//! When the caller has no actor identity at all (anonymous request without a
+//! session, or a code path the migration has not threaded yet), every mode
+//! falls back to the single slot — never a silent error, never a wrong-actor
+//! lookup. The single slot is also what the historical `set` / `get` /
+//! `clear` API touches, so existing callers compile unchanged and admin ops
+//! like `move-project` still invalidate the pointer correctly.
+//!
+//! ## Memory bound
+//!
+//! Per-key entries carry an [`Instant`] insertion timestamp and are evicted
+//! on read or write once they exceed the configured TTL (default 1 hour).
+//! A hard `max_entries` cap (default 4096) drops the oldest entries when
+//! exceeded, so an adversarial / runaway client cannot grow the map without
+//! bound. Both knobs are exposed via the CLI's `[auto_scope]` config block.
+//!
+//! ## Locking
+//!
+//! Locks are held only for the microseconds it takes to copy a small tuple
+//! or do a single hash lookup; callers never `.await` while holding them, so
+//! plain `std::sync::RwLock` is the right primitive (no async lock needed).
 
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
 
 use crate::ids::{ProjectId, WorkspaceId};
 
-/// Cheap, cloneable handle to the shared "currently active project" slot.
+/// Default TTL for per-key entries in the opt-in isolation modes.
+pub const DEFAULT_PER_KEY_TTL: Duration = Duration::from_secs(60 * 60);
+/// Default upper bound on per-key entries, to keep memory finite on shared
+/// installs where many short-lived sessions may come and go.
+pub const DEFAULT_MAX_ENTRIES: usize = 4096;
+
+/// Selects how the hook router and the MCP tools share the "currently active
+/// project" pointer. `Single` is the legacy behaviour and remains the default
+/// — the other modes are opt-in via the CLI's `[auto_scope]` config block.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActiveProjectMode {
+    /// Process-wide slot, last-write-wins. Backward-compatible default.
+    #[default]
+    Single,
+    /// Keyed by `session_id`. Isolates concurrent agent runs of the same
+    /// operator from each other.
+    PerSession,
+    /// Keyed by `(user, session_id)`. Isolates across operators as well,
+    /// for installs with multi-user mode enabled.
+    PerActor,
+}
+
+/// Composite identity used to key per-actor entries.
 ///
-/// Clones share the same underlying slot. Starts empty; the hook router
+/// - `PerSession` mode populates only `session_id`.
+/// - `PerActor` mode populates both (`user` is the username row from
+///   `users`, or the configured `root_username` for rung 1 callers).
+///
+/// An [`ActorKey`] with both fields `None` is treated the same as "no actor"
+/// — the request falls back to the single slot. That keeps anonymous /
+/// pre-identity callers working without a special branch at every call site.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct ActorKey {
+    /// Stable username when the request was authenticated as a known user
+    /// (rung 1 root with `root_username`, or rung 2 DB user). `None` for
+    /// anonymous calls.
+    pub user: Option<String>,
+    /// Per-agent-run session identifier published by the lifecycle hooks
+    /// (Claude Code, Codex, OpenCode, …). `None` when the call site has no
+    /// session context (e.g. an ad-hoc MCP probe with no hook history).
+    pub session_id: Option<String>,
+}
+
+impl ActorKey {
+    /// `true` when neither identity coordinate is present — used to short-
+    /// circuit the per-key map and fall back to the single slot.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.user.is_none() && self.session_id.is_none()
+    }
+}
+
+#[derive(Debug)]
+struct PerActorMap {
+    entries: HashMap<ActorKey, (WorkspaceId, ProjectId, Instant)>,
+    ttl: Duration,
+    max_entries: usize,
+}
+
+impl PerActorMap {
+    fn new(ttl: Duration, max_entries: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            ttl: if ttl.is_zero() {
+                DEFAULT_PER_KEY_TTL
+            } else {
+                ttl
+            },
+            max_entries: max_entries.max(1),
+        }
+    }
+
+    /// Drop expired entries. Run on every read + write so a stale key never
+    /// surfaces to a tool handler and the cap below sees an accurate size.
+    fn purge_expired(&mut self, now: Instant) {
+        self.entries
+            .retain(|_, (_, _, inserted)| now.saturating_duration_since(*inserted) < self.ttl);
+    }
+
+    /// Cap the map at `max_entries`, dropping the oldest insertions first.
+    /// O(n log n) when over the cap; called only at insertion time, so the
+    /// amortised cost is well below the hash insertion itself.
+    fn enforce_cap(&mut self) {
+        if self.entries.len() <= self.max_entries {
+            return;
+        }
+        let excess = self.entries.len() - self.max_entries;
+        let mut by_age: Vec<(ActorKey, Instant)> =
+            self.entries.iter().map(|(k, v)| (k.clone(), v.2)).collect();
+        by_age.sort_by_key(|(_, inserted)| *inserted);
+        for (k, _) in by_age.into_iter().take(excess) {
+            self.entries.remove(&k);
+        }
+    }
+
+    fn insert(&mut self, key: ActorKey, ws: WorkspaceId, proj: ProjectId, now: Instant) {
+        self.purge_expired(now);
+        self.entries.insert(key, (ws, proj, now));
+        self.enforce_cap();
+    }
+
+    fn get(&mut self, key: &ActorKey, now: Instant) -> Option<(WorkspaceId, ProjectId)> {
+        self.purge_expired(now);
+        self.entries.get(key).map(|(ws, proj, _)| (*ws, *proj))
+    }
+}
+
+/// Cheap, cloneable handle to the shared "currently active project" pointer.
+///
+/// Clones share the same underlying state. Starts empty; the hook router
 /// fills it as events arrive.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct ActiveProject {
-    inner: Arc<RwLock<Option<(WorkspaceId, ProjectId)>>>,
+    mode: ActiveProjectMode,
+    single: Arc<RwLock<Option<(WorkspaceId, ProjectId)>>>,
+    per_actor: Arc<RwLock<PerActorMap>>,
+}
+
+impl Default for ActiveProject {
+    fn default() -> Self {
+        Self::with_config(
+            ActiveProjectMode::Single,
+            DEFAULT_PER_KEY_TTL,
+            DEFAULT_MAX_ENTRIES,
+        )
+    }
 }
 
 impl ActiveProject {
-    /// Create an empty pointer (no project resolved yet).
+    /// Create an empty `Single`-mode pointer — the legacy default.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Publish the project the agent is currently active in. Called by the
-    /// hook router after it resolves an event's `cwd` to a real project.
-    pub fn set(&self, workspace_id: WorkspaceId, project_id: ProjectId) {
-        // A poisoned lock means a writer panicked mid-update. The slot holds
-        // only a Copy tuple, so there's no torn state to recover — recover the
-        // guard and overwrite rather than propagating the panic into a hook
-        // handler that must stay fire-and-forget.
-        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
-        *guard = Some((workspace_id, project_id));
+    /// Create an empty pointer in the given mode, using the default TTL +
+    /// cap for the per-key backing map.
+    #[must_use]
+    pub fn with_mode(mode: ActiveProjectMode) -> Self {
+        Self::with_config(mode, DEFAULT_PER_KEY_TTL, DEFAULT_MAX_ENTRIES)
     }
 
-    /// Read the currently active project, if any has been published yet.
+    /// Full-fidelity constructor used by the CLI's `serve` wiring and by
+    /// unit tests that need to exercise eviction.
     #[must_use]
-    pub fn get(&self) -> Option<(WorkspaceId, ProjectId)> {
-        let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
+    pub fn with_config(mode: ActiveProjectMode, ttl: Duration, max_entries: usize) -> Self {
+        Self {
+            mode,
+            single: Arc::new(RwLock::new(None)),
+            per_actor: Arc::new(RwLock::new(PerActorMap::new(ttl, max_entries))),
+        }
+    }
+
+    /// The mode this handle was built with. Mostly useful for tests and for
+    /// observability (the `serve` startup log records it once).
+    #[must_use]
+    pub fn mode(&self) -> ActiveProjectMode {
+        self.mode
+    }
+
+    /// Publish the project the agent is currently active in. Called by the
+    /// hook router after it resolves an event's `cwd` to a real project.
+    ///
+    /// The actor's identity steers which slot is updated:
+    /// - In `Single` mode (the default), the process-wide slot is overwritten.
+    /// - In `PerSession` / `PerActor`, the entry keyed by the actor is set
+    ///   *and* the single slot is updated as well, so callers that have no
+    ///   actor identity (anonymous probes, legacy code paths) still see the
+    ///   latest project rather than an empty pointer.
+    pub fn set_for(&self, actor: &ActorKey, workspace_id: WorkspaceId, project_id: ProjectId) {
+        self.write_single(workspace_id, project_id);
+        if self.mode == ActiveProjectMode::Single || actor.is_empty() {
+            return;
+        }
+        let scoped = self.scoped_key(actor);
+        if scoped.is_empty() {
+            return;
+        }
+        let mut guard = self.per_actor.write().unwrap_or_else(|e| e.into_inner());
+        guard.insert(scoped, workspace_id, project_id, Instant::now());
+    }
+
+    /// Read the currently active project for the given actor, if any has
+    /// been published yet. Falls back to the single slot when:
+    /// - the mode is `Single`, or
+    /// - the actor is empty (no identity coordinates), or
+    /// - no per-actor entry matches (graceful degradation).
+    #[must_use]
+    pub fn get_for(&self, actor: &ActorKey) -> Option<(WorkspaceId, ProjectId)> {
+        if self.mode != ActiveProjectMode::Single && !actor.is_empty() {
+            let scoped = self.scoped_key(actor);
+            if !scoped.is_empty() {
+                let mut guard = self.per_actor.write().unwrap_or_else(|e| e.into_inner());
+                if let Some(found) = guard.get(&scoped, Instant::now()) {
+                    return Some(found);
+                }
+            }
+        }
+        self.read_single()
+    }
+
+    /// Project the actor's identity onto only the coordinates the current
+    /// mode uses: `PerSession` keeps `session_id`, `PerActor` keeps both.
+    fn scoped_key(&self, actor: &ActorKey) -> ActorKey {
+        match self.mode {
+            ActiveProjectMode::Single => ActorKey {
+                user: None,
+                session_id: None,
+            },
+            ActiveProjectMode::PerSession => ActorKey {
+                user: None,
+                session_id: actor.session_id.clone(),
+            },
+            ActiveProjectMode::PerActor => actor.clone(),
+        }
+    }
+
+    fn write_single(&self, ws: WorkspaceId, proj: ProjectId) {
+        let mut guard = self.single.write().unwrap_or_else(|e| e.into_inner());
+        *guard = Some((ws, proj));
+    }
+
+    fn read_single(&self) -> Option<(WorkspaceId, ProjectId)> {
+        let guard = self.single.read().unwrap_or_else(|e| e.into_inner());
         *guard
     }
 
+    /// Legacy single-slot setter — used by tests and by call sites that
+    /// have no actor context yet. Touches the single slot only; the per-key
+    /// map is untouched.
+    pub fn set(&self, workspace_id: WorkspaceId, project_id: ProjectId) {
+        self.write_single(workspace_id, project_id);
+    }
+
+    /// Legacy single-slot getter — same contract as [`Self::set`].
+    #[must_use]
+    pub fn get(&self) -> Option<(WorkspaceId, ProjectId)> {
+        self.read_single()
+    }
+
     /// Forget the active project. Called after an admin operation invalidates
-    /// the published pointer (e.g. a `move-project` whose copy-purge path gives
-    /// the project a NEW id, so the old pointer no longer resolves).
+    /// the published pointer (e.g. a `move-project` whose copy-purge path
+    /// gives the project a NEW id, so the old pointer no longer resolves).
+    /// Clears both the single slot AND the per-key map, since the project
+    /// id is gone for every caller.
     pub fn clear(&self) {
-        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
-        *guard = None;
+        {
+            let mut guard = self.single.write().unwrap_or_else(|e| e.into_inner());
+            *guard = None;
+        }
+        let mut guard = self.per_actor.write().unwrap_or_else(|e| e.into_inner());
+        guard.entries.clear();
+    }
+
+    /// Test-only: look up only the per-key backing store, bypassing the
+    /// single-slot fallback that the production `get_for` returns. Used to
+    /// prove eviction in tests where the fallback would otherwise mask a
+    /// missing entry.
+    #[cfg(test)]
+    fn keyed_only_get(&self, actor: &ActorKey) -> Option<(WorkspaceId, ProjectId)> {
+        if self.mode == ActiveProjectMode::Single || actor.is_empty() {
+            return None;
+        }
+        let scoped = self.scoped_key(actor);
+        if scoped.is_empty() {
+            return None;
+        }
+        let mut guard = self.per_actor.write().unwrap_or_else(|e| e.into_inner());
+        guard.get(&scoped, Instant::now())
     }
 }
 
@@ -76,13 +339,34 @@ impl ActiveProject {
 mod tests {
     use super::*;
 
+    fn key_session(s: &str) -> ActorKey {
+        ActorKey {
+            user: None,
+            session_id: Some(s.to_string()),
+        }
+    }
+
+    fn key_actor(user: &str, session: &str) -> ActorKey {
+        ActorKey {
+            user: Some(user.to_string()),
+            session_id: Some(session.to_string()),
+        }
+    }
+
+    fn empty_actor() -> ActorKey {
+        ActorKey {
+            user: None,
+            session_id: None,
+        }
+    }
+
     #[test]
     fn starts_empty() {
         assert!(ActiveProject::new().get().is_none());
     }
 
     #[test]
-    fn set_then_get_round_trips() {
+    fn set_then_get_round_trips_legacy_api() {
         let ap = ActiveProject::new();
         let ws = WorkspaceId::new();
         let proj = ProjectId::new();
@@ -91,7 +375,7 @@ mod tests {
     }
 
     #[test]
-    fn set_overwrites_previous() {
+    fn set_overwrites_previous_legacy_api() {
         let ap = ActiveProject::new();
         ap.set(WorkspaceId::new(), ProjectId::new());
         let ws2 = WorkspaceId::new();
@@ -108,5 +392,148 @@ mod tests {
         let proj = ProjectId::new();
         a.set(ws, proj);
         assert_eq!(b.get(), Some((ws, proj)), "clone must see the same slot");
+    }
+
+    #[test]
+    fn clear_drops_single_and_per_actor() {
+        let ap = ActiveProject::with_mode(ActiveProjectMode::PerActor);
+        let alice = key_actor("alice", "sA");
+        let ws = WorkspaceId::new();
+        let proj = ProjectId::new();
+        ap.set_for(&alice, ws, proj);
+        assert_eq!(ap.get_for(&alice), Some((ws, proj)));
+
+        ap.clear();
+        assert!(ap.get_for(&alice).is_none(), "per-actor entry must be gone");
+        assert!(ap.get().is_none(), "single slot must be gone");
+    }
+
+    #[test]
+    fn single_mode_ignores_actor_coordinates() {
+        let ap = ActiveProject::new();
+        let alice = key_actor("alice", "sA");
+        let bob = key_actor("bob", "sB");
+        let ws = WorkspaceId::new();
+        let p_alice = ProjectId::new();
+        let p_bob = ProjectId::new();
+        ap.set_for(&alice, ws, p_alice);
+        ap.set_for(&bob, ws, p_bob);
+        // Both reads see the last write; that's the legacy contract.
+        assert_eq!(ap.get_for(&alice), Some((ws, p_bob)));
+        assert_eq!(ap.get_for(&bob), Some((ws, p_bob)));
+        assert_eq!(ap.get(), Some((ws, p_bob)));
+    }
+
+    #[test]
+    fn per_session_isolates_by_session_id() {
+        let ap = ActiveProject::with_mode(ActiveProjectMode::PerSession);
+        let sess_a = key_session("sA");
+        let sess_b = key_session("sB");
+        let ws = WorkspaceId::new();
+        let p_a = ProjectId::new();
+        let p_b = ProjectId::new();
+        ap.set_for(&sess_a, ws, p_a);
+        ap.set_for(&sess_b, ws, p_b);
+        assert_eq!(ap.get_for(&sess_a), Some((ws, p_a)));
+        assert_eq!(ap.get_for(&sess_b), Some((ws, p_b)));
+    }
+
+    #[test]
+    fn per_session_ignores_user_field() {
+        let ap = ActiveProject::with_mode(ActiveProjectMode::PerSession);
+        let ws = WorkspaceId::new();
+        let p = ProjectId::new();
+        let alice = key_actor("alice", "shared-session");
+        let bob = key_actor("bob", "shared-session");
+        ap.set_for(&alice, ws, p);
+        let p_bob = ProjectId::new();
+        ap.set_for(&bob, ws, p_bob);
+        // Same session_id, different users → still collapses to one entry
+        // (intentional: per_session is the right mode for single-operator,
+        // multi-cwd installs; per_actor is the mode for multi-operator).
+        assert_eq!(ap.get_for(&alice), Some((ws, p_bob)));
+    }
+
+    #[test]
+    fn per_actor_isolates_by_user_and_session() {
+        let ap = ActiveProject::with_mode(ActiveProjectMode::PerActor);
+        let alice_a = key_actor("alice", "sA");
+        let alice_b = key_actor("alice", "sB");
+        let bob_a = key_actor("bob", "sA");
+        let ws = WorkspaceId::new();
+        let p1 = ProjectId::new();
+        let p2 = ProjectId::new();
+        let p3 = ProjectId::new();
+        ap.set_for(&alice_a, ws, p1);
+        ap.set_for(&alice_b, ws, p2);
+        ap.set_for(&bob_a, ws, p3);
+        assert_eq!(ap.get_for(&alice_a), Some((ws, p1)));
+        assert_eq!(ap.get_for(&alice_b), Some((ws, p2)));
+        assert_eq!(ap.get_for(&bob_a), Some((ws, p3)));
+    }
+
+    #[test]
+    fn per_actor_falls_back_to_single_when_actor_is_empty() {
+        let ap = ActiveProject::with_mode(ActiveProjectMode::PerActor);
+        let ws = WorkspaceId::new();
+        let proj = ProjectId::new();
+        ap.set(ws, proj);
+        assert_eq!(ap.get_for(&empty_actor()), Some((ws, proj)));
+    }
+
+    #[test]
+    fn per_actor_set_also_updates_single_slot() {
+        // Legacy callers (anonymous probes, code paths the migration has not
+        // touched yet) keep seeing a fresh pointer via `get()`.
+        let ap = ActiveProject::with_mode(ActiveProjectMode::PerActor);
+        let alice = key_actor("alice", "sA");
+        let ws = WorkspaceId::new();
+        let proj = ProjectId::new();
+        ap.set_for(&alice, ws, proj);
+        assert_eq!(ap.get(), Some((ws, proj)));
+    }
+
+    #[test]
+    fn per_actor_max_entries_evicts_oldest() {
+        let ap = ActiveProject::with_config(ActiveProjectMode::PerActor, DEFAULT_PER_KEY_TTL, 2);
+        let ws = WorkspaceId::new();
+        let p1 = ProjectId::new();
+        let p2 = ProjectId::new();
+        let p3 = ProjectId::new();
+        let k1 = key_session("s1");
+        let k2 = key_session("s2");
+        let k3 = key_session("s3");
+        ap.set_for(&k1, ws, p1);
+        std::thread::sleep(Duration::from_millis(2));
+        ap.set_for(&k2, ws, p2);
+        std::thread::sleep(Duration::from_millis(2));
+        ap.set_for(&k3, ws, p3);
+        // Use the test-only keyed-only getter; the production `get_for`
+        // would mask the eviction by falling back to the single slot
+        // (which was last written with p3).
+        assert!(ap.keyed_only_get(&k1).is_none(), "k1 must be evicted");
+        assert_eq!(ap.keyed_only_get(&k2), Some((ws, p2)));
+        assert_eq!(ap.keyed_only_get(&k3), Some((ws, p3)));
+    }
+
+    #[test]
+    fn per_actor_ttl_expires_entries() {
+        let ap = ActiveProject::with_config(
+            ActiveProjectMode::PerActor,
+            Duration::from_millis(20),
+            DEFAULT_MAX_ENTRIES,
+        );
+        let k = key_session("s");
+        let ws = WorkspaceId::new();
+        let proj = ProjectId::new();
+        ap.set_for(&k, ws, proj);
+        assert_eq!(ap.get_for(&k), Some((ws, proj)));
+        std::thread::sleep(Duration::from_millis(40));
+        // The per-actor entry must be gone (the single-slot fallback still
+        // returns the stored value — that is the desired graceful degradation,
+        // so anonymous callers never see an empty pointer just because
+        // the keyed entry expired).
+        ap.clear();
+        assert!(ap.get_for(&k).is_none());
     }
 }

--- a/crates/ai-memory-core/src/lib.rs
+++ b/crates/ai-memory-core/src/lib.rs
@@ -22,7 +22,9 @@ pub const DEFAULT_WORKSPACE_NAME: &str = "default";
 /// Defensive project fallback used only when no cwd/project is available.
 pub const DEFAULT_PROJECT_NAME: &str = "scratch";
 
-pub use active_project::ActiveProject;
+pub use active_project::{
+    ActiveProject, ActiveProjectMode, ActorKey, DEFAULT_MAX_ENTRIES, DEFAULT_PER_KEY_TTL,
+};
 pub use actor::{ActorContext, AuthLevel};
 pub use error::{MemoryError, MemoryResult};
 pub use handoff::{Handoff, HandoffState, NewHandoff};

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -509,11 +509,16 @@ async fn process(
     let session_id = resolve_session_id(&env)?;
     // Build the actor key used to scope the in-process `ActiveProject`
     // pointer. `user` is whatever the auth middleware extracted from this
-    // request; `session_id` comes from the envelope. Empty actor (anonymous
-    // + no session) is allowed — `set_for` falls back to the single slot.
+    // request; `session_id` is the RAW string from the payload (NOT the
+    // resolved UUID) — agents that forward an opaque session id over
+    // `X-Memory-Actor-Session-Id` on /mcp pass the same raw string, so set
+    // and get land on the same map slot. The MCP server's
+    // `actor_key_from_parts` mirrors this convention. Empty actor
+    // (anonymous + no session) is allowed — `set_for` falls back to the
+    // single slot.
     let actor_key = ai_memory_core::ActorKey {
         user: actor_user.clone(),
-        session_id: Some(session_id.to_string()),
+        session_id: env.session_id.clone(),
     };
     let (mut ws, mut proj) = resolve_project_ids(
         state,

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -192,16 +192,25 @@ pub fn hook_router(state: HookState) -> Router {
 async fn handle_hook(
     State(state): State<Arc<HookState>>,
     Query(query): Query<HookQuery>,
+    actor_ext: Option<axum::Extension<ai_memory_core::ActorContext>>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     let env = HookEnvelope::from_query_and_body(query, body);
+    // The auth middleware in front of `/hook` injects the request's
+    // [`ActorContext`] (rung 1 root, rung 2 DB user, or anonymous). We
+    // capture its `user` field NOW — before the spawn drops the request
+    // extensions — so `process()` can key the `ActiveProject` map by the
+    // authenticated identity when `[auto_scope] mode = per_actor` is on.
+    let actor_user = actor_ext
+        .map(|axum::Extension(ctx)| ctx.user)
+        .unwrap_or_default();
     let Ok(permit) = state.ingest_semaphore.clone().try_acquire_owned() else {
         warn!("hook ingest saturated; dropping event with 429");
         return (StatusCode::TOO_MANY_REQUESTS, "hook queue full");
     };
     tokio::spawn(async move {
         let _permit = permit;
-        process_envelope(state, env).await;
+        process_envelope(state, env, actor_user).await;
     });
     (StatusCode::ACCEPTED, "queued")
 }
@@ -240,8 +249,12 @@ pub struct HandoffQuery {
 async fn handle_handoff(
     State(state): State<Arc<HookState>>,
     Query(query): Query<HandoffQuery>,
+    actor_ext: Option<axum::Extension<ai_memory_core::ActorContext>>,
 ) -> impl IntoResponse {
-    match fetch_and_accept_handoff(&state, query).await {
+    let actor_user = actor_ext
+        .map(|axum::Extension(ctx)| ctx.user)
+        .unwrap_or_default();
+    match fetch_and_accept_handoff(&state, query, actor_user).await {
         Ok(Some(markdown)) => (StatusCode::OK, markdown),
         Ok(None) => (StatusCode::OK, String::new()),
         Err(e) => {
@@ -254,14 +267,23 @@ async fn handle_handoff(
 async fn fetch_and_accept_handoff(
     state: &HookState,
     query: HandoffQuery,
+    actor_user: Option<String>,
 ) -> anyhow::Result<Option<String>> {
     let agent = query.agent.as_deref().map_or(AgentKind::Other, parse_agent);
+    // `/handoff` has no session_id in the request — `per_session` mode
+    // therefore falls back to the single slot (graceful degradation),
+    // while `per_actor` keys by `user` alone.
+    let actor_key = ai_memory_core::ActorKey {
+        user: actor_user,
+        session_id: None,
+    };
     let (ws, proj) = resolve_project_ids(
         state,
         query.cwd.as_deref(),
         query.workspace.as_deref(),
         query.project.as_deref(),
         ProjectStrategy::parse(query.project_strategy.as_deref()),
+        &actor_key,
     )
     .await?;
     let handoff = state
@@ -374,6 +396,7 @@ async fn resolve_project_ids(
     workspace_override: Option<&str>,
     project_override: Option<&str>,
     project_strategy: ProjectStrategy,
+    actor: &ai_memory_core::ActorKey,
 ) -> anyhow::Result<(WorkspaceId, ProjectId)> {
     let cwd_norm = cwd.filter(|s| !s.is_empty()).map(str::to_string);
 
@@ -395,8 +418,10 @@ async fn resolve_project_ids(
         if let Some(ids) = cache.get(&cache_key) {
             // Republish on every hit: a cache hit still means the agent
             // is active in this project *now*, which is exactly what the
-            // MCP read tools need as their default.
-            state.active_project.set(ids.0, ids.1);
+            // MCP read tools need as their default. Keyed by the actor so
+            // opt-in isolation modes (`per_session`/`per_actor`) keep
+            // concurrent callers separated.
+            state.active_project.set_for(actor, ids.0, ids.1);
             return Ok(ids);
         }
     }
@@ -412,7 +437,7 @@ async fn resolve_project_ids(
             None => {
                 state
                     .active_project
-                    .set(state.workspace_id, state.project_id);
+                    .set_for(actor, state.workspace_id, state.project_id);
                 return Ok((state.workspace_id, state.project_id));
             }
         },
@@ -425,7 +450,7 @@ async fn resolve_project_ids(
             // message.
             state
                 .active_project
-                .set(state.workspace_id, state.project_id);
+                .set_for(actor, state.workspace_id, state.project_id);
             return Ok((state.workspace_id, state.project_id));
         }
     };
@@ -466,24 +491,37 @@ async fn resolve_project_ids(
         .map_err(|e| anyhow::anyhow!("get_or_create_project: {e}"))?;
     let ids = (ws, proj);
     state.project_cache.lock().await.insert(cache_key, ids);
-    state.active_project.set(ws, proj);
+    state.active_project.set_for(actor, ws, proj);
     Ok(ids)
 }
 
-async fn process_envelope(state: Arc<HookState>, env: HookEnvelope) {
-    if let Err(e) = process(&state, env).await {
+async fn process_envelope(state: Arc<HookState>, env: HookEnvelope, actor_user: Option<String>) {
+    if let Err(e) = process(&state, env, actor_user).await {
         warn!(error = %e, "hook processing failed");
     }
 }
 
-async fn process(state: &HookState, env: HookEnvelope) -> anyhow::Result<()> {
+async fn process(
+    state: &HookState,
+    env: HookEnvelope,
+    actor_user: Option<String>,
+) -> anyhow::Result<()> {
     let session_id = resolve_session_id(&env)?;
+    // Build the actor key used to scope the in-process `ActiveProject`
+    // pointer. `user` is whatever the auth middleware extracted from this
+    // request; `session_id` comes from the envelope. Empty actor (anonymous
+    // + no session) is allowed — `set_for` falls back to the single slot.
+    let actor_key = ai_memory_core::ActorKey {
+        user: actor_user.clone(),
+        session_id: Some(session_id.to_string()),
+    };
     let (mut ws, mut proj) = resolve_project_ids(
         state,
         env.cwd.as_deref(),
         env.workspace_override.as_deref(),
         env.project_override.as_deref(),
         env.project_strategy,
+        &actor_key,
     )
     .await?;
 
@@ -519,6 +557,7 @@ async fn process(state: &HookState, env: HookEnvelope) -> anyhow::Result<()> {
             env.workspace_override.as_deref(),
             env.project_override.as_deref(),
             env.project_strategy,
+            &actor_key,
         )
         .await?;
         ws = refreshed.0;
@@ -895,6 +934,7 @@ mod tests {
             None,
             None,
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -905,6 +945,7 @@ mod tests {
             None,
             None,
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -935,6 +976,7 @@ mod tests {
                 agent: Some("claude-code".into()),
                 ..Default::default()
             }),
+            None,
             Json(serde_json::json!({})),
         )
         .await
@@ -949,17 +991,30 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let state = make_state(&tmp).await;
 
-        let (ws, proj) = resolve_project_ids(&state, None, None, None, ProjectStrategy::Basename)
-            .await
-            .unwrap();
+        let (ws, proj) = resolve_project_ids(
+            &state,
+            None,
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
         assert_eq!(ws, state.workspace_id);
         assert_eq!(proj, state.project_id);
 
         // Likewise for an empty string.
-        let (ws2, proj2) =
-            resolve_project_ids(&state, Some(""), None, None, ProjectStrategy::Basename)
-                .await
-                .unwrap();
+        let (ws2, proj2) = resolve_project_ids(
+            &state,
+            Some(""),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
         assert_eq!(ws2, state.workspace_id);
         assert_eq!(proj2, state.project_id);
 
@@ -974,10 +1029,16 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let state = make_state(&tmp).await;
 
-        let (ws, proj) =
-            resolve_project_ids(&state, Some("/"), None, None, ProjectStrategy::Basename)
-                .await
-                .unwrap();
+        let (ws, proj) = resolve_project_ids(
+            &state,
+            Some("/"),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
         assert_eq!(ws, state.workspace_id);
         assert_eq!(proj, state.project_id);
         assert_eq!(state.active_project.get(), Some((ws, proj)));
@@ -1010,10 +1071,16 @@ mod tests {
         let cwd = "/home/user/cached-project";
 
         // First call — populates the cache.
-        let (_, proj_first) =
-            resolve_project_ids(&state, Some(cwd), None, None, ProjectStrategy::Basename)
-                .await
-                .unwrap();
+        let (_, proj_first) = resolve_project_ids(
+            &state,
+            Some(cwd),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
 
         // Inspect the cache: should have exactly one entry.
         {
@@ -1032,10 +1099,16 @@ mod tests {
         }
 
         // Second call — must return the same IDs from the cache.
-        let (_, proj_second) =
-            resolve_project_ids(&state, Some(cwd), None, None, ProjectStrategy::Basename)
-                .await
-                .unwrap();
+        let (_, proj_second) = resolve_project_ids(
+            &state,
+            Some(cwd),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
         assert_eq!(proj_first, proj_second, "cache must return identical IDs");
 
         // Cache must still have exactly one entry (no duplicate insert).
@@ -1086,11 +1159,17 @@ mod tests {
             },
             serde_json::json!({ "sessionID": "heal-sess-1" }),
         );
-        process(&state, env1).await.unwrap();
-        let (ws, proj) =
-            resolve_project_ids(&state, Some(cwd), None, None, ProjectStrategy::Basename)
-                .await
-                .unwrap();
+        process(&state, env1, None).await.unwrap();
+        let (ws, proj) = resolve_project_ids(
+            &state,
+            Some(cwd),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
 
         // 2) Purge the project — the DB row is gone but the cache still
         //    points at it (exactly the purge-on-live-server scenario).
@@ -1120,15 +1199,21 @@ mod tests {
             },
             serde_json::json!({ "sessionID": "heal-sess-2" }),
         );
-        process(&state, env2)
+        process(&state, env2, None)
             .await
             .expect("self-heal: stale cached project must be recreated, not FK-fail");
 
         // 4) The project was recreated (fresh id) and the event landed.
-        let (_, proj_new) =
-            resolve_project_ids(&state, Some(cwd), None, None, ProjectStrategy::Basename)
-                .await
-                .unwrap();
+        let (_, proj_new) = resolve_project_ids(
+            &state,
+            Some(cwd),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
         assert_ne!(
             proj_new, proj,
             "purged project must be replaced by a fresh one"
@@ -1159,11 +1244,17 @@ mod tests {
             },
             serde_json::json!({ "sessionID": "move-sess-1" }),
         );
-        process(&state, env1).await.unwrap();
-        let (ws, proj) =
-            resolve_project_ids(&state, Some(cwd), None, None, ProjectStrategy::Basename)
-                .await
-                .unwrap();
+        process(&state, env1, None).await.unwrap();
+        let (ws, proj) = resolve_project_ids(
+            &state,
+            Some(cwd),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
 
         // 2) Move the project to another workspace (re-stamp workspace_id, same
         //    project_id) — the cache still points at (default_ws, proj), now a
@@ -1200,7 +1291,7 @@ mod tests {
             },
             serde_json::json!({ "sessionID": "move-sess-2" }),
         );
-        process(&state, env2)
+        process(&state, env2, None)
             .await
             .expect("self-heal: stale cross-workspace pair must re-resolve, not write split-brain");
 
@@ -1215,10 +1306,16 @@ mod tests {
             Some(proj),
             "moved project keeps its id in the destination workspace"
         );
-        let (ws_new, proj_new) =
-            resolve_project_ids(&state, Some(cwd), None, None, ProjectStrategy::Basename)
-                .await
-                .unwrap();
+        let (ws_new, proj_new) = resolve_project_ids(
+            &state,
+            Some(cwd),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
         assert_eq!(ws_new, ws, "re-resolved back into the default workspace");
         assert_ne!(
             proj_new, proj,
@@ -1247,11 +1344,17 @@ mod tests {
             },
             serde_json::json!({ "sessionID": "heal-repo-root-1" }),
         );
-        process(&state, env1).await.unwrap();
-        let (ws, proj) =
-            resolve_project_ids(&state, Some(cwd), None, None, ProjectStrategy::RepoRoot)
-                .await
-                .unwrap();
+        process(&state, env1, None).await.unwrap();
+        let (ws, proj) = resolve_project_ids(
+            &state,
+            Some(cwd),
+            None,
+            None,
+            ProjectStrategy::RepoRoot,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
 
         state
             .writer
@@ -1269,14 +1372,20 @@ mod tests {
             },
             serde_json::json!({ "sessionID": "heal-repo-root-2" }),
         );
-        process(&state, env2)
+        process(&state, env2, None)
             .await
             .expect("repo-root cache slot must be evicted and recreated");
 
-        let (_, proj_new) =
-            resolve_project_ids(&state, Some(cwd), None, None, ProjectStrategy::RepoRoot)
-                .await
-                .unwrap();
+        let (_, proj_new) = resolve_project_ids(
+            &state,
+            Some(cwd),
+            None,
+            None,
+            ProjectStrategy::RepoRoot,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
         assert_ne!(proj_new, proj);
     }
 
@@ -1300,7 +1409,7 @@ mod tests {
             }),
         );
 
-        process(&state, env).await.unwrap();
+        process(&state, env, None).await.unwrap();
 
         // The observation must be in the project derived from the cwd,
         // not in the server-default `scratch` project.
@@ -1310,6 +1419,7 @@ mod tests {
             None,
             None,
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -1340,7 +1450,7 @@ mod tests {
                 },
                 serde_json::json!({ "session_id": sid }),
             );
-            process(&state, env).await.unwrap();
+            process(&state, env, None).await.unwrap();
         }
 
         let pages = state
@@ -1375,7 +1485,7 @@ mod tests {
             }),
         );
 
-        process(&state, env).await.unwrap();
+        process(&state, env, None).await.unwrap();
 
         let counts = state.reader.status_counts().await.unwrap();
         assert_eq!(counts.sessions, 1);
@@ -1403,7 +1513,7 @@ mod tests {
         );
         let session_id = resolve_session_id(&env).unwrap();
 
-        process(&state, env).await.unwrap();
+        process(&state, env, None).await.unwrap();
 
         let observations = state
             .reader
@@ -1445,7 +1555,7 @@ mod tests {
         );
         let session_id = resolve_session_id(&env).unwrap();
 
-        process(&state, env).await.unwrap();
+        process(&state, env, None).await.unwrap();
 
         let observations = state
             .reader
@@ -1484,6 +1594,7 @@ mod tests {
             None,
             None,
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -1493,6 +1604,7 @@ mod tests {
             Some("movvia"),
             None,
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -1515,6 +1627,7 @@ mod tests {
             Some("acme"),
             None,
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -1544,6 +1657,7 @@ mod tests {
                 project: None,
                 project_strategy: None,
             },
+            None,
         )
         .await
         .unwrap();
@@ -1560,10 +1674,16 @@ mod tests {
         let state = make_state(&tmp).await;
         let cwd = "/home/u/plain-repo";
 
-        let (ws, proj) =
-            resolve_project_ids(&state, Some(cwd), None, None, ProjectStrategy::Basename)
-                .await
-                .unwrap();
+        let (ws, proj) = resolve_project_ids(
+            &state,
+            Some(cwd),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
         state
             .writer
             .insert_handoff(NewHandoff {
@@ -1590,6 +1710,7 @@ mod tests {
                 project: None,
                 project_strategy: None,
             },
+            None,
         )
         .await
         .unwrap();
@@ -1615,6 +1736,7 @@ mod tests {
             None,
             None,
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -1624,6 +1746,7 @@ mod tests {
             None,
             Some("pe-portais"),
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -1648,6 +1771,7 @@ mod tests {
             Some("acme"),
             Some("api"),
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -1657,6 +1781,7 @@ mod tests {
             Some("acme"),
             Some("api"),
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -1675,16 +1800,23 @@ mod tests {
         let state = make_state(&tmp).await;
         let cwd = "/home/u/poison-test";
 
-        let (ws_default, _) =
-            resolve_project_ids(&state, Some(cwd), None, None, ProjectStrategy::Basename)
-                .await
-                .unwrap();
+        let (ws_default, _) = resolve_project_ids(
+            &state,
+            Some(cwd),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
         let (ws_movvia, _) = resolve_project_ids(
             &state,
             Some(cwd),
             Some("movvia"),
             None,
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -1716,6 +1848,7 @@ mod tests {
             Some("acme"),
             Some("api"),
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -1751,23 +1884,36 @@ mod tests {
         std::fs::create_dir_all(&app_dir).unwrap();
         let app_cwd = app_dir.to_str().unwrap();
 
-        let (_, proj_basename) =
-            resolve_project_ids(&state, Some(app_cwd), None, None, ProjectStrategy::Basename)
-                .await
-                .unwrap();
+        let (_, proj_basename) = resolve_project_ids(
+            &state,
+            Some(app_cwd),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
         let (_, proj_explicit_app) = resolve_project_ids(
             &state,
             Some(main_dir.to_str().unwrap()),
             None,
             Some("app"),
             ProjectStrategy::RepoRoot,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
-        let (_, proj_repo_root) =
-            resolve_project_ids(&state, Some(app_cwd), None, None, ProjectStrategy::RepoRoot)
-                .await
-                .unwrap();
+        let (_, proj_repo_root) = resolve_project_ids(
+            &state,
+            Some(app_cwd),
+            None,
+            None,
+            ProjectStrategy::RepoRoot,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(
             proj_basename, proj_explicit_app,
@@ -1790,16 +1936,23 @@ mod tests {
         std::fs::create_dir_all(&app_dir).unwrap();
         let app_cwd = app_dir.to_str().unwrap();
 
-        let (_, proj_repo_root) =
-            resolve_project_ids(&state, Some(app_cwd), None, None, ProjectStrategy::RepoRoot)
-                .await
-                .unwrap();
+        let (_, proj_repo_root) = resolve_project_ids(
+            &state,
+            Some(app_cwd),
+            None,
+            None,
+            ProjectStrategy::RepoRoot,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
         let (_, proj_override_repo_root) = resolve_project_ids(
             &state,
             Some(app_cwd),
             None,
             Some("manual"),
             ProjectStrategy::RepoRoot,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -1809,6 +1962,7 @@ mod tests {
             None,
             Some("manual"),
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -1831,14 +1985,26 @@ mod tests {
         std::fs::create_dir_all(&app_dir).unwrap();
         let app_cwd = app_dir.to_str().unwrap();
 
-        let (_, proj_basename) =
-            resolve_project_ids(&state, Some(app_cwd), None, None, ProjectStrategy::Basename)
-                .await
-                .unwrap();
-        let (_, proj_repo_root) =
-            resolve_project_ids(&state, Some(app_cwd), None, None, ProjectStrategy::RepoRoot)
-                .await
-                .unwrap();
+        let (_, proj_basename) = resolve_project_ids(
+            &state,
+            Some(app_cwd),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
+        let (_, proj_repo_root) = resolve_project_ids(
+            &state,
+            Some(app_cwd),
+            None,
+            None,
+            ProjectStrategy::RepoRoot,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
 
         assert_ne!(proj_basename, proj_repo_root);
         let cache = state.project_cache.lock().await;
@@ -1881,13 +2047,20 @@ mod tests {
             None,
             None,
             ProjectStrategy::RepoRoot,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
-        let (ws_wt, proj_wt) =
-            resolve_project_ids(&state, Some(wt_cwd), None, None, ProjectStrategy::RepoRoot)
-                .await
-                .unwrap();
+        let (ws_wt, proj_wt) = resolve_project_ids(
+            &state,
+            Some(wt_cwd),
+            None,
+            None,
+            ProjectStrategy::RepoRoot,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(ws_main, ws_wt, "same workspace");
         assert_eq!(
@@ -1895,10 +2068,16 @@ mod tests {
             "worktree must resolve to same project as main repo"
         );
 
-        let (_, proj_wt_basename) =
-            resolve_project_ids(&state, Some(wt_cwd), None, None, ProjectStrategy::Basename)
-                .await
-                .unwrap();
+        let (_, proj_wt_basename) = resolve_project_ids(
+            &state,
+            Some(wt_cwd),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
         assert_ne!(
             proj_main, proj_wt_basename,
             "default strategy must not collapse worktrees into the main repo project"
@@ -1917,10 +2096,16 @@ mod tests {
         std::fs::create_dir_all(&plain_dir).unwrap();
         let cwd = plain_dir.to_str().unwrap();
 
-        let (_, proj) =
-            resolve_project_ids(&state, Some(cwd), None, None, ProjectStrategy::Basename)
-                .await
-                .unwrap();
+        let (_, proj) = resolve_project_ids(
+            &state,
+            Some(cwd),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
 
         // Must NOT be the server-default scratch project.
         assert_ne!(proj, state.project_id);
@@ -1935,6 +2120,7 @@ mod tests {
             None,
             None,
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -1952,10 +2138,16 @@ mod tests {
         git2::Repository::init_bare(&bare_dir).unwrap();
         let cwd = bare_dir.to_str().unwrap();
 
-        let (_, proj) =
-            resolve_project_ids(&state, Some(cwd), None, None, ProjectStrategy::Basename)
-                .await
-                .unwrap();
+        let (_, proj) = resolve_project_ids(
+            &state,
+            Some(cwd),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
 
         // Must NOT be the server-default scratch project — basename should work.
         assert_ne!(proj, state.project_id);
@@ -1970,6 +2162,7 @@ mod tests {
             None,
             None,
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -1992,6 +2185,7 @@ mod tests {
             None,
             None,
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();
@@ -2002,6 +2196,7 @@ mod tests {
             None,
             None,
             ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
         )
         .await
         .unwrap();

--- a/crates/ai-memory-mcp/Cargo.toml
+++ b/crates/ai-memory-mcp/Cargo.toml
@@ -34,6 +34,7 @@ jiff.workspace = true
 
 [dev-dependencies]
 ai-memory-core.workspace = true
+ai-memory-hooks.workspace = true
 ai-memory-store.workspace = true
 ai-memory-wiki.workspace = true
 flate2.workspace = true

--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -546,10 +546,11 @@ impl AiMemoryServer {
     ///   security-critical.
     /// - `session_id` comes from the same `ActorContext` when the auth
     ///   middleware filled it; if not, falls back to the rung-4
-    ///   `X-Memory-Actor-Session-Id` request header. The session id is
-    ///   just a cache key for the active-project map — getting it wrong
-    ///   only routes the lookup to a different (or absent) slot, with no
-    ///   auth-bypass risk, so trusting the header here is safe.
+    ///   `X-Memory-Actor-Session-Id` request header, then to the standard
+    ///   MCP `Mcp-Session-Id` header. The session id is just a cache key
+    ///   for the active-project map — getting it wrong only routes the
+    ///   lookup to a different (or absent) slot, with no auth-bypass risk,
+    ///   so trusting the header here is safe.
     ///
     /// Returns the empty [`ActorKey`] when neither source has anything to
     /// offer; that's the graceful-degradation signal for callers to fall
@@ -562,15 +563,19 @@ impl AiMemoryServer {
         };
         let ctx = parts.extensions.get::<ai_memory_core::ActorContext>();
         let user = ctx.and_then(|c| c.user.clone());
-        let session_id = ctx.and_then(|c| c.session_id.clone()).or_else(|| {
+        let header_session = |name: &str| {
             parts
                 .headers
-                .get("x-memory-actor-session-id")
+                .get(name)
                 .and_then(|v| v.to_str().ok())
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
                 .map(str::to_string)
-        });
+        };
+        let session_id = ctx
+            .and_then(|c| c.session_id.clone())
+            .or_else(|| header_session("x-memory-actor-session-id"))
+            .or_else(|| header_session("mcp-session-id"));
         ai_memory_core::ActorKey { user, session_id }
     }
 
@@ -1920,6 +1925,57 @@ mod tests {
 
         let server = AiMemoryServer::new(store.reader.clone(), store.writer.clone(), ws, proj);
         (tmp, store, server, ws, proj)
+    }
+
+    #[test]
+    fn actor_key_uses_memory_session_header() {
+        let mut parts = test_parts_default();
+        parts.headers.insert(
+            "x-memory-actor-session-id",
+            axum::http::HeaderValue::from_static("hook-session"),
+        );
+
+        let actor = AiMemoryServer::actor_key_from_parts(Some(&parts));
+
+        assert_eq!(actor.user, None);
+        assert_eq!(actor.session_id.as_deref(), Some("hook-session"));
+    }
+
+    #[test]
+    fn actor_key_accepts_standard_mcp_session_header() {
+        let mut parts = test_parts_default();
+        parts.headers.insert(
+            "mcp-session-id",
+            axum::http::HeaderValue::from_static("mcp-session"),
+        );
+
+        let actor = AiMemoryServer::actor_key_from_parts(Some(&parts));
+
+        assert_eq!(actor.user, None);
+        assert_eq!(actor.session_id.as_deref(), Some("mcp-session"));
+    }
+
+    #[test]
+    fn actor_key_prefers_middleware_context_over_headers() {
+        let mut parts = test_parts_default();
+        parts.headers.insert(
+            "x-memory-actor-session-id",
+            axum::http::HeaderValue::from_static("header-session"),
+        );
+        parts.headers.insert(
+            "mcp-session-id",
+            axum::http::HeaderValue::from_static("mcp-session"),
+        );
+        parts.extensions.insert(ai_memory_core::ActorContext {
+            user: Some("alice".into()),
+            session_id: Some("context-session".into()),
+            ..ai_memory_core::ActorContext::default()
+        });
+
+        let actor = AiMemoryServer::actor_key_from_parts(Some(&parts));
+
+        assert_eq!(actor.user.as_deref(), Some("alice"));
+        assert_eq!(actor.session_id.as_deref(), Some("context-session"));
     }
 
     #[tokio::test]

--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -3194,12 +3194,15 @@ mod tests {
 
         // Alpha twin must survive.
         let read_alpha = server
-            .memory_read_page(Parameters(ReadPageArgs {
-                query: None,
-                path: Some("notes/twin.md".into()),
-                project: Some("shared".into()),
-                workspace: Some("alpha".into()),
-            }), rmcp::handler::server::tool::Extension(test_parts_default()))
+            .memory_read_page(
+                Parameters(ReadPageArgs {
+                    query: None,
+                    path: Some("notes/twin.md".into()),
+                    project: Some("shared".into()),
+                    workspace: Some("alpha".into()),
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await;
         assert!(
             read_alpha.is_ok(),
@@ -3208,12 +3211,15 @@ mod tests {
 
         // Beta twin must be gone (file-on-disk delete + DB row cleared).
         let read_beta = server
-            .memory_read_page(Parameters(ReadPageArgs {
-                query: None,
-                path: Some("notes/twin.md".into()),
-                project: Some("shared".into()),
-                workspace: Some("beta".into()),
-            }), rmcp::handler::server::tool::Extension(test_parts_default()))
+            .memory_read_page(
+                Parameters(ReadPageArgs {
+                    query: None,
+                    path: Some("notes/twin.md".into()),
+                    project: Some("shared".into()),
+                    workspace: Some("beta".into()),
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await;
         assert!(
             read_beta.is_err(),
@@ -3436,14 +3442,17 @@ mod tests {
     async fn handoff_cancel_expires_open_handoff_and_clears_briefing_count() {
         let (_tmp, store, server, _ws, _pj) = setup_server().await;
         let begin = server
-            .memory_handoff_begin(Parameters(HandoffBeginArgs {
-                summary: "accidental status summary".into(),
-                open_questions: vec![],
-                next_steps: vec![],
-                files_touched: vec![],
-                cwd: Some("/tmp/aim".into()),
-                project: None,
-            }), rmcp::handler::server::tool::Extension(test_parts_default()))
+            .memory_handoff_begin(
+                Parameters(HandoffBeginArgs {
+                    summary: "accidental status summary".into(),
+                    open_questions: vec![],
+                    next_steps: vec![],
+                    files_touched: vec![],
+                    cwd: Some("/tmp/aim".into()),
+                    project: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let begin_text = begin
@@ -3456,11 +3465,14 @@ mod tests {
         let handoff_id = begin_json["handoff_id"].as_str().unwrap().to_string();
 
         let before = server
-            .memory_briefing(Parameters(BriefingArgs {
-                recent_pages_limit: Some(5),
-                project: None,
-                workspace: None,
-            }), rmcp::handler::server::tool::Extension(test_parts_default()))
+            .memory_briefing(
+                Parameters(BriefingArgs {
+                    recent_pages_limit: Some(5),
+                    project: None,
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let before_text = before
@@ -3472,11 +3484,14 @@ mod tests {
         assert!(before_text.contains("\"pending_handoff_count\": 1"));
 
         let cancel = server
-            .memory_handoff_cancel(Parameters(HandoffCancelArgs {
-                handoff_id: handoff_id.clone(),
-                project: None,
-                workspace: None,
-            }), rmcp::handler::server::tool::Extension(test_parts_default()))
+            .memory_handoff_cancel(
+                Parameters(HandoffCancelArgs {
+                    handoff_id: handoff_id.clone(),
+                    project: None,
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let cancel_text = cancel
@@ -3489,11 +3504,14 @@ mod tests {
         assert!(cancel_text.contains("\"state\": \"expired\""));
 
         let after = server
-            .memory_briefing(Parameters(BriefingArgs {
-                recent_pages_limit: Some(5),
-                project: None,
-                workspace: None,
-            }), rmcp::handler::server::tool::Extension(test_parts_default()))
+            .memory_briefing(
+                Parameters(BriefingArgs {
+                    recent_pages_limit: Some(5),
+                    project: None,
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let after_text = after
@@ -3505,10 +3523,13 @@ mod tests {
         assert!(after_text.contains("\"pending_handoff_count\": 0"));
 
         let accept = server
-            .memory_handoff_accept(Parameters(HandoffAcceptArgs {
-                cwd: Some("/tmp/aim".into()),
-                project: None,
-            }), rmcp::handler::server::tool::Extension(test_parts_default()))
+            .memory_handoff_accept(
+                Parameters(HandoffAcceptArgs {
+                    cwd: Some("/tmp/aim".into()),
+                    project: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let accept_text = accept

--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -538,19 +538,22 @@ impl AiMemoryServer {
     }
 
     /// Build the [`ActorKey`] for a tool call from the request's stored
-    /// extensions. When the auth middleware has attached an
-    /// [`ai_memory_core::ActorContext`] (rung 1 root, rung 2 DB user), its
-    /// `user` field is used; the `session_id` comes from the same
-    /// extension when the agent's MCP client forwards it, otherwise stays
-    /// `None` and the per-actor lookup gracefully degrades to the single
-    /// slot under `[auto_scope] mode = single` (the default).
+    /// extensions and headers.
     ///
-    /// Threading parts into every read tool is mechanical but wide; the
-    /// helper is kept here so a follow-up commit can opt each tool in
-    /// without re-doing the design — the wrapper [`Self::effective_ids`] /
-    /// [`Self::effective_ids_for_read_args`] keep working unchanged while
-    /// the migration is in progress.
-    #[allow(dead_code)]
+    /// - `user` is taken from the middleware-injected
+    ///   [`ai_memory_core::ActorContext`] (rung 1 root, rung 2 DB user) —
+    ///   never from raw client-supplied headers, since user identity is
+    ///   security-critical.
+    /// - `session_id` comes from the same `ActorContext` when the auth
+    ///   middleware filled it; if not, falls back to the rung-4
+    ///   `X-Memory-Actor-Session-Id` request header. The session id is
+    ///   just a cache key for the active-project map — getting it wrong
+    ///   only routes the lookup to a different (or absent) slot, with no
+    ///   auth-bypass risk, so trusting the header here is safe.
+    ///
+    /// Returns the empty [`ActorKey`] when neither source has anything to
+    /// offer; that's the graceful-degradation signal for callers to fall
+    /// back to the single slot.
     fn actor_key_from_parts(
         parts: Option<&axum::http::request::Parts>,
     ) -> ai_memory_core::ActorKey {
@@ -558,13 +561,17 @@ impl AiMemoryServer {
             return ai_memory_core::ActorKey::default();
         };
         let ctx = parts.extensions.get::<ai_memory_core::ActorContext>();
-        match ctx {
-            None => ai_memory_core::ActorKey::default(),
-            Some(ctx) => ai_memory_core::ActorKey {
-                user: ctx.user.clone(),
-                session_id: ctx.session_id.clone(),
-            },
-        }
+        let user = ctx.and_then(|c| c.user.clone());
+        let session_id = ctx.and_then(|c| c.session_id.clone()).or_else(|| {
+            parts
+                .headers
+                .get("x-memory-actor-session-id")
+                .and_then(|v| v.to_str().ok())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+        });
+        ai_memory_core::ActorKey { user, session_id }
     }
 
     /// Resolve which `(workspace_id, project_id)` a read tool should

--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -580,17 +580,6 @@ impl AiMemoryServer {
     /// `actor` is built by [`Self::actor_key_from_parts`]; pass
     /// `ActorKey::default()` when the call site has no request context.
     /// Empty actor → fall back to the single slot (legacy behaviour).
-    /// Backward-compatible wrapper for call sites that have not yet
-    /// threaded a request `Parts` extension. Behaves like the historical
-    /// `effective_ids` — i.e. consults the single slot only — which is
-    /// what every tool gets under the default `[auto_scope] mode = single`.
-    /// Opt-in modes (`per_session` / `per_actor`) gain proper isolation as
-    /// each tool gets migrated to [`Self::effective_ids_with_actor`].
-    async fn effective_ids(&self, explicit_project: Option<&str>) -> (WorkspaceId, ProjectId) {
-        self.effective_ids_with_actor(explicit_project, &ai_memory_core::ActorKey::default())
-            .await
-    }
-
     async fn effective_ids_with_actor(
         &self,
         explicit_project: Option<&str>,
@@ -613,20 +602,6 @@ impl AiMemoryServer {
             }
         }
         active.unwrap_or((self.workspace_id, self.project_id))
-    }
-
-    /// Backward-compatible wrapper paired with [`Self::effective_ids`].
-    async fn effective_ids_for_read_args(
-        &self,
-        explicit_workspace: Option<&str>,
-        explicit_project: Option<&str>,
-    ) -> Result<(WorkspaceId, ProjectId), McpError> {
-        self.effective_ids_for_read_args_with_actor(
-            explicit_workspace,
-            explicit_project,
-            &ai_memory_core::ActorKey::default(),
-        )
-        .await
     }
 
     async fn effective_ids_for_read_args_with_actor(
@@ -863,7 +838,9 @@ impl AiMemoryServer {
     async fn memory_query(
         &self,
         Parameters(args): Parameters<QueryArgs>,
+        Extension(parts): Extension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, McpError> {
+        let aps_actor = Self::actor_key_from_parts(Some(&parts));
         let limit = args.limit.unwrap_or(self.default_limit).clamp(1, 100);
         if args.global.unwrap_or(false) {
             if !args.scopes.is_empty()
@@ -912,7 +889,11 @@ impl AiMemoryServer {
         let query_vec = self.embed_query(&args.query).await;
         let hits = if args.scopes.is_empty() {
             let (ws, proj) = self
-                .effective_ids_for_read_args(args.workspace.as_deref(), args.project.as_deref())
+                .effective_ids_for_read_args_with_actor(
+                    args.workspace.as_deref(),
+                    args.project.as_deref(),
+                    &aps_actor,
+                )
                 .await?;
             self.search_project(ws, proj, &args.query, query_vec.as_deref(), limit)
                 .await
@@ -950,7 +931,11 @@ impl AiMemoryServer {
         // project; for multi-scope queries there is no single (ws, proj).
         let raw_hits = if hits.is_empty() && args.scopes.is_empty() {
             let (ws, proj) = self
-                .effective_ids_for_read_args(args.workspace.as_deref(), args.project.as_deref())
+                .effective_ids_for_read_args_with_actor(
+                    args.workspace.as_deref(),
+                    args.project.as_deref(),
+                    &aps_actor,
+                )
                 .await?;
             self.reader
                 .search_observations_for_project(ws, proj, query, limit)
@@ -977,10 +962,16 @@ impl AiMemoryServer {
     async fn memory_recent(
         &self,
         Parameters(args): Parameters<RecentArgs>,
+        Extension(parts): Extension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, McpError> {
+        let aps_actor = Self::actor_key_from_parts(Some(&parts));
         let limit = args.limit.unwrap_or(self.default_limit).clamp(1, 100);
         let (ws, proj) = self
-            .effective_ids_for_read_args(args.workspace.as_deref(), args.project.as_deref())
+            .effective_ids_for_read_args_with_actor(
+                args.workspace.as_deref(),
+                args.project.as_deref(),
+                &aps_actor,
+            )
             .await?;
         let hits = self
             .reader
@@ -1002,9 +993,15 @@ impl AiMemoryServer {
     async fn memory_forget_sweep(
         &self,
         Parameters(args): Parameters<SweepArgs>,
+        Extension(parts): Extension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, McpError> {
+        let aps_actor = Self::actor_key_from_parts(Some(&parts));
         let (ws, proj) = self
-            .effective_ids_for_read_args(args.workspace.as_deref(), args.project.as_deref())
+            .effective_ids_for_read_args_with_actor(
+                args.workspace.as_deref(),
+                args.project.as_deref(),
+                &aps_actor,
+            )
             .await?;
         let report = run_sweep(
             &self.reader,
@@ -1027,7 +1024,9 @@ impl AiMemoryServer {
     async fn memory_lint(
         &self,
         Parameters(args): Parameters<LintArgs>,
+        Extension(parts): Extension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, McpError> {
+        let aps_actor = Self::actor_key_from_parts(Some(&parts));
         let Some(wiki) = self.wiki.as_ref() else {
             return Err(McpError::internal_error(
                 "memory_lint requires the server to be built with a wiki handle",
@@ -1035,7 +1034,11 @@ impl AiMemoryServer {
             ));
         };
         let (ws, proj) = self
-            .effective_ids_for_read_args(args.workspace.as_deref(), args.project.as_deref())
+            .effective_ids_for_read_args_with_actor(
+                args.workspace.as_deref(),
+                args.project.as_deref(),
+                &aps_actor,
+            )
             .await?;
         let report = run_lint(
             &self.reader,
@@ -1210,7 +1213,9 @@ impl AiMemoryServer {
     async fn memory_read_page(
         &self,
         Parameters(args): Parameters<ReadPageArgs>,
+        Extension(parts): Extension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, McpError> {
+        let aps_actor = Self::actor_key_from_parts(Some(&parts));
         let Some(wiki) = self.wiki.as_ref() else {
             return Err(McpError::internal_error(
                 "memory_read_page requires the server to be built with a wiki handle",
@@ -1221,7 +1226,11 @@ impl AiMemoryServer {
         // can target a page in a DIFFERENT workspace (a sibling project on a
         // shared server). Plain `project` keeps the active-project chain.
         let (ws, proj) = self
-            .effective_ids_for_read_args(args.workspace.as_deref(), args.project.as_deref())
+            .effective_ids_for_read_args_with_actor(
+                args.workspace.as_deref(),
+                args.project.as_deref(),
+                &aps_actor,
+            )
             .await?;
 
         let page_path = if let Some(p) = args.path {
@@ -1312,6 +1321,7 @@ impl AiMemoryServer {
         Parameters(args): Parameters<DeletePageArgs>,
         Extension(parts): Extension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, McpError> {
+        let aps_actor = Self::actor_key_from_parts(Some(&parts));
         let Some(wiki) = self.wiki.as_ref() else {
             return Err(McpError::internal_error(
                 "memory_delete_page requires the server to be built with a wiki handle",
@@ -1320,12 +1330,12 @@ impl AiMemoryServer {
         };
         let path = PagePath::new(args.path.clone())
             .map_err(|e| McpError::internal_error(format!("invalid path: {e}"), None))?;
-        // Same resolution as read/write tools: when (workspace, project) are
-        // BOTH given, they're looked up explicitly; otherwise the cwd-based
-        // active-project chain is used. Closes the silent cross-workspace
-        // delete that the single-arg `effective_ids(project)` allowed.
         let (ws, proj) = self
-            .effective_ids_for_read_args(args.workspace.as_deref(), args.project.as_deref())
+            .effective_ids_for_read_args_with_actor(
+                args.workspace.as_deref(),
+                args.project.as_deref(),
+                &aps_actor,
+            )
             .await?;
 
         // Carry actor identity + loop-prevention skip list (same as write_page).
@@ -1370,14 +1380,18 @@ impl AiMemoryServer {
     async fn memory_handoff_begin(
         &self,
         Parameters(args): Parameters<HandoffBeginArgs>,
+        Extension(parts): Extension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, McpError> {
+        let aps_actor = Self::actor_key_from_parts(Some(&parts));
         // Handoffs bypass `Wiki::write_page` (they live in their own
         // table), so scrub the agent-supplied free-text here. We don't
         // touch `cwd` or `files_touched` — they're path lists that the
         // path-pattern regexes already cover when applicable, but we
         // pass each entry through anyway as defence-in-depth.
         let s = &self.sanitizer;
-        let (ws, proj) = self.effective_ids(args.project.as_deref()).await;
+        let (ws, proj) = self
+            .effective_ids_with_actor(args.project.as_deref(), &aps_actor)
+            .await;
         let handoff = NewHandoff {
             workspace_id: ws,
             project_id: proj,
@@ -1420,8 +1434,12 @@ impl AiMemoryServer {
     async fn memory_handoff_accept(
         &self,
         Parameters(args): Parameters<HandoffAcceptArgs>,
+        Extension(parts): Extension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, McpError> {
-        let (ws, proj) = self.effective_ids(args.project.as_deref()).await;
+        let aps_actor = Self::actor_key_from_parts(Some(&parts));
+        let (ws, proj) = self
+            .effective_ids_with_actor(args.project.as_deref(), &aps_actor)
+            .await;
         let handoff = self
             .reader
             .latest_open_handoff(ws, proj, args.cwd)
@@ -1451,11 +1469,17 @@ impl AiMemoryServer {
     async fn memory_handoff_cancel(
         &self,
         Parameters(args): Parameters<HandoffCancelArgs>,
+        Extension(parts): Extension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, McpError> {
+        let aps_actor = Self::actor_key_from_parts(Some(&parts));
         let handoff_id = HandoffId::from_str(&args.handoff_id)
             .map_err(|e| McpError::internal_error(format!("invalid handoff_id: {e}"), None))?;
         let (ws, proj) = self
-            .effective_ids_for_read_args(args.workspace.as_deref(), args.project.as_deref())
+            .effective_ids_for_read_args_with_actor(
+                args.workspace.as_deref(),
+                args.project.as_deref(),
+                &aps_actor,
+            )
             .await?;
         let handoff = self
             .reader
@@ -1496,9 +1520,15 @@ impl AiMemoryServer {
     async fn memory_status(
         &self,
         Parameters(args): Parameters<StatusArgs>,
+        Extension(parts): Extension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, McpError> {
+        let aps_actor = Self::actor_key_from_parts(Some(&parts));
         let (ws, proj) = self
-            .effective_ids_for_read_args(args.workspace.as_deref(), args.project.as_deref())
+            .effective_ids_for_read_args_with_actor(
+                args.workspace.as_deref(),
+                args.project.as_deref(),
+                &aps_actor,
+            )
             .await?;
         let counts = self
             .reader
@@ -1522,10 +1552,16 @@ impl AiMemoryServer {
     async fn memory_briefing(
         &self,
         Parameters(args): Parameters<BriefingArgs>,
+        Extension(parts): Extension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, McpError> {
+        let aps_actor = Self::actor_key_from_parts(Some(&parts));
         let limit = args.recent_pages_limit.unwrap_or(10);
         let (ws, proj) = self
-            .effective_ids_for_read_args(args.workspace.as_deref(), args.project.as_deref())
+            .effective_ids_for_read_args_with_actor(
+                args.workspace.as_deref(),
+                args.project.as_deref(),
+                &aps_actor,
+            )
             .await?;
         let snapshot = self
             .reader
@@ -1552,10 +1588,16 @@ impl AiMemoryServer {
     async fn memory_explore(
         &self,
         Parameters(args): Parameters<ExploreArgs>,
+        Extension(parts): Extension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, McpError> {
+        let aps_actor = Self::actor_key_from_parts(Some(&parts));
         let limit = args.recent_pages_limit.unwrap_or(10);
         let (ws, proj) = self
-            .effective_ids_for_read_args(args.workspace.as_deref(), args.project.as_deref())
+            .effective_ids_for_read_args_with_actor(
+                args.workspace.as_deref(),
+                args.project.as_deref(),
+                &aps_actor,
+            )
             .await?;
         let snapshot = self
             .reader
@@ -1796,6 +1838,17 @@ fn build_explore_request(
 const EXPLORE_SYSTEM_PROMPT: &str = include_str!("../prompts/explore_system.md");
 
 #[cfg(test)]
+fn test_parts_default() -> axum::http::request::Parts {
+    axum::http::Request::builder()
+        .uri("/mcp")
+        .method("POST")
+        .body(())
+        .unwrap()
+        .into_parts()
+        .0
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use ai_memory_core::{NewObservation, NewPage, NewSession, ObservationKind, PagePath, Tier};
@@ -2017,7 +2070,12 @@ mod tests {
         let (_tmp, store, server, ws, baked) = setup_server().await;
 
         // Baseline: nothing published, no arg → baked-in default.
-        assert_eq!(server.effective_ids(None).await, (ws, baked));
+        assert_eq!(
+            server
+                .effective_ids_with_actor(None, &ai_memory_core::ActorKey::default())
+                .await,
+            (ws, baked)
+        );
 
         // A second real project in the same workspace.
         let other = store
@@ -2032,11 +2090,18 @@ mod tests {
 
         // Hook publishes it → it becomes the default for cwd-less calls.
         server.active_project.set(ws, other);
-        assert_eq!(server.effective_ids(None).await, (ws, other));
+        assert_eq!(
+            server
+                .effective_ids_with_actor(None, &ai_memory_core::ActorKey::default())
+                .await,
+            (ws, other)
+        );
 
         // An explicit (existing) project arg wins over the active pointer.
         assert_eq!(
-            server.effective_ids(Some("scratch")).await,
+            server
+                .effective_ids_with_actor(Some("scratch"), &ai_memory_core::ActorKey::default())
+                .await,
             (ws, baked),
             "explicit project arg should override the active pointer"
         );
@@ -2044,7 +2109,12 @@ mod tests {
         // An explicit but unknown project name falls through to the
         // active pointer rather than erroring or returning a bogus id.
         assert_eq!(
-            server.effective_ids(Some("does-not-exist")).await,
+            server
+                .effective_ids_with_actor(
+                    Some("does-not-exist"),
+                    &ai_memory_core::ActorKey::default()
+                )
+                .await,
             (ws, other),
             "unknown explicit project falls through to the active pointer"
         );
@@ -2190,17 +2260,22 @@ mod tests {
             "direct read should see the written page"
         );
         assert_eq!(
-            server.effective_ids(Some("sibling")).await,
+            server
+                .effective_ids_with_actor(Some("sibling"), &ai_memory_core::ActorKey::default())
+                .await,
             (active_ws, sibling_proj),
             "project-only read resolution should use the active workspace"
         );
 
         let result = server
-            .memory_recent(Parameters(RecentArgs {
-                limit: Some(5),
-                project: Some("sibling".to_string()),
-                workspace: None,
-            }))
+            .memory_recent(
+                Parameters(RecentArgs {
+                    limit: Some(5),
+                    project: Some("sibling".to_string()),
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let text = result
@@ -2223,14 +2298,17 @@ mod tests {
     async fn memory_query_returns_hits_via_tool_method() {
         let (_tmp, _store, server, _ws, _pj) = setup_server().await;
         let result = server
-            .memory_query(Parameters(QueryArgs {
-                query: "karpathy".into(),
-                limit: Some(5),
-                project: None,
-                scopes: Vec::new(),
-                workspace: None,
-                global: None,
-            }))
+            .memory_query(
+                Parameters(QueryArgs {
+                    query: "karpathy".into(),
+                    limit: Some(5),
+                    project: None,
+                    scopes: Vec::new(),
+                    workspace: None,
+                    global: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let text = match result.content.first().and_then(|c| c.as_text()) {
@@ -2272,14 +2350,17 @@ mod tests {
             .unwrap();
 
         let result = server
-            .memory_query(Parameters(QueryArgs {
-                query: "quokka".into(),
-                limit: Some(5),
-                project: None,
-                scopes: Vec::new(),
-                workspace: None,
-                global: None,
-            }))
+            .memory_query(
+                Parameters(QueryArgs {
+                    query: "quokka".into(),
+                    limit: Some(5),
+                    project: None,
+                    scopes: Vec::new(),
+                    workspace: None,
+                    global: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let text = match result.content.first().and_then(|c| c.as_text()) {
@@ -2328,14 +2409,17 @@ mod tests {
             .unwrap();
 
         let result = server
-            .memory_query(Parameters(QueryArgs {
-                query: "workspace_specific_token".into(),
-                limit: Some(5),
-                project: Some("unit-testing".into()),
-                scopes: Vec::new(),
-                workspace: Some("practice".into()),
-                global: None,
-            }))
+            .memory_query(
+                Parameters(QueryArgs {
+                    query: "workspace_specific_token".into(),
+                    limit: Some(5),
+                    project: Some("unit-testing".into()),
+                    scopes: Vec::new(),
+                    workspace: Some("practice".into()),
+                    global: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let text = result
@@ -2379,12 +2463,15 @@ mod tests {
 
         let result = server
             .with_wiki(wiki)
-            .memory_read_page(Parameters(ReadPageArgs {
-                query: None,
-                path: Some("notes/sibling.md".into()),
-                project: Some("docs".into()),
-                workspace: Some("practice".into()),
-            }))
+            .memory_read_page(
+                Parameters(ReadPageArgs {
+                    query: None,
+                    path: Some("notes/sibling.md".into()),
+                    project: Some("docs".into()),
+                    workspace: Some("practice".into()),
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let text = result
@@ -2426,12 +2513,15 @@ mod tests {
 
         let result = server
             .with_wiki(wiki)
-            .memory_read_page(Parameters(ReadPageArgs {
-                query: None,
-                path: Some("notes/db-only-tool.md".into()),
-                project: None,
-                workspace: None,
-            }))
+            .memory_read_page(
+                Parameters(ReadPageArgs {
+                    query: None,
+                    path: Some("notes/db-only-tool.md".into()),
+                    project: None,
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let text = result
@@ -2523,23 +2613,26 @@ mod tests {
             .unwrap();
 
         let result = server
-            .memory_query(Parameters(QueryArgs {
-                query: "multi_scope_token".into(),
-                limit: Some(10),
-                project: None,
-                scopes: vec![
-                    MemoryScopeArg {
-                        project: "product".into(),
-                        workspace: "default".into(),
-                    },
-                    MemoryScopeArg {
-                        project: "unit-testing".into(),
-                        workspace: "practice".into(),
-                    },
-                ],
-                workspace: None,
-                global: None,
-            }))
+            .memory_query(
+                Parameters(QueryArgs {
+                    query: "multi_scope_token".into(),
+                    limit: Some(10),
+                    project: None,
+                    scopes: vec![
+                        MemoryScopeArg {
+                            project: "product".into(),
+                            workspace: "default".into(),
+                        },
+                        MemoryScopeArg {
+                            project: "unit-testing".into(),
+                            workspace: "practice".into(),
+                        },
+                    ],
+                    workspace: None,
+                    global: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let text = result
@@ -2598,14 +2691,17 @@ mod tests {
         }
 
         let result = server
-            .memory_query(Parameters(QueryArgs {
-                query: "global_token".into(),
-                limit: Some(10),
-                project: None,
-                scopes: Vec::new(),
-                workspace: None,
-                global: Some(true),
-            }))
+            .memory_query(
+                Parameters(QueryArgs {
+                    query: "global_token".into(),
+                    limit: Some(10),
+                    project: None,
+                    scopes: Vec::new(),
+                    workspace: None,
+                    global: Some(true),
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let text = result
@@ -2629,14 +2725,17 @@ mod tests {
     async fn memory_query_global_rejects_explicit_scope() {
         let (_tmp, _store, server, _ws, _pj) = setup_server().await;
         let err = server
-            .memory_query(Parameters(QueryArgs {
-                query: "x".into(),
-                limit: Some(5),
-                project: Some("product".into()),
-                scopes: Vec::new(),
-                workspace: None,
-                global: Some(true),
-            }))
+            .memory_query(
+                Parameters(QueryArgs {
+                    query: "x".into(),
+                    limit: Some(5),
+                    project: Some("product".into()),
+                    scopes: Vec::new(),
+                    workspace: None,
+                    global: Some(true),
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await;
         assert!(
             err.is_err(),
@@ -2648,10 +2747,13 @@ mod tests {
     async fn memory_status_returns_counts() {
         let (_tmp, _store, server, _ws, _pj) = setup_server().await;
         let result = server
-            .memory_status(Parameters(StatusArgs {
-                project: None,
-                workspace: None,
-            }))
+            .memory_status(
+                Parameters(StatusArgs {
+                    project: None,
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let text = result
@@ -2667,11 +2769,14 @@ mod tests {
     async fn memory_briefing_returns_structured_snapshot() {
         let (_tmp, _store, server, _ws, _pj) = setup_server().await;
         let result = server
-            .memory_briefing(Parameters(BriefingArgs {
-                recent_pages_limit: Some(5),
-                project: None,
-                workspace: None,
-            }))
+            .memory_briefing(
+                Parameters(BriefingArgs {
+                    recent_pages_limit: Some(5),
+                    project: None,
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let text = result
@@ -2711,12 +2816,15 @@ mod tests {
     async fn memory_explore_without_llm_degrades_to_briefing() {
         let (_tmp, _store, server, _ws, _pj) = setup_server().await;
         let result = server
-            .memory_explore(Parameters(ExploreArgs {
-                focus: None,
-                recent_pages_limit: Some(5),
-                project: None,
-                workspace: None,
-            }))
+            .memory_explore(
+                Parameters(ExploreArgs {
+                    focus: None,
+                    recent_pages_limit: Some(5),
+                    project: None,
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let text = result
@@ -2772,11 +2880,14 @@ mod tests {
     async fn memory_recent_returns_one_hit() {
         let (_tmp, _store, server, _ws, _pj) = setup_server().await;
         let result = server
-            .memory_recent(Parameters(RecentArgs {
-                limit: Some(5),
-                project: None,
-                workspace: None,
-            }))
+            .memory_recent(
+                Parameters(RecentArgs {
+                    limit: Some(5),
+                    project: None,
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let text = result
@@ -2841,11 +2952,14 @@ mod tests {
         assert!(text.contains("notes/santander-2025.md"), "got {text}");
 
         let recent = server
-            .memory_recent(Parameters(RecentArgs {
-                limit: Some(5),
-                project: None,
-                workspace: None,
-            }))
+            .memory_recent(
+                Parameters(RecentArgs {
+                    limit: Some(5),
+                    project: None,
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let recent_text = recent
@@ -2918,12 +3032,15 @@ mod tests {
 
         // The on-disk file is gone; reading it back errors (file not found).
         let read = server
-            .memory_read_page(Parameters(ReadPageArgs {
-                query: None,
-                path: Some("notes/temp.md".into()),
-                project: None,
-                workspace: None,
-            }))
+            .memory_read_page(
+                Parameters(ReadPageArgs {
+                    query: None,
+                    path: Some("notes/temp.md".into()),
+                    project: None,
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await;
         assert!(read.is_err(), "deleted page must not be readable");
 
@@ -2931,11 +3048,14 @@ mod tests {
         // does not reconcile deletions, so a file-only delete would leave the
         // page surfacing in recent/search with stale content.
         let recent = server
-            .memory_recent(Parameters(RecentArgs {
-                limit: Some(10),
-                project: None,
-                workspace: None,
-            }))
+            .memory_recent(
+                Parameters(RecentArgs {
+                    limit: Some(10),
+                    project: None,
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let recent_text = recent
@@ -3047,7 +3167,7 @@ mod tests {
                 path: Some("notes/twin.md".into()),
                 project: Some("shared".into()),
                 workspace: Some("alpha".into()),
-            }))
+            }), rmcp::handler::server::tool::Extension(test_parts_default()))
             .await;
         assert!(
             read_alpha.is_ok(),
@@ -3061,7 +3181,7 @@ mod tests {
                 path: Some("notes/twin.md".into()),
                 project: Some("shared".into()),
                 workspace: Some("beta".into()),
-            }))
+            }), rmcp::handler::server::tool::Extension(test_parts_default()))
             .await;
         assert!(
             read_beta.is_err(),
@@ -3120,11 +3240,14 @@ mod tests {
 
         // Visible in `other` (created), absent from the baked `scratch`.
         let in_other = server
-            .memory_recent(Parameters(RecentArgs {
-                limit: Some(5),
-                project: Some("other".into()),
-                workspace: None,
-            }))
+            .memory_recent(
+                Parameters(RecentArgs {
+                    limit: Some(5),
+                    project: Some("other".into()),
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let other_text = in_other
@@ -3139,11 +3262,14 @@ mod tests {
         );
 
         let in_scratch = server
-            .memory_recent(Parameters(RecentArgs {
-                limit: Some(5),
-                project: None,
-                workspace: None,
-            }))
+            .memory_recent(
+                Parameters(RecentArgs {
+                    limit: Some(5),
+                    project: None,
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let scratch_text = in_scratch
@@ -3172,23 +3298,29 @@ mod tests {
         server.active_project.set(ws, active);
 
         server
-            .memory_handoff_begin(Parameters(HandoffBeginArgs {
-                summary: "fix omp CHECK".into(),
-                open_questions: vec![],
-                next_steps: vec![],
-                files_touched: vec![],
-                cwd: Some(r"C:\GIT\ai-memory".into()),
-                project: None,
-            }))
+            .memory_handoff_begin(
+                Parameters(HandoffBeginArgs {
+                    summary: "fix omp CHECK".into(),
+                    open_questions: vec![],
+                    next_steps: vec![],
+                    files_touched: vec![],
+                    cwd: Some(r"C:\GIT\ai-memory".into()),
+                    project: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
 
         let briefing = server
-            .memory_briefing(Parameters(BriefingArgs {
-                recent_pages_limit: Some(5),
-                project: None,
-                workspace: None,
-            }))
+            .memory_briefing(
+                Parameters(BriefingArgs {
+                    recent_pages_limit: Some(5),
+                    project: None,
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let text = briefing
@@ -3207,14 +3339,17 @@ mod tests {
     async fn handoff_begin_then_accept_round_trips() {
         let (_tmp, _store, server, _ws, _pj) = setup_server().await;
         let begin = server
-            .memory_handoff_begin(Parameters(HandoffBeginArgs {
-                summary: "left mid-refactor of writer actor".into(),
-                open_questions: vec!["what max channel size?".into()],
-                next_steps: vec!["finish supersession path".into()],
-                files_touched: vec!["crates/ai-memory-store/src/writer.rs".into()],
-                cwd: Some("/tmp/aim".into()),
-                project: None,
-            }))
+            .memory_handoff_begin(
+                Parameters(HandoffBeginArgs {
+                    summary: "left mid-refactor of writer actor".into(),
+                    open_questions: vec!["what max channel size?".into()],
+                    next_steps: vec!["finish supersession path".into()],
+                    files_touched: vec!["crates/ai-memory-store/src/writer.rs".into()],
+                    cwd: Some("/tmp/aim".into()),
+                    project: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let begin_text = begin
@@ -3227,10 +3362,13 @@ mod tests {
 
         // Accepting with matching cwd returns the handoff.
         let accept = server
-            .memory_handoff_accept(Parameters(HandoffAcceptArgs {
-                cwd: Some("/tmp/aim".into()),
-                project: None,
-            }))
+            .memory_handoff_accept(
+                Parameters(HandoffAcceptArgs {
+                    cwd: Some("/tmp/aim".into()),
+                    project: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let accept_text = accept
@@ -3244,10 +3382,13 @@ mod tests {
 
         // Second accept returns null (handoff is now accepted).
         let again = server
-            .memory_handoff_accept(Parameters(HandoffAcceptArgs {
-                cwd: Some("/tmp/aim".into()),
-                project: None,
-            }))
+            .memory_handoff_accept(
+                Parameters(HandoffAcceptArgs {
+                    cwd: Some("/tmp/aim".into()),
+                    project: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .unwrap();
         let again_text = again
@@ -3270,7 +3411,7 @@ mod tests {
                 files_touched: vec![],
                 cwd: Some("/tmp/aim".into()),
                 project: None,
-            }))
+            }), rmcp::handler::server::tool::Extension(test_parts_default()))
             .await
             .unwrap();
         let begin_text = begin
@@ -3287,7 +3428,7 @@ mod tests {
                 recent_pages_limit: Some(5),
                 project: None,
                 workspace: None,
-            }))
+            }), rmcp::handler::server::tool::Extension(test_parts_default()))
             .await
             .unwrap();
         let before_text = before
@@ -3303,7 +3444,7 @@ mod tests {
                 handoff_id: handoff_id.clone(),
                 project: None,
                 workspace: None,
-            }))
+            }), rmcp::handler::server::tool::Extension(test_parts_default()))
             .await
             .unwrap();
         let cancel_text = cancel
@@ -3320,7 +3461,7 @@ mod tests {
                 recent_pages_limit: Some(5),
                 project: None,
                 workspace: None,
-            }))
+            }), rmcp::handler::server::tool::Extension(test_parts_default()))
             .await
             .unwrap();
         let after_text = after
@@ -3335,7 +3476,7 @@ mod tests {
             .memory_handoff_accept(Parameters(HandoffAcceptArgs {
                 cwd: Some("/tmp/aim".into()),
                 project: None,
-            }))
+            }), rmcp::handler::server::tool::Extension(test_parts_default()))
             .await
             .unwrap();
         let accept_text = accept
@@ -3387,12 +3528,15 @@ mod tests {
     async fn memory_lint_without_wiki_errors_cleanly() {
         let (_tmp, _store, server, _ws, _pj) = setup_server().await;
         let err = server
-            .memory_lint(Parameters(LintArgs {
-                dry_run: Some(true),
-                no_llm: None,
-                project: None,
-                workspace: None,
-            }))
+            .memory_lint(
+                Parameters(LintArgs {
+                    dry_run: Some(true),
+                    no_llm: None,
+                    project: None,
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .expect_err("must reject when wiki is not attached");
         let msg = format!("{err:?}");
@@ -3456,7 +3600,13 @@ mod tests {
         let sweep_count = |args: SweepArgs| {
             let server = &server;
             async move {
-                let out = server.memory_forget_sweep(Parameters(args)).await.unwrap();
+                let out = server
+                    .memory_forget_sweep(
+                        Parameters(args),
+                        rmcp::handler::server::tool::Extension(test_parts_default()),
+                    )
+                    .await
+                    .unwrap();
                 let text = out
                     .content
                     .first()
@@ -3500,10 +3650,13 @@ mod tests {
     async fn memory_handoff_accept_when_none_pending_returns_null() {
         let (_tmp, _store, server, _ws, _pj) = setup_server().await;
         let result = server
-            .memory_handoff_accept(Parameters(HandoffAcceptArgs {
-                cwd: None,
-                project: None,
-            }))
+            .memory_handoff_accept(
+                Parameters(HandoffAcceptArgs {
+                    cwd: None,
+                    project: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .expect("empty-queue must be Ok, not Err");
         let text = result
@@ -3528,14 +3681,17 @@ mod tests {
         // with a sane response. (We don't have 10k pages, so the
         // hit count is small — we just need NOT to error.)
         let result = server
-            .memory_query(Parameters(QueryArgs {
-                query: "Karpathy".into(),
-                limit: Some(99_999),
-                project: None,
-                scopes: Vec::new(),
-                workspace: None,
-                global: None,
-            }))
+            .memory_query(
+                Parameters(QueryArgs {
+                    query: "Karpathy".into(),
+                    limit: Some(99_999),
+                    project: None,
+                    scopes: Vec::new(),
+                    workspace: None,
+                    global: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await
             .expect("oversized limit should be clamped, not refused");
         let text = result
@@ -3556,14 +3712,17 @@ mod tests {
     async fn memory_query_malformed_fts5_returns_error() {
         let (_tmp, _store, server, _ws, _pj) = setup_server().await;
         let err = server
-            .memory_query(Parameters(QueryArgs {
-                query: "\"unbalanced".into(),
-                limit: Some(10),
-                project: None,
-                scopes: Vec::new(),
-                workspace: None,
-                global: None,
-            }))
+            .memory_query(
+                Parameters(QueryArgs {
+                    query: "\"unbalanced".into(),
+                    limit: Some(10),
+                    project: None,
+                    scopes: Vec::new(),
+                    workspace: None,
+                    global: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
             .await;
         // Either a tidy 0-hit Ok (FTS5 is occasionally lenient) or
         // an Err — both are acceptable. A panic is not.

--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -537,16 +537,66 @@ impl AiMemoryServer {
         self
     }
 
+    /// Build the [`ActorKey`] for a tool call from the request's stored
+    /// extensions. When the auth middleware has attached an
+    /// [`ai_memory_core::ActorContext`] (rung 1 root, rung 2 DB user), its
+    /// `user` field is used; the `session_id` comes from the same
+    /// extension when the agent's MCP client forwards it, otherwise stays
+    /// `None` and the per-actor lookup gracefully degrades to the single
+    /// slot under `[auto_scope] mode = single` (the default).
+    ///
+    /// Threading parts into every read tool is mechanical but wide; the
+    /// helper is kept here so a follow-up commit can opt each tool in
+    /// without re-doing the design — the wrapper [`Self::effective_ids`] /
+    /// [`Self::effective_ids_for_read_args`] keep working unchanged while
+    /// the migration is in progress.
+    #[allow(dead_code)]
+    fn actor_key_from_parts(
+        parts: Option<&axum::http::request::Parts>,
+    ) -> ai_memory_core::ActorKey {
+        let Some(parts) = parts else {
+            return ai_memory_core::ActorKey::default();
+        };
+        let ctx = parts.extensions.get::<ai_memory_core::ActorContext>();
+        match ctx {
+            None => ai_memory_core::ActorKey::default(),
+            Some(ctx) => ai_memory_core::ActorKey {
+                user: ctx.user.clone(),
+                session_id: ctx.session_id.clone(),
+            },
+        }
+    }
+
     /// Resolve which `(workspace_id, project_id)` a read tool should
     /// query. Precedence (matches the documented resolution chain):
     ///   1. an explicit `project` name argument in the active workspace
-    ///      when hooks have published one,
+    ///      when hooks have published one (for THIS actor),
     ///   2. that same explicit `project` in the server's baked workspace,
     ///   3. the hook-published [`ActiveProject`] (the cwd the agent is
-    ///      currently working in),
+    ///      currently working in, keyed by `actor` in opt-in isolation
+    ///      modes),
     ///   4. the server's baked-in `--project` default.
+    ///
+    /// `actor` is built by [`Self::actor_key_from_parts`]; pass
+    /// `ActorKey::default()` when the call site has no request context.
+    /// Empty actor → fall back to the single slot (legacy behaviour).
+    /// Backward-compatible wrapper for call sites that have not yet
+    /// threaded a request `Parts` extension. Behaves like the historical
+    /// `effective_ids` — i.e. consults the single slot only — which is
+    /// what every tool gets under the default `[auto_scope] mode = single`.
+    /// Opt-in modes (`per_session` / `per_actor`) gain proper isolation as
+    /// each tool gets migrated to [`Self::effective_ids_with_actor`].
     async fn effective_ids(&self, explicit_project: Option<&str>) -> (WorkspaceId, ProjectId) {
-        let active = self.active_project.get();
+        self.effective_ids_with_actor(explicit_project, &ai_memory_core::ActorKey::default())
+            .await
+    }
+
+    async fn effective_ids_with_actor(
+        &self,
+        explicit_project: Option<&str>,
+        actor: &ai_memory_core::ActorKey,
+    ) -> (WorkspaceId, ProjectId) {
+        let active = self.active_project.get_for(actor);
         if let Some(name) = explicit_project.map(str::trim).filter(|s| !s.is_empty()) {
             if let Some((active_ws, _)) = active
                 && let Ok(Some(pid)) = self.reader.find_project(active_ws, name.to_string()).await
@@ -565,10 +615,25 @@ impl AiMemoryServer {
         active.unwrap_or((self.workspace_id, self.project_id))
     }
 
+    /// Backward-compatible wrapper paired with [`Self::effective_ids`].
     async fn effective_ids_for_read_args(
         &self,
         explicit_workspace: Option<&str>,
         explicit_project: Option<&str>,
+    ) -> Result<(WorkspaceId, ProjectId), McpError> {
+        self.effective_ids_for_read_args_with_actor(
+            explicit_workspace,
+            explicit_project,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+    }
+
+    async fn effective_ids_for_read_args_with_actor(
+        &self,
+        explicit_workspace: Option<&str>,
+        explicit_project: Option<&str>,
+        actor: &ai_memory_core::ActorKey,
     ) -> Result<(WorkspaceId, ProjectId), McpError> {
         match (
             trimmed_opt(explicit_workspace),
@@ -579,7 +644,7 @@ impl AiMemoryServer {
                 "workspace and project must be provided together",
                 None,
             )),
-            (None, project) => Ok(self.effective_ids(project).await),
+            (None, project) => Ok(self.effective_ids_with_actor(project, actor).await),
         }
     }
 

--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -668,17 +668,37 @@ impl AiMemoryServer {
     /// `bar/foo`. To target the baked/shared workspace explicitly, pass
     /// `workspace`. Falls back to the baked default only when no `ActiveProject`
     /// has been published yet (early startup / no hooks).
+    /// Legacy single-slot wrapper retained for test fixtures that pre-date
+    /// the actor-aware variant. Production tools must use
+    /// [`Self::write_target_ids_with_actor`] so per-session/per-actor
+    /// isolation modes route the write to the caller's project, not
+    /// whichever single-slot value was published last.
+    #[cfg(test)]
     async fn write_target_ids(
         &self,
         explicit_workspace: Option<&str>,
         explicit_project: Option<&str>,
+    ) -> Result<(WorkspaceId, ProjectId), McpError> {
+        self.write_target_ids_with_actor(
+            explicit_workspace,
+            explicit_project,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+    }
+
+    async fn write_target_ids_with_actor(
+        &self,
+        explicit_workspace: Option<&str>,
+        explicit_project: Option<&str>,
+        actor: &ai_memory_core::ActorKey,
     ) -> Result<(WorkspaceId, ProjectId), McpError> {
         let Some(project) = trimmed_opt(explicit_project) else {
             // No explicit project → current project (hook-published active, or
             // the baked default). Explicit workspace alone has nothing to scope.
             return Ok(self
                 .active_project
-                .get()
+                .get_for(actor)
                 .unwrap_or((self.workspace_id, self.project_id)));
         };
         let workspace_id = match trimmed_opt(explicit_workspace) {
@@ -691,7 +711,7 @@ impl AiMemoryServer {
             // baked global default — keeps writes consistent with reads.
             None => self
                 .active_project
-                .get()
+                .get_for(actor)
                 .map(|(ws, _)| ws)
                 .unwrap_or(self.workspace_id),
         };
@@ -1118,6 +1138,7 @@ impl AiMemoryServer {
         Parameters(args): Parameters<WritePageArgs>,
         Extension(parts): Extension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, McpError> {
+        let aps_actor = Self::actor_key_from_parts(Some(&parts));
         let Some(wiki) = self.wiki.as_ref() else {
             return Err(McpError::internal_error(
                 "memory_write_page requires the server to be built with a wiki handle",
@@ -1131,7 +1152,11 @@ impl AiMemoryServer {
         let path = PagePath::new(args.path.clone())
             .map_err(|e| McpError::internal_error(format!("invalid path: {e}"), None))?;
         let (ws, proj) = self
-            .write_target_ids(args.workspace.as_deref(), args.project.as_deref())
+            .write_target_ids_with_actor(
+                args.workspace.as_deref(),
+                args.project.as_deref(),
+                &aps_actor,
+            )
             .await?;
 
         let mut fm = serde_json::Map::new();

--- a/crates/ai-memory-mcp/tests/autoscope_multiuser.rs
+++ b/crates/ai-memory-mcp/tests/autoscope_multiuser.rs
@@ -1,0 +1,484 @@
+//! End-to-end test for `auto_scope.mode = per_actor` with the **production
+//! auth chain**: real `users` table rows, hashed bearer tokens, and a
+//! middleware that mirrors `ai_memory_cli::auth::require_bearer`'s Bearer
+//! → hash → DB-lookup → `ActorContext.user = user.username` path.
+//!
+//! Why a replica and not the real one: `ai-memory-cli` is a binary-only
+//! crate (no `lib.rs`), so its `auth` module isn't reachable from an
+//! integration test in another crate. The slice that matters for
+//! `auto_scope` is the (Bearer header → ActorContext.user) wiring, which
+//! is short enough to replicate verbatim. Cookie / Basic-auth paths are
+//! covered elsewhere and have no bearing on actor-key derivation.
+//!
+//! If `require_bearer` adds a new ActorContext field that affects the
+//! per-actor key, the replica below must mirror it. The
+//! `users.username -> ActorContext.user` invariant is the load-bearing
+//! one: an autoscope regression that fed `user.id` (UUID) instead of
+//! `user.username` into the actor key would split the per-actor map
+//! across rungs, which is exactly what this test pins.
+
+use ai_memory_core::{ActiveProject, ActiveProjectMode, ActorContext, NewUser, Tier};
+use ai_memory_hooks::{
+    DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT, HookState, ProjectCacheStore, hook_router,
+};
+use ai_memory_mcp::AiMemoryServer;
+use ai_memory_store::{Store, TokenPepper, generate_token, hash_token};
+use ai_memory_wiki::Wiki;
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+struct SeededUser {
+    /// Kept for debugging panics and future assertions on the
+    /// `ActorContext.user` path; the tests below probe by token, but
+    /// retaining the username avoids re-deriving it from the index.
+    #[allow(dead_code)]
+    username: String,
+    token: String,
+    project_index: usize,
+}
+
+struct MultiUserHarness {
+    router: Router,
+    _store: Store,
+    _tmp: TempDir,
+    users: Vec<SeededUser>,
+}
+
+impl MultiUserHarness {
+    /// Build a server with multi-user auth enabled, seed N users (each
+    /// owning a distinct seeded project), and assemble the production-
+    /// shaped Router (Bearer middleware → /mcp + /hook).
+    async fn build(num_users: usize) -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let store = Store::open(tmp.path()).expect("store");
+        let ws = store
+            .writer
+            .get_or_create_workspace("default")
+            .await
+            .expect("ws");
+        let baked = store
+            .writer
+            .get_or_create_project(ws, "scratch", None)
+            .await
+            .expect("baked");
+        let wiki = Wiki::new(tmp.path(), store.writer.clone()).expect("wiki");
+
+        // Seed N users with hashed tokens + their own project + marker page.
+        let pepper = TokenPepper::new("test-pepper-multiuser-1234567890abcdef");
+        let mut users = Vec::with_capacity(num_users);
+        for i in 1..=num_users {
+            let username = format!("user{i}");
+            let raw_token = generate_token().expect("gen token");
+            let hash = hash_token(&raw_token, &pepper);
+            store
+                .writer
+                .create_user(
+                    NewUser {
+                        username: username.clone(),
+                        name: Some(format!("User {i}")),
+                        email: Some(format!("user{i}@example.com")),
+                    },
+                    hash,
+                )
+                .await
+                .expect("create user");
+
+            // Each user "owns" a uniquely-named project + marker page; the
+            // FTS5 tokenizer treats `_` as a TOKEN character, so the body
+            // uses space-separated alphabetic words to stay searchable.
+            let proj = store
+                .writer
+                .get_or_create_project(ws, format!("user{i}-proj"), None)
+                .await
+                .expect("seed proj");
+            store
+                .writer
+                .upsert_page(ai_memory_core::NewPage {
+                    workspace_id: ws,
+                    project_id: proj,
+                    path: ai_memory_core::PagePath::new("marker.md").expect("path"),
+                    title: format!("Marker for user {i}"),
+                    body: format!("multistream {tag}", tag = number_word(i)),
+                    tier: Tier::Semantic,
+                    frontmatter_json: serde_json::json!({}),
+                    pinned: false,
+                    links: Vec::new(),
+                    author_id: None,
+                })
+                .await
+                .expect("seed page");
+
+            users.push(SeededUser {
+                username,
+                token: raw_token,
+                project_index: i,
+            });
+        }
+
+        let active_project = ActiveProject::with_config(
+            ActiveProjectMode::PerActor,
+            Duration::from_secs(60),
+            ai_memory_core::DEFAULT_MAX_ENTRIES,
+        );
+
+        let server = AiMemoryServer::new(store.reader.clone(), store.writer.clone(), ws, baked)
+            .with_wiki(wiki.clone())
+            .with_active_project(active_project.clone());
+
+        let mcp_service = StreamableHttpService::new(
+            move || Ok(server.clone()),
+            LocalSessionManager::default().into(),
+            StreamableHttpServerConfig::default()
+                .with_stateful_mode(false)
+                .with_json_response(true),
+        );
+
+        let project_cache: ai_memory_hooks::ProjectCache =
+            Arc::new(tokio::sync::Mutex::new(ProjectCacheStore::default()));
+        let hooks = hook_router(HookState {
+            workspace_id: ws,
+            project_id: baked,
+            writer: store.writer.clone(),
+            reader: store.reader.clone(),
+            wiki: wiki.clone(),
+            consolidator: None,
+            sanitizer: ai_memory_core::Sanitizer::default(),
+            project_cache,
+            active_project: active_project.clone(),
+            ingest_semaphore: Arc::new(tokio::sync::Semaphore::new(
+                DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT,
+            )),
+            consolidate_on_session_end: false,
+        });
+
+        // Production-equivalent Bearer middleware. Pepper + reader are
+        // shared via a small Arc state. The implementation mirrors the
+        // Bearer-only branch of `ai_memory_cli::auth::require_bearer`:
+        // valid token → ActorContext { user: Some(username), name, email }.
+        let auth_state = Arc::new(BearerAuthState {
+            pepper,
+            reader: store.reader.clone(),
+        });
+        let router = Router::new()
+            .nest_service("/mcp", mcp_service)
+            .merge(hooks)
+            .layer(axum::middleware::from_fn_with_state(
+                auth_state,
+                bearer_lookup,
+            ));
+
+        MultiUserHarness {
+            router,
+            _store: store,
+            _tmp: tmp,
+            users,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct BearerAuthState {
+    pepper: TokenPepper,
+    reader: ai_memory_store::ReaderPool,
+}
+
+async fn bearer_lookup(
+    axum::extract::State(state): axum::extract::State<Arc<BearerAuthState>>,
+    mut req: Request<Body>,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    // No token → anonymous. This mirrors require_bearer's rung 0/
+    // unrecognised-Bearer behaviour for our autoscope test:
+    // ActorContext is injected with no `user`, so PerActor falls back
+    // to the single slot (intentional graceful degradation).
+    let bearer = req
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    if let Some(token) = bearer {
+        let hash = hash_token(token, &state.pepper);
+        match state.reader.find_active_user_by_token_hash(hash).await {
+            Ok(Some(user)) => {
+                // Mirror require_bearer:
+                //   ActorContext.user = user.username
+                //   ActorContext.name  = user.name
+                //   ActorContext.email = user.email
+                req.extensions_mut().insert(ActorContext {
+                    user: Some(user.username.clone()),
+                    name: user.name.clone(),
+                    email: user.email.clone(),
+                    ..ActorContext::default()
+                });
+                req.extensions_mut().insert(user.id);
+            }
+            _ => {
+                req.extensions_mut().insert(ActorContext::anonymous());
+            }
+        }
+    } else {
+        req.extensions_mut().insert(ActorContext::anonymous());
+    }
+    next.run(req).await
+}
+
+fn number_word(i: usize) -> &'static str {
+    match i {
+        1 => "alphaone",
+        2 => "alphatwo",
+        3 => "alphathree",
+        4 => "alphafour",
+        _ => panic!("number_word: 1..=4 only"),
+    }
+}
+
+fn hook_request(token: &str, session_id: &str, project_name: &str) -> Request<Body> {
+    let body = json!({
+        "event": "session-start",
+        "session_id": session_id,
+        "cwd": format!("/tmp/aim-test/{project_name}"),
+    });
+    Request::builder()
+        .method("POST")
+        .uri(format!(
+            "/hook?event=session-start&agent=claude-code&project={project_name}"
+        ))
+        .header("host", "localhost")
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::from(body.to_string()))
+        .expect("hook req")
+}
+
+fn mcp_query_request(token: &str, session_id: &str) -> Request<Body> {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "memory_query",
+            "arguments": { "query": "multistream", "limit": 20 }
+        }
+    });
+    Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header("host", "localhost")
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .header("authorization", format!("Bearer {token}"))
+        .header("x-memory-actor-session-id", session_id)
+        .body(Body::from(body.to_string()))
+        .expect("mcp req")
+}
+
+async fn response_text(resp: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(resp.into_body(), 4_000_000)
+        .await
+        .expect("body bytes");
+    String::from_utf8(bytes.to_vec()).expect("utf8")
+}
+
+fn tool_text(body: &str) -> String {
+    let v: serde_json::Value =
+        serde_json::from_str(body).unwrap_or_else(|e| panic!("non-JSON: {body}\nerr: {e}"));
+    if let Some(err) = v.get("error") {
+        panic!("JSON-RPC error: {err}\nfull: {body}");
+    }
+    v.pointer("/result/content")
+        .and_then(|c| c.as_array())
+        .unwrap_or_else(|| panic!("missing result.content: {body}"))
+        .iter()
+        .filter_map(|i| i.get("text").and_then(|t| t.as_str()))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+async fn fire_hook_and_settle(router: &Router, token: &str, session_id: &str, proj: &str) {
+    let resp = router
+        .clone()
+        .oneshot(hook_request(token, session_id, proj))
+        .await
+        .expect("hook oneshot");
+    assert_eq!(resp.status(), StatusCode::ACCEPTED, "hook must accept");
+    let _ = response_text(resp).await;
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+    }
+    tokio::time::sleep(Duration::from_millis(15)).await;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Each user, authenticated by their real Bearer token, hooks their own
+// project; concurrent reads must resolve into their OWN slot, never any
+// sibling user's, even though they all share the same `session_id` value.
+// ────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn per_actor_isolates_real_bearer_users() {
+    let h = MultiUserHarness::build(3).await;
+
+    // Intentionally shared session id across all users: the per_actor map
+    // must key by `(user, session)`, so even with collisions on the
+    // session-id half, the user-half from the auth middleware partitions
+    // them correctly. If a regression dropped `user` from the actor key,
+    // ALL three users would collapse into one slot and the assertion
+    // below would fail.
+    let shared_sess = "shared-session-across-users";
+    for u in &h.users {
+        let proj = format!("user{}-proj", u.project_index);
+        fire_hook_and_settle(&h.router, &u.token, shared_sess, &proj).await;
+    }
+
+    // Concurrent reads, one per user, with the shared session id.
+    let mut handles = Vec::new();
+    for u in &h.users {
+        let router = h.router.clone();
+        let token = u.token.clone();
+        let i = u.project_index;
+        handles.push(tokio::spawn(async move {
+            let resp = router
+                .oneshot(mcp_query_request(&token, shared_sess))
+                .await
+                .expect("mcp oneshot");
+            assert_eq!(resp.status(), StatusCode::OK, "user{i} read status");
+            let body = response_text(resp).await;
+            (i, tool_text(&body))
+        }));
+    }
+
+    for hd in handles {
+        let (i, text) = hd.await.expect("join");
+        let own = number_word(i);
+        assert!(
+            text.contains(own),
+            "user{i} did NOT see its own marker. Expected {own:?}:\n{text}"
+        );
+        for j in 1..=3 {
+            if j == i {
+                continue;
+            }
+            let foreign = number_word(j);
+            assert!(
+                !text.contains(foreign),
+                "user{i} leaked into user{j}'s project. Saw {foreign:?}:\n{text}"
+            );
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// A request without a Bearer token authenticates as anonymous → no
+// `user` in the actor key. PerActor falls back to the single slot; the
+// MCP read sees whatever was last published there. The key invariant
+// here is *no leak of a DB-user's slot* to anonymous callers — i.e.
+// the per-actor map must NOT serve user1's pointer to an anonymous
+// request, because the keys `(user1, sess)` and `(None, sess)` are
+// distinct.
+// ────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn anonymous_request_does_not_inherit_user_slot() {
+    let h = MultiUserHarness::build(2).await;
+    let sess = "anon-vs-user1";
+
+    let user1 = &h.users[0]; // owns user1-proj (alphaone marker)
+
+    // user1 publishes their per_actor slot.
+    fire_hook_and_settle(&h.router, &user1.token, sess, "user1-proj").await;
+
+    // Anonymous read with the SAME session id. Because `user` differs
+    // (`None` vs `Some("user1")`), the per_actor slot is a different
+    // key, and the slot is empty for anonymous → fallback to single
+    // slot. The single slot was last written by user1's hook, so this
+    // is acceptable graceful degradation; the *strict* invariant we
+    // pin is that an anonymous read MUST NOT come back keyed as
+    // user1 in the actor-aware path.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("host", "localhost")
+                .header("content-type", "application/json")
+                .header("accept", "application/json, text/event-stream")
+                .header("x-memory-actor-session-id", sess)
+                // NO authorization header.
+                .body(Body::from(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "tools/call",
+                        "params": {
+                            "name": "memory_query",
+                            "arguments": { "query": "multistream", "limit": 20 }
+                        }
+                    })
+                    .to_string(),
+                ))
+                .expect("anon mcp req"),
+        )
+        .await
+        .expect("anon mcp oneshot");
+    assert_eq!(resp.status(), StatusCode::OK);
+    // Body must parse cleanly; engine must not crash on anonymous +
+    // per_actor mode. Content can be anything (likely user1's project
+    // via single-slot fallback) — that's documented graceful
+    // degradation.
+    let _ = tool_text(&response_text(resp).await);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// A request with an unknown Bearer (typo, revoked token) must also fall
+// through to anonymous, not get spoofed into another user's slot. This
+// pins the rung-2 lookup-miss path.
+// ────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unknown_bearer_does_not_match_any_user_slot() {
+    let h = MultiUserHarness::build(2).await;
+    let sess = "unknown-bearer-probe";
+    let user1 = &h.users[0];
+
+    fire_hook_and_settle(&h.router, &user1.token, sess, "user1-proj").await;
+
+    // Forged Bearer of the right shape but unknown to the users table.
+    let forged = "deadbeef".repeat(8);
+    let resp = h
+        .router
+        .clone()
+        .oneshot(mcp_query_request(&forged, sess))
+        .await
+        .expect("forged mcp oneshot");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_text(resp).await;
+    let text = tool_text(&body);
+
+    // The forged caller's key is `(None, sess)` after the middleware's
+    // anonymous-fallback. It must NOT key into user1's `(Some("user1"),
+    // sess)` slot. The acceptable outcomes are:
+    //   - empty hits (no per-actor slot, no single-slot match), or
+    //   - single-slot fallback content from whatever was last published
+    //     (which here is alphaone — user1's hook).
+    // The forbidden outcome is the request being *attributed* to
+    // user1's actor identity in any downstream write/audit. We can't
+    // assert that from a read body alone, but the read result is
+    // bounded by the slot semantics: same alpha as legit user, but
+    // routed via single-slot fallback, never via a spoofed per-actor
+    // hit. Documentation test; the load-bearing assertion is the
+    // multi-user one above.
+    let _ = text;
+}

--- a/crates/ai-memory-mcp/tests/autoscope_stress.rs
+++ b/crates/ai-memory-mcp/tests/autoscope_stress.rs
@@ -1,0 +1,1081 @@
+//! Multi-actor concurrency stress tests for the per-session / per-actor
+//! [`ActiveProject`] isolation modes.
+//!
+//! Unit tests in `ai_memory_core::active_project` cover the map's
+//! single-threaded contract. These tests exercise the *production wiring*
+//! — `/hook` → `process_envelope` → `set_for(actor)` interleaved with
+//! `/mcp tools/call` → `actor_key_from_parts` → `get_for(actor)` — under
+//! genuine `tokio::spawn` concurrency, so a race in the mutex, the LRU
+//! eviction order, or the actor-key extraction surfaces here rather than
+//! in prod.
+//!
+//! The router is assembled in-process (axum `Router` + tower
+//! `ServiceExt::oneshot`), the auth middleware is replaced by a fake that
+//! injects `ActorContext` from `x-test-actor-user` / `x-test-actor-session-id`
+//! request headers — exactly the field the production middleware fills.
+//! Session id is also accepted via the production `x-memory-actor-session-id`
+//! header on /mcp so the "header is cache key, not credential" scenario can
+//! exercise the same fallback the real server walks.
+
+use ai_memory_core::{ActiveProject, ActiveProjectMode, ActorContext};
+use ai_memory_hooks::{
+    DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT, HookState, ProjectCacheStore, hook_router,
+};
+use ai_memory_mcp::AiMemoryServer;
+use ai_memory_store::Store;
+use ai_memory_wiki::Wiki;
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+/// All scenarios share a server with this many seeded projects, each with a
+/// `marker.md` page whose body uniquely identifies the project. Reads after a
+/// hook event must find the marker for the project the hook published — not
+/// any other.
+const SEEDED_PROJECTS: usize = 8;
+
+/// English number words, indexed from 1 — used as space-separated FTS5
+/// tokens so we can both find any marker via the shared `markerstream`
+/// word and tell which project a given hit came from. Indexed 1..=8.
+fn number_word(i: usize) -> &'static str {
+    match i {
+        1 => "alphaone",
+        2 => "alphatwo",
+        3 => "alphathree",
+        4 => "alphafour",
+        5 => "alphafive",
+        6 => "alphasix",
+        7 => "alphaseven",
+        8 => "alphaeight",
+        _ => panic!("number_word: only 1..=8 supported, got {i}"),
+    }
+}
+
+/// Per-actor map config used by most scenarios — large enough not to evict
+/// under normal concurrency, small enough that the burst test can overflow it.
+const TEST_TTL: Duration = Duration::from_secs(60);
+
+struct Harness {
+    router: Router,
+    active_project: ActiveProject,
+    _store: Store,
+    _wiki: Wiki,
+    _tmp: TempDir,
+}
+
+impl Harness {
+    /// Build a complete in-process server: store + wiki + N seeded projects
+    /// + MCP service + hook router + actor-injecting fake-auth middleware.
+    async fn build(mode: ActiveProjectMode, ttl: Duration, max_entries: usize) -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let store = Store::open(tmp.path()).expect("store");
+        let ws = store
+            .writer
+            .get_or_create_workspace("default")
+            .await
+            .expect("ws");
+        // Baked default project; hook events that set their own cwd take
+        // precedence via the per-actor map.
+        let baked_proj = store
+            .writer
+            .get_or_create_project(ws, "scratch", None)
+            .await
+            .expect("baked proj");
+
+        let wiki = Wiki::new(tmp.path(), store.writer.clone()).expect("wiki");
+
+        // Seed N distinct projects, each with a unique marker page so MCP
+        // reads can verify they resolved into the right active_project.
+        //
+        // The FTS5 tokenizer is `unicode61 ... tokenchars '/_-'`, so
+        // `_` is part of a token (NOT a separator). A body like
+        // "PROJ_1_BODY" tokenizes as a single token and a `PROJ` query
+        // misses it. Use space-separated words instead: a shared word
+        // "markerstream" that every marker carries, plus a per-project
+        // unique english-number word so we can both find any marker and
+        // tell which project it came from.
+        for i in 1..=SEEDED_PROJECTS {
+            let proj = store
+                .writer
+                .get_or_create_project(ws, format!("proj-{i}"), None)
+                .await
+                .expect("seed proj");
+            store
+                .writer
+                .upsert_page(ai_memory_core::NewPage {
+                    workspace_id: ws,
+                    project_id: proj,
+                    path: ai_memory_core::PagePath::new("marker.md").expect("path"),
+                    title: format!("Marker {i}"),
+                    body: format!("markerstream {tag}", tag = number_word(i)),
+                    tier: ai_memory_core::Tier::Semantic,
+                    frontmatter_json: serde_json::json!({}),
+                    pinned: false,
+                    links: Vec::new(),
+                    author_id: None,
+                })
+                .await
+                .expect("seed page");
+        }
+
+        let active_project = ActiveProject::with_config(mode, ttl, max_entries);
+
+        let server = AiMemoryServer::new(store.reader.clone(), store.writer.clone(), ws, baked_proj)
+            .with_wiki(wiki.clone())
+            .with_active_project(active_project.clone());
+
+        let mcp_service = StreamableHttpService::new(
+            move || Ok(server.clone()),
+            LocalSessionManager::default().into(),
+            StreamableHttpServerConfig::default()
+                .with_stateful_mode(false)
+                .with_json_response(true),
+        );
+
+        let project_cache: ai_memory_hooks::ProjectCache =
+            Arc::new(tokio::sync::Mutex::new(ProjectCacheStore::default()));
+        let hooks = hook_router(HookState {
+            workspace_id: ws,
+            project_id: baked_proj,
+            writer: store.writer.clone(),
+            reader: store.reader.clone(),
+            wiki: wiki.clone(),
+            consolidator: None,
+            sanitizer: ai_memory_core::Sanitizer::default(),
+            project_cache,
+            active_project: active_project.clone(),
+            ingest_semaphore: Arc::new(tokio::sync::Semaphore::new(
+                DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT,
+            )),
+            consolidate_on_session_end: false,
+        });
+
+        let router = Router::new()
+            .nest_service("/mcp", mcp_service)
+            .merge(hooks)
+            // Fake auth: read test headers, inject ActorContext exactly the
+            // way the production auth middleware (rung 1 / rung 2) does.
+            // This is the seam under test — the engine's per-actor map keys
+            // off the *extension*, never the raw header value, for `user`.
+            .layer(axum::middleware::from_fn(inject_actor_from_test_headers));
+
+        Self {
+            router,
+            active_project,
+            _store: store,
+            _wiki: wiki,
+            _tmp: tmp,
+        }
+    }
+}
+
+/// Test-only middleware that mimics production auth: read `x-test-actor-user`
+/// and `x-test-actor-session-id`, inject them as an [`ActorContext`] extension.
+async fn inject_actor_from_test_headers(
+    mut req: Request<Body>,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let user = req
+        .headers()
+        .get("x-test-actor-user")
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let session_id = req
+        .headers()
+        .get("x-test-actor-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    if user.is_some() || session_id.is_some() {
+        req.extensions_mut().insert(ActorContext {
+            user,
+            session_id,
+            ..ActorContext::default()
+        });
+    }
+    next.run(req).await
+}
+
+/// Build a `POST /hook` request publishing `cwd → proj-{i}` for the given
+/// `session_id` (and optional `user` for per-actor mode). The body
+/// `session_id` field is what the engine actually keys the map by — we mirror
+/// it in the header so the MCP read in the same actor's lane lines up.
+fn hook_request(user: Option<&str>, session_id: &str, project_index: usize) -> Request<Body> {
+    let body = json!({
+        "event": "session-start",
+        "session_id": session_id,
+        "cwd": format!("/tmp/aim-test/proj-{project_index}"),
+    });
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/hook?event=session-start&agent=claude-code&project=proj-{i}".replace(
+            "{i}",
+            &project_index.to_string(),
+        ))
+        .header("host", "localhost")
+        .header("content-type", "application/json")
+        .header("x-test-actor-session-id", session_id);
+    if let Some(u) = user {
+        builder = builder.header("x-test-actor-user", u);
+    }
+    builder.body(Body::from(body.to_string())).expect("hook req")
+}
+
+/// Build a `POST /mcp` tools/call request for `memory_query` matching the
+/// shared `markerstream` token every seeded marker carries. The
+/// assertion downstream is on WHICH marker (and therefore which
+/// project's unique `alpha*` word) the per-actor scope resolves to.
+fn mcp_query_request(user: Option<&str>, session_id: Option<&str>) -> Request<Body> {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "memory_query",
+            "arguments": { "query": "markerstream", "limit": 20 }
+        }
+    });
+    build_mcp_request(body.to_string(), user, session_id)
+}
+
+/// Build a `POST /mcp` tools/call request for `memory_write_page`. The page
+/// path is unique per call so concurrent writes don't collide on the same
+/// row; the per-actor map decides which *project* the write lands in.
+fn mcp_write_request(
+    user: Option<&str>,
+    session_id: Option<&str>,
+    page_path: &str,
+    body_text: &str,
+) -> Request<Body> {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {
+            "name": "memory_write_page",
+            "arguments": {
+                "path": page_path,
+                "body": format!("# Title\n\n{body_text}"),
+            }
+        }
+    });
+    build_mcp_request(body.to_string(), user, session_id)
+}
+
+fn build_mcp_request(
+    body: String,
+    user: Option<&str>,
+    session_id: Option<&str>,
+) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header("host", "localhost")
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream");
+    if let Some(u) = user {
+        builder = builder.header("x-test-actor-user", u);
+    }
+    if let Some(s) = session_id {
+        // Send BOTH the test-only header (which the fake middleware lifts
+        // into the ActorContext extension) AND the production
+        // `x-memory-actor-session-id` header (which the MCP server reads
+        // directly from raw headers as the rung-4 fallback). Setting both
+        // mirrors what an authenticated browser session would look like
+        // and avoids depending on which one the server prefers.
+        builder = builder
+            .header("x-test-actor-session-id", s)
+            .header("x-memory-actor-session-id", s);
+    }
+    builder.body(Body::from(body)).expect("mcp req")
+}
+
+async fn response_body_text(resp: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(resp.into_body(), 4_000_000)
+        .await
+        .expect("body bytes");
+    String::from_utf8(bytes.to_vec()).expect("utf8 body")
+}
+
+/// Parse a JSON-RPC tools/call response and return the joined text of all
+/// `content[]` text items. Panics with the raw body on protocol errors so
+/// failures are debuggable.
+fn extract_tool_text(body: &str) -> String {
+    let v: serde_json::Value = serde_json::from_str(body)
+        .unwrap_or_else(|e| panic!("non-JSON response: {body}\nerr: {e}"));
+    if let Some(err) = v.get("error") {
+        panic!("JSON-RPC error: {err}\nfull: {body}");
+    }
+    let content = v
+        .pointer("/result/content")
+        .and_then(|c| c.as_array())
+        .unwrap_or_else(|| panic!("missing result.content: {body}"));
+    content
+        .iter()
+        .filter_map(|item| item.get("text").and_then(|t| t.as_str()))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Fire a hook synchronously and wait for the `/hook` 202 ACCEPTED + a
+/// brief settle so the spawned `process_envelope` task lands its write to
+/// the active-project map before the caller continues. This matches the
+/// production "hooks are fire-and-forget" contract — tests need an explicit
+/// barrier because they assert on what the map looks like immediately after.
+async fn fire_hook_and_settle(
+    router: &Router,
+    user: Option<&str>,
+    session_id: &str,
+    project_index: usize,
+) {
+    let resp = router
+        .clone()
+        .oneshot(hook_request(user, session_id, project_index))
+        .await
+        .expect("hook oneshot");
+    assert_eq!(resp.status(), StatusCode::ACCEPTED, "hook must accept");
+    // Drain the response body before settling so the connection releases.
+    let _ = response_body_text(resp).await;
+    // `process_envelope` is `tokio::spawn`-ed; give it a generous window
+    // to land the active_project write on a loaded machine. Empirically a
+    // single yield is enough; we go higher for headroom in CI.
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+    }
+    tokio::time::sleep(Duration::from_millis(15)).await;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Scenario 1 — per_session isolates concurrent reads after one hook each.
+// ────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn per_session_isolates_concurrent_reads_after_hook() {
+    let h = Harness::build(
+        ActiveProjectMode::PerSession,
+        TEST_TTL,
+        ai_memory_core::DEFAULT_MAX_ENTRIES,
+    )
+    .await;
+
+    // Each session i sets its active project to proj-i via one hook event.
+    for i in 1..=SEEDED_PROJECTS {
+        fire_hook_and_settle(&h.router, None, &format!("sess-{i}"), i).await;
+    }
+
+    // Now fan out: each session does M parallel reads. Every read must
+    // resolve to its own project's marker, not some neighbour's.
+    const READS_PER_SESSION: usize = 20;
+    let mut handles = Vec::new();
+    for i in 1..=SEEDED_PROJECTS {
+        for _ in 0..READS_PER_SESSION {
+            let router = h.router.clone();
+            let session = format!("sess-{i}");
+            handles.push(tokio::spawn(async move {
+                let resp = router
+                    .oneshot(mcp_query_request(None, Some(&session)))
+                    .await
+                    .expect("mcp oneshot");
+                assert_eq!(resp.status(), StatusCode::OK, "session {i} read status");
+                let body = response_body_text(resp).await;
+                let text = extract_tool_text(&body);
+                (i, text)
+            }));
+        }
+    }
+
+    for h in handles {
+        let (i, text) = h.await.expect("join");
+        let own = number_word(i);
+        assert!(
+            text.contains(own),
+            "session {i} did NOT see its own marker. Expected {own:?} in result text:\n{text}"
+        );
+        // Every other project's marker must be ABSENT — that's the
+        // isolation guarantee. Reads must not bleed across sessions.
+        for j in 1..=SEEDED_PROJECTS {
+            if j == i {
+                continue;
+            }
+            let foreign = number_word(j);
+            assert!(
+                !text.contains(foreign),
+                "session {i} leaked into sibling proj-{j}.\n  saw: {foreign:?}\n  in:  {text}"
+            );
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Scenario 2 — per_session isolates concurrent writes.
+// ────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn per_session_isolates_concurrent_writes() {
+    let h = Harness::build(
+        ActiveProjectMode::PerSession,
+        TEST_TTL,
+        ai_memory_core::DEFAULT_MAX_ENTRIES,
+    )
+    .await;
+
+    for i in 1..=SEEDED_PROJECTS {
+        fire_hook_and_settle(&h.router, None, &format!("sess-{i}"), i).await;
+    }
+
+    // Each session writes a uniquely-named page concurrently.
+    let mut write_handles = Vec::new();
+    for i in 1..=SEEDED_PROJECTS {
+        let router = h.router.clone();
+        let session = format!("sess-{i}");
+        let page_path = format!("writes/from-sess-{i}.md");
+        // Underscore-free body word so the FTS5 tokenizer (which treats
+        // `_` as a TOKEN character, not a separator) keeps the marker
+        // searchable. Each session gets a unique english-number-tagged
+        // word so the round-trip read can distinguish own vs leaked.
+        let body = format!("writefromsess{tag}", tag = number_word(i));
+        write_handles.push(tokio::spawn(async move {
+            let resp = router
+                .oneshot(mcp_write_request(None, Some(&session), &page_path, &body))
+                .await
+                .expect("mcp write oneshot");
+            assert_eq!(resp.status(), StatusCode::OK, "write {i} status");
+            let body = response_body_text(resp).await;
+            // Ensure the call did NOT error; we don't need to parse the
+            // detailed result here — the round-trip read below is the
+            // real assertion.
+            let _ = extract_tool_text(&body);
+            i
+        }));
+    }
+    for w in write_handles {
+        w.await.expect("write join");
+    }
+
+    // Round-trip: each session reads back its own page. Because the per-
+    // session active_project still points at proj-i, memory_query for
+    // "WRITE_FROM_SESS_" must find ONLY the row that landed in proj-i.
+    let mut read_handles = Vec::new();
+    for i in 1..=SEEDED_PROJECTS {
+        let router = h.router.clone();
+        let session = format!("sess-{i}");
+        read_handles.push(tokio::spawn(async move {
+            let body_q = json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "memory_query",
+                    "arguments": { "query": "writefromsess*", "limit": 20 }
+                }
+            });
+            let resp = router
+                .oneshot(build_mcp_request(body_q.to_string(), None, Some(&session)))
+                .await
+                .expect("mcp read oneshot");
+            let body = response_body_text(resp).await;
+            (i, extract_tool_text(&body))
+        }));
+    }
+
+    for r in read_handles {
+        let (i, text) = r.await.expect("read join");
+        let own = format!("writefromsess{tag}", tag = number_word(i));
+        assert!(
+            text.contains(&own),
+            "sess-{i} write did not round-trip in its own scope:\n{text}"
+        );
+        // Strict isolation: no other session's payload should leak. The
+        // per-session map keeps each write in its own project_id, so a
+        // memory_query scoped by the same session cannot see siblings.
+        for j in 1..=SEEDED_PROJECTS {
+            if j == i {
+                continue;
+            }
+            let foreign = format!("writefromsess{tag}", tag = number_word(j));
+            assert!(
+                !text.contains(&foreign),
+                "sess-{i} read leaked write from sess-{j}:\n{text}"
+            );
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Scenario 3 — per_actor: users sharing a session_id are still isolated.
+// ────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn per_actor_isolates_users_sharing_session_id() {
+    let h = Harness::build(
+        ActiveProjectMode::PerActor,
+        TEST_TTL,
+        ai_memory_core::DEFAULT_MAX_ENTRIES,
+    )
+    .await;
+
+    // Alice and Bob send hooks with the SAME `session_id` but DIFFERENT
+    // users. In `per_actor` mode they must land in distinct map slots
+    // because the key is `(user, session_id)`, not `session_id` alone.
+    let shared_sess = "shared-session-x";
+    fire_hook_and_settle(&h.router, Some("alice"), shared_sess, 1).await;
+    fire_hook_and_settle(&h.router, Some("bob"), shared_sess, 5).await;
+
+    // Alice reads — must see proj-1's marker, never proj-5's.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(mcp_query_request(Some("alice"), Some(shared_sess)))
+        .await
+        .expect("alice read");
+    let alice_text = extract_tool_text(&response_body_text(resp).await);
+    assert!(
+        alice_text.contains(number_word(1)),
+        "alice did not see her own proj-1 marker:\n{alice_text}"
+    );
+    assert!(
+        !alice_text.contains(number_word(5)),
+        "alice leaked into bob's proj-5:\n{alice_text}"
+    );
+
+    // Bob reads — must see proj-5's marker, never proj-1's.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(mcp_query_request(Some("bob"), Some(shared_sess)))
+        .await
+        .expect("bob read");
+    let bob_text = extract_tool_text(&response_body_text(resp).await);
+    assert!(
+        bob_text.contains(number_word(5)),
+        "bob did not see his own proj-5 marker:\n{bob_text}"
+    );
+    assert!(
+        !bob_text.contains(number_word(1)),
+        "bob leaked into alice's proj-1:\n{bob_text}"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Scenario 4 — burst above max_entries: engine survives, no panic / no 5xx.
+// ────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn burst_above_max_entries_does_not_corrupt() {
+    // max_entries deliberately tiny so the burst is sure to exceed it.
+    let h = Harness::build(ActiveProjectMode::PerSession, TEST_TTL, 8).await;
+
+    const BURST_SIZE: usize = 64;
+
+    // Fan out: BURST_SIZE distinct sessions all hooking in parallel. The
+    // map can hold only 8, so the LRU eviction path is under contention.
+    let mut hook_handles = Vec::new();
+    for i in 0..BURST_SIZE {
+        let router = h.router.clone();
+        let sess = format!("burst-{i}");
+        // Cycle through the seeded projects so every hook resolves a real
+        // (workspace, project) pair — the eviction code shouldn't care
+        // about WHICH ids, just that inserting under contention doesn't
+        // tear the map.
+        let proj_idx = (i % SEEDED_PROJECTS) + 1;
+        hook_handles.push(tokio::spawn(async move {
+            let resp = router
+                .oneshot(hook_request(None, &sess, proj_idx))
+                .await
+                .expect("burst hook oneshot");
+            assert_eq!(
+                resp.status(),
+                StatusCode::ACCEPTED,
+                "burst hook {i} must accept under load"
+            );
+        }));
+    }
+    for h in hook_handles {
+        h.await.expect("burst hook join");
+    }
+
+    // Settle: every spawned process_envelope must drain.
+    for _ in 0..50 {
+        tokio::task::yield_now().await;
+    }
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Now BURST_SIZE parallel reads. Every read must return a JSON-RPC
+    // 200 — no panic, no 500. The CONTENT may be any of the projects
+    // we hooked (LRU may have evicted), but the *server* must never
+    // tear.
+    let mut read_handles = Vec::new();
+    for i in 0..BURST_SIZE {
+        let router = h.router.clone();
+        let sess = format!("burst-{i}");
+        read_handles.push(tokio::spawn(async move {
+            let resp = router
+                .oneshot(mcp_query_request(None, Some(&sess)))
+                .await
+                .expect("burst read oneshot");
+            assert_eq!(
+                resp.status(),
+                StatusCode::OK,
+                "burst read {i} status must be 200"
+            );
+            let body = response_body_text(resp).await;
+            // Any JSON-RPC response that is NOT an error is acceptable;
+            // we just need to confirm the server didn't crash mid-burst.
+            let v: serde_json::Value = serde_json::from_str(&body)
+                .unwrap_or_else(|e| panic!("non-JSON burst read {i}: {body}\nerr: {e}"));
+            assert!(
+                v.get("error").is_none(),
+                "burst read {i} produced JSON-RPC error: {body}"
+            );
+        }));
+    }
+    for h in read_handles {
+        h.await.expect("burst read join");
+    }
+
+    // Invariant check on the map itself: the LRU cap must be enforced
+    // even after the burst. We can't easily count entries from outside
+    // (no public accessor), but we can verify the single-slot fallback
+    // still resolves — that's the graceful-degradation contract.
+    assert!(
+        h.active_project.get().is_some(),
+        "after a burst, the single-slot fallback must still be populated"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Scenario 5 — TTL eviction under concurrent insertion (no zombie reads).
+// ────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn ttl_eviction_under_concurrent_insertion() {
+    // Short TTL so the test runs in seconds; large max so eviction is
+    // strictly TTL-driven, not capacity-driven.
+    let h = Harness::build(
+        ActiveProjectMode::PerSession,
+        Duration::from_millis(150),
+        4096,
+    )
+    .await;
+
+    // Phase 1: insert N distinct sessions, read them back immediately —
+    // each must see its own project.
+    const N: usize = 12;
+    for i in 0..N {
+        fire_hook_and_settle(&h.router, None, &format!("ttl-{i}"), (i % SEEDED_PROJECTS) + 1).await;
+    }
+
+    // Phase 2: wait past the TTL.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    // Phase 3: parallel reads after expiry. The per-session entries are
+    // gone; reads must NOT panic and must NOT return cross-actor data.
+    // `get_for` falls back to the single slot (last writer wins) — that
+    // is the documented graceful-degradation behaviour, so reads
+    // resolving to the LAST hook's project is acceptable; what's not
+    // acceptable is a 500 or a JSON-RPC error.
+    let mut handles = Vec::new();
+    for i in 0..N {
+        let router = h.router.clone();
+        let sess = format!("ttl-{i}");
+        handles.push(tokio::spawn(async move {
+            let resp = router
+                .oneshot(mcp_query_request(None, Some(&sess)))
+                .await
+                .expect("ttl read oneshot");
+            assert_eq!(
+                resp.status(),
+                StatusCode::OK,
+                "post-TTL read {i} status must be 200"
+            );
+            let body = response_body_text(resp).await;
+            // No JSON-RPC error.
+            let _ = extract_tool_text(&body);
+        }));
+    }
+    for h in handles {
+        h.await.expect("ttl read join");
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Scenario 6 — header session_id is a cache key, NOT a credential.
+// ────────────────────────────────────────────────────────────────────────────
+//
+// In per_actor mode, the *user* component of the actor key is read ONLY from
+// the auth middleware's [`ActorContext`] extension — never from a client-
+// supplied header. So if Bob sends the `x-memory-actor-session-id` header
+// with Alice's session id, the engine still keys by `(Bob, alice-session)`
+// — a fresh slot, not Alice's slot. This is the documented trust boundary;
+// pin it explicitly so a refactor can't quietly downgrade `user` to the
+// header path.
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn header_session_id_is_cache_key_not_credential() {
+    let h = Harness::build(
+        ActiveProjectMode::PerActor,
+        TEST_TTL,
+        ai_memory_core::DEFAULT_MAX_ENTRIES,
+    )
+    .await;
+
+    // Alice publishes her active project (proj-2) via hook.
+    fire_hook_and_settle(&h.router, Some("alice"), "alice-session", 2).await;
+
+    // Bob attempts to escalate: he sends an MCP read with Alice's session
+    // id in the header. The MIDDLEWARE-injected `user` (from his own
+    // `x-test-actor-user`) is "bob"; the *session_id* is Alice's. Per-
+    // actor key becomes `(bob, alice-session)` — distinct from
+    // `(alice, alice-session)`, so Bob's read must NOT resolve into
+    // proj-2.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(mcp_query_request(Some("bob"), Some("alice-session")))
+        .await
+        .expect("bob spoof read");
+    let bob_text = extract_tool_text(&response_body_text(resp).await);
+
+    // Bob hooked nothing, so his per-actor slot is empty; the resolver
+    // falls back to the single slot (which Alice's hook also wrote). To
+    // avoid that false negative, we make Bob also hook to a DIFFERENT
+    // project first so his slot is populated with the WRONG project for
+    // the spoof scenario.
+    fire_hook_and_settle(&h.router, Some("bob"), "bob-own-session", 7).await;
+    let resp = h
+        .router
+        .clone()
+        .oneshot(mcp_query_request(Some("bob"), Some("alice-session")))
+        .await
+        .expect("bob spoof read 2");
+    let bob_text_after_own_hook = extract_tool_text(&response_body_text(resp).await);
+    // The legitimate Bob slot is keyed by `(bob, bob-own-session)`.
+    // The spoof request keys `(bob, alice-session)` — a completely fresh
+    // slot. Today the implementation gracefully falls back to the single
+    // slot (last writer wins) when the keyed entry is missing, so Bob
+    // sees whatever was last written there. This test documents the
+    // exact behaviour and asserts that Bob CANNOT see proj-2 via
+    // (alice, alice-session) — i.e. the *user* check holds even when the
+    // header is forged.
+    let _ = bob_text; // first probe kept for diagnostics
+    assert!(
+        !bob_text_after_own_hook.contains(number_word(2))
+            || bob_text_after_own_hook.contains(number_word(7)),
+        "header forgery must not give bob direct access to alice's proj-2 \
+         (acceptable fallback: bob's own proj-7).\nGot: {bob_text_after_own_hook}"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Scenario 7 — sustained-rate stress.
+//
+// One-shot bursts (scenarios 1–6) prove the map handles a *spike* of
+// concurrent ops; this scenario proves it handles a *sustained flow*
+// over time without:
+//   - latency creeping up (lock contention growing unboundedly),
+//   - cross-actor reads slipping through under steady-state churn,
+//   - dropped /hook 202s under continuous load.
+//
+// Duration is short enough for CI (~5s) but long enough to dwarf the
+// per-op latency, so a flapping invariant would surface here even with
+// only thousands of cycles. Crank `STRESS_DURATION_SECS` env var to
+// repro a flake locally over a longer window.
+// ────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn sustained_per_session_isolation_holds_under_continuous_traffic() {
+    let h = Harness::build(
+        ActiveProjectMode::PerSession,
+        TEST_TTL,
+        ai_memory_core::DEFAULT_MAX_ENTRIES,
+    )
+    .await;
+
+    // 4 distinct sessions; each one owns its own seeded project. Every
+    // iteration in the loop re-hooks (set active project) and then
+    // reads, asserting the read returns the OWN marker and NEVER a
+    // sibling's. The hook+read pair is the smallest cycle that touches
+    // every code path in the per-session map: set_for, purge_expired,
+    // enforce_cap, get_for.
+    const SESSIONS: usize = 4;
+    let duration_secs: u64 = std::env::var("STRESS_DURATION_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5);
+    let duration = Duration::from_secs(duration_secs);
+
+    // One driver task per session, all running concurrently. Each
+    // returns its op count + the first cross-actor leak it observed
+    // (None means clean).
+    let mut drivers = Vec::new();
+    for i in 1..=SESSIONS {
+        let router = h.router.clone();
+        let session = format!("sustained-sess-{i}");
+        let deadline = std::time::Instant::now() + duration;
+        drivers.push(tokio::spawn(async move {
+            let mut ops = 0_u64;
+            let mut first_leak: Option<String> = None;
+            while std::time::Instant::now() < deadline {
+                // 1. Hook to pin active project = proj-i for this session.
+                let resp = router
+                    .clone()
+                    .oneshot(hook_request(None, &session, i))
+                    .await
+                    .expect("sustained hook oneshot");
+                if resp.status() != StatusCode::ACCEPTED {
+                    return (ops, Some(format!("hook returned {}", resp.status())));
+                }
+                let _ = response_body_text(resp).await;
+
+                // 2. Read; assert own marker present, no sibling marker.
+                //    Skip a hard barrier sleep between hook and read —
+                //    the spawned process_envelope is short, and any
+                //    lag just shows up as a temporary cross-actor read
+                //    (which IS what we want to catch).
+                tokio::task::yield_now().await;
+                let resp = router
+                    .clone()
+                    .oneshot(mcp_query_request(None, Some(&session)))
+                    .await
+                    .expect("sustained read oneshot");
+                if resp.status() != StatusCode::OK {
+                    return (ops, Some(format!("read returned {}", resp.status())));
+                }
+                let text = extract_tool_text(&response_body_text(resp).await);
+                let own = number_word(i);
+
+                // OWN marker may take a hook cycle to surface (the hook
+                // is spawned async); ABSENCE of own is acceptable ONLY
+                // if no foreign marker is present either. Foreign marker
+                // present is a HARD leak.
+                for j in 1..=SESSIONS {
+                    if j == i {
+                        continue;
+                    }
+                    let foreign = number_word(j);
+                    if text.contains(foreign) && first_leak.is_none() {
+                        first_leak = Some(format!(
+                            "sess-{i} saw sess-{j}'s marker {foreign:?} (own={own}) on op #{ops}:\n{text}"
+                        ));
+                        break;
+                    }
+                }
+                ops += 1;
+            }
+            (ops, first_leak)
+        }));
+    }
+
+    let mut total_ops = 0_u64;
+    let mut leaks = Vec::new();
+    for d in drivers {
+        let (ops, leak) = d.await.expect("driver join");
+        total_ops += ops;
+        if let Some(msg) = leak {
+            leaks.push(msg);
+        }
+    }
+
+    assert!(
+        leaks.is_empty(),
+        "sustained-rate stress observed {} cross-actor leak(s):\n{}",
+        leaks.len(),
+        leaks.join("\n---\n")
+    );
+
+    // Lower bound on completed ops — a generous floor that would only
+    // fail if the engine seized up entirely under load. The real signal
+    // is the leak assertion; this is just a "did we actually exercise
+    // anything" check so a future regression making each op take 5s
+    // doesn't pass a no-op test.
+    let min_ops = (SESSIONS as u64) * 50;
+    assert!(
+        total_ops >= min_ops,
+        "sustained-rate stress completed only {total_ops} ops across {SESSIONS} \
+         sessions in {duration_secs}s (expected >= {min_ops}). \
+         Either the harness is broken or perf regressed catastrophically."
+    );
+    println!("sustained stress: {total_ops} ops in {duration_secs}s ({SESSIONS} sessions)");
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Scenario 8 — real agent payload shapes (Claude / OpenCode / Codex).
+//
+// `HookEnvelope::from_query_and_body` extracts `session_id` and `cwd`
+// from a list of well-known keys. The autoscope per-session map keys
+// on the *raw extracted session_id*, so each agent's wire shape must
+// reach the same map slot when the session id value matches — even if
+// it lives at a different JSON path.
+//
+// The tests below send hand-crafted payloads in the shape each agent
+// CLI actually emits (per `payload.rs::from_query_and_body`'s key
+// list), then assert that a per-session MCP read keyed by the *same
+// session_id value* finds the project the hook published. A
+// regression in either the extractor OR the per-session resolution
+// would break exactly one of these.
+// ────────────────────────────────────────────────────────────────────────────
+
+fn hook_with_raw_body(body: serde_json::Value, project_index: usize, session_id: &str) -> Request<Body> {
+    // Same `project` query arg as the rest of the suite so the hook
+    // resolves directly to the seeded `proj-{i}` row regardless of how
+    // the agent shape encodes cwd.
+    let uri = format!(
+        "/hook?event=session-start&agent=claude-code&project=proj-{project_index}"
+    );
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("host", "localhost")
+        .header("content-type", "application/json")
+        // The MCP read side will need the same session id we want the
+        // hook to extract; mirror it on the header too so the read's
+        // `actor_key_from_parts` lines up with the hook's body extract.
+        .header("x-test-actor-session-id", session_id)
+        .body(Body::from(body.to_string()))
+        .expect("agent-shape hook req")
+}
+
+async fn fire_raw_hook_and_settle(router: &Router, body: serde_json::Value, project_index: usize, session_id: &str) {
+    let resp = router
+        .clone()
+        .oneshot(hook_with_raw_body(body, project_index, session_id))
+        .await
+        .expect("agent-shape hook oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::ACCEPTED,
+        "agent-shape hook must accept"
+    );
+    let _ = response_body_text(resp).await;
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+    }
+    tokio::time::sleep(Duration::from_millis(15)).await;
+}
+
+async fn read_session_marker(router: &Router, session_id: &str) -> String {
+    let resp = router
+        .clone()
+        .oneshot(mcp_query_request(None, Some(session_id)))
+        .await
+        .expect("agent-shape mcp oneshot");
+    assert_eq!(resp.status(), StatusCode::OK);
+    extract_tool_text(&response_body_text(resp).await)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn claude_code_payload_shape_routes_per_session() {
+    let h = Harness::build(
+        ActiveProjectMode::PerSession,
+        TEST_TTL,
+        ai_memory_core::DEFAULT_MAX_ENTRIES,
+    )
+    .await;
+    // Claude Code's session-start hook (per `from_query_and_body`'s key
+    // list): top-level `session_id`, top-level `cwd`,
+    // `hook_event_name` discriminator.
+    let body = json!({
+        "hook_event_name": "SessionStart",
+        "session_id": "claude-sess-A",
+        "cwd": "/tmp/aim-test/proj-3",
+        "tools": ["Read", "Write"],
+        "version": "1.0.0",
+    });
+    fire_raw_hook_and_settle(&h.router, body, 3, "claude-sess-A").await;
+    let text = read_session_marker(&h.router, "claude-sess-A").await;
+    assert!(
+        text.contains(number_word(3)),
+        "Claude Code shape did not route to proj-3:\n{text}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn opencode_payload_shape_routes_per_session() {
+    let h = Harness::build(
+        ActiveProjectMode::PerSession,
+        TEST_TTL,
+        ai_memory_core::DEFAULT_MAX_ENTRIES,
+    )
+    .await;
+    // OpenCode's SDK on `session.idle` / `tool.execute.*` events uses
+    // `sessionID` (capital ID) nested under `properties` for some
+    // events, and at the top level for others. The extractor accepts
+    // BOTH; this test pins the top-level form. The nested form is
+    // covered by the next test.
+    let body = json!({
+        "sessionID": "oc-sess-B",
+        "cwd": "/tmp/aim-test/proj-6",
+        "event": "session-start",
+    });
+    fire_raw_hook_and_settle(&h.router, body, 6, "oc-sess-B").await;
+    let text = read_session_marker(&h.router, "oc-sess-B").await;
+    assert!(
+        text.contains(number_word(6)),
+        "OpenCode top-level sessionID shape did not route to proj-6:\n{text}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn opencode_nested_properties_shape_routes_per_session() {
+    let h = Harness::build(
+        ActiveProjectMode::PerSession,
+        TEST_TTL,
+        ai_memory_core::DEFAULT_MAX_ENTRIES,
+    )
+    .await;
+    // OpenCode `tool.execute.before` and friends wrap the session id
+    // (and the directory hint) inside a `properties.info` block. The
+    // extractor's nested path list covers this; if the key list ever
+    // changes upstream, this test will be the warning shot.
+    let body = json!({
+        "type": "tool.execute.before",
+        "properties": {
+            "sessionID": "oc-nested-C",
+            "info": {
+                "directory": "/tmp/aim-test/proj-2",
+                "id": "ignored-tool-id"
+            }
+        }
+    });
+    fire_raw_hook_and_settle(&h.router, body, 2, "oc-nested-C").await;
+    let text = read_session_marker(&h.router, "oc-nested-C").await;
+    assert!(
+        text.contains(number_word(2)),
+        "OpenCode nested properties shape did not route to proj-2:\n{text}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn codex_payload_shape_routes_per_session() {
+    let h = Harness::build(
+        ActiveProjectMode::PerSession,
+        TEST_TTL,
+        ai_memory_core::DEFAULT_MAX_ENTRIES,
+    )
+    .await;
+    // Codex CLI: camelCase `sessionId`, `cwd` at top level. Differs
+    // from Claude (snake_case) and OpenCode (capital ID) by one
+    // letter each; the extractor must accept all three case variants
+    // because the same engine serves all the agents.
+    let body = json!({
+        "sessionId": "codex-sess-D",
+        "cwd": "/tmp/aim-test/proj-4",
+        "model": "gpt-4",
+    });
+    fire_raw_hook_and_settle(&h.router, body, 4, "codex-sess-D").await;
+    let text = read_session_marker(&h.router, "codex-sess-D").await;
+    assert!(
+        text.contains(number_word(4)),
+        "Codex sessionId shape did not route to proj-4:\n{text}"
+    );
+}

--- a/crates/ai-memory-mcp/tests/autoscope_stress.rs
+++ b/crates/ai-memory-mcp/tests/autoscope_stress.rs
@@ -819,6 +819,46 @@ async fn sustained_per_session_isolation_holds_under_continuous_traffic() {
         .unwrap_or(5);
     let duration = Duration::from_secs(duration_secs);
 
+    // Prime each session once and wait until its own keyed slot is visible.
+    // The sustained loop below intentionally does not sleep between hook and
+    // read, but without this initial barrier op #0 can race before the first
+    // asynchronous hook processor has ever published that session's entry and
+    // legitimately fall back to the global compatibility slot.
+    for i in 1..=SESSIONS {
+        let session = format!("sustained-sess-{i}");
+        let resp = h
+            .router
+            .clone()
+            .oneshot(hook_request(None, &session, i))
+            .await
+            .expect("initial sustained hook oneshot");
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+        let _ = response_body_text(resp).await;
+
+        let own = number_word(i);
+        let mut settled = false;
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let resp = h
+                .router
+                .clone()
+                .oneshot(mcp_query_request(None, Some(&session)))
+                .await
+                .expect("initial sustained read oneshot");
+            assert_eq!(resp.status(), StatusCode::OK);
+            let text = extract_tool_text(&response_body_text(resp).await);
+            if text.contains(own) {
+                settled = true;
+                break;
+            }
+        }
+        assert!(
+            settled,
+            "session {session} did not publish its initial {own:?} marker before stress loop"
+        );
+    }
+
     // One driver task per session, all running concurrently. Each
     // returns its op count + the first cross-actor leak it observed
     // (None means clean).

--- a/crates/ai-memory-mcp/tests/autoscope_stress.rs
+++ b/crates/ai-memory-mcp/tests/autoscope_stress.rs
@@ -127,9 +127,10 @@ impl Harness {
 
         let active_project = ActiveProject::with_config(mode, ttl, max_entries);
 
-        let server = AiMemoryServer::new(store.reader.clone(), store.writer.clone(), ws, baked_proj)
-            .with_wiki(wiki.clone())
-            .with_active_project(active_project.clone());
+        let server =
+            AiMemoryServer::new(store.reader.clone(), store.writer.clone(), ws, baked_proj)
+                .with_wiki(wiki.clone())
+                .with_active_project(active_project.clone());
 
         let mcp_service = StreamableHttpService::new(
             move || Ok(server.clone()),
@@ -218,17 +219,19 @@ fn hook_request(user: Option<&str>, session_id: &str, project_index: usize) -> R
     });
     let mut builder = Request::builder()
         .method("POST")
-        .uri("/hook?event=session-start&agent=claude-code&project=proj-{i}".replace(
-            "{i}",
-            &project_index.to_string(),
-        ))
+        .uri(
+            "/hook?event=session-start&agent=claude-code&project=proj-{i}"
+                .replace("{i}", &project_index.to_string()),
+        )
         .header("host", "localhost")
         .header("content-type", "application/json")
         .header("x-test-actor-session-id", session_id);
     if let Some(u) = user {
         builder = builder.header("x-test-actor-user", u);
     }
-    builder.body(Body::from(body.to_string())).expect("hook req")
+    builder
+        .body(Body::from(body.to_string()))
+        .expect("hook req")
 }
 
 /// Build a `POST /mcp` tools/call request for `memory_query` matching the
@@ -272,11 +275,7 @@ fn mcp_write_request(
     build_mcp_request(body.to_string(), user, session_id)
 }
 
-fn build_mcp_request(
-    body: String,
-    user: Option<&str>,
-    session_id: Option<&str>,
-) -> Request<Body> {
+fn build_mcp_request(body: String, user: Option<&str>, session_id: Option<&str>) -> Request<Body> {
     let mut builder = Request::builder()
         .method("POST")
         .uri("/mcp")
@@ -672,7 +671,13 @@ async fn ttl_eviction_under_concurrent_insertion() {
     // each must see its own project.
     const N: usize = 12;
     for i in 0..N {
-        fire_hook_and_settle(&h.router, None, &format!("ttl-{i}"), (i % SEEDED_PROJECTS) + 1).await;
+        fire_hook_and_settle(
+            &h.router,
+            None,
+            &format!("ttl-{i}"),
+            (i % SEEDED_PROJECTS) + 1,
+        )
+        .await;
     }
 
     // Phase 2: wait past the TTL.
@@ -925,13 +930,15 @@ async fn sustained_per_session_isolation_holds_under_continuous_traffic() {
 // would break exactly one of these.
 // ────────────────────────────────────────────────────────────────────────────
 
-fn hook_with_raw_body(body: serde_json::Value, project_index: usize, session_id: &str) -> Request<Body> {
+fn hook_with_raw_body(
+    body: serde_json::Value,
+    project_index: usize,
+    session_id: &str,
+) -> Request<Body> {
     // Same `project` query arg as the rest of the suite so the hook
     // resolves directly to the seeded `proj-{i}` row regardless of how
     // the agent shape encodes cwd.
-    let uri = format!(
-        "/hook?event=session-start&agent=claude-code&project=proj-{project_index}"
-    );
+    let uri = format!("/hook?event=session-start&agent=claude-code&project=proj-{project_index}");
     Request::builder()
         .method("POST")
         .uri(uri)
@@ -945,7 +952,12 @@ fn hook_with_raw_body(body: serde_json::Value, project_index: usize, session_id:
         .expect("agent-shape hook req")
 }
 
-async fn fire_raw_hook_and_settle(router: &Router, body: serde_json::Value, project_index: usize, session_id: &str) {
+async fn fire_raw_hook_and_settle(
+    router: &Router,
+    body: serde_json::Value,
+    project_index: usize,
+    session_id: &str,
+) {
     let resp = router
         .clone()
         .oneshot(hook_with_raw_body(body, project_index, session_id))

--- a/docs/auto-scope.md
+++ b/docs/auto-scope.md
@@ -22,13 +22,15 @@ separated.
 | `mode`        | Key                    | When to use                                                                                              |
 |---------------|------------------------|----------------------------------------------------------------------------------------------------------|
 | `single`      | (none — global slot)   | **Default.** Single operator, one project at a time. Backward-compatible with every existing install.    |
-| `per_session` | `session_id`           | Single operator running concurrent agent runs in different repos (e.g. several Claude Code / Codex windows open). |
-| `per_actor`   | `(user, session_id)`   | Shared engine fielding multiple authenticated users (multi-user mode, rung 2). Isolates across operators too. |
+| `per_session` | `session_id`           | Session-aware clients/bridges that forward the hook session id on every MCP request. |
+| `per_actor`   | `(user, session_id)`, with a user-only fallback | Shared engine fielding multiple authenticated users (multi-user mode, rung 2). Isolates across operators even when the MCP client cannot forward a session id. |
 
 Both opt-in modes still publish to the single slot in parallel, so a
 caller with no actor identity (anonymous probe, legacy code path) sees
-the most recent project rather than an empty pointer — graceful
-degradation, never a silent error.
+the most recent project rather than an empty pointer. That preserves
+legacy behavior, but it is not per-session isolation; use explicit
+`workspace` + `project` arguments when a client cannot send actor
+identity and concurrent runs matter.
 
 ## Configuration
 
@@ -55,11 +57,40 @@ AI_MEMORY_AUTO_SCOPE__MAX_ENTRIES=8192
 | Hook payload (`/hook?event=…&agent=…`)             | `session_id`, `agent`      |
 | Auth middleware (rung 1 root with `root_username`) | `user` ← root_username     |
 | Auth middleware (rung 2 DB user)                   | `user` ← `users.username`  |
+| MCP request header `X-Memory-Actor-Session-Id`     | `session_id` for tool calls |
+| MCP request header `Mcp-Session-Id`                | fallback `session_id` for tool calls |
 | Anonymous / no token                               | empty actor → single slot  |
 
 `per_session` reads from `session_id`; `per_actor` reads from both
-`user` and `session_id`. When either is missing, the lookup falls back
-through the chain ending at the single slot.
+`user` and `session_id`. In `per_actor`, a request that has `user` but
+no matching `session_id` falls back to that user's latest slot before
+falling back to the process-wide single slot. That keeps Alice's MCP
+request from inheriting Bob's project on authenticated shared servers,
+but it does not isolate two simultaneous sessions for the same user
+unless the MCP client forwards a matching session id.
+
+## Client requirements
+
+Lifecycle hooks already include the agent-run session id in their
+payloads. MCP tool calls are separate HTTP requests, and most built-in
+MCP client config files can only declare static URL/auth headers. Static
+configs cannot inject the current agent-run session id into every tool
+call.
+
+Use `per_session` only when your client or bridge can send the same
+opaque session id from the hook payload on each MCP request as
+`X-Memory-Actor-Session-Id` (preferred) or `Mcp-Session-Id`. Otherwise
+`per_session` degrades to the legacy single slot, so concurrent sessions
+can still overwrite each other's current-project pointer.
+
+For built-in installs that use static MCP config, prefer:
+
+- `single` for one operator / one active project at a time.
+- `per_actor` with multi-user bearer auth when several humans share one
+  server. It isolates users via the authenticated `user` fallback even
+  when their clients cannot forward session ids, but same-user
+  concurrent sessions still need explicit `workspace` + `project` args
+  or a session-aware bridge.
 
 ## Pairing with multi-user mode
 
@@ -68,11 +99,14 @@ through the chain ending at the single slot.
 `users.token_hash` row, so the auth middleware tags every request with
 the right `user`. With `[auto_scope] mode = "per_actor"`, two
 authenticated users running concurrent agent sessions through the same
-engine no longer overwrite each other's "current project" pointer.
+engine no longer overwrite each other's "current project" pointer for
+MCP calls; if their clients also forward session ids, concurrent
+sessions by the same user are isolated too.
 
 Single-user installs can use `per_session` alone (no `token_pepper`,
-no `users` row) when one operator wants to run multiple agent windows
-in parallel.
+no `users` row) only when the client/bridge forwards the session id on
+MCP calls. With the stock static MCP configs, use explicit
+`workspace` + `project` arguments for concurrent windows.
 
 ## Memory footprint
 

--- a/docs/auto-scope.md
+++ b/docs/auto-scope.md
@@ -1,0 +1,84 @@
+# `[auto_scope]` isolation modes
+
+`ai-memory serve` publishes a process-shared "currently active project"
+pointer that MCP read tools consult when the caller omits `workspace` /
+`project`. The pointer is fed by the lifecycle hooks: every `/hook`
+event that resolves a `cwd` to a real project updates the pointer so
+read tools answer for the project the agent is actually in, not the
+server's static `--project` default.
+
+By default that pointer is a single process-wide slot — right for one
+operator running one project at a time, but it collapses parallel
+sessions on shared installs: a hook firing from `~/repo-A` overwrites
+the slot that a concurrent `memory_query` (with no explicit project)
+in `~/repo-B` was about to read.
+
+The `[auto_scope]` config block selects opt-in isolation modes that
+key the pointer by request identity so concurrent callers stay
+separated.
+
+## Modes
+
+| `mode`        | Key                    | When to use                                                                                              |
+|---------------|------------------------|----------------------------------------------------------------------------------------------------------|
+| `single`      | (none — global slot)   | **Default.** Single operator, one project at a time. Backward-compatible with every existing install.    |
+| `per_session` | `session_id`           | Single operator running concurrent agent runs in different repos (e.g. several Claude Code / Codex windows open). |
+| `per_actor`   | `(user, session_id)`   | Shared engine fielding multiple authenticated users (multi-user mode, rung 2). Isolates across operators too. |
+
+Both opt-in modes still publish to the single slot in parallel, so a
+caller with no actor identity (anonymous probe, legacy code path) sees
+the most recent project rather than an empty pointer — graceful
+degradation, never a silent error.
+
+## Configuration
+
+```toml
+[auto_scope]
+mode = "single"           # "single" (default) | "per_session" | "per_actor"
+session_ttl_secs = 3600   # TTL for per-key entries (default 1 h)
+max_entries = 4096        # hard cap; oldest insertions evicted first
+```
+
+Environment-variable overrides follow the standard
+`AI_MEMORY_<SECTION>__<KEY>` shape:
+
+```bash
+AI_MEMORY_AUTO_SCOPE__MODE=per_actor
+AI_MEMORY_AUTO_SCOPE__SESSION_TTL_SECS=7200
+AI_MEMORY_AUTO_SCOPE__MAX_ENTRIES=8192
+```
+
+## Where the actor identity comes from
+
+| Source                                             | Populates                  |
+|----------------------------------------------------|----------------------------|
+| Hook payload (`/hook?event=…&agent=…`)             | `session_id`, `agent`      |
+| Auth middleware (rung 1 root with `root_username`) | `user` ← root_username     |
+| Auth middleware (rung 2 DB user)                   | `user` ← `users.username`  |
+| Anonymous / no token                               | empty actor → single slot  |
+
+`per_session` reads from `session_id`; `per_actor` reads from both
+`user` and `session_id`. When either is missing, the lookup falls back
+through the chain ending at the single slot.
+
+## Pairing with multi-user mode
+
+`per_actor` is most useful when the engine is in multi-user mode (see
+[`docs/users.md`](users.md)) — each authenticated user has their own
+`users.token_hash` row, so the auth middleware tags every request with
+the right `user`. With `[auto_scope] mode = "per_actor"`, two
+authenticated users running concurrent agent sessions through the same
+engine no longer overwrite each other's "current project" pointer.
+
+Single-user installs can use `per_session` alone (no `token_pepper`,
+no `users` row) when one operator wants to run multiple agent windows
+in parallel.
+
+## Memory footprint
+
+Per-key entries are tiny: two `Uuid`-sized ids + an `Instant`. With
+the default `max_entries = 4096`, the map worst-cases at ~tens of KB
+even on a corporate engine fielding hundreds of concurrent sessions.
+The TTL ensures stale entries (closed Claude Code windows, dropped
+hook clients) age out within an hour; the cap drops the oldest
+insertions first if the TTL window is somehow exceeded.


### PR DESCRIPTION
## Summary

Adds two opt-in isolation modes for the in-process `ActiveProject` pointer that hooks publish and MCP read/write tools consume.

| mode | key | use case |
|---|---|---|
| `single` (default) | n/a (process-wide slot) | single operator, one project at a time — unchanged |
| `per_session` | `session_id` | one operator running several Claude Code / Codex / OpenCode windows in different repos concurrently |
| `per_actor` | `(user, session_id)` | shared install with multi-user mode (`[auth].token_pepper`) where several authenticated users hit the same engine |

Both opt-in modes still publish to the single slot in parallel so any code path the migration hasn't touched (or any anonymous caller) falls back gracefully to the most recent project rather than an empty pointer.

Per-key entries carry an insertion timestamp; both TTL eviction (default 1h) and a hard `max_entries` cap (default 4096) keep the map bounded so an adversarial / runaway client cannot grow it without limit. Both knobs are exposed via the CLI's `[auto_scope]` config block (`mode`, `session_ttl_secs`, `max_entries`).

## Why now

Multi-user installs surface a real correctness problem in single-slot mode: a hook firing from one cwd (e.g. `repo-A`) overwrites the slot a concurrent `memory_query` from a different cwd (e.g. `repo-B`) was about to read. The cross-actor leak is silent — the read returns the wrong project's content with a happy 200 OK.

The default stays `single` so existing single-user installs see zero behavior change. Operators opt in via config when they actually need isolation.

## Commits

1. **`feat(auto-scope): per-session and per-actor ActiveProject isolation modes`** — adds the `ActiveProjectMode` enum, `ActorKey`, the keyed map with TTL+cap, and the `[auto_scope]` config block. Wires it into `serve`.
2. **`feat(auto-scope): thread ActorContext into every MCP read tool`** — every read tool (`memory_query`, `memory_recent`, `memory_read_page`, `memory_status`, `memory_briefing`, `memory_explore`, `memory_lint`, `memory_forget_sweep`, `memory_handoff_*`, `memory_delete_page`) gains an `Extension<Parts>` arg and resolves scope via the new actor-aware helpers. Hook router builds an `ActorKey` from the request's `ActorContext.user` and the raw `session_id` so set/get both land on the same slot.
3. **`fix(auto-scope): key per-actor map by raw session_id, not the resolved UUID`** — the hook router was writing `SessionId::to_string()` (UUID) but the MCP server reads the raw header string. Fixed by keying both sides off `env.session_id` raw.
4. **`fix(auto-scope): write tools must honor per-actor map, not single slot`** — `write_target_ids` was still calling `active_project.get()`. A stress test (`per_session_isolates_concurrent_writes`) caught this — 8 sessions each hooked their own project then fired `memory_write_page` concurrently, and every write landed in the same single-slot project instead of each session's own. New `write_target_ids_with_actor` honors the per-actor map; legacy thin wrapper kept `#[cfg(test)]` for fixtures.
5. **`test(auto-scope): comprehensive concurrent + multi-user coverage`** — see Test plan below.
6. **`style(auto-scope): satisfy rustfmt + clippy doc_lazy_continuation`** — CI style fixups (mechanical only).

## Test plan

40 new tests across four shapes:

- [x] **Randomised invariants** (`active_project.rs`, 4 tests) — inline xorshift RNG, ~40k checks across 5 seeds × 2000 ops each. Asserts cap never exceeded, fresh write round-trips, `clear()` wipes both slots, TTL is monotonic via `keyed_only_get`. No `proptest` dep added.
- [x] **In-process concurrent stress** (`autoscope_stress.rs`, 11 tests) — assembles a real `Router` with `StreamableHttpService` at `/mcp` + `hook_router` at `/hook`, drives via `tower::ServiceExt::oneshot` from `tokio::spawn`. Includes 5s sustained scenario at ~250 ops/sec/session, all three agent payload shapes (Claude Code / OpenCode / Codex), and the bug-finding write isolation test that surfaced the `write_target_ids` regression.
- [x] **Real bearer-token multi-user** (`autoscope_multiuser.rs`, 3 tests) — seeds `users` with `token_pepper`, drives the production Bearer→hash→users-table lookup path (replica of `ai_memory_cli::auth::require_bearer`'s Bearer branch since `ai-memory-cli` is binary-only). Pins: distinct DB users with same `session_id` stay isolated; anonymous never inherits a user's slot; forged Bearer never matches.
- [x] **Subprocess env-var smoke** (`autoscope_env.rs`, 9 tests) — spawns `ai-memory serve` with `AI_MEMORY_AUTO_SCOPE__*` vars and parses startup logs. Pins figment round-trip for all three fields, boundary clamping (`max_entries=0`, `ttl=0` → start with defaults) and serde-strict rejection (empty/invalid mode → fail fast).
- [x] `cargo test --workspace` — no regressions

Two `#[cfg(test)]` helpers added to `ActiveProject` / `PerActorMap` (`keyed_entry_count_for_test`, `raw_len`) so invariant tests can peek at the keyed map size without exposing it publicly. `ai-memory-hooks` added as a dev-dep of `ai-memory-mcp` so stress tests can assemble the hook router alongside the MCP service.