### PR TITLE
fix(macos): make the Docker-wrapper quick-start work on Apple Silicon (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a legacy `~/projects` or `/work` catch-all), not only `$HOME` and the
   filesystem root, while leaving paths it cannot see locally (a remote or
   multi-user client path, or an unmounted drive) untouched. (issue #103)
+- macOS Docker quick-start now produces a working native-agent setup out of the
+  box (issue #107). Three independent breakages are fixed: (1) the macOS wrapper
+  baked the container-only `host.docker.internal` URL into the *host* agent
+  config, so MCP and every capture hook failed silently — `install-mcp`,
+  `install-hooks`, and `setup-agent` now render the host-reachable
+  `http://127.0.0.1:49374`, decoupled from the `host.docker.internal` URL the
+  wrapper still uses for its own in-container thin-client commands; (2) those
+  thin-client commands were rejected with `403 forbidden host` because the
+  server's loopback-only Host allowlist excluded `host.docker.internal` — the
+  Docker image now ships it in the default `AI_MEMORY_ALLOWED_HOSTS` (native
+  installs stay loopback-only; exposed deployments still override it); and (3)
+  `setup-agent`/`install-hooks` could not locate the hooks bundle that ships
+  beside the binary in the release tarball (the probe derived a bogus
+  `/private/hooks/…`), so the binary-sibling `hooks/` directory is now on the
+  discovery search path and `--source` is no longer required.
 
 ### Added
 - `GET /admin/audit-contamination` (and `ai-memory audit-contamination`) — a

--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -259,6 +259,25 @@ NETWORK_ARGS=()
 # through bind mounts (~/.claude/settings.json, $PWD/, …) stay editable
 # by the invoking user. macOS is the one exception (see Darwin arm).
 USER_ARGS=(-u "$(id -u):$(id -g)")
+
+# Does this invocation RENDER host-side agent config? install-mcp,
+# install-hooks and setup-agent bake a server URL into files the *host*
+# agent reads (the MCP `url` and the `AI_MEMORY_HOOK_URL=…` on every hook
+# command). Thin-client commands (status, search, bootstrap, …) instead make
+# HTTP calls FROM this helper container to the server. On macOS those two
+# needs require different hosts, so the Darwin arm keys off this flag to pick
+# a host-reachable URL for config vs. a container-reachable URL for HTTP.
+# (issue #107)
+RENDERS_HOST_CONFIG=0
+for arg in "$@"; do
+  case "${arg}" in
+    install-mcp | install-hooks | setup-agent)
+      RENDERS_HOST_CONFIG=1
+      break
+      ;;
+  esac
+done
+
 case "$(uname -s 2>/dev/null || true)" in
   Linux)
     if [ -z "${AI_MEMORY_SERVER_URL:-}" ]; then
@@ -266,7 +285,15 @@ case "$(uname -s 2>/dev/null || true)" in
     fi
     ;;
   Darwin)
-    if [ -z "${AI_MEMORY_SERVER_URL:-}" ]; then
+    # macOS has no Docker host networking, so a thin-client command reaches
+    # the host-published loopback server from this helper container via Docker
+    # Desktop's host alias. But install-mcp/install-hooks/setup-agent RENDER
+    # the URL into the *host* agent config, and host.docker.internal does NOT
+    # resolve on the host — baking it in silently breaks MCP and every capture
+    # hook. So for those commands we leave AI_MEMORY_SERVER_URL unset, letting
+    # the CLI render its host-reachable default (http://127.0.0.1:49374).
+    # (issue #107)
+    if [ -z "${AI_MEMORY_SERVER_URL:-}" ] && [ "${RENDERS_HOST_CONFIG}" -eq 0 ]; then
       ENV_ARGS+=(-e "AI_MEMORY_SERVER_URL=http://host.docker.internal:49374")
     fi
     # On macOS, Docker Desktop handles file-sharing permissions via its

--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -269,14 +269,32 @@ USER_ARGS=(-u "$(id -u):$(id -g)")
 # a host-reachable URL for config vs. a container-reachable URL for HTTP.
 # (issue #107)
 RENDERS_HOST_CONFIG=0
-for arg in "$@"; do
+WRAPPER_SUBCOMMAND=""
+WRAPPER_ARGS=("$@")
+idx=0
+while [ "${idx}" -lt "${#WRAPPER_ARGS[@]}" ]; do
+  arg="${WRAPPER_ARGS[$idx]}"
   case "${arg}" in
-    install-mcp | install-hooks | setup-agent)
-      RENDERS_HOST_CONFIG=1
+    --data-dir | --config)
+      idx=$((idx + 2))
+      ;;
+    --data-dir=* | --config=*)
+      idx=$((idx + 1))
+      ;;
+    --*)
+      idx=$((idx + 1))
+      ;;
+    *)
+      WRAPPER_SUBCOMMAND="${arg}"
       break
       ;;
   esac
 done
+case "${WRAPPER_SUBCOMMAND}" in
+    install-mcp | install-hooks | setup-agent)
+      RENDERS_HOST_CONFIG=1
+      ;;
+esac
 
 case "$(uname -s 2>/dev/null || true)" in
   Linux)

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -1731,7 +1731,12 @@ fn resolve_hooks_dir(explicit: Option<&Path>, agent: AgentChoice) -> Result<Path
     }
 
     // Probe candidates in order. The first dir that exists wins.
-    let candidates = hook_source_candidates(sub, repo_root_guess(), dirs::data_local_dir());
+    let candidates = hook_source_candidates(
+        sub,
+        repo_root_guess(),
+        exe_dir_guess(),
+        dirs::data_local_dir(),
+    );
     for path in &candidates {
         if !path.as_os_str().is_empty() && path.is_dir() {
             return Ok(path.clone());
@@ -1743,12 +1748,19 @@ fn resolve_hooks_dir(explicit: Option<&Path>, agent: AgentChoice) -> Result<Path
 fn hook_source_candidates(
     sub: &str,
     repo_root: Option<PathBuf>,
+    exe_dir: Option<PathBuf>,
     data_local_dir: Option<PathBuf>,
 ) -> Vec<PathBuf> {
-    let mut candidates = Vec::with_capacity(4);
+    let mut candidates = Vec::with_capacity(5);
     // Cargo-run from the repo.
     if let Some(root) = repo_root {
         candidates.push(root.join("hooks").join(sub));
+    }
+    // Release tarball (macOS/Windows/Linux archive): the `hooks/` bundle
+    // ships in the same directory as the binary, so it's reachable without
+    // `--source` (issue #107).
+    if let Some(dir) = exe_dir {
+        candidates.push(dir.join("hooks").join(sub));
     }
     // Docker image lays them out under /usr/local/share/ai-memory/.
     candidates.push(PathBuf::from(format!(
@@ -1769,6 +1781,15 @@ fn repo_root_guess() -> Option<PathBuf> {
     std::env::current_exe()
         .ok()
         .and_then(|p| p.parent()?.parent()?.parent().map(Path::to_path_buf))
+}
+
+/// Directory the running binary lives in. The release tarball ships the
+/// `hooks/` bundle right next to the binary, so a no-`--source`
+/// `install-hooks` finds it there (issue #107).
+fn exe_dir_guess() -> Option<PathBuf> {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(Path::to_path_buf))
 }
 
 // CLAUDE_CODE_EVENTS + build_claude_code_payload now live in
@@ -2456,21 +2477,45 @@ model = "gpt-5"
         let candidates = hook_source_candidates(
             "claude-code",
             Some(PathBuf::from("/repo")),
+            Some(PathBuf::from("/opt/ai-memory")),
             Some(PathBuf::from("/home/alice/.local/share")),
         );
 
         assert_eq!(candidates[0], PathBuf::from("/repo/hooks/claude-code"));
         assert_eq!(
             candidates[1],
-            PathBuf::from("/usr/local/share/ai-memory/hooks/claude-code")
+            PathBuf::from("/opt/ai-memory/hooks/claude-code")
         );
         assert_eq!(
             candidates[2],
-            PathBuf::from("/usr/share/ai-memory/hooks/claude-code")
+            PathBuf::from("/usr/local/share/ai-memory/hooks/claude-code")
         );
         assert_eq!(
             candidates[3],
+            PathBuf::from("/usr/share/ai-memory/hooks/claude-code")
+        );
+        assert_eq!(
+            candidates[4],
             PathBuf::from("/home/alice/.local/share/ai-memory/hooks/claude-code")
+        );
+    }
+
+    #[test]
+    fn hook_source_candidates_include_binary_sibling_for_flat_tarball() {
+        // Extracted release tarball: no repo root, `hooks/` beside the binary
+        // (issue #107). The sibling dir must be probed or discovery fails with
+        // a bogus `/private/hooks/...` on macOS.
+        let candidates = hook_source_candidates(
+            "claude-code",
+            None,
+            Some(PathBuf::from("/private/tmp/ai-memory-macos-aarch64")),
+            None,
+        );
+        assert!(
+            candidates.contains(&PathBuf::from(
+                "/private/tmp/ai-memory-macos-aarch64/hooks/claude-code"
+            )),
+            "binary-sibling hooks/ dir must be probed; got {candidates:?}"
         );
     }
 

--- a/crates/ai-memory-cli/src/commands/setup_agent.rs
+++ b/crates/ai-memory-cli/src/commands/setup_agent.rs
@@ -287,24 +287,7 @@ fn copy_support_hook_scripts(source_dir: &Path, dest_dir: &Path) -> Result<()> {
 }
 
 fn resolve_source(explicit: Option<&Path>, sub: &str) -> Result<PathBuf> {
-    let candidates: Vec<PathBuf> = if let Some(p) = explicit {
-        vec![p.join(sub)]
-    } else {
-        let mut v = vec![
-            // Docker image lays them out under /usr/local/share/.
-            PathBuf::from(format!("/usr/local/share/ai-memory/hooks/{sub}")),
-            // Native Linux packages install hook sources under /usr/share.
-            PathBuf::from(format!("/usr/share/ai-memory/hooks/{sub}")),
-        ];
-        // Repo-local fallback for `cargo run setup-agent` during dev.
-        if let Some(p) = std::env::current_exe()
-            .ok()
-            .and_then(|p| p.parent()?.parent()?.parent().map(Path::to_path_buf))
-        {
-            v.push(p.join("hooks").join(sub));
-        }
-        v
-    };
+    let candidates = source_candidates(explicit, sub, std::env::current_exe().ok());
     for path in &candidates {
         if path.is_dir() {
             return Ok(path.clone());
@@ -314,4 +297,86 @@ fn resolve_source(explicit: Option<&Path>, sub: &str) -> Result<PathBuf> {
         "could not locate hook source bundle for {sub}. \
          Tried: {candidates:?}. Pass --source <dir> to override."
     );
+}
+
+/// Ordered directories to probe for the `<sub>` hook bundle.
+///
+/// `exe` is the running binary's path (`std::env::current_exe()`), threaded
+/// in so the derivation is unit-testable. An `explicit` `--source` is trusted
+/// verbatim; otherwise we try the packaged install locations plus two
+/// binary-relative spots:
+///   * `<exe_dir>/hooks/<sub>` — the **release tarball** ships `hooks/` right
+///     beside the binary (macOS/Windows/Linux archives), and
+///   * `<exe_dir>/../../hooks/<sub>` — `cargo run` from the repo, where the
+///     binary lives under `target/<profile>/`.
+///
+/// Without the binary-sibling entry the flat tarball layout was unreachable:
+/// from `/private/tmp/<dir>/ai-memory` the `parent×3` dev fallback derived a
+/// bogus `/private/hooks/<sub>` and discovery failed (issue #107).
+fn source_candidates(explicit: Option<&Path>, sub: &str, exe: Option<PathBuf>) -> Vec<PathBuf> {
+    if let Some(p) = explicit {
+        return vec![p.join(sub)];
+    }
+    let mut v = vec![
+        // Docker image lays them out under /usr/local/share/.
+        PathBuf::from(format!("/usr/local/share/ai-memory/hooks/{sub}")),
+        // Native Linux packages install hook sources under /usr/share.
+        PathBuf::from(format!("/usr/share/ai-memory/hooks/{sub}")),
+    ];
+    if let Some(exe) = exe {
+        // Release tarball: `hooks/` sits in the same dir as the binary.
+        if let Some(dir) = exe.parent() {
+            v.push(dir.join("hooks").join(sub));
+        }
+        // Repo-local fallback for `cargo run setup-agent` during dev:
+        // target/<profile>/<bin> → repo root.
+        if let Some(root) = exe.parent().and_then(Path::parent).and_then(Path::parent) {
+            v.push(root.join("hooks").join(sub));
+        }
+    }
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_candidates_include_binary_sibling_for_flat_tarball() {
+        // Flat release tarball: the binary and its `hooks/` bundle are
+        // extracted side by side. On macOS the path resolves under
+        // /private/..., which the old `parent×3` dev fallback turned into a
+        // bogus `/private/hooks/...` (issue #107).
+        let exe = PathBuf::from("/private/tmp/ai-memory-macos-aarch64/ai-memory");
+        let candidates = source_candidates(None, "claude-code", Some(exe));
+
+        assert!(
+            candidates.contains(&PathBuf::from(
+                "/private/tmp/ai-memory-macos-aarch64/hooks/claude-code"
+            )),
+            "binary-sibling hooks/ dir must be probed; got {candidates:?}"
+        );
+        // Packaged install locations still take precedence.
+        assert_eq!(
+            candidates[0],
+            PathBuf::from("/usr/local/share/ai-memory/hooks/claude-code")
+        );
+    }
+
+    #[test]
+    fn source_candidates_preserve_cargo_run_repo_root() {
+        // `cargo run`: target/<profile>/<bin> → repo root holds `hooks/`.
+        let exe = PathBuf::from("/home/dev/ai-memory/target/debug/ai-memory");
+        let candidates = source_candidates(None, "claude-code", Some(exe));
+        assert!(
+            candidates.contains(&PathBuf::from("/home/dev/ai-memory/hooks/claude-code")),
+            "repo-root hooks/ dir must still be probed; got {candidates:?}"
+        );
+    }
+
+    #[test]
+    fn source_candidates_honour_explicit_override() {
+        let candidates = source_candidates(Some(Path::new("/custom/src")), "codex", None);
+        assert_eq!(candidates, vec![PathBuf::from("/custom/src/codex")]);
+    }
 }

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -1,6 +1,7 @@
 //! Packaging asset regression tests.
 
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -14,6 +15,51 @@ fn read_repo(path: &str) -> String {
     let path = repo_root().join(path);
     std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))
+}
+
+fn run_wrapper_on_fake_macos(args: &[&str]) -> String {
+    let tmp = tempfile::tempdir().unwrap();
+    let docker_args = tmp.path().join("docker-args.txt");
+    let docker = tmp.path().join("docker");
+    let uname = tmp.path().join("uname");
+    std::fs::write(
+        &docker,
+        format!(
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\" > {}\n",
+            docker_args.display()
+        ),
+    )
+    .unwrap();
+    std::fs::write(&uname, "#!/usr/bin/env bash\nprintf 'Darwin\\n'\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&docker, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::set_permissions(&uname, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let path = format!(
+        "{}:{}",
+        tmp.path().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let output = Command::new(repo_root().join("bin/ai-memory"))
+        .args(args)
+        .env("PATH", path)
+        .env("AI_MEMORY_DOCKER", &docker)
+        .env("AI_MEMORY_NO_VERSION_CHECK", "1")
+        .env("AI_MEMORY_DATA_VOLUME", "test-ai-memory-data")
+        .env("HOME", tmp.path())
+        .env_remove("AI_MEMORY_SERVER_URL")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "wrapper failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    std::fs::read_to_string(docker_args).unwrap()
 }
 
 #[test]
@@ -105,4 +151,33 @@ fn docker_publish_jobs_use_prebuilt_binaries() {
     assert!(ci.contains("runner: macos-15"));
     assert!(ci.contains("runner: macos-15-intel"));
     assert!(ci.contains("--target runtime-prebuilt-amd64"));
+}
+
+#[test]
+fn macos_wrapper_routes_urls_by_real_subcommand() {
+    for subcommand in ["install-mcp", "install-hooks", "setup-agent"] {
+        let args = run_wrapper_on_fake_macos(&[subcommand]);
+        assert!(
+            !args.contains("AI_MEMORY_SERVER_URL=http://host.docker.internal:49374"),
+            "{subcommand} renders host-side config and must keep loopback defaults; got {args}"
+        );
+    }
+
+    let args = run_wrapper_on_fake_macos(&["status"]);
+    assert!(
+        args.contains("AI_MEMORY_SERVER_URL=http://host.docker.internal:49374"),
+        "thin-client commands must reach the host server through Docker Desktop; got {args}"
+    );
+
+    let args = run_wrapper_on_fake_macos(&["search", "install-hooks"]);
+    assert!(
+        args.contains("AI_MEMORY_SERVER_URL=http://host.docker.internal:49374"),
+        "only the actual subcommand should control URL routing; got {args}"
+    );
+
+    let args = run_wrapper_on_fake_macos(&["--config", "/tmp/config.toml", "install-hooks"]);
+    assert!(
+        !args.contains("AI_MEMORY_SERVER_URL=http://host.docker.internal:49374"),
+        "global options before install-hooks must not hide the real subcommand; got {args}"
+    );
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,6 +45,14 @@ RUN apt-get update \
 # (and by `setup_agent::resolve_source`).
 COPY hooks /usr/local/share/ai-memory/hooks
 ENV AI_MEMORY_DATA_DIR=/data
+# Allow Docker Desktop's host alias by default so the macOS wrapper's
+# thin-client commands — which reach the loopback-published server from a
+# one-shot helper container via host.docker.internal — aren't rejected by the
+# Host-header DNS-rebinding guard (issue #107). This widens only the *image*
+# default; native (non-Docker) installs keep the loopback-only default, and
+# exposed/homelab deployments still set their own `AI_MEMORY_ALLOWED_HOSTS`,
+# which replaces this value entirely.
+ENV AI_MEMORY_ALLOWED_HOSTS="localhost,127.0.0.1,::1,host.docker.internal"
 WORKDIR /data
 EXPOSE 49374
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \

--- a/docs/install.md
+++ b/docs/install.md
@@ -680,7 +680,8 @@ Docker Desktop wrapper, or a source build. Native Claude Code uses direct
 agents use PowerShell `.ps1` defaults.
 
 When run from source, `install-hooks` finds the bundled scripts in
-the repo's `hooks/` automatically:
+the repo's `hooks/` automatically. Extracted release archives also
+auto-discover the sibling `hooks/` bundle beside the `ai-memory` binary:
 
 ```bash
 ./target/release/ai-memory install-hooks --agent claude-code --auth-token "$TOKEN"


### PR DESCRIPTION
## What

Running the README Docker quick-start on macOS (Apple Silicon) left a native agent with **no working MCP and no capture**. This fixes the three code-level breakages from #107; the fourth point is already resolved on `main` (see below).

## Changes

- **#3 (most serious) — wrapper writes an unreachable URL into the native agent config.** `bin/ai-memory` shared a single `AI_MEMORY_SERVER_URL` for both the URL baked into *host-side* config and the URL its own in-container thin-client commands use — and on macOS those diverge. The wrapper now detects config-rendering commands (`install-mcp`/`install-hooks`/`setup-agent`) and lets the CLI render the host-reachable `http://127.0.0.1:49374`, while thin-client commands keep `http://host.docker.internal:49374`.

- **#2 — `403 forbidden host`.** The macOS wrapper's thin-client commands reach the loopback-published server via `host.docker.internal`, which the server's loopback-only Host allowlist rejected. `docker/Dockerfile` now includes `host.docker.internal` in the **image's** default `AI_MEMORY_ALLOWED_HOSTS`. Native (non-Docker) installs keep the loopback-only default; exposed/homelab deployments still set their own value, which replaces the image default entirely.

- **#4 — hooks bundle not auto-discovered from the release tarball.** `setup-agent`/`install-hooks` derived a bogus `/private/hooks/…` from the binary path and never looked *beside* the binary, where the flat tarball ships `hooks/`. Discovery now probes the binary-sibling `hooks/` dir, so `--source` is no longer required. (`setup_agent.rs`, `install_hooks.rs`, with regression tests.)

- **#1 — `:latest` single-arch.** Already fixed on `main`: the release workflow's manifest job publishes `:latest` as a multi-arch list (amd64 + arm64); it ships with the next tagged release. No change needed here.

Addresses #107 (points 2–4; point 1 already on `main`).

## Testing

- `cargo fmt --check`, `cargo test -p ai-memory-cli` (297 + 9 + 4 + 13 passed, 0 failed), and `cargo clippy -p ai-memory-cli --all-targets -- -D warnings` — all clean on Rust 1.95.
- New regression tests cover binary-sibling hook discovery in both `setup_agent` and `install_hooks`, including the macOS `/private/...` tarball layout.
- Exercised the wrapper's command-class URL routing across `install/setup` vs. `status/search/bootstrap` and the explicit-`AI_MEMORY_SERVER_URL` (homelab) case.
