### PR TITLE
Add macOS release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,20 @@ jobs:
   # (LTO crash, codegen issue, dead-code-with-debug-assertions) doesn't
   # ship to Docker Hub silently.
   release-build:
-    name: cargo build --release
-    # Match the release workflow so the prebuilt binary runs on Debian bookworm
-    # in the Docker runtime image.
-    runs-on: ubuntu-22.04
+    name: cargo build --release (${{ matrix.artifact }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Keep Linux on Debian bookworm so the prebuilt binary matches the
+          # Docker runtime image. macOS entries mirror the release assets.
+          - artifact: linux-x86_64
+            runner: ubuntu-22.04
+          - artifact: macos-aarch64
+            runner: macos-15
+          - artifact: macos-x86_64
+            runner: macos-15-intel
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -64,7 +74,7 @@ jobs:
         run: cargo build --release --bin ai-memory
       - uses: actions/upload-artifact@v4
         with:
-          name: ci-ai-memory-linux-x86_64
+          name: ci-ai-memory-${{ matrix.artifact }}
           path: target/release/ai-memory
 
   native-packaging:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,11 @@
 name: release
 
 # Triggered when a version tag is pushed, e.g. git push origin v0.3.2.
-# Builds native Linux release tarballs, creates the GitHub Release,
-# and pushes the Docker image to Docker Hub with both the version tag
-# and `latest` when Docker Hub credentials are configured. Docker images
-# reuse the native release artifacts instead of recompiling in Docker.
+# Builds native Linux/macOS release tarballs plus the Windows zip, creates the
+# GitHub Release, and pushes the Docker image to Docker Hub with both the
+# version tag and `latest` when Docker Hub credentials are configured. Docker
+# images reuse the native Linux release artifacts instead of recompiling in
+# Docker.
 #
 # Optional publish secrets (set in repo Settings → Secrets and variables → Actions):
 #   DOCKERHUB_USERNAME  — Docker Hub account name
@@ -106,6 +107,81 @@ jobs:
           cp docs/install.md "dist/$artifact/docs/install.md"
           tar -C "dist/$artifact" -czf "$artifact.tar.gz" .
           sha256sum "$artifact.tar.gz" > "$artifact.tar.gz.sha256"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: |
+            ${{ matrix.artifact }}.tar.gz
+            ${{ matrix.artifact }}.tar.gz.sha256
+
+  macos:
+    name: macos ${{ matrix.arch }} binary
+    needs: validate-version
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            artifact: ai-memory-macos-aarch64
+            runner: macos-15
+          - arch: x86_64
+            artifact: ai-memory-macos-x86_64
+            runner: macos-15-intel
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.95
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        env:
+          TAILWIND_SKIP: "1"
+        run: cargo build --release -p ai-memory-cli
+
+      # Mirrors the Linux tarball, minus Linux-only service assets
+      # (packaging/systemd|sysusers|tmpfiles|env). macOS users get the binary,
+      # hooks bundle, default config template, and install docs.
+      - name: Create release tarball
+        env:
+          RELEASE_ARTIFACT: ${{ matrix.artifact }}
+        run: |
+          set -euo pipefail
+          artifact="$RELEASE_ARTIFACT"
+          mkdir -p "dist/$artifact"
+          cp target/release/ai-memory "dist/$artifact/ai-memory"
+          cp -a hooks "dist/$artifact/hooks"
+          mkdir -p "dist/$artifact/crates/ai-memory-cli/templates"
+          cp crates/ai-memory-cli/templates/config.default.toml \
+            "dist/$artifact/crates/ai-memory-cli/templates/config.default.toml"
+          mkdir -p "dist/$artifact/docs"
+          cp README.md LICENSE "dist/$artifact/"
+          cp docs/install.md "dist/$artifact/docs/install.md"
+          tar -C "dist/$artifact" -czf "$artifact.tar.gz" .
+          shasum -a 256 "$artifact.tar.gz" > "$artifact.tar.gz.sha256"
+
+      - name: Smoke test release tarball
+        env:
+          RELEASE_ARTIFACT: ${{ matrix.artifact }}
+        run: |
+          set -euo pipefail
+          artifact="$RELEASE_ARTIFACT"
+          smoke="dist/smoke-$artifact"
+          mkdir -p "$smoke"
+          tar -xzf "$artifact.tar.gz" -C "$smoke"
+          "$smoke/ai-memory" --version
+          for path in \
+            hooks \
+            crates/ai-memory-cli/templates/config.default.toml \
+            docs/install.md \
+            README.md \
+            LICENSE
+          do
+            test -e "$smoke/$path" || { echo "macOS release tarball missing $path" >&2; exit 1; }
+          done
+          grep -Eq "^[0-9a-f]{64}  $artifact\.tar\.gz$" "$artifact.tar.gz.sha256"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -404,7 +480,7 @@ jobs:
 
   github-release:
     name: github release
-    needs: [binary, windows, validate-version]
+    needs: [binary, macos, windows, validate-version]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -428,6 +504,9 @@ jobs:
           echo "" >> body.md
           echo "# Docker" >> body.md
           echo "docker pull akitaonrails/ai-memory:${{ needs.validate-version.outputs.version }}" >> body.md
+          echo "" >> body.md
+          echo "# macOS arm64/x86_64 (no toolchain): download the matching" >> body.md
+          echo "# ai-memory-macos-*.tar.gz below, extract it, and put ai-memory on PATH." >> body.md
           echo "" >> body.md
           echo "# Windows x86_64 (no toolchain): download ai-memory-windows-x86_64.zip below," >> body.md
           echo "# extract it, and follow the bundled docs/windows.md." >> body.md

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 | Area | Status | Notes |
 |---|---|---|
 | Linux | Supported | Primary Docker/server target and CI platform. Published Docker images support `linux/amd64` and `linux/arm64`. Native Arch/AUR packages include system and user systemd units. |
-| macOS | Supported | Workspace tests run in CI; native source builds are supported. Docker images run natively on Apple Silicon via the `linux/arm64` manifest. |
+| macOS | Supported | Workspace tests run in CI; tagged releases publish native `ai-memory-macos-aarch64.tar.gz` and `ai-memory-macos-x86_64.tar.gz` binaries. Docker images run natively on Apple Silicon via the `linux/arm64` manifest. |
 | Windows via WSL2 | Supported | Use the Linux install path inside WSL2 when the agent runs there. |
 | Native Windows | Experimental | Tagged releases publish `ai-memory-windows-x86_64.zip` with `ai-memory.exe`; Docker Desktop wrapper and source builds are also available. Claude Code uses direct native `ai-memory.exe hook` commands by default; other script-hook agents use the current PowerShell defaults pending harness feedback. See [`docs/windows.md`](docs/windows.md). |
 | Claude Code | Supported | MCP config + lifecycle hooks. |

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -91,10 +91,18 @@ fn docker_publish_jobs_use_prebuilt_binaries() {
     let release = read_repo(".github/workflows/release.yml");
     assert!(release.contains("artifact: ai-memory-linux-x86_64"));
     assert!(release.contains("artifact: ai-memory-linux-aarch64"));
+    assert!(release.contains("artifact: ai-memory-macos-aarch64"));
+    assert!(release.contains("artifact: ai-memory-macos-x86_64"));
+    assert!(release.contains("needs: [binary, macos, windows, validate-version]"));
     assert!(release.contains("target: runtime-prebuilt-amd64"));
     assert!(release.contains("target: runtime-prebuilt-arm64"));
 
     let ci = read_repo(".github/workflows/ci.yml");
-    assert!(ci.contains("ci-ai-memory-linux-x86_64"));
+    assert!(ci.contains("ci-ai-memory-${{ matrix.artifact }}"));
+    assert!(ci.contains("artifact: linux-x86_64"));
+    assert!(ci.contains("artifact: macos-aarch64"));
+    assert!(ci.contains("artifact: macos-x86_64"));
+    assert!(ci.contains("runner: macos-15"));
+    assert!(ci.contains("runner: macos-15-intel"));
     assert!(ci.contains("--target runtime-prebuilt-amd64"));
 }

--- a/docs/install.md
+++ b/docs/install.md
@@ -619,9 +619,11 @@ This path is friction-free when:
 
 ## Running ai-memory without docker
 
-Most users should stick to the docker wrapper from the Quick start. Build from
-source only when hacking on ai-memory itself or running on a platform docker
-doesn't support.
+Most users should stick to the docker wrapper from the Quick start. On macOS,
+tagged releases also publish native `ai-memory-macos-aarch64.tar.gz` and
+`ai-memory-macos-x86_64.tar.gz` archives when you only need the client CLI.
+Build from source only when hacking on ai-memory itself or running on a platform
+docker doesn't support.
 
 ```bash
 git clone https://github.com/akitaonrails/ai-memory ~/.ai-memory
@@ -651,13 +653,14 @@ The `serve` subcommand also accepts:
 | `--web-ui-dir <path>` | `AI_MEMORY_WEB_UI_DIR` | Serve a custom SPA from `<path>` instead of the built-in browser. ai-memory injects `<base href>` and `<meta name="ai-memory-base-path">` so the SPA can build relative URLs and API calls under the configured prefix. |
 | `--cors-allow-origin <origin>` | `AI_MEMORY_CORS_ALLOW_ORIGINS` (CSV) | Allow listed origins to call `/api/v1`. Layer is scoped only to that route — `/mcp`, `/hook`, `/admin`, and `/web` remain origin-locked. |
 
-On Windows, see [`docs/windows.md`](windows.md). The short version: run
-the install commands from the same environment that launches the agent.
-WSL2-launched agents need WSL paths and POSIX `.sh` hooks. Native Windows
-agents can use the tagged `ai-memory-windows-x86_64.zip`, the Docker Desktop
-wrapper, or a source build. Native Claude Code uses direct `ai-memory.exe hook`
-commands by default; other native Windows script-hook agents use PowerShell
-`.ps1` defaults.
+On macOS, use the archive matching your architecture: `aarch64` for Apple
+Silicon, `x86_64` for Intel. On Windows, see [`docs/windows.md`](windows.md).
+The short version: run the install commands from the same environment that
+launches the agent. WSL2-launched agents need WSL paths and POSIX `.sh` hooks.
+Native Windows agents can use the tagged `ai-memory-windows-x86_64.zip`, the
+Docker Desktop wrapper, or a source build. Native Claude Code uses direct
+`ai-memory.exe hook` commands by default; other native Windows script-hook
+agents use PowerShell `.ps1` defaults.
 
 When run from source, `install-hooks` finds the bundled scripts in
 the repo's `hooks/` automatically:


### PR DESCRIPTION
## Summary
- add native macOS aarch64 and x86_64 release tarballs
- include macOS release-mode builds in CI
- document macOS release archives and cover them in packaging regression tests

## Tests
- cargo test -p ai-memory-cli --test packaging
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/release.yml