### PR TITLE
fix(omp): skip subagent sessions to prevent noise handoffs

### DIFF
--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -1224,6 +1224,8 @@ const handoffChecked = new Set<string>();
 const preCompactLast = new Map<string, number>();
 
 function startSession(ctx: any, extra: Record<string, unknown> = {{}}): void {{
+  // Skip subagent sessions (--mode json --no-session) — ephemeral, no ai-memory tracking
+  if (ctx?.mode === "json") return;
   const id = sessionID(ctx);
   if (!id || startedSessions.has(id)) return;
   startedSessions.add(id);
@@ -1339,6 +1341,8 @@ export default function AiMemoryExtension(api: any): void {{
   }});
 
   api.on("session_shutdown", (_event: any, ctx: any) => {{
+    // Skip subagent sessions (--mode json --no-session) — they create noise handoffs
+    if (ctx.mode === "json") return;
     startSession(ctx);
     postHook("session-end", sessionPayload(ctx));
   }});


### PR DESCRIPTION
## Problem

Pi/OMP subagents run with `--mode json --no-session`. Each subagent process triggers the `session_shutdown` hook in the ai-memory extension, which creates a handoff. With 6 subagents per session, the handoff queue gets polluted with subagent handoffs, and the next SessionStart consumes the wrong one (a subagent's stale handoff instead of the main session's).

## Root Cause

The `build_omp_extension()` template in `install_hooks.rs` has no guard against subagent sessions. Both `startSession()` and the `session_shutdown` handler fire unconditionally for every pi process, including ephemeral subagents.

## Fix

Two one-line guards in the generated OMP extension template:

1. **`startSession()`**: skip when `ctx?.mode === "json"` — subagents are ephemeral, no ai-memory session tracking needed
2. **`session_shutdown` handler**: skip when `ctx.mode === "json"` — no handoff for subagent sessions

Subagents are detected by their `--mode json` flag, which is always present for pi subagents and never present for interactive sessions.

## Testing

All 38 existing `install_hooks` tests pass. The fix only affects the generated template string — no runtime logic changes.