### PR TITLE
fix(hooks): emit JSON from Claude Code hooks to stop "plain text" debug spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for the full read surface.
 
 ### Fixed
+- Claude Code lifecycle hooks now emit structured JSON on stdout. Fire-and-
+  forget hooks return `{}`, and `SessionStart` wraps pending handoff text in
+  `hookSpecificOutput.additionalContext`, avoiding Claude Code's repeated
+  "Hook output does not start with {" debug spam while preserving handoff
+  injection.
 - `POST /admin/rename-project` now returns `404 Not Found` when the project row
   has been deleted (typically by a concurrent `purge-project`) between the
   handler's id lookup and the writer's `UPDATE`. The pre-fix path silently

--- a/hooks/_lib.sh
+++ b/hooks/_lib.sh
@@ -117,14 +117,17 @@ ai_memory_get_handoff() {
     fi
 }
 
-# Encode stdin as a JSON string. Used only by Antigravity's PreInvocation
-# hook, whose stdout contract is JSON rather than raw context text.
+# Encode stdin as a JSON string (with surrounding quotes). Used by hooks
+# whose stdout contract is JSON rather than raw context text: Antigravity's
+# PreInvocation hook and Claude Code's session-start hook (which wraps the
+# handoff in hookSpecificOutput.additionalContext).
 ai_memory_json_string() {
     awk '
         BEGIN { printf "\"" }
         {
             gsub(/\\/, "\\\\")
             gsub(/"/, "\\\"")
+            gsub(/\t/, "\\t")
             gsub(/\r/, "\\r")
             printf "%s%s", sep, $0
             sep = "\\n"

--- a/hooks/claude-code/post-tool-use.sh
+++ b/hooks/claude-code/post-tool-use.sh
@@ -18,4 +18,10 @@ QS=$(ai_memory_marker_qs "$CWD")
 
 printf '%s' "$PAYLOAD" \
     | ai_memory_post_hook "$SERVER/hook?event=post-tool-use&agent=claude-code${QS}" >/dev/null 2>&1 || true
+# Acknowledge to Claude Code with an empty JSON object. This hook only
+# POSTs (fire-and-forget) and injects no context; without "{" on stdout
+# Claude Code treats the (empty) output as plain text and logs
+# "Hook output does not start with {, treating as plain text" on every
+# tool call. Emitting {} keeps the debug log clean.
+printf '{}\n'
 exit 0

--- a/hooks/claude-code/pre-compact.sh
+++ b/hooks/claude-code/pre-compact.sh
@@ -18,4 +18,10 @@ QS=$(ai_memory_marker_qs "$CWD")
 
 printf '%s' "$PAYLOAD" \
     | ai_memory_post_hook "$SERVER/hook?event=pre-compact&agent=claude-code${QS}" >/dev/null 2>&1 || true
+# Acknowledge to Claude Code with an empty JSON object. This hook only
+# POSTs (fire-and-forget) and injects no context; without "{" on stdout
+# Claude Code treats the (empty) output as plain text and logs
+# "Hook output does not start with {, treating as plain text".
+# Emitting {} keeps the debug log clean.
+printf '{}\n'
 exit 0

--- a/hooks/claude-code/pre-tool-use.sh
+++ b/hooks/claude-code/pre-tool-use.sh
@@ -18,4 +18,10 @@ QS=$(ai_memory_marker_qs "$CWD")
 
 printf '%s' "$PAYLOAD" \
     | ai_memory_post_hook "$SERVER/hook?event=pre-tool-use&agent=claude-code${QS}" >/dev/null 2>&1 || true
+# Acknowledge to Claude Code with an empty JSON object. This hook only
+# POSTs (fire-and-forget) and injects no context; without "{" on stdout
+# Claude Code treats the (empty) output as plain text and logs
+# "Hook output does not start with {, treating as plain text" on every
+# tool call. Emitting {} keeps the debug log clean.
+printf '{}\n'
 exit 0

--- a/hooks/claude-code/session-end.sh
+++ b/hooks/claude-code/session-end.sh
@@ -18,4 +18,10 @@ QS=$(ai_memory_marker_qs "$CWD")
 
 printf '%s' "$PAYLOAD" \
     | ai_memory_post_hook "$SERVER/hook?event=session-end&agent=claude-code${QS}" >/dev/null 2>&1 || true
+# Acknowledge to Claude Code with an empty JSON object. This hook only
+# POSTs (fire-and-forget) and injects no context; without "{" on stdout
+# Claude Code treats the (empty) output as plain text and logs
+# "Hook output does not start with {, treating as plain text".
+# Emitting {} keeps the debug log clean.
+printf '{}\n'
 exit 0

--- a/hooks/claude-code/session-start.sh
+++ b/hooks/claude-code/session-start.sh
@@ -24,5 +24,17 @@ QS=$(ai_memory_marker_qs "$CWD")
 printf '%s' "$PAYLOAD" \
     | ai_memory_post_hook "$SERVER/hook?event=session-start&agent=claude-code${QS}" >/dev/null 2>&1 || true
 
-ai_memory_get_handoff "$SERVER/handoff?agent=claude-code${QS}" 2>/dev/null || true
+# Claude Code prepends a SessionStart hook's stdout to the resuming
+# session as context. Emit it as structured JSON
+# (hookSpecificOutput.additionalContext) instead of raw text: bare text
+# does not start with "{", so Claude Code logs every session start as
+# "Hook output does not start with {, treating as plain text". JSON
+# injects the same handoff with a clean debug log; no handoff -> "{}".
+HANDOFF=$(ai_memory_get_handoff "$SERVER/handoff?agent=claude-code${QS}" 2>/dev/null || true)
+if [ -n "$HANDOFF" ]; then
+    printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' \
+        "$(printf '%s' "$HANDOFF" | ai_memory_json_string)"
+else
+    printf '{}\n'
+fi
 exit 0

--- a/hooks/claude-code/stop.sh
+++ b/hooks/claude-code/stop.sh
@@ -18,4 +18,10 @@ QS=$(ai_memory_marker_qs "$CWD")
 
 printf '%s' "$PAYLOAD" \
     | ai_memory_post_hook "$SERVER/hook?event=stop&agent=claude-code${QS}" >/dev/null 2>&1 || true
+# Acknowledge to Claude Code with an empty JSON object. This hook only
+# POSTs (fire-and-forget) and injects no context; without "{" on stdout
+# Claude Code treats the (empty) output as plain text and logs
+# "Hook output does not start with {, treating as plain text".
+# Emitting {} keeps the debug log clean.
+printf '{}\n'
 exit 0

--- a/hooks/claude-code/user-prompt-submit.sh
+++ b/hooks/claude-code/user-prompt-submit.sh
@@ -18,4 +18,10 @@ QS=$(ai_memory_marker_qs "$CWD")
 
 printf '%s' "$PAYLOAD" \
     | ai_memory_post_hook "$SERVER/hook?event=user-prompt&agent=claude-code${QS}" >/dev/null 2>&1 || true
+# Acknowledge to Claude Code with an empty JSON object. This hook only
+# POSTs (fire-and-forget) and injects no context; without "{" on stdout
+# Claude Code treats the (empty) output as plain text and logs
+# "Hook output does not start with {, treating as plain text" on every
+# prompt. Emitting {} keeps the debug log clean.
+printf '{}\n'
 exit 0


### PR DESCRIPTION
## What changed

Every ai-memory Claude Code hook now writes structured JSON to stdout, so Claude Code stops logging `Hook output does not start with {, treating as plain text`.

- The six fire-and-forget hooks (`pre-tool-use`, `post-tool-use`, `user-prompt-submit`, `stop`, `pre-compact`, `session-end`) now `printf '{}\n'`.
- `session-start` now wraps the handoff in `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":...}}` instead of printing it raw. No pending handoff -> `{}`.
- `ai_memory_json_string` now also escapes TAB.

**Before:** the DEBUG line is logged on (in the worst case) every tool call. **After:** clean debug log. Runtime behaviour is identical — the capture POSTs still fire and the handoff still reaches the resuming session as context.

## Why

Claude Code parses a hook's stdout as JSON only when it starts with `{`; otherwise it emits, at DEBUG level:

```
Hook output does not start with {, treating as plain text
```

ai-memory's seven CC hooks never satisfied that — six print nothing and `session-start` prints raw handoff text, and *empty* output also fails the `{` check. Because `pre-tool-use` and `post-tool-use` run on every tool call, the log fills with this line (reported by a user; reproduced in the Claude Code VSCode/Antigravity extension log as bursts of 5-7 lines per tool call).

This mirrors the `antigravity-cli` hooks, which already emit JSON on stdout (`printf '{}\n'`, `printf '{"decision": "allow"}\n'`). The `hookSpecificOutput.additionalContext` shape is the documented SessionStart context-injection form and matches what other SessionStart hooks emit.

## Test plan

This change touches only POSIX shell under `hooks/` — no Rust crate is modified, and no crate embeds (`include_str!`) or asserts these script bodies — so the Rust gates are unaffected. I did not run the full Rust suite for a shell-only change; instead I verified at the shell level (git-bash):

- [x] `sh -n` passes on all seven edited scripts and `_lib.sh`
- [x] each fire-and-forget hook prints exactly `{}` (server unreachable, POST fails silently via the existing `|| true`)
- [x] `session-start` with no pending handoff prints `{}`
- [x] `session-start` with a handoff containing `"`, `\`, newline and TAB produces valid JSON (`JSON.parse` accepts it) and `additionalContext` round-trips byte-for-byte
- [ ] `cargo fmt` / `clippy` / `test` / `deny` — not run (no Rust changed; unaffected)

## Notes for reviewers

- **`bin/regen-hooks` is stale.** It predates the `_lib.sh` / `.ai-memory.toml` marker-file refactor (it generates simple scripts with no `_lib.sh` sourcing and no marker logic), so it no longer reproduces the vendored `hooks/*/*.sh`. I edited the vendored scripts directly to match current maintained state. Worth updating or retiring `regen-hooks` in a follow-up.
- **Scope is claude-code only.** `codex` and `opencode` share the same empty-stdout pattern but have different stdout contracts I can't verify here — happy to extend if you confirm they'd benefit.
- **PowerShell hooks untouched.** Claude Code on Windows runs the `.sh` scripts via `bash -c` (`for_bash_runner()`), so the `.ps1` path isn't exercised by Claude Code.
