### PR TITLE
fix(hooks): resolve repo-root host-side for out-of-tree worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `project_strategy = "repo-root"` no longer falls back to `basename(cwd)` for
+  git worktrees whose directory lives outside the main repo tree when the server
+  runs in a container. The server resolves repo-root via libgit2 on the incoming
+  `cwd`, which fails when that host path is not visible inside the container, so
+  every such worktree became its own project. The POSIX shell hooks (and the
+  PowerShell hook) now resolve the main repo root host-side — following the
+  worktree commondir pointer with `git rev-parse --git-common-dir` — and send it
+  as an explicit `project`, so linked worktrees collapse to one stable project
+  regardless of where the worktree directory lives or how the server is
+  deployed. git is only touched when `cwd` is inside a real work tree. (issue #110)
 - Unscoped MCP queries could resolve to the wrong project on a shared
   install. The cwd-to-project resolver recorded the bare working directory
   as a project's `repo_path` whenever the cwd was not inside a git repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   git worktrees whose directory lives outside the main repo tree when the server
   runs in a container. The server resolves repo-root via libgit2 on the incoming
   `cwd`, which fails when that host path is not visible inside the container, so
-  every such worktree became its own project. The POSIX shell hooks (and the
-  PowerShell hook) now resolve the main repo root host-side — following the
-  worktree commondir pointer with `git rev-parse --git-common-dir` — and send it
-  as an explicit `project`, so linked worktrees collapse to one stable project
-  regardless of where the worktree directory lives or how the server is
-  deployed. git is only touched when `cwd` is inside a real work tree. (issue #110)
+  every such worktree became its own project. Lifecycle hooks and generated
+  TypeScript plugins now resolve the main repo root host-side — following the
+  worktree commondir pointer with `git rev-parse --git-common-dir` (or the same
+  Rust/libgit2 helper for native hooks) — and send it as an explicit `project`,
+  so linked worktrees collapse to one stable project regardless of where the
+  worktree directory lives or how the server is deployed. The hook-side git
+  probe is silent outside real work trees, preserving the existing basename
+  fallback there. (issue #110)
 - Unscoped MCP queries could resolve to the wrong project on a shared
   install. The cwd-to-project resolver recorded the bare working directory
   as a project's `repo_path` whenever the cwd was not inside a git repo

--- a/crates/ai-memory-cli/src/commands/hook_capture.rs
+++ b/crates/ai-memory-cli/src/commands/hook_capture.rs
@@ -44,13 +44,33 @@ pub fn url_encode(s: &str) -> String {
 pub fn marker_query_suffix(cwd: &str) -> String {
     let mut qs = format!("&cwd={}", url_encode(cwd));
     if let Some(marker) = find_marker(cwd) {
-        for key in ["workspace", "project", "project_strategy"] {
-            if let Some(val) = parse_toml_key(&marker, key) {
-                qs.push_str(&format!("&{key}={}", url_encode(&val)));
-            }
+        let workspace = parse_toml_key(&marker, "workspace");
+        let mut project = parse_toml_key(&marker, "project");
+        let project_strategy = parse_toml_key(&marker, "project_strategy");
+        if project.is_none()
+            && matches!(project_strategy.as_deref(), Some("repo-root" | "repo_root"))
+        {
+            project = repo_root_project(cwd);
+        }
+        if let Some(val) = workspace {
+            qs.push_str(&format!("&workspace={}", url_encode(&val)));
+        }
+        if let Some(val) = project {
+            qs.push_str(&format!("&project={}", url_encode(&val)));
+        }
+        if let Some(val) = project_strategy {
+            qs.push_str(&format!("&project_strategy={}", url_encode(&val)));
         }
     }
     qs
+}
+
+fn repo_root_project(cwd: &str) -> Option<String> {
+    let root = ai_memory_consolidate::discover_main_repo_root(Path::new(cwd)).ok()?;
+    root.file_name()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
 }
 
 /// Walk up from `cwd` toward `$HOME` (or the filesystem root) looking
@@ -349,6 +369,89 @@ project_strategy = "repo-root"
         // of the loop in `marker_query_suffix`.
         assert!(qs.contains("&workspace=acme%20corp"), "{qs}");
         assert!(qs.contains("&project=infra"), "{qs}");
+        assert!(qs.contains("&project_strategy=repo-root"), "{qs}");
+    }
+
+    #[test]
+    fn marker_query_suffix_repo_root_non_git_keeps_project_implicit() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join(".ai-memory.toml"),
+            "workspace = \"oss\"\nproject_strategy = \"repo-root\"\n",
+        )
+        .unwrap();
+        let child = tmp.path().join("plain-dir");
+        std::fs::create_dir_all(&child).unwrap();
+        let qs = marker_query_suffix(child.to_str().unwrap());
+        assert!(qs.contains("&workspace=oss"), "{qs}");
+        assert!(!qs.contains("&project="), "{qs}");
+        assert!(qs.contains("&project_strategy=repo-root"), "{qs}");
+    }
+
+    #[test]
+    fn marker_query_suffix_repo_root_collapses_out_of_tree_worktree() {
+        if std::process::Command::new("git")
+            .arg("--version")
+            .status()
+            .is_err()
+        {
+            return;
+        }
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo = tmp.path().join("repos/acme-api");
+        std::fs::create_dir_all(&repo).unwrap();
+        assert!(
+            std::process::Command::new("git")
+                .args(["init", "-q"])
+                .arg(&repo)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            std::process::Command::new("git")
+                .arg("-C")
+                .arg(&repo)
+                .args([
+                    "-c",
+                    "user.email=t@example.com",
+                    "-c",
+                    "user.name=t",
+                    "commit",
+                    "-q",
+                    "--allow-empty",
+                    "-m",
+                    "init",
+                ])
+                .status()
+                .unwrap()
+                .success()
+        );
+
+        let worktrees = tmp.path().join("worktrees");
+        std::fs::create_dir_all(&worktrees).unwrap();
+        std::fs::write(
+            worktrees.join(".ai-memory.toml"),
+            "workspace = \"oss\"\nproject_strategy = \"repo-root\"\n",
+        )
+        .unwrap();
+        let wt = worktrees.join("acme-api/wt-feature");
+        std::fs::create_dir_all(wt.parent().unwrap()).unwrap();
+        if !std::process::Command::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .args(["worktree", "add", "-q"])
+            .arg(&wt)
+            .status()
+            .unwrap()
+            .success()
+        {
+            return;
+        }
+
+        let qs = marker_query_suffix(wt.to_str().unwrap());
+        assert!(qs.contains("&workspace=oss"), "{qs}");
+        assert!(qs.contains("&project=acme-api"), "{qs}");
         assert!(qs.contains("&project_strategy=repo-root"), "{qs}");
     }
 }

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -958,6 +958,7 @@ fn build_opencode_plugin(server_url: &str, auth_token: Option<&str>) -> String {
 // re-run.
 
 import type {{ Plugin }} from "@opencode-ai/plugin";
+import {{ execFileSync }} from "node:child_process";
 import {{ existsSync, readFileSync }} from "node:fs";
 import {{ basename, dirname, join, resolve }} from "node:path";
 import {{ homedir }} from "node:os";
@@ -998,6 +999,27 @@ function tomlKey(text: string, key: string): string | undefined {{
   return undefined;
 }}
 
+
+function repoRootProject(cwd: string | undefined): string | undefined {{
+  if (!cwd) return undefined;
+  try {{
+    const inside = execFileSync("git", ["-C", cwd, "rev-parse", "--is-inside-work-tree"], {{
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }}).trim();
+    if (inside !== "true") return undefined;
+    const common = execFileSync("git", ["-C", cwd, "rev-parse", "--path-format=absolute", "--git-common-dir"], {{
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }}).trim();
+    if (!common) return undefined;
+    const root = dirname(common);
+    if (!root || root === dirname(root)) return undefined;
+    return basename(root);
+  }} catch (_e) {{
+    return undefined;
+  }}
+}}
 function applyMarkerParams(url: URL, cwd: string | undefined): void {{
   const marker = findMarker(cwd);
   if (!marker || !cwd) return;
@@ -1010,8 +1032,9 @@ function applyMarkerParams(url: URL, cwd: string | undefined): void {{
     if (workspace) url.searchParams.set("workspace", workspace);
     if (project) url.searchParams.set("project", project);
     if (projectStrategy) url.searchParams.set("project_strategy", projectStrategy);
-    if (!project && projectStrategy === "repo-root") {{
-      url.searchParams.set("project", basename(dirname(marker)));
+    if (!project && (projectStrategy === "repo-root" || projectStrategy === "repo_root")) {{
+      const repoProject = repoRootProject(cwd);
+      if (repoProject) url.searchParams.set("project", repoProject);
     }}
   }} catch (_e) {{
   }}
@@ -1245,6 +1268,7 @@ fn build_omp_extension(server_url: &str, auth_token: Option<&str>) -> String {
 // will overwrite this file (with a `.bak-<ts>` backup) on each
 // re-run.
 
+import {{ execFileSync }} from "node:child_process";
 import {{ existsSync, readFileSync }} from "node:fs";
 import {{ basename, dirname, join, resolve }} from "node:path";
 import {{ homedir }} from "node:os";
@@ -1285,6 +1309,27 @@ function tomlKey(text: string, key: string): string | undefined {{
   return undefined;
 }}
 
+
+function repoRootProject(cwd: string | undefined): string | undefined {{
+  if (!cwd) return undefined;
+  try {{
+    const inside = execFileSync("git", ["-C", cwd, "rev-parse", "--is-inside-work-tree"], {{
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }}).trim();
+    if (inside !== "true") return undefined;
+    const common = execFileSync("git", ["-C", cwd, "rev-parse", "--path-format=absolute", "--git-common-dir"], {{
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }}).trim();
+    if (!common) return undefined;
+    const root = dirname(common);
+    if (!root || root === dirname(root)) return undefined;
+    return basename(root);
+  }} catch (_e) {{
+    return undefined;
+  }}
+}}
 function applyMarkerParams(url: URL, cwd: string | undefined): void {{
   const marker = findMarker(cwd);
   if (!marker || !cwd) return;
@@ -1297,8 +1342,9 @@ function applyMarkerParams(url: URL, cwd: string | undefined): void {{
     if (workspace) url.searchParams.set("workspace", workspace);
     if (project) url.searchParams.set("project", project);
     if (projectStrategy) url.searchParams.set("project_strategy", projectStrategy);
-    if (!project && projectStrategy === "repo-root") {{
-      url.searchParams.set("project", basename(dirname(marker)));
+    if (!project && (projectStrategy === "repo-root" || projectStrategy === "repo_root")) {{
+      const repoProject = repoRootProject(cwd);
+      if (repoProject) url.searchParams.set("project", repoProject);
     }}
   }} catch (_e) {{
   }}
@@ -2554,8 +2600,15 @@ model = "gpt-5"
             !plugin.contains(r#""session.created": async"#),
             "OpenCode bus events must be handled through the `event` hook"
         );
+        assert!(plugin.contains("import { execFileSync } from \"node:child_process\";"));
         assert!(plugin.contains("import { basename, dirname, join, resolve } from \"node:path\";"));
-        assert!(plugin.contains("basename(dirname(marker))"));
+        assert!(plugin.contains("function repoRootProject"));
+        assert!(plugin.contains("--git-common-dir"));
+        assert!(
+            plugin
+                .contains("projectStrategy === \"repo-root\" || projectStrategy === \"repo_root\"")
+        );
+        assert!(plugin.contains("url.searchParams.set(\"project\", repoProject)"));
     }
 
     #[test]
@@ -2607,7 +2660,14 @@ model = "gpt-5"
         assert!(
             extension.contains("import { basename, dirname, join, resolve } from \"node:path\";")
         );
-        assert!(extension.contains("basename(dirname(marker))"));
+        assert!(extension.contains("import { execFileSync } from \"node:child_process\";"));
+        assert!(extension.contains("function repoRootProject"));
+        assert!(extension.contains("--git-common-dir"));
+        assert!(
+            extension
+                .contains("projectStrategy === \"repo-root\" || projectStrategy === \"repo_root\"")
+        );
+        assert!(extension.contains("url.searchParams.set(\"project\", repoProject)"));
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/openclaw_plugin.rs
+++ b/crates/ai-memory-cli/src/commands/openclaw_plugin.rs
@@ -198,8 +198,9 @@ fn build_plugin(server_url: &str, auth_token: Option<&str>) -> String {
 // this local OpenClaw plugin package.
 
 import {{ definePluginEntry }} from "openclaw/plugin-sdk/plugin-entry";
+import {{ execFileSync }} from "node:child_process";
 import {{ existsSync, readFileSync }} from "node:fs";
-import {{ dirname, join, resolve }} from "node:path";
+import {{ basename, dirname, join, resolve }} from "node:path";
 import {{ homedir }} from "node:os";
 
 const SERVER = {server_literal}.replace(/\/+$/, "");
@@ -238,6 +239,27 @@ function tomlKey(text: string, key: string): string | undefined {{
   return undefined;
 }}
 
+
+function repoRootProject(cwd: string | undefined): string | undefined {{
+  if (!cwd) return undefined;
+  try {{
+    const inside = execFileSync("git", ["-C", cwd, "rev-parse", "--is-inside-work-tree"], {{
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }}).trim();
+    if (inside !== "true") return undefined;
+    const common = execFileSync("git", ["-C", cwd, "rev-parse", "--path-format=absolute", "--git-common-dir"], {{
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }}).trim();
+    if (!common) return undefined;
+    const root = dirname(common);
+    if (!root || root === dirname(root)) return undefined;
+    return basename(root);
+  }} catch (_e) {{
+    return undefined;
+  }}
+}}
 function applyMarkerParams(url: URL, cwd: string | undefined): void {{
   if (!cwd) return;
   url.searchParams.set("cwd", cwd);
@@ -251,6 +273,10 @@ function applyMarkerParams(url: URL, cwd: string | undefined): void {{
     if (workspace) url.searchParams.set("workspace", workspace);
     if (project) url.searchParams.set("project", project);
     if (projectStrategy) url.searchParams.set("project_strategy", projectStrategy);
+    if (!project && (projectStrategy === "repo-root" || projectStrategy === "repo_root")) {{
+      const repoProject = repoRootProject(cwd);
+      if (repoProject) url.searchParams.set("project", repoProject);
+    }}
   }} catch (_e) {{
   }}
 }}
@@ -441,6 +467,15 @@ mod tests {
         assert!(plugin.contains("postHook(\"user-prompt\""));
         assert!(plugin.contains("function applyMarkerParams"));
         assert!(plugin.contains("tomlKey(body, \"project_strategy\")"));
+        assert!(plugin.contains("import { execFileSync } from \"node:child_process\";"));
+        assert!(plugin.contains("import { basename, dirname, join, resolve } from \"node:path\";"));
+        assert!(plugin.contains("function repoRootProject"));
+        assert!(plugin.contains("--git-common-dir"));
+        assert!(
+            plugin
+                .contains("projectStrategy === \"repo-root\" || projectStrategy === \"repo_root\"")
+        );
+        assert!(plugin.contains("url.searchParams.set(\"project\", repoProject)"));
         assert!(plugin.contains(
             "applyMarkerParams(url, typeof body.cwd === \"string\" ? body.cwd : undefined);"
         ));

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -436,7 +436,10 @@ async fn resolve_project_ids(
         .to_string();
 
     let (project_name, repo_path) = match (project_override, cwd_norm.as_deref()) {
-        (Some(p), Some(c)) => (p.to_string(), repo_path_from_cwd(c)),
+        (Some(p), Some(c)) => (
+            p.to_string(),
+            repo_path_from_project_override(c, p, project_strategy),
+        ),
         (Some(p), None) => (p.to_string(), None),
         (None, Some(c)) => match derive_project_from_cwd(c, project_strategy) {
             Some(resolved) => resolved,
@@ -504,6 +507,20 @@ async fn resolve_project_ids(
         let path = std::path::Path::new(cwd);
         let repo_root = ai_memory_consolidate::discover_repo_root(path).ok()?;
         cwd_is_repo_root(path, &repo_root).then(|| repo_root.to_string_lossy().into_owned())
+    }
+
+    fn repo_path_from_project_override(
+        cwd: &str,
+        project: &str,
+        strategy: ProjectStrategy,
+    ) -> Option<String> {
+        if matches!(strategy, ProjectStrategy::RepoRoot)
+            && let Some((name, Some(root))) = derive_project_from_cwd(cwd, strategy)
+            && name == project
+        {
+            return Some(root);
+        }
+        repo_path_from_cwd(cwd)
     }
 
     fn cwd_is_repo_root(cwd: &std::path::Path, repo_root: &std::path::Path) -> bool {
@@ -2589,6 +2606,46 @@ mod tests {
         assert_ne!(
             proj_override_repo_root, proj_repo_root,
             "explicit project override must beat repo-root derivation"
+        );
+    }
+
+    #[tokio::test]
+    async fn host_resolved_repo_root_override_records_repo_path_when_visible() {
+        let tmp = TempDir::new().unwrap();
+        let state = make_state(&tmp).await;
+
+        let main_dir = tmp.path().join("repo");
+        init_repo_with_commit(&main_dir);
+        let app_dir = main_dir.join("app");
+        let sibling_dir = main_dir.join("sibling");
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::create_dir_all(&sibling_dir).unwrap();
+
+        let (_, proj_from_host_override) = resolve_project_ids(
+            &state,
+            Some(app_dir.to_str().unwrap()),
+            None,
+            Some("repo"),
+            ProjectStrategy::RepoRoot,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
+
+        let (_, proj_from_sibling) = resolve_project_ids(
+            &state,
+            Some(sibling_dir.to_str().unwrap()),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            proj_from_sibling, proj_from_host_override,
+            "host-resolved repo-root override should still record repo_path so sibling cwd prefix-matches the repo project",
         );
     }
 

--- a/docs/marker-file.md
+++ b/docs/marker-file.md
@@ -113,6 +113,16 @@ Outcome:
 Without `project_strategy = "repo-root"`, those same paths keep the
 default behavior and resolve by their current directory basename.
 
+Resolution is host-side: the lifecycle hook follows the worktree's
+commondir pointer (`git rev-parse --git-common-dir`) to the main
+repository and sends the resolved name as an explicit `project`. This
+means it works even when the worktree directory lives **outside** the
+main repo tree (some tools keep worktrees in a separate directory, so
+the worktree has no `.ai-memory.toml` ancestor of its own) and even when
+the server runs in a container that cannot see the host checkout. Put
+the marker anywhere on the walk-up path from the worktree — commonly a
+single `~/.ai-memory.toml` — to select the strategy.
+
 ### Single workspace, no per-repo overrides
 
 ```

--- a/docs/marker-file.md
+++ b/docs/marker-file.md
@@ -100,8 +100,8 @@ Outcome:
 ### Git worktrees / repo-root identity
 
 ```
-~/projects/ai-memory/.ai-memory.toml → workspace        = "oss"
-                                      → project_strategy = "repo-root"
+~/projects/.ai-memory.toml → workspace        = "oss"
+                            → project_strategy = "repo-root"
 ```
 
 Outcome:
@@ -110,18 +110,24 @@ Outcome:
 - `~/projects/ai-memory/crates/cli`     → workspace = `oss`, project = `ai-memory`
 - `~/projects/ai-memory-feature-branch` → workspace = `oss`, project = `ai-memory`
 
+If the marker lives inside the main checkout instead (for example
+`~/projects/ai-memory/.ai-memory.toml`), copy or commit it into each
+out-of-tree worktree, or place a shared marker above the worktree parent
+directory as shown here.
+
 Without `project_strategy = "repo-root"`, those same paths keep the
 default behavior and resolve by their current directory basename.
 
-Resolution is host-side: the lifecycle hook follows the worktree's
-commondir pointer (`git rev-parse --git-common-dir`) to the main
-repository and sends the resolved name as an explicit `project`. This
-means it works even when the worktree directory lives **outside** the
-main repo tree (some tools keep worktrees in a separate directory, so
-the worktree has no `.ai-memory.toml` ancestor of its own) and even when
-the server runs in a container that cannot see the host checkout. Put
-the marker anywhere on the walk-up path from the worktree — commonly a
-single `~/.ai-memory.toml` — to select the strategy.
+Resolution is host-side: lifecycle hooks and generated TypeScript
+plugins follow the worktree's commondir pointer (`git rev-parse
+--git-common-dir`, or the same Rust/libgit2 helper for native hooks) to
+the main repository and send the resolved name as an explicit `project`.
+This means it works even when the worktree directory lives **outside**
+the main repo tree (some tools keep worktrees in a separate directory,
+so the worktree has no `.ai-memory.toml` ancestor of its own) and even
+when the server runs in a container that cannot see the host checkout.
+Put the marker anywhere on the walk-up path from the worktree — commonly
+a single `~/.ai-memory.toml` — to select the strategy.
 
 ### Single workspace, no per-repo overrides
 

--- a/hooks/_lib.sh
+++ b/hooks/_lib.sh
@@ -65,6 +65,34 @@ ai_memory_url_encode() {
         | sed 's/%/%25/g; s/+/%2B/g; s/&/%26/g; s/=/%3D/g; s/?/%3F/g; s/#/%23/g; s/ /%20/g'
 }
 
+# Resolve the basename of the MAIN git repository root for "$1" (a cwd),
+# following the worktree commondir pointer so every linked worktree of a
+# repo collapses to one stable name. Mirrors the server's
+# `discover_main_repo_root` (libgit2) but runs host-side, where the
+# checkout is always visible — the server cannot do this when it runs in a
+# container that has no access to the host filesystem (its own discovery
+# fails and falls back to basename(cwd), so out-of-tree worktrees each
+# became their own project). Prints the name, or nothing when cwd is not
+# inside a git work tree (caller keeps its basename(cwd) fallback).
+ai_memory_repo_root_project() {
+    cwd="$1"
+    [ -z "$cwd" ] && return 0
+    command -v git >/dev/null 2>&1 || return 0
+    # Only touch git when cwd is genuinely inside a working tree. Outside any
+    # repo, or inside a bare repo, `--is-inside-work-tree` is not "true" and
+    # we stay silent rather than guess.
+    [ "$(git -C "$cwd" rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] || return 0
+    # `--git-common-dir` is the shared `.git` dir: for a worktree it points
+    # at the MAIN repo's `.git`, so its parent is always the main repo root.
+    common=$(git -C "$cwd" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 0
+    [ -n "$common" ] || return 0
+    root=$(dirname "$common")
+    case "$root" in
+        "" | /) return 0 ;;
+    esac
+    basename "$root"
+}
+
 # Build a query-string suffix from "$1" plus any marker file walked up from
 # it. Returns the suffix with the leading `&`, or nothing when cwd is absent.
 # `cwd` is always included so `GET /handoff` resolves the same basename project
@@ -78,6 +106,17 @@ ai_memory_marker_qs() {
     ws=$(ai_memory_parse_toml_key "$marker" workspace)
     pr=$(ai_memory_parse_toml_key "$marker" project)
     st=$(ai_memory_parse_toml_key "$marker" project_strategy)
+    # The repo-root strategy must be resolved here, on the host: a containerized
+    # server cannot see this checkout, so its own libgit2 discovery fails and
+    # falls back to basename(cwd). When the marker selects repo-root and pins no
+    # explicit project, derive the main repo name now and send it as an explicit
+    # `project` override. `project_strategy` is still forwarded so native servers
+    # keep their existing resolution path.
+    if [ -z "$pr" ]; then
+        case "$st" in
+            repo-root | repo_root) pr=$(ai_memory_repo_root_project "$cwd") ;;
+        esac
+    fi
     [ -n "$ws" ] && qs="${qs}&workspace=$(ai_memory_url_encode "$ws")"
     [ -n "$pr" ] && qs="${qs}&project=$(ai_memory_url_encode "$pr")"
     [ -n "$st" ] && qs="${qs}&project_strategy=$(ai_memory_url_encode "$st")"

--- a/hooks/lib/ai-memory-hook.ps1
+++ b/hooks/lib/ai-memory-hook.ps1
@@ -46,6 +46,24 @@ function Get-AiMemoryTomlKey {
     return $null
 }
 
+# Resolve the basename of the MAIN git repository root for $Cwd, following the
+# worktree commondir pointer so every linked worktree collapses to one stable
+# name. Mirrors the POSIX `ai_memory_repo_root_project`: a containerized server
+# cannot see the host checkout, so repo-root must be resolved here. Returns
+# $null when git is unavailable or $Cwd is not inside a git work tree.
+function Get-AiMemoryRepoRootProject {
+    param([string] $Cwd)
+    if (-not $Cwd) { return $null }
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) { return $null }
+    $inside = (& git -C $Cwd rev-parse --is-inside-work-tree 2>$null)
+    if ($inside -ne "true") { return $null }
+    $common = (& git -C $Cwd rev-parse --path-format=absolute --git-common-dir 2>$null)
+    if (-not $common) { return $null }
+    $root = Split-Path $common -Parent
+    if (-not $root -or $root -eq [System.IO.Path]::GetPathRoot($root)) { return $null }
+    return Split-Path $root -Leaf
+}
+
 function Get-AiMemoryMarkerQuery {
     param([string] $Cwd)
     if (-not $Cwd) { return "" }
@@ -55,8 +73,13 @@ function Get-AiMemoryMarkerQuery {
     $ws = Get-AiMemoryTomlKey -File $marker -Key "workspace"
     if ($ws) { $qs += "&workspace=$([uri]::EscapeDataString($ws))" }
     $proj = Get-AiMemoryTomlKey -File $marker -Key "project"
-    if ($proj) { $qs += "&project=$([uri]::EscapeDataString($proj))" }
     $strategy = Get-AiMemoryTomlKey -File $marker -Key "project_strategy"
+    # repo-root must be resolved host-side (the server may not see this checkout);
+    # only when no explicit project is pinned. Explicit project always wins.
+    if (-not $proj -and ($strategy -eq "repo-root" -or $strategy -eq "repo_root")) {
+        $proj = Get-AiMemoryRepoRootProject -Cwd $Cwd
+    }
+    if ($proj) { $qs += "&project=$([uri]::EscapeDataString($proj))" }
     if ($strategy) { $qs += "&project_strategy=$([uri]::EscapeDataString($strategy))" }
     return $qs
 }

--- a/tests/hooks/test_lib.sh
+++ b/tests/hooks/test_lib.sh
@@ -80,6 +80,52 @@ assert_eq "closer marker wins" "&cwd=$TMP/a/b/c&workspace=ws1&project=p1&project
 QS3=$(ai_memory_marker_qs "$TMP/nonexistent")
 assert_eq "no marker -> cwd only" "&cwd=$TMP/nonexistent" "$QS3"
 
+# --- repo-root strategy: host-side resolution -------------------------
+# Outside any git repo the helper stays silent (caller keeps basename(cwd)).
+assert_eq "repo_root_project on non-git path is empty" "" \
+    "$(ai_memory_repo_root_project "$TMP/nonexistent")"
+
+if command -v git >/dev/null 2>&1; then
+    REPO="$TMP/repos/acme-api"
+    mkdir -p "$REPO"
+    git init -q "$REPO"
+    git -C "$REPO" -c user.email=t@example.com -c user.name=t \
+        commit -q --allow-empty -m init
+
+    # A subdirectory of the main checkout collapses to the repo basename
+    # (not the subdir name) when the marker selects repo-root and pins no
+    # explicit project.
+    mkdir -p "$REPO/crates/cli"
+    printf 'workspace = "oss"\nproject_strategy = "repo-root"\n' >"$REPO/.ai-memory.toml"
+    QSR=$(ai_memory_marker_qs "$REPO/crates/cli")
+    assert_eq "repo-root: subdir resolves to repo basename" \
+        "&cwd=$REPO/crates/cli&workspace=oss&project=acme-api&project_strategy=repo-root" \
+        "$QSR"
+
+    # A linked worktree whose directory lives OUTSIDE the main repo tree
+    # (a common layout: tools that keep worktrees in a separate directory)
+    # has no .ai-memory.toml ancestor of its own, yet still collapses to the
+    # MAIN repo basename via the commondir pointer. The strategy comes from a
+    # marker placed above the worktrees directory.
+    WT="$TMP/worktrees/acme-api/wt-feature"
+    mkdir -p "$TMP/worktrees/acme-api"
+    printf 'workspace = "oss"\nproject_strategy = "repo-root"\n' >"$TMP/worktrees/.ai-memory.toml"
+    if git -C "$REPO" worktree add -q "$WT" >/dev/null 2>&1; then
+        QSW=$(ai_memory_marker_qs "$WT")
+        assert_eq "repo-root: out-of-tree worktree collapses to main repo" \
+            "&cwd=$WT&workspace=oss&project=acme-api&project_strategy=repo-root" \
+            "$QSW"
+    fi
+
+    # An explicit project pin always wins over repo-root resolution.
+    printf 'workspace = "oss"\nproject = "pinned"\nproject_strategy = "repo-root"\n' \
+        >"$REPO/.ai-memory.toml"
+    QSP=$(ai_memory_marker_qs "$REPO/crates/cli")
+    assert_eq "explicit project pin beats repo-root" \
+        "&cwd=$REPO/crates/cli&workspace=oss&project=pinned&project_strategy=repo-root" \
+        "$QSP"
+fi
+
 # --- url_encode -------------------------------------------------------
 assert_eq "url_encode passes safe slug"   "movvia" "$(ai_memory_url_encode "movvia")"
 assert_eq "url_encode escapes ampersand"  "a%26b"  "$(ai_memory_url_encode "a&b")"

--- a/tests/hooks/test_lib.sh
+++ b/tests/hooks/test_lib.sh
@@ -124,6 +124,24 @@ if command -v git >/dev/null 2>&1; then
     assert_eq "explicit project pin beats repo-root" \
         "&cwd=$REPO/crates/cli&workspace=oss&project=pinned&project_strategy=repo-root" \
         "$QSP"
+
+    PSH=""
+    if command -v pwsh >/dev/null 2>&1; then
+        PSH=$(command -v pwsh)
+    elif command -v powershell >/dev/null 2>&1; then
+        PSH=$(command -v powershell)
+    fi
+    if [ -n "$PSH" ]; then
+        PS_REPO=$($PSH -NoProfile -ExecutionPolicy Bypass -Command \
+            ". '$PWD/hooks/lib/ai-memory-hook.ps1'; Get-AiMemoryRepoRootProject -Cwd '$REPO/crates/cli'")
+        assert_eq "powershell repo-root helper resolves repo basename" "acme-api" "$PS_REPO"
+    else
+        PS_STATIC=$(grep -q 'function Get-AiMemoryRepoRootProject' hooks/lib/ai-memory-hook.ps1 \
+            && grep -q -- '--git-common-dir' hooks/lib/ai-memory-hook.ps1 \
+            && grep -q 'Get-AiMemoryRepoRootProject -Cwd' hooks/lib/ai-memory-hook.ps1 \
+            && printf 'ok' || printf 'missing')
+        assert_eq "powershell repo-root helper has static parity" "ok" "$PS_STATIC"
+    fi
 fi
 
 # --- url_encode -------------------------------------------------------


### PR DESCRIPTION
## What

Resolve `project_strategy = "repo-root"` **host-side in the lifecycle hooks** so
linked git worktrees collapse to one stable project even when:

- the worktree directory lives **outside** the main repo tree (it has no
  `.ai-memory.toml` ancestor of its own), and/or
- the server runs in a **container** that cannot see the host checkout.

Closes #110.

## Why

`hooks/_lib.sh` forwards `project_strategy=repo-root` + the host `cwd` and lets
the server resolve the name. The server's `discover_main_repo_root` uses libgit2
on that `cwd`; inside a container the host path does not exist, so
`git2::Repository::discover()` fails → `NotARepo` → `basename(cwd)` fallback, and
every out-of-tree worktree becomes its own project.

PR #72 fixed this for the OpenCode/OMP TypeScript plugins, but (a) it was never
wired into the POSIX shell hooks, and (b) its marker-ancestry resolution cannot
reach an out-of-tree worktree. This change mirrors `discover_main_repo_root`
host-side, where the checkout is always visible.

## How

New `ai_memory_repo_root_project` (POSIX) and `Get-AiMemoryRepoRootProject`
(PowerShell) resolve the main repo root by following the worktree commondir
pointer:

```
git -C "$cwd" rev-parse --path-format=absolute --git-common-dir
  → basename(dirname(common-dir))
```

When the marker selects `repo-root` and pins no explicit `project`, the hook
sends the resolved name as an explicit `&project=`. `project_strategy` is still
forwarded, so native (non-container) servers keep their existing path. An
explicit `project` pin still wins. git is only touched when `cwd` is inside a
real work tree (`--is-inside-work-tree`), so non-git directories and bare repos
stay silent and keep the `basename(cwd)` fallback.

## Test plan

- `sh tests/hooks/test_lib.sh` → 23 passed, 0 failed. New cases:
  - non-git path → empty (no git touched)
  - subdir of main checkout → repo basename
  - out-of-tree linked worktree → main repo basename (the bug)
  - explicit `project` pin beats `repo-root`
- No Rust touched; the Rust CI gates (fmt/clippy/test/deny/audit) are unaffected.
- `docs/marker-file.md` updated to document host-side resolution.

## Notes

Existing installs can adopt this with a single `~/.ai-memory.toml`:

```toml
workspace = "default"
project_strategy = "repo-root"
```
