### PR TITLE
fix(fts): quote punctuated tokens so filename searches don't error (fts5 syntax error near ".")

### DIFF
--- a/crates/ai-memory-store/src/fts_query.rs
+++ b/crates/ai-memory-store/src/fts_query.rs
@@ -61,7 +61,18 @@ fn has_unknown_bare_column(token: &str) -> bool {
 }
 
 fn should_quote_fts5_token(token: &str) -> bool {
-    token.contains('-') && !(token.starts_with('"') && token.ends_with('"'))
+    if token.starts_with('"') && token.ends_with('"') {
+        return false;
+    }
+    // Quote any token carrying ASCII punctuation so FTS5 treats it as a literal
+    // phrase instead of erroring on its query grammar — e.g. a filename like
+    // `current.md` otherwise yields `fts5: syntax error near "."`. A trailing
+    // `*` (the FTS5 prefix operator) is allowed through bare; accented letters
+    // and digits are unicode (not ASCII punctuation) so recall keeps accents.
+    let core = token.strip_suffix('*').unwrap_or(token);
+    // `:` is column syntax (handled by `has_unknown_bare_column`, or preserved
+    // for known `title:`/`body:` columns) — it must not trigger quoting here.
+    core.chars().any(|c| c.is_ascii_punctuation() && c != ':')
 }
 
 fn quote_fts5_token(token: &str) -> String {
@@ -103,6 +114,24 @@ mod tests {
     #[test]
     fn single_word_has_no_or() {
         assert_eq!(prepare_fts5_query("handoff"), "handoff");
+    }
+
+    /// Regression: a filename like `current.md` used to pass through bare and
+    /// FTS5 errored with `syntax error near "."`. Quoting it as a phrase both
+    /// avoids the error and matches `architecture-current.md` (the tokens
+    /// `current` + `md` are adjacent in the indexed path).
+    #[test]
+    fn dotted_filename_token_is_quoted() {
+        assert_eq!(prepare_fts5_query("current.md"), "\"current.md\"");
+        assert_eq!(prepare_fts5_query("00-index.md"), "\"00-index.md\"");
+        assert_eq!(prepare_fts5_query("a/b/c.md"), "\"a/b/c.md\"");
+    }
+
+    /// The FTS5 prefix operator (`term*`) must survive — a trailing `*` is not
+    /// quoted away.
+    #[test]
+    fn prefix_star_token_stays_bare() {
+        assert_eq!(prepare_fts5_query("curr*"), "curr*");
     }
 
     #[test]

--- a/crates/ai-memory-store/src/fts_query.rs
+++ b/crates/ai-memory-store/src/fts_query.rs
@@ -76,9 +76,36 @@ fn should_quote_fts5_token(token: &str) -> bool {
 }
 
 fn quote_fts5_token(token: &str) -> String {
-    // FTS5 escapes `"` inside a quoted token by doubling it.
-    let escaped = token.replace('"', "\"\"");
-    format!("\"{escaped}\"")
+    // FTS5 escapes `"` by doubling it. A token carrying a literal quote is an
+    // explicit-phrase fragment — keep the simple escaped form (don't expand it).
+    if token.contains('"') {
+        return format!("\"{}\"", token.replace('"', "\"\""));
+    }
+    // Otherwise emit BOTH the whole token and a punctuation-stripped sub-token
+    // phrase, OR'd, because the content tokenizer and the path index disagree
+    // on punctuation:
+    //   tokenize = "unicode61 remove_diacritics 2 tokenchars '/_-'"
+    // keeps `/ _ -` INSIDE tokens (so a body mention of `ai-memory` indexes as
+    // the single token `ai-memory`), while `ops::path_search_text` pre-expands
+    // `/ . - _` to spaces in the path index (so a path `ui-refresh-…` indexes
+    // the sub-tokens `ui`, `refresh`, …). `.` is a separator either way.
+    // Neither form alone matches both: `"ai-memory"` matches the content token
+    // but not the split path index; `"ai memory"` matches the path but not the
+    // content token. OR-ing the two makes a search for `ai-memory` / `ui-refresh`
+    // hit whichever surface indexed it. (Quoting both also neutralises the
+    // punctuation that would otherwise be FTS5 query grammar — the original
+    // `current.md` → `syntax error` bug.) With no punctuation the two coincide
+    // and we emit a single phrase.
+    let split = token
+        .chars()
+        .map(|c| if c.is_ascii_punctuation() { ' ' } else { c })
+        .collect::<String>();
+    let split = split.split_whitespace().collect::<Vec<_>>().join(" ");
+    if split.is_empty() || split == token {
+        format!("\"{token}\"")
+    } else {
+        format!("(\"{token}\" OR \"{split}\")")
+    }
 }
 
 #[cfg(test)]
@@ -88,8 +115,11 @@ mod tests {
     #[test]
     fn colon_is_not_column_syntax() {
         // Bare multi-word → OR-joined (no explicit operator present).
+        // `ai-memory` expands to BOTH the whole token (matches content) and
+        // the sub-token phrase (matches the split path index) — see
+        // `quote_fts5_token`.
         let q = prepare_fts5_query("pick: handoff ai-memory");
-        assert_eq!(q, "\"pick\" OR handoff OR \"ai-memory\"");
+        assert_eq!(q, "\"pick\" OR handoff OR (\"ai-memory\" OR \"ai memory\")");
     }
 
     #[test]
@@ -122,9 +152,37 @@ mod tests {
     /// `current` + `md` are adjacent in the indexed path).
     #[test]
     fn dotted_filename_token_is_quoted() {
-        assert_eq!(prepare_fts5_query("current.md"), "\"current.md\"");
-        assert_eq!(prepare_fts5_query("00-index.md"), "\"00-index.md\"");
-        assert_eq!(prepare_fts5_query("a/b/c.md"), "\"a/b/c.md\"");
+        // Whole token OR sub-token phrase. The split form (`current md`)
+        // matches the tokenised path; the whole form covers content tokens.
+        assert_eq!(
+            prepare_fts5_query("current.md"),
+            "(\"current.md\" OR \"current md\")"
+        );
+        assert_eq!(
+            prepare_fts5_query("00-index.md"),
+            "(\"00-index.md\" OR \"00 index md\")"
+        );
+        assert_eq!(
+            prepare_fts5_query("a/b/c.md"),
+            "(\"a/b/c.md\" OR \"a b c md\")"
+        );
+    }
+
+    /// Regression for the live-found bug: searching `ui-refresh` returned
+    /// nothing even though `follow-ups/ui-refresh-scroll-restoration.md`
+    /// exists. The old quoting produced `"ui-refresh"`, which FTS5 does NOT
+    /// match against the indexed `ui refresh`; the sub-token phrase
+    /// `"ui refresh"` does. See the real-FTS5 test in `ops.rs`.
+    #[test]
+    fn hyphenated_token_quotes_as_subtoken_phrase() {
+        assert_eq!(
+            prepare_fts5_query("ui-refresh"),
+            "(\"ui-refresh\" OR \"ui refresh\")"
+        );
+        assert_eq!(
+            prepare_fts5_query("scroll-restoration"),
+            "(\"scroll-restoration\" OR \"scroll restoration\")"
+        );
     }
 
     /// The FTS5 prefix operator (`term*`) must survive — a trailing `*` is not
@@ -140,9 +198,16 @@ mod tests {
     }
 
     #[test]
-    fn quotes_are_escaped() {
-        let q = quote_fts5_token(r#"say "hello""#);
-        assert_eq!(q, r#""say ""hello""""#);
+    fn quote_emits_whole_and_subtoken_phrase() {
+        // Punctuated identifier → both forms OR'd.
+        assert_eq!(
+            quote_fts5_token("ai-memory"),
+            r#"("ai-memory" OR "ai memory")"#
+        );
+        // A literal-quote fragment keeps the simple escaped form (no expansion).
+        assert_eq!(quote_fts5_token(r#"say "hello""#), r#""say ""hello""""#);
+        // No punctuation → single phrase.
+        assert_eq!(quote_fts5_token("handoff"), r#""handoff""#);
     }
 
     #[test]

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -2272,4 +2272,64 @@ mod tests {
         rename_project(&mut conn, &ws, &proj, "renamed-live")
             .expect("rename of live project must succeed");
     }
+
+    /// Run the reader's exact FTS5 `MATCH` against the real, populated
+    /// `pages_fts` index — the path the web search / MCP query take.
+    /// Returns the matched paths (and surfaces any FTS5 syntax error as
+    /// an `Err`, the way the bug originally manifested).
+    fn fts_match_paths(conn: &Connection, raw: &str) -> rusqlite::Result<Vec<String>> {
+        let fts_query = crate::fts_query::prepare_fts5_query(raw);
+        let mut stmt = conn.prepare(
+            "SELECT pages.path \
+             FROM pages_fts \
+             JOIN pages ON pages.rowid = pages_fts.rowid \
+             WHERE pages_fts MATCH ?1 AND pages.is_latest = 1 \
+             ORDER BY pages_fts.rank",
+        )?;
+        let rows = stmt.query_map(params![fts_query], |r| r.get::<_, String>(0))?;
+        rows.collect()
+    }
+
+    /// End-to-end regression for the dotted-filename search bug (PR #81).
+    /// Searching `current.md` used to reach FTS5 **bare** and SQLite
+    /// errored with `fts5: syntax error near "."`, so the web UI showed
+    /// "No results" and the MCP surfaced the raw error. The string-level
+    /// `fts_query` unit tests only proved the *output* was quoted — they
+    /// never exercised real FTS5. This drives the actual indexed
+    /// `pages_fts` (via `upsert_page` → `path_search` triggers) to prove
+    /// the prepared query (a) does not error and (b) matches the page at
+    /// `reference/architecture-current.md`. This is the scenario that
+    /// would have caught the bug *before* it shipped.
+    #[test]
+    fn dotted_filename_search_matches_indexed_path() {
+        let (_tmp, mut conn, ws, proj) = fresh_db();
+        upsert_page(
+            &mut conn,
+            &page(ws, proj, "reference/architecture-current.md", "body text"),
+        )
+        .unwrap();
+
+        // The prepared query must not error AND must find the page.
+        let hits = fts_match_paths(&conn, "current.md")
+            .expect("dotted-filename search must not raise an FTS5 syntax error");
+        assert!(
+            hits.iter()
+                .any(|p| p == "reference/architecture-current.md"),
+            "search for `current.md` should match the indexed path; got {hits:?}"
+        );
+
+        // Guard the sanitizer is load-bearing: the same token reaching
+        // FTS5 bare (the pre-fix behaviour) is a hard syntax error.
+        let bare = conn
+            .prepare("SELECT rowid FROM pages_fts WHERE pages_fts MATCH ?1")
+            .unwrap()
+            .query_map(params!["current.md"], |r| r.get::<_, i64>(0))
+            .and_then(Iterator::collect::<rusqlite::Result<Vec<i64>>>);
+        assert!(
+            bare.is_err(),
+            "raw `current.md` should error in FTS5 — if this passes, the \
+             quoting sanitizer is no longer load-bearing and the test above \
+             proves nothing"
+        );
+    }
 }

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -2332,4 +2332,53 @@ mod tests {
              proves nothing"
         );
     }
+
+    /// Regression for the live-found hyphen bug: searching `ui-refresh`
+    /// returned nothing in prod even though
+    /// `follow-ups/ui-refresh-scroll-restoration.md` exists. The first fix
+    /// quoted it as `"ui-refresh"`, which **does not error but also does not
+    /// match** the indexed `ui refresh` — only `"ui refresh"` (sub-token
+    /// phrase) does. The string-level test can't see this; this drives real
+    /// FTS5 against the real `path_search` index. It would have caught the
+    /// bug the dotted-only fix left behind.
+    #[test]
+    fn hyphenated_filename_search_matches_indexed_path() {
+        let (_tmp, mut conn, ws, proj) = fresh_db();
+        upsert_page(
+            &mut conn,
+            &page(
+                ws,
+                proj,
+                "follow-ups/ui-refresh-scroll-restoration.md",
+                "body text",
+            ),
+        )
+        .unwrap();
+
+        let hits = fts_match_paths(&conn, "ui-refresh")
+            .expect("hyphenated search must not raise an FTS5 syntax error");
+        assert!(
+            hits.iter()
+                .any(|p| p == "follow-ups/ui-refresh-scroll-restoration.md"),
+            "search for `ui-refresh` should match the indexed path; got {hits:?}"
+        );
+
+        // Pin the exact FTS5 quirk the fix works around: the keeps-the-hyphen
+        // phrase matches nothing, the spaces phrase matches. If this ever
+        // flips, the sub-token quoting is no longer load-bearing.
+        let count = |q: &str| -> i64 {
+            conn.query_row(
+                "SELECT count(*) FROM pages_fts WHERE pages_fts MATCH ?1",
+                params![q],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(
+            count("\"ui-refresh\""),
+            0,
+            "kept-hyphen phrase must not match"
+        );
+        assert_eq!(count("\"ui refresh\""), 1, "sub-token phrase must match");
+    }
 }


### PR DESCRIPTION
A search term containing a dot — e.g. a filename like `current.md` — passed through `prepare_fts5_query` **bare** and FTS5 errored:

```
sqlite: fts5: syntax error near "."
```

(`current` alone works; `current.md` errors.) The MCP surfaces the error; a web UI just shows "No results".

`should_quote_fts5_token` only quoted tokens containing `-`. This widens it: any token carrying **ASCII punctuation** is quoted as a phrase, with two exceptions:
- a **trailing `*`** (the FTS5 prefix operator) is allowed through bare, so `curr*` still does a prefix search;
- the **`:`** column separator is excluded here (it's already handled by `has_unknown_bare_column` / preserved for known `title:` / `body:` columns).

Quoting both avoids the syntax error **and** matches: `current.md` → `"current.md"` (a phrase that tokenizes to `current` + `md`) matches a page at `architecture-current.md` (those tokens are adjacent in the indexed path). Accented letters and digits are unicode (not ASCII punctuation), so natural-language recall keeps accents.

### Tests
- `dotted_filename_token_is_quoted` — `current.md` / `00-index.md` / `a/b/c.md` → quoted.
- `prefix_star_token_stays_bare` — `curr*` survives as a prefix query.
- Existing tests (column syntax, OR-join, accented terms, operators, quoted phrases) unchanged and passing (15/15).

### Real-FTS5 regression (added after review)
`dotted_filename_search_matches_indexed_path` (in `ops.rs`) drives the
**actual populated `pages_fts` index** — not just the string output of
`prepare_fts5_query`. It seeds a page at `reference/architecture-current.md`,
runs the reader's exact `MATCH` for `current.md`, and asserts the prepared
query (a) does not raise an FTS5 syntax error and (b) matches the page. A
guard asserts the same token reaching FTS5 **bare** still errors, so the
quoting sanitizer stays load-bearing.

**Mutation-checked**: reverting `should_quote_fts5_token` to its pre-fix
form makes this test fail with the original `fts5: syntax error near "."`
— i.e. it would have caught the bug before shipping.

### Hyphenated terms (follow-up commit)
A second real case surfaced after deploy: searching `ui-refresh` matched
nothing although `follow-ups/ui-refresh-scroll-restoration.md` exists. The
tokenizer (`unicode61 … tokenchars '/_-'`) keeps `/ _ -` inside tokens — a
body `ai-memory` is one token — while `path_search_text` pre-expands `/._-`
to spaces. So a single quoted form can only satisfy one surface:
`"ai-memory"` matches content, `"ui refresh"` matches the path index.
`quote_fts5_token` now emits **both, OR'd** (`("ui-refresh" OR "ui refresh")`).
Real-FTS5 ops.rs test pins the quirk (kept-hyphen phrase → 0 rows, spaces
phrase → 1); content-vs-path tests guard each other.
