### PR TITLE
docs: add macOS install guide

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,8 @@ jobs:
 
       # Mirrors the Linux tarball, minus Linux-only service assets
       # (packaging/systemd|sysusers|tmpfiles|env). macOS users get the binary,
-      # hooks bundle, default config template, and install docs.
+      # hooks bundle, default config template, and the docs a macOS user needs
+      # (install.md + macos.md).
       - name: Create release tarball
         env:
           RELEASE_ARTIFACT: ${{ matrix.artifact }}
@@ -159,6 +160,7 @@ jobs:
           mkdir -p "dist/$artifact/docs"
           cp README.md LICENSE "dist/$artifact/"
           cp docs/install.md "dist/$artifact/docs/install.md"
+          cp docs/macos.md "dist/$artifact/docs/macos.md"
           tar -C "dist/$artifact" -czf "$artifact.tar.gz" .
           shasum -a 256 "$artifact.tar.gz" > "$artifact.tar.gz.sha256"
 
@@ -176,6 +178,7 @@ jobs:
             hooks \
             crates/ai-memory-cli/templates/config.default.toml \
             docs/install.md \
+            docs/macos.md \
             README.md \
             LICENSE
           do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -509,7 +509,7 @@ jobs:
           echo "docker pull akitaonrails/ai-memory:${{ needs.validate-version.outputs.version }}" >> body.md
           echo "" >> body.md
           echo "# macOS aarch64/x86_64 (no toolchain): download the matching ai-memory-macos-<arch>.tar.gz below," >> body.md
-          echo "# extract it, and put ai-memory on PATH." >> body.md
+          echo "# extract it, and follow the bundled docs/macos.md." >> body.md
           echo "" >> body.md
           echo "# Windows x86_64 (no toolchain): download ai-memory-windows-x86_64.zip below," >> body.md
           echo "# extract it, and follow the bundled docs/windows.md." >> body.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   drain so a heavy session keeps the backlog flat instead of waiting for the next
   session boundary. Tunable via `AI_MEMORY_HOOK_INCREMENTAL_THRESHOLD`
   (default 32 events).
+- Added [`docs/macos.md`](docs/macos.md) covering macOS install paths (prebuilt
+  release binary, source build, and the Docker wrapper) and the `posix` vs
+  `posix-native` hook platform split, with a "Known limitations" section for the
+  current macOS rough edges. Linked it from the README support matrix, the docs
+  table, and `docs/install.md`, and bundled it into the macOS release tarballs
+  alongside `docs/install.md` (mirroring how the Windows zip ships
+  `docs/windows.md`).
 
 ### Fixed
 - Hook spool no longer counts a server `429` (saturation / `hook queue full`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (default 32 events).
 - Added [`docs/macos.md`](docs/macos.md) covering macOS install paths (prebuilt
   release binary, source build, and the Docker wrapper) and the `posix` vs
-  `posix-native` hook platform split, with a "Known limitations" section for the
-  current macOS rough edges. Linked it from the README support matrix, the docs
+  `posix-native` hook platform split, with troubleshooting notes for macOS
+  wrapper and hook-discovery issues. Linked it from the README support matrix, the docs
   table, and `docs/install.md`, and bundled it into the macOS release tarballs
   alongside `docs/install.md` (mirroring how the Windows zip ships
   `docs/windows.md`).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 | Area | Status | Notes |
 |---|---|---|
 | Linux | Supported | Primary Docker/server target and CI platform. Published Docker images support `linux/amd64` and `linux/arm64`. Native Arch/AUR packages include system and user systemd units. |
-| macOS | Supported | Workspace tests run in CI; tagged releases publish native `ai-memory-macos-aarch64.tar.gz` and `ai-memory-macos-x86_64.tar.gz` binaries. Docker images run natively on Apple Silicon via the `linux/arm64` manifest. |
+| macOS | Supported | Workspace tests run in CI; tagged releases publish native `ai-memory-macos-aarch64.tar.gz` and `ai-memory-macos-x86_64.tar.gz` binaries. The native binary is the recommended path on Apple Silicon. See [`docs/macos.md`](docs/macos.md). |
 | Windows via WSL2 | Supported | Use the Linux install path inside WSL2 when the agent runs there. |
 | Native Windows | Experimental | Tagged releases publish `ai-memory-windows-x86_64.zip` with `ai-memory.exe`; Docker Desktop wrapper and source builds are also available. Claude Code uses direct native `ai-memory.exe hook` commands by default; other script-hook agents use the current PowerShell defaults pending harness feedback. See [`docs/windows.md`](docs/windows.md). |
 | Claude Code | Supported | MCP config + lifecycle hooks. |
@@ -559,6 +559,7 @@ diagram, crate breakdown, schema notes, and invariants.
 | [`docs/usage.md`](docs/usage.md) | Handoffs, proactive memory queries, routing snippet, web UI, raw-wiki inspection, and rules-vs-facts workflow. |
 | [`docs/marker-file.md`](docs/marker-file.md) | `.ai-memory.toml` workspace/project routing for multi-client trees, mono-repos, worktrees, and work/personal separation. |
 | [`docs/auto-scope.md`](docs/auto-scope.md) | `[auto_scope]` modes for shared servers: default single-slot routing, session-aware isolation, and multi-user `per_actor` behavior. |
+| [`docs/macos.md`](docs/macos.md) | macOS install paths: native release binary (recommended), source build, the Docker wrapper, hook-platform notes, and current macOS limitations. |
 | [`docs/windows.md`](docs/windows.md) | Windows install modes: full WSL2, native Windows with Docker Desktop, prebuilt native release zip, native source builds, and current hook/MCP harness caveats. |
 | [`docs/mcp-install.md`](docs/mcp-install.md) | Per-client MCP and lifecycle notes (Cursor, Claude Desktop, Gemini CLI, Antigravity CLI, OpenClaw, OMP, VS Code Copilot). |
 | [`docs/deploy.md`](docs/deploy.md) | Homelab deploy: bin/deploy, bearer-token auth, pointers to the TLS guide. |

--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ ai-memory install-hooks --agent  claude-code --apply
 On Linux/macOS, that's it. Start a Claude Code session as usual - every
 prompt and tool call now lands in ai-memory, and the next session you
 open in this project will see a handoff with where you left off.
+On macOS, the native release binary is also supported and recommended when you
+do not need Docker; see [`docs/macos.md`](docs/macos.md).
 
 The `install-mcp` / `install-hooks` commands use
 `AI_MEMORY_SERVER_URL` / `AI_MEMORY_AUTH_TOKEN` when set; otherwise

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -181,3 +181,23 @@ fn macos_wrapper_routes_urls_by_real_subcommand() {
         "global options before install-hooks must not hide the real subcommand; got {args}"
     );
 }
+
+#[test]
+fn macos_docs_use_valid_install_commands_and_release_body_points_to_them() {
+    let docs = read_repo("docs/macos.md");
+    assert!(docs.contains("install-hooks --agent claude-code --apply"));
+    assert!(docs.contains("install-mcp --client claude-code --apply"));
+    assert!(
+        !docs.contains("setup-agent --agent claude-code --source ./hooks"),
+        "setup-agent has no --apply path; use install-hooks for native macOS docs"
+    );
+    assert!(
+        !docs.contains("init` configures the bearer token"),
+        "init writes token_pepper, not a bearer token"
+    );
+    assert!(docs.contains("Host-side agent config should use"));
+    assert!(docs.contains("Tagged releases publish a multi-arch manifest"));
+
+    let release = read_repo(".github/workflows/release.yml");
+    assert!(release.contains("follow the bundled docs/macos.md"));
+}

--- a/docs/install.md
+++ b/docs/install.md
@@ -670,8 +670,9 @@ The `serve` subcommand also accepts:
 | `--web-ui-dir <path>` | `AI_MEMORY_WEB_UI_DIR` | Serve a custom SPA from `<path>` instead of the built-in browser. ai-memory injects `<base href>` and `<meta name="ai-memory-base-path">` so the SPA can build relative URLs and API calls under the configured prefix. |
 | `--cors-allow-origin <origin>` | `AI_MEMORY_CORS_ALLOW_ORIGINS` (CSV) | Allow listed origins to call `/api/v1`. Layer is scoped only to that route — `/mcp`, `/hook`, `/admin`, and `/web` remain origin-locked. |
 
-On macOS, use the archive matching your architecture: `aarch64` for Apple
-Silicon, `x86_64` for Intel. On Windows, see [`docs/windows.md`](windows.md).
+On macOS, see [`docs/macos.md`](macos.md); use the archive matching your
+architecture: `aarch64` for Apple Silicon, `x86_64` for Intel. On Windows, see
+[`docs/windows.md`](windows.md).
 The short version: run the install commands from the same environment that
 launches the agent. WSL2-launched agents need WSL paths and POSIX `.sh` hooks.
 Native Windows agents can use the tagged `ai-memory-windows-x86_64.zip`, the

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,180 @@
+# macOS Support
+
+macOS is a supported platform: the workspace test suite runs on macOS CI and
+tagged releases publish native `ai-memory-macos-aarch64.tar.gz` (Apple Silicon)
+and `ai-memory-macos-x86_64.tar.gz` (Intel) binaries.
+
+On macOS the **native binary** (a prebuilt release or a source build) is the
+recommended way to run ai-memory today. It binds the server on
+`127.0.0.1:49374`, and both the MCP endpoint and the lifecycle hooks talk to
+that loopback address — which the native agent can reach and which is already in
+the default Host-header allowlist. The Docker wrapper is the recommended path on
+Linux, but on macOS it currently has the rough edges listed under
+[Known limitations](#known-limitations-on-macos); prefer the native binary until
+those are resolved.
+
+Unlike Windows there is only one "path world" on macOS: POSIX paths and POSIX
+`.sh` hooks throughout. There is no WSL-vs-native split to get wrong.
+
+## Rule Of Thumb
+
+Run `setup-agent` / `install-mcp` / `install-hooks` from the same shell that
+launches Claude Code, Codex, Cursor, Gemini CLI, or another agent — on macOS
+that is just your normal Terminal.
+
+- The agent runs as a native macOS process, so its config must point at a
+  **host-reachable** server URL. The native binary renders
+  `http://127.0.0.1:49374`, which works. (The Docker wrapper renders
+  `http://host.docker.internal:49374`, which does **not** resolve on the macOS
+  host — see [Known limitations](#known-limitations-on-macos).)
+- Hooks are rendered for one of two platforms:
+  - `posix-native` — a direct `ai-memory hook --event …` call. The default for
+    native macOS/Linux Claude Code installs (cargo / release binary); it uses
+    the local event spool + OIDC-token fallback.
+  - `posix` — `sh` runs the bundled `.sh` script. The Docker wrapper's default
+    (the host has no local binary).
+
+  Set `AI_MEMORY_HOOK_PLATFORM` before wiring hooks to override the default.
+
+## Scenario A: Prebuilt Release Binary (Recommended, No Toolchain)
+
+Use this when you want a local server plus native hooks without a Rust toolchain
+or Docker. Each tagged release publishes a macOS tarball per architecture.
+
+```bash
+# 1. Download the archive for your chip and extract it to a stable location.
+#    aarch64 = Apple Silicon (M-series); x86_64 = Intel.
+mkdir -p ~/Applications/ai-memory && cd ~/Applications/ai-memory
+curl -fsSL -O https://github.com/akitaonrails/ai-memory/releases/latest/download/ai-memory-macos-aarch64.tar.gz
+tar -xzf ai-memory-macos-aarch64.tar.gz
+# `curl` downloads are not Gatekeeper-quarantined, so the binary runs as-is.
+# If you downloaded via a browser instead, clear the quarantine flag once:
+#   xattr -d com.apple.quarantine ./ai-memory
+
+# 2. Initialise the data dir (defaults to
+#    ~/Library/Application Support/ai-memory; override with AI_MEMORY_DATA_DIR).
+./ai-memory init
+
+# 3. Start the server (loopback only).
+./ai-memory serve --transport http --bind 127.0.0.1:49374
+```
+
+In a second terminal, stage the hook bundle and wire the agent:
+
+```bash
+cd ~/Applications/ai-memory
+# `setup-agent` extracts the bundled hook scripts and writes the hook config.
+# Pass --source ./hooks because the scripts ship beside the binary in the
+# release tarball (see Known limitations #4).
+./ai-memory setup-agent --agent claude-code --source ./hooks \
+    --to ~/.local/share/ai-memory/hooks --apply
+./ai-memory install-mcp --client claude-code --apply
+```
+
+Notes:
+
+- The MCP endpoint and the capture hooks work without a token in this
+  single-user loopback setup. Admin/diagnostic routes are gated, so
+  `ai-memory status` needs the bearer token `init` configures for new installs —
+  pass `--auth-token <token>` or export `AI_MEMORY_AUTH_TOKEN`.
+- Keep the extracted `ai-memory` at a stable path; the hook commands reference
+  it. Re-run `setup-agent` / `install-hooks` if you move it.
+
+## Scenario B: Source Build
+
+Use this when developing ai-memory itself. Requires Rust 1.95
+(`rust-toolchain.toml`) plus the Xcode Command Line Tools
+(`xcode-select --install`); SQLite is bundled and libgit2 is vendored, so no
+extra system libraries are needed.
+
+```bash
+git clone https://github.com/akitaonrails/ai-memory
+cd ai-memory
+cargo build --release --workspace
+./target/release/ai-memory init
+./target/release/ai-memory serve --transport http --bind 127.0.0.1:49374
+```
+
+From another shell in the repo, `install-hooks` finds the bundled `hooks/`
+automatically (no `--source` needed from the repo root):
+
+```bash
+./target/release/ai-memory install-hooks --agent claude-code --apply
+./target/release/ai-memory install-mcp   --client claude-code --apply
+```
+
+## Scenario C: Docker Wrapper
+
+The server itself runs fine in Docker on macOS; the rough edges are in how the
+macOS wrapper wires the **native** agent and how its thin-client CLI reaches the
+server (see [Known limitations](#known-limitations-on-macos)). If you still want
+the Docker server on macOS, apply both workarounds:
+
+```bash
+# Start the server, allowlisting the Docker-Desktop host alias so the wrapper's
+# own thin-client commands (status, search, …) are not rejected with 403.
+docker run -d --name ai-memory --restart unless-stopped \
+    -p 127.0.0.1:49374:49374 -v ai-memory-data:/data \
+    -e AI_MEMORY_ALLOWED_HOSTS="localhost,127.0.0.1,::1,host.docker.internal" \
+    akitaonrails/ai-memory:latest
+
+# Wire the agent with an explicit loopback URL so install-mcp/install-hooks emit
+# a host-reachable address instead of the unresolvable host.docker.internal.
+AI_MEMORY_SERVER_URL=http://127.0.0.1:49374 \
+    ai-memory install-mcp   --client claude-code --apply
+AI_MEMORY_SERVER_URL=http://127.0.0.1:49374 \
+    ai-memory install-hooks --agent  claude-code --apply
+```
+
+On Apple Silicon the published `:latest` image currently runs as `linux/amd64`
+under emulation (Docker prints a platform-mismatch warning); it works but is not
+native.
+
+## Hook Platform on macOS
+
+`AI_MEMORY_HOOK_PLATFORM` selects how hook commands are rendered. On macOS the
+two relevant values are `posix-native` (direct binary call; the native default)
+and `posix` (the bundled `.sh` scripts; the Docker-wrapper default). Set it
+before running `setup-agent` / `install-hooks` so the choice is baked into the
+rendered commands. The native hook spools events locally and drains them at
+session boundaries; the whole-minute spool-timing overrides are shared with
+Windows and documented in
+[`docs/windows.md`](windows.md#tuning-the-spool-timings-high-latency-instances).
+
+## Known limitations on macOS
+
+These were observed on Apple Silicon (macOS 26, Docker Desktop 28). Until they
+are fixed, prefer the native binary (Scenario A/B).
+
+1. **`:latest` runs under emulation on Apple Silicon.** The published `:latest`
+   tag currently resolves to a single `linux/amd64` image, so Docker Desktop
+   runs it through emulation with a platform-mismatch warning rather than
+   natively on `arm64`.
+2. **Docker wrapper thin-client → `403 forbidden host`.** The macOS wrapper
+   reaches the server via `host.docker.internal`, which is not in the default
+   Host-header allowlist (`localhost`, `127.0.0.1`, `::1`). Add
+   `host.docker.internal` to `AI_MEMORY_ALLOWED_HOSTS` on the server (Scenario C).
+3. **Docker wrapper renders an unreachable agent URL.** Run through the wrapper,
+   `install-mcp` / `install-hooks` emit `http://host.docker.internal:49374`,
+   which does not resolve on the macOS host — so the native agent's MCP client
+   and capture hooks cannot reach the server. Wire with
+   `AI_MEMORY_SERVER_URL=http://127.0.0.1:49374` (Scenario C).
+4. **Release-binary hook discovery needs `--source`.** `setup-agent` /
+   `install-hooks` do not auto-locate the `hooks/` bundle that ships beside the
+   binary in the release tarball, so pass `--source ./hooks` (Scenario A).
+
+## Suggested Test Checklist
+
+1. `ai-memory serve --bind 127.0.0.1:49374` starts and logs `bind=127.0.0.1:49374`.
+2. `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:49374/mcp` returns
+   `405` (reachable; GET not allowed), confirming the loopback server is up.
+3. `setup-agent --agent claude-code --source ./hooks --to … --apply` extracts the
+   hook scripts and writes a config whose commands reference
+   `http://127.0.0.1:49374` and host-side `.sh` paths.
+4. `install-mcp --client claude-code` renders `http://127.0.0.1:49374/mcp`.
+5. Launch the agent, call `memory_status`, send a prompt, then confirm capture
+   (`ai-memory status --auth-token <token>` shows non-zero observations, or query
+   the SQLite `observations` table).
+
+Report which scenario you used, your chip (Apple Silicon / Intel), the agent and
+version, and whether hooks executed or failed with a connect/resolve error.

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -5,34 +5,30 @@ tagged releases publish native `ai-memory-macos-aarch64.tar.gz` (Apple Silicon)
 and `ai-memory-macos-x86_64.tar.gz` (Intel) binaries.
 
 On macOS the **native binary** (a prebuilt release or a source build) is the
-recommended way to run ai-memory today. It binds the server on
-`127.0.0.1:49374`, and both the MCP endpoint and the lifecycle hooks talk to
-that loopback address — which the native agent can reach and which is already in
-the default Host-header allowlist. The Docker wrapper is the recommended path on
-Linux, but on macOS it currently has the rough edges listed under
-[Known limitations](#known-limitations-on-macos); prefer the native binary until
-those are resolved.
+recommended way to run ai-memory. It binds the server on `127.0.0.1:49374`, and
+both the MCP endpoint and the lifecycle hooks talk to that loopback address —
+which the native agent can reach and which is already in the default Host-header
+allowlist. The Docker wrapper is also supported when you prefer a containerised
+server.
 
 Unlike Windows there is only one "path world" on macOS: POSIX paths and POSIX
 `.sh` hooks throughout. There is no WSL-vs-native split to get wrong.
 
 ## Rule Of Thumb
 
-Run `setup-agent` / `install-mcp` / `install-hooks` from the same shell that
-launches Claude Code, Codex, Cursor, Gemini CLI, or another agent — on macOS
-that is just your normal Terminal.
+Run `install-mcp` / `install-hooks` from the same shell that launches Claude
+Code, Codex, Cursor, Gemini CLI, or another agent — on macOS that is just your
+normal Terminal.
 
 - The agent runs as a native macOS process, so its config must point at a
-  **host-reachable** server URL. The native binary renders
-  `http://127.0.0.1:49374`, which works. (The Docker wrapper renders
-  `http://host.docker.internal:49374`, which does **not** resolve on the macOS
-  host — see [Known limitations](#known-limitations-on-macos).)
+  **host-reachable** server URL. Native installs and Docker-wrapper
+  `install-mcp` / `install-hooks` commands render `http://127.0.0.1:49374`,
+  which works from the host agent.
 - Hooks are rendered for one of two platforms:
   - `posix-native` — a direct `ai-memory hook --event …` call. The default for
     native macOS/Linux Claude Code installs (cargo / release binary); it uses
     the local event spool + OIDC-token fallback.
-  - `posix` — `sh` runs the bundled `.sh` script. The Docker wrapper's default
-    (the host has no local binary).
+  - `posix` — `sh` runs the bundled `.sh` script. The Docker wrapper's default.
 
   Set `AI_MEMORY_HOOK_PLATFORM` before wiring hooks to override the default.
 
@@ -59,26 +55,23 @@ tar -xzf ai-memory-macos-aarch64.tar.gz
 ./ai-memory serve --transport http --bind 127.0.0.1:49374
 ```
 
-In a second terminal, stage the hook bundle and wire the agent:
+In a second terminal, wire the agent:
 
 ```bash
 cd ~/Applications/ai-memory
-# `setup-agent` extracts the bundled hook scripts and writes the hook config.
-# Pass --source ./hooks because the scripts ship beside the binary in the
-# release tarball (see Known limitations #4).
-./ai-memory setup-agent --agent claude-code --source ./hooks \
-    --to ~/.local/share/ai-memory/hooks --apply
+# `install-hooks` auto-discovers the bundled hooks/ directory beside the binary.
+./ai-memory install-hooks --agent claude-code --apply
 ./ai-memory install-mcp --client claude-code --apply
 ```
 
 Notes:
 
-- The MCP endpoint and the capture hooks work without a token in this
-  single-user loopback setup. Admin/diagnostic routes are gated, so
-  `ai-memory status` needs the bearer token `init` configures for new installs —
-  pass `--auth-token <token>` or export `AI_MEMORY_AUTH_TOKEN`.
+- The MCP endpoint, capture hooks, and `ai-memory status` work without a token
+  in this single-user loopback setup. If you explicitly configure
+  `AI_MEMORY_AUTH_TOKEN` for the server, pass the same token with `--auth-token`
+  or export it for CLI commands.
 - Keep the extracted `ai-memory` at a stable path; the hook commands reference
-  it. Re-run `setup-agent` / `install-hooks` if you move it.
+  it. Re-run `install-hooks` if you move it.
 
 ## Scenario B: Source Build
 
@@ -105,76 +98,63 @@ automatically (no `--source` needed from the repo root):
 
 ## Scenario C: Docker Wrapper
 
-The server itself runs fine in Docker on macOS; the rough edges are in how the
-macOS wrapper wires the **native** agent and how its thin-client CLI reaches the
-server (see [Known limitations](#known-limitations-on-macos)). If you still want
-the Docker server on macOS, apply both workarounds:
+Use this when you want the server data in a Docker volume while the agent still
+runs as a native macOS process. The wrapper renders host-side agent config with
+`http://127.0.0.1:49374`, but its own thin-client commands reach the server from
+inside a helper container via Docker Desktop's `host.docker.internal` alias.
 
 ```bash
-# Start the server, allowlisting the Docker-Desktop host alias so the wrapper's
-# own thin-client commands (status, search, …) are not rejected with 403.
+# Start the server. The image default allowlist includes host.docker.internal so
+# wrapper thin-client commands (status, search, …) are not rejected with 403.
 docker run -d --name ai-memory --restart unless-stopped \
     -p 127.0.0.1:49374:49374 -v ai-memory-data:/data \
-    -e AI_MEMORY_ALLOWED_HOSTS="localhost,127.0.0.1,::1,host.docker.internal" \
     akitaonrails/ai-memory:latest
 
-# Wire the agent with an explicit loopback URL so install-mcp/install-hooks emit
-# a host-reachable address instead of the unresolvable host.docker.internal.
-AI_MEMORY_SERVER_URL=http://127.0.0.1:49374 \
-    ai-memory install-mcp   --client claude-code --apply
-AI_MEMORY_SERVER_URL=http://127.0.0.1:49374 \
-    ai-memory install-hooks --agent  claude-code --apply
+# Wire the native host agent. The wrapper keeps these rendered URLs on loopback.
+ai-memory install-mcp   --client claude-code --apply
+ai-memory install-hooks --agent  claude-code --apply
 ```
 
-On Apple Silicon the published `:latest` image currently runs as `linux/amd64`
-under emulation (Docker prints a platform-mismatch warning); it works but is not
-native.
+The published Docker image includes both `linux/amd64` and `linux/arm64`, so
+Apple Silicon pulls the native arm64 image without `--platform linux/amd64`.
 
 ## Hook Platform on macOS
 
 `AI_MEMORY_HOOK_PLATFORM` selects how hook commands are rendered. On macOS the
 two relevant values are `posix-native` (direct binary call; the native default)
 and `posix` (the bundled `.sh` scripts; the Docker-wrapper default). Set it
-before running `setup-agent` / `install-hooks` so the choice is baked into the
-rendered commands. The native hook spools events locally and drains them at
+before running `install-hooks` so the choice is baked into the rendered
+commands. The native hook spools events locally and drains them at
 session boundaries; the whole-minute spool-timing overrides are shared with
 Windows and documented in
 [`docs/windows.md`](windows.md#tuning-the-spool-timings-high-latency-instances).
 
-## Known limitations on macOS
+## Troubleshooting on macOS
 
-These were observed on Apple Silicon (macOS 26, Docker Desktop 28). Until they
-are fixed, prefer the native binary (Scenario A/B).
-
-1. **`:latest` runs under emulation on Apple Silicon.** The published `:latest`
-   tag currently resolves to a single `linux/amd64` image, so Docker Desktop
-   runs it through emulation with a platform-mismatch warning rather than
-   natively on `arm64`.
-2. **Docker wrapper thin-client → `403 forbidden host`.** The macOS wrapper
-   reaches the server via `host.docker.internal`, which is not in the default
-   Host-header allowlist (`localhost`, `127.0.0.1`, `::1`). Add
-   `host.docker.internal` to `AI_MEMORY_ALLOWED_HOSTS` on the server (Scenario C).
-3. **Docker wrapper renders an unreachable agent URL.** Run through the wrapper,
-   `install-mcp` / `install-hooks` emit `http://host.docker.internal:49374`,
-   which does not resolve on the macOS host — so the native agent's MCP client
-   and capture hooks cannot reach the server. Wire with
-   `AI_MEMORY_SERVER_URL=http://127.0.0.1:49374` (Scenario C).
-4. **Release-binary hook discovery needs `--source`.** `setup-agent` /
-   `install-hooks` do not auto-locate the `hooks/` bundle that ships beside the
-   binary in the release tarball, so pass `--source ./hooks` (Scenario A).
+- **`403 forbidden host` from Docker-wrapper CLI commands:** update the Docker
+  image and wrapper script. Current images allowlist `host.docker.internal` for
+  loopback-published Docker Desktop servers.
+- **Agent config points at `host.docker.internal`:** re-run `ai-memory
+  install-mcp --client <client> --apply` and `ai-memory install-hooks --agent
+  <agent> --apply` with the current wrapper. Host-side agent config should use
+  `http://127.0.0.1:49374`.
+- **Hooks bundle not found from a release archive:** ensure you extracted the
+  whole tarball, not just the binary. Current `install-hooks` probes the sibling
+  `hooks/` directory automatically.
+- **Platform-mismatch warning on Apple Silicon:** update to a current Docker
+  tag. Tagged releases publish a multi-arch manifest with `linux/arm64`.
 
 ## Suggested Test Checklist
 
 1. `ai-memory serve --bind 127.0.0.1:49374` starts and logs `bind=127.0.0.1:49374`.
 2. `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:49374/mcp` returns
    `405` (reachable; GET not allowed), confirming the loopback server is up.
-3. `setup-agent --agent claude-code --source ./hooks --to … --apply` extracts the
-   hook scripts and writes a config whose commands reference
-   `http://127.0.0.1:49374` and host-side `.sh` paths.
+3. `install-hooks --agent claude-code --apply` writes hook commands that
+   reference `http://127.0.0.1:49374` and host-side paths.
 4. `install-mcp --client claude-code` renders `http://127.0.0.1:49374/mcp`.
 5. Launch the agent, call `memory_status`, send a prompt, then confirm capture
-   (`ai-memory status --auth-token <token>` shows non-zero observations, or query
-   the SQLite `observations` table).
+   (`ai-memory status` shows non-zero observations, or query the SQLite
+   `observations` table).
 
 Report which scenario you used, your chip (Apple Silicon / Intel), the agent and
 version, and whether hooks executed or failed with a connect/resolve error.


### PR DESCRIPTION
## What changed

New `docs/macos.md` (modeled on `docs/windows.md`): native binary (recommended), source build, and Docker wrapper install paths; the `posix` vs `posix-native` hook split; and a "Known limitations" section. Linked from the README support matrix + docs table and `docs/install.md`, and bundled into the macOS release tarballs the same way `docs/windows.md` is.

## Why

macOS is Supported but had no dedicated install page — its guidance was scattered through `install.md`. This mirrors the Windows doc and documents the macOS-specific rough edges found while setting it up (filed as #107).

## Test plan

- [ ] `cargo fmt` / `clippy` / `test` — N/A: docs + workflow YAML only, no Rust changed
- [x] Verified the native macOS install end-to-end (`init` → `serve` → MCP → hook capture) on Apple Silicon
- [x] Replayed the `release.yml` macOS tarball staging + smoke list locally (`docs/macos.md` bundles and passes); validated YAML; `git diff --check` clean; added cross-links/anchors resolve

## Notes for reviewers

The "Known limitations" section and the support-matrix edit (dropping the "runs natively on Apple Silicon" claim) reflect #107: the macOS Docker quick-start currently doesn't work out of the box (amd64-only `:latest`, `403 forbidden host` on the wrapper thin-client, and an unresolvable `host.docker.internal` baked into the native agent config). The doc recommends the native binary until those are addressed.
