### PR TITLE
ci(release): add Windows x86_64 binary to tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,60 @@ jobs:
             ${{ matrix.artifact }}.tar.gz
             ${{ matrix.artifact }}.tar.gz.sha256
 
+  windows:
+    name: windows x86_64 binary
+    needs: validate-version
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.95
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        env:
+          TAILWIND_SKIP: "1"
+        run: cargo build --release -p ai-memory-cli
+
+      # Mirrors the Linux tarball, minus the Linux-only service assets
+      # (packaging/systemd|sysusers|tmpfiles|env). Ships the `.exe`, the full
+      # hooks bundle (the .ps1 + .sh scripts), the default config template, and
+      # the docs a Windows user needs (install.md + windows.md). Zipped (native
+      # Windows archive) with a sha256sum-format checksum so the release body's
+      # checksums block stays uniform across platforms.
+      - name: Create release zip
+        shell: pwsh
+        env:
+          RELEASE_ARTIFACT: ai-memory-windows-x86_64
+        run: |
+          $artifact = $env:RELEASE_ARTIFACT
+          $stage = "dist/$artifact"
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+          Copy-Item target/release/ai-memory.exe "$stage/ai-memory.exe"
+          Copy-Item -Recurse hooks "$stage/hooks"
+          New-Item -ItemType Directory -Force -Path "$stage/crates/ai-memory-cli/templates" | Out-Null
+          Copy-Item crates/ai-memory-cli/templates/config.default.toml `
+            "$stage/crates/ai-memory-cli/templates/config.default.toml"
+          New-Item -ItemType Directory -Force -Path "$stage/docs" | Out-Null
+          Copy-Item README.md, LICENSE $stage
+          Copy-Item docs/install.md "$stage/docs/install.md"
+          Copy-Item docs/windows.md "$stage/docs/windows.md"
+          $zip = "$artifact.zip"
+          # Pipe the staged items in (rather than a "$stage/*" glob) so the
+          # archive is rooted at the files themselves — ai-memory.exe, hooks/,
+          # etc. land at the zip root, mirroring the Linux tarball layout.
+          Get-ChildItem $stage | Compress-Archive -DestinationPath $zip
+          $hash = (Get-FileHash $zip -Algorithm SHA256).Hash.ToLower()
+          "$hash  $zip" | Out-File -Encoding ascii "$zip.sha256"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ai-memory-windows-x86_64
+          path: |
+            ai-memory-windows-x86_64.zip
+            ai-memory-windows-x86_64.zip.sha256
+
   # Gate the publish on the Docker Hub secrets actually being present, so a
   # fresh clone (or a fork) doesn't get a red failing run on every tag. The
   # docker job activates automatically once DOCKERHUB_USERNAME + _TOKEN are
@@ -325,7 +379,7 @@ jobs:
 
   github-release:
     name: github release
-    needs: [binary, validate-version]
+    needs: [binary, windows, validate-version]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -348,6 +402,9 @@ jobs:
           echo "" >> body.md
           echo "# Docker" >> body.md
           echo "docker pull akitaonrails/ai-memory:${{ needs.validate-version.outputs.version }}" >> body.md
+          echo "" >> body.md
+          echo "# Windows x86_64 (no toolchain): download ai-memory-windows-x86_64.zip below," >> body.md
+          echo "# extract it, and follow the bundled docs/windows.md." >> body.md
           echo "" >> body.md
           echo "# From source" >> body.md
           echo "cargo install --git https://github.com/akitaonrails/ai-memory --tag ${GITHUB_REF_NAME}" >> body.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,31 @@ jobs:
           $hash = (Get-FileHash $zip -Algorithm SHA256).Hash.ToLower()
           "$hash  $zip" | Out-File -Encoding ascii "$zip.sha256"
 
+      - name: Smoke test release zip
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $zip = "ai-memory-windows-x86_64.zip"
+          $smoke = "dist/smoke-windows-zip"
+          Expand-Archive $zip -DestinationPath $smoke -Force
+          & "$smoke/ai-memory.exe" --version
+          foreach ($path in @(
+            "hooks",
+            "crates/ai-memory-cli/templates/config.default.toml",
+            "docs/install.md",
+            "docs/windows.md",
+            "README.md",
+            "LICENSE"
+          )) {
+            if (-not (Test-Path "$smoke/$path")) {
+              throw "Windows release zip missing $path"
+            }
+          }
+          $checksum = Get-Content "$zip.sha256" -Raw
+          if ($checksum -notmatch '^[0-9a-f]{64}  ai-memory-windows-x86_64\.zip\r?\n?$') {
+            throw "Windows release zip checksum is not sha256sum format"
+          }
+
       - uses: actions/upload-artifact@v4
         with:
           name: ai-memory-windows-x86_64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Tagged releases now publish a native Windows x86_64 zip artifact
+  (`ai-memory-windows-x86_64.zip`) with `ai-memory.exe`, hooks, default
+  config template, checksums, and Windows install docs, giving native
+  Windows agents a no-toolchain path to the fast direct-binary hook mode.
 
 ## [0.13.0] - 2026-06-08
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 | Linux | Supported | Primary Docker/server target and CI platform. Published Docker images support `linux/amd64` and `linux/arm64`. Native Arch/AUR packages include system and user systemd units. |
 | macOS | Supported | Workspace tests run in CI; native source builds are supported. Docker images run natively on Apple Silicon via the `linux/arm64` manifest. |
 | Windows via WSL2 | Supported | Use the Linux install path inside WSL2 when the agent runs there. |
-| Native Windows | Experimental | PowerShell wrapper is available. Claude Code uses Git Bash `.sh` hooks on native Windows; other script-hook agents use the current PowerShell defaults pending harness feedback. See [`docs/windows.md`](docs/windows.md). |
+| Native Windows | Experimental | Tagged releases publish `ai-memory-windows-x86_64.zip` with `ai-memory.exe`; Docker Desktop wrapper and source builds are also available. Claude Code uses direct native `ai-memory.exe hook` commands by default; other script-hook agents use the current PowerShell defaults pending harness feedback. See [`docs/windows.md`](docs/windows.md). |
 | Claude Code | Supported | MCP config + lifecycle hooks. |
 | Codex | Supported | MCP config + lifecycle hooks. |
 | OpenCode | Supported | Remote MCP config + generated TypeScript plugin. |
@@ -495,7 +495,7 @@ diagram, crate breakdown, schema notes, and invariants.
 | [`docs/usage.md`](docs/usage.md) | Handoffs, proactive memory queries, routing snippet, web UI, raw-wiki inspection, and rules-vs-facts workflow. |
 | [`docs/marker-file.md`](docs/marker-file.md) | `.ai-memory.toml` workspace/project routing for multi-client trees, mono-repos, worktrees, and work/personal separation. |
 | [`docs/auto-scope.md`](docs/auto-scope.md) | `[auto_scope]` modes for shared servers: default single-slot routing, session-aware isolation, and multi-user `per_actor` behavior. |
-| [`docs/windows.md`](docs/windows.md) | Windows install modes: full WSL2, native Windows with Docker Desktop, native source builds, and current hook/MCP harness caveats. |
+| [`docs/windows.md`](docs/windows.md) | Windows install modes: full WSL2, native Windows with Docker Desktop, prebuilt native release zip, native source builds, and current hook/MCP harness caveats. |
 | [`docs/mcp-install.md`](docs/mcp-install.md) | Per-client MCP and lifecycle notes (Cursor, Claude Desktop, Gemini CLI, Antigravity CLI, OpenClaw, OMP). |
 | [`docs/deploy.md`](docs/deploy.md) | Homelab deploy: bin/deploy, bearer-token auth, pointers to the TLS guide. |
 | [`docs/users.md`](docs/users.md) | **Multi-user attribution (v0.8).** Four-rung auth ladder, `ai-memory user add/list/expire/revive/rotate-token` walkthrough, backward-compat migration for pre-v0.8 installs, token storage rationale. |

--- a/docs/install.md
+++ b/docs/install.md
@@ -624,9 +624,11 @@ The `serve` subcommand also accepts:
 
 On Windows, see [`docs/windows.md`](windows.md). The short version: run
 the install commands from the same environment that launches the agent.
-WSL2-launched agents need WSL paths and POSIX `.sh` hooks. Native Claude Code
-uses Git Bash `.sh` hooks with Windows paths converted to `/c/...`; other
-native Windows script-hook agents use PowerShell `.ps1` defaults.
+WSL2-launched agents need WSL paths and POSIX `.sh` hooks. Native Windows
+agents can use the tagged `ai-memory-windows-x86_64.zip`, the Docker Desktop
+wrapper, or a source build. Native Claude Code uses direct `ai-memory.exe hook`
+commands by default; other native Windows script-hook agents use PowerShell
+`.ps1` defaults.
 
 When run from source, `install-hooks` finds the bundled scripts in
 the repo's `hooks/` automatically:

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -114,7 +114,45 @@ the CLI to render hook commands for the native Windows agent:
 Use the matching `--client` / `--agent` values for other clients, for
 example `codex`, `cursor`, or `gemini-cli`.
 
-## Scenario C: Native Windows Source Build
+## Scenario C: Prebuilt Release Binary (No Toolchain)
+
+Use this when the agent CLI runs as a native Windows process and you want
+the fast native hook path **without** installing a Rust toolchain or
+Docker. Each tagged release publishes
+`ai-memory-windows-x86_64.zip` (see the repo's Releases page).
+
+```powershell
+# Download + extract into your user data dir (any stable path works; the
+# native hook command is rendered from wherever ai-memory.exe lives).
+$Dest = "$env:LOCALAPPDATA\ai-memory"
+New-Item -ItemType Directory -Force $Dest | Out-Null
+Invoke-WebRequest `
+    -Uri "https://github.com/akitaonrails/ai-memory/releases/latest/download/ai-memory-windows-x86_64.zip" `
+    -OutFile "$env:TEMP\ai-memory.zip"
+Expand-Archive "$env:TEMP\ai-memory.zip" -DestinationPath $Dest -Force
+Get-ChildItem "$Dest\ai-memory.exe" | Unblock-File
+
+# Put it on PATH for future terminals (optional but convenient).
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if (($UserPath -split ';') -notcontains $Dest) {
+    [Environment]::SetEnvironmentVariable("Path", "$UserPath;$Dest", "User")
+    $env:Path = "$env:Path;$Dest"
+}
+
+# Wire MCP + lifecycle hooks against your server.
+& "$Dest\ai-memory.exe" install-mcp --client claude-code --apply
+& "$Dest\ai-memory.exe" install-hooks --agent claude-code --apply `
+    --server-url "https://memory.example.com" --auth-token "<token>"
+```
+
+The zip mirrors the Linux release tarball, minus the Linux-only service
+assets: it contains `ai-memory.exe`, the full `hooks/` bundle (`.ps1` +
+`.sh`), `crates/ai-memory-cli/templates/config.default.toml`, `README.md`,
+`LICENSE`, and `docs/{install,windows}.md`. Because `install-hooks` reads
+the `ai-memory.exe` path from the running binary, keep the extracted `.exe`
+at a stable location (re-run `install-hooks` if you move it).
+
+## Scenario D: Native Windows Source Build
 
 Use this when developing ai-memory itself on Windows or when you do not
 want the Docker wrapper for CLI commands.


### PR DESCRIPTION
## Problem

`docs/windows.md` documents a **windows-native** hook path that calls the
`ai-memory.exe` binary directly (no shell) and is ~3-5× faster per hook than the
Git Bash fallback. But there's no published Windows binary: a native-Windows user
today must install a Rust 1.95 toolchain and `cargo install`, or run the Docker
wrapper. The release pipeline builds native binaries for Linux x86_64/aarch64 —
Windows is just a gap in that matrix.

## Proposal

Add a `windows` job to `release.yml` that builds `ai-memory-cli` on
`windows-latest` and publishes `ai-memory-windows-x86_64.zip` alongside the Linux
tarballs on every tagged release. The zip mirrors the Linux release layout, minus
the Linux-only service assets:

```
ai-memory.exe
hooks/            (full bundle — .ps1 + .sh)
crates/ai-memory-cli/templates/config.default.toml
docs/install.md
docs/windows.md
README.md  LICENSE
```

(No `packaging/{systemd,sysusers,tmpfiles,env}` — those are Linux-only.) Checksum
is emitted in `sha256sum` format so the release body's checksums block stays
uniform across platforms. `docs/windows.md` gains a "Prebuilt Release Binary (No
Toolchain)" scenario.

## Footprint (invasion)

| Area | Change |
|---|---|
| Rust / core source | **0 LOC** |
| `.github/workflows/release.yml` | +55 / -1 (new `windows` job; `windows` added to `github-release` needs; 3 echo lines in the release body) |
| `docs/windows.md` | +40 / -1 (new install scenario; existing "Source Build" renumbered C→D) |

Opt-in by nature: a CI-only addition. Existing jobs are untouched except the
one-line `github-release` `needs` (so the release waits for the Windows artifact).
The `aur` job already filters `pattern: ai-memory-linux-*`, so it ignores the
Windows artifact; the `docker-*` jobs consume only the Linux artifacts.

## Verification

Validated the actual job commands on a real Windows 11 machine (not just the YAML):

- `cargo build --release -p ai-memory-cli` (TAILWIND_SKIP=1) → `ai-memory.exe` ✓
- Ran the exact `pwsh` packaging step → `ai-memory-windows-x86_64.zip` (9.5 MB),
  correct root layout, `sha256sum`-format checksum ✓
- Extracted the zip to a clean dir (fresh-user simulation) and exercised it:
  - `ai-memory.exe --version` → `ai-memory 0.13.0` ✓
  - `install-mcp` / `install-hooks` render the correct **windows-native** command
    from the bundled `hooks/` ✓
  - Ran `ai-memory.exe serve` (the same binary) and drove a full lifecycle through
    the `hook` subcommand (session-start → prompt → pre/post-tool-use → stop →
    session-end). `POST /hook` → `202 queued`; the server wrote a session page with
    **6 observations** captured + `Bash: 2` tool calls ✓
- Gates on the branch: `cargo fmt --all -- --check` ✓ · `cargo clippy --workspace
  --all-targets -- -D warnings` ✓ · `git diff --check` ✓
- `actionlint` on `release.yml`: clean for the new job (the only report is a
  pre-existing `SC2129` style nit in the unrelated release-body block, present on
  `main` before this change).

### Where to verify the high-stakes parts

- `release.yml` `windows:` job — the `pwsh` packaging step (paths + `sha256sum`
  format).
- `release.yml` `github-release.needs` — now includes `windows` so the release
  can't publish before the Windows artifact uploads.
- `release.yml` `aur` job — unchanged; `pattern: ai-memory-linux-*` already
  excludes the Windows zip.

## Non-blocking follow-ups

- The `.exe` is unsigned → SmartScreen prompt on first run. Code-signing is a
  separate concern (cert + secret).
- No Windows CI **test** job here — this only adds release packaging. A
  `windows-latest` test matrix entry in `ci.yml` could come later.
- ARM64 Windows can be added as a second matrix entry once there's demand.
