### PR TITLE
fix(hooks): de-verbatim Windows data dir so native capture isn't dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   kept working, masking the loss. The data dir is now de-verbatim'd both when
   rendering the hook command (new installs emit a plain `--data-dir`) and when
   the hook resolves its data dir at capture time (an already-installed hook
-  recovers on the next session without re-running `install-hooks`). (issue #116)
+  recovers on the next session without re-running `install-hooks`), and future
+  spool enqueue failures emit a sanitized stderr warning instead of staying fully
+  silent. (issue #116)
 
 ## [1.1.2] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Native Windows Claude Code hooks no longer silently drop every captured event.
+  On Windows, `install-hooks` canonicalizes the data dir, which yields a verbatim
+  extended-length path (`\\?\C:\…`), and that prefix was baked verbatim into the
+  generated `--data-dir` for each native hook command. At capture time the
+  hook-spool write under a `\\?\`-prefixed data dir never lands, and the failure
+  was swallowed (`let _ = enqueue(...)`), so every `UserPromptSubmit` /
+  `PreToolUse` / `PostToolUse` / `PreCompact` / `Stop` / `SessionEnd` event was
+  lost while each hook still exited 0 — only `SessionStart` (handoff retrieval)
+  kept working, masking the loss. The data dir is now de-verbatim'd both when
+  rendering the hook command (new installs emit a plain `--data-dir`) and when
+  the hook resolves its data dir at capture time (an already-installed hook
+  recovers on the next session without re-running `install-hooks`). (issue #116)
+
 ## [1.1.2] - 2026-06-19
 
 ### Added

--- a/crates/ai-memory-cli/src/commands/hook.rs
+++ b/crates/ai-memory-cli/src/commands/hook.rs
@@ -21,6 +21,7 @@ use crate::cli::HookArgs;
 
 use super::hook_capture::{build_client, extract_cwd, get_handoff, marker_query_suffix};
 use super::hook_spool;
+use super::render_shared::strip_windows_verbatim_prefix;
 
 // All drain/handoff timings default to the current short values and can be
 // overridden by whole-minute env vars for very high-latency or large-backlog
@@ -226,19 +227,48 @@ pub async fn run(data_dir: Option<PathBuf>, args: HookArgs) -> anyhow::Result<()
 /// fast-path skips config for latency). Mirrors `config.rs`: explicit
 /// `--data-dir`, else `AI_MEMORY_DATA_DIR`, else the platform local-data dir.
 fn resolve_data_dir(data_dir: Option<&Path>) -> PathBuf {
-    data_dir
+    let dir = data_dir
         .map(Path::to_path_buf)
         .or_else(|| std::env::var_os("AI_MEMORY_DATA_DIR").map(PathBuf::from))
         .unwrap_or_else(|| {
             dirs::data_local_dir()
                 .unwrap_or_else(|| PathBuf::from("."))
                 .join("ai-memory")
-        })
+        });
+    // A verbatim `\\?\…` data dir — what `install-hooks` baked into
+    // settings.json before #116 was fixed — silently breaks the hook-spool
+    // write, dropping every event. Normalise it so an already-installed hook
+    // recovers on the next session without re-running `install-hooks`.
+    match dir.to_str() {
+        Some(s) if s.starts_with(r"\\?\") => {
+            PathBuf::from(strip_windows_verbatim_prefix(s).into_owned())
+        }
+        _ => dir,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_data_dir_strips_verbatim_prefix_from_baked_arg() {
+        // A pre-#116 install baked a verbatim `--data-dir` into settings.json;
+        // the hook must resolve it to the plain path so the spool write lands
+        // and enqueue/drain agree on the directory.
+        let resolved =
+            resolve_data_dir(Some(Path::new(r"\\?\C:\Users\me\AppData\Local\ai-memory")));
+        assert_eq!(
+            resolved,
+            PathBuf::from(r"C:\Users\me\AppData\Local\ai-memory")
+        );
+    }
+
+    #[test]
+    fn resolve_data_dir_leaves_plain_path_untouched() {
+        let resolved = resolve_data_dir(Some(Path::new(r"C:\Users\me\ai-memory")));
+        assert_eq!(resolved, PathBuf::from(r"C:\Users\me\ai-memory"));
+    }
 
     #[test]
     fn should_incremental_drain_only_post_tool_use_over_threshold() {

--- a/crates/ai-memory-cli/src/commands/hook.rs
+++ b/crates/ai-memory-cli/src/commands/hook.rs
@@ -21,7 +21,7 @@ use crate::cli::HookArgs;
 
 use super::hook_capture::{build_client, extract_cwd, get_handoff, marker_query_suffix};
 use super::hook_spool;
-use super::render_shared::strip_windows_verbatim_prefix;
+use super::path_util::strip_windows_verbatim_prefix;
 
 // All drain/handoff timings default to the current short values and can be
 // overridden by whole-minute env vars for very high-latency or large-backlog
@@ -164,7 +164,11 @@ pub async fn run(data_dir: Option<PathBuf>, args: HookArgs) -> anyhow::Result<()
         args.auth_token.as_deref(),
         oidc_present,
     );
-    let _ = hook_spool::enqueue(&spool, &entry);
+    if hook_spool::enqueue(&spool, &entry).is_err() {
+        eprintln!(
+            "ai-memory hook warning: failed to spool lifecycle event; capture for this event was skipped"
+        );
+    }
 
     // Mid-session catch-up: per-event hooks only enqueue, so a heavy session
     // outpaces the boundary-only drain and the spool grows until the next
@@ -235,10 +239,7 @@ fn resolve_data_dir(data_dir: Option<&Path>) -> PathBuf {
                 .unwrap_or_else(|| PathBuf::from("."))
                 .join("ai-memory")
         });
-    // A verbatim `\\?\…` data dir — what `install-hooks` baked into
-    // settings.json before #116 was fixed — silently breaks the hook-spool
-    // write, dropping every event. Normalise it so an already-installed hook
-    // recovers on the next session without re-running `install-hooks`.
+    // Recover already-installed hooks that baked a safe verbatim data-dir form.
     match dir.to_str() {
         Some(s) if s.starts_with(r"\\?\") => {
             PathBuf::from(strip_windows_verbatim_prefix(s).into_owned())
@@ -253,9 +254,7 @@ mod tests {
 
     #[test]
     fn resolve_data_dir_strips_verbatim_prefix_from_baked_arg() {
-        // A pre-#116 install baked a verbatim `--data-dir` into settings.json;
-        // the hook must resolve it to the plain path so the spool write lands
-        // and enqueue/drain agree on the directory.
+        // Recover safe verbatim data dirs baked by older installs (#116).
         let resolved =
             resolve_data_dir(Some(Path::new(r"\\?\C:\Users\me\AppData\Local\ai-memory")));
         assert_eq!(

--- a/crates/ai-memory-cli/src/commands/mod.rs
+++ b/crates/ai-memory-cli/src/commands/mod.rs
@@ -29,6 +29,7 @@ pub mod lint;
 pub mod llm_test;
 pub mod move_project;
 pub mod openclaw_plugin;
+pub mod path_util;
 pub mod pending_writes;
 pub mod purge_project;
 pub mod read_page;

--- a/crates/ai-memory-cli/src/commands/path_util.rs
+++ b/crates/ai-memory-cli/src/commands/path_util.rs
@@ -1,0 +1,92 @@
+//! Path helpers shared by command renderers and hook capture.
+
+use std::borrow::Cow;
+
+/// Strip only Windows verbatim path prefixes that are safe to render as plain
+/// paths. Unknown verbatim forms are left unchanged.
+pub(crate) fn strip_windows_verbatim_prefix(path: &str) -> Cow<'_, str> {
+    let Some(rest) = path.strip_prefix(r"\\?\") else {
+        return Cow::Borrowed(path);
+    };
+
+    if rest.len() >= 3
+        && rest.as_bytes()[0].is_ascii_alphabetic()
+        && rest.as_bytes()[1] == b':'
+        && rest.as_bytes()[2] == b'\\'
+    {
+        return Cow::Borrowed(rest);
+    }
+
+    let bytes = rest.as_bytes();
+    if bytes.len() >= 4
+        && bytes[0].eq_ignore_ascii_case(&b'U')
+        && bytes[1].eq_ignore_ascii_case(&b'N')
+        && bytes[2].eq_ignore_ascii_case(&b'C')
+        && bytes[3] == b'\\'
+    {
+        return Cow::Owned(format!(r"\\{}", &rest[4..]));
+    }
+
+    Cow::Borrowed(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_windows_verbatim_prefix_handles_drive_paths() {
+        assert_eq!(
+            &*strip_windows_verbatim_prefix(r"\\?\C:\Users\me\AppData\Local\ai-memory"),
+            r"C:\Users\me\AppData\Local\ai-memory"
+        );
+        assert_eq!(
+            &*strip_windows_verbatim_prefix(r"\\?\c:\Users\me\AppData\Local\ai-memory"),
+            r"c:\Users\me\AppData\Local\ai-memory"
+        );
+    }
+
+    #[test]
+    fn strip_windows_verbatim_prefix_handles_unc_case_insensitively() {
+        assert_eq!(
+            &*strip_windows_verbatim_prefix(r"\\?\UNC\server\share\m"),
+            r"\\server\share\m"
+        );
+        assert_eq!(
+            &*strip_windows_verbatim_prefix(r"\\?\unc\Server\Share\m"),
+            r"\\Server\Share\m"
+        );
+    }
+
+    #[test]
+    fn strip_windows_verbatim_prefix_leaves_non_verbatim_paths_untouched() {
+        assert_eq!(
+            &*strip_windows_verbatim_prefix(r"C:\Users\me\ai-memory"),
+            r"C:\Users\me\ai-memory"
+        );
+        assert_eq!(
+            &*strip_windows_verbatim_prefix("/home/alice/.local/share/ai-memory"),
+            "/home/alice/.local/share/ai-memory"
+        );
+    }
+
+    #[test]
+    fn strip_windows_verbatim_prefix_leaves_unknown_forms_untouched() {
+        assert_eq!(
+            &*strip_windows_verbatim_prefix(r"\\?\Volume{01234567-89ab-cdef-0123-456789abcdef}\m"),
+            r"\\?\Volume{01234567-89ab-cdef-0123-456789abcdef}\m"
+        );
+        assert_eq!(
+            &*strip_windows_verbatim_prefix(r"\\?\GLOBALROOT\Device\HarddiskVolume1\m"),
+            r"\\?\GLOBALROOT\Device\HarddiskVolume1\m"
+        );
+        assert_eq!(
+            &*strip_windows_verbatim_prefix(r"\\.\PhysicalDrive0"),
+            r"\\.\PhysicalDrive0"
+        );
+        assert_eq!(
+            &*strip_windows_verbatim_prefix(r"\\?\C:relative\m"),
+            r"\\?\C:relative\m"
+        );
+    }
+}

--- a/crates/ai-memory-cli/src/commands/render_shared.rs
+++ b/crates/ai-memory-cli/src/commands/render_shared.rs
@@ -21,6 +21,8 @@ use std::path::Path;
 
 use serde_json::json;
 
+use crate::commands::path_util::strip_windows_verbatim_prefix;
+
 /// Claude Code lifecycle events ai-memory hooks. Each pair is
 /// `(event-name-in-Claude-Code-settings, POSIX hook-script-filename)`.
 ///
@@ -685,36 +687,11 @@ enum NativeQuote {
     Windows,
 }
 
-/// Strip the Windows extended-length (verbatim) prefix from a path string so it
-/// can be safely embedded in a hook command line.
-///
-/// `install-hooks` canonicalizes the data dir (see `config.rs`), which on
-/// Windows yields a verbatim path — `\\?\C:\Users\…\ai-memory`, or
-/// `\\?\UNC\server\share` for a network location. Emitting that verbatim form
-/// into the native hook command silently breaks the hook-spool write at capture
-/// time, so every lifecycle event is dropped while each hook still exits 0
-/// (issue #116). Rendering the plain path avoids that. A no-op for any path
-/// without the prefix — including every POSIX path — so it is safe to apply
-/// before either quote style.
-pub(crate) fn strip_windows_verbatim_prefix(path: &str) -> Cow<'_, str> {
-    if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
-        // `\\?\UNC\server\share` → `\\server\share`
-        Cow::Owned(format!(r"\\{rest}"))
-    } else if let Some(rest) = path.strip_prefix(r"\\?\") {
-        // `\\?\C:\…` → `C:\…`
-        Cow::Borrowed(rest)
-    } else {
-        Cow::Borrowed(path)
-    }
-}
-
 fn native_data_dir_arg(data_dir: Option<&Path>, quote: NativeQuote) -> String {
     let Some(data_dir) = data_dir else {
         return String::new();
     };
-    // A canonicalized data dir is verbatim on Windows (`\\?\C:\…`); emitting
-    // that into the hook command silently breaks the native hook-spool write
-    // (#116), so render the plain path. No-op for non-verbatim / POSIX paths.
+    // Render safe verbatim Windows data-dir forms as plain paths (#116).
     let lossy = data_dir.to_string_lossy();
     let path = strip_windows_verbatim_prefix(&lossy);
     match quote {
@@ -1361,32 +1338,11 @@ mod tests {
     }
 
     #[test]
-    fn strip_windows_verbatim_prefix_handles_disk_unc_and_plain() {
-        let strip = strip_windows_verbatim_prefix;
-        // Disk verbatim → plain drive path.
-        assert_eq!(
-            &*strip(r"\\?\C:\Users\me\AppData\Local\ai-memory"),
-            r"C:\Users\me\AppData\Local\ai-memory"
-        );
-        // UNC verbatim → plain UNC path.
-        assert_eq!(&*strip(r"\\?\UNC\server\share\m"), r"\\server\share\m");
-        // Already-plain Windows path is left untouched.
-        assert_eq!(&*strip(r"C:\Users\me\ai-memory"), r"C:\Users\me\ai-memory");
-        // POSIX path is left untouched.
-        assert_eq!(
-            &*strip("/home/alice/.local/share/ai-memory"),
-            "/home/alice/.local/share/ai-memory"
-        );
-    }
-
-    #[test]
     fn windows_native_command_strips_verbatim_data_dir() {
-        // Regression for #116: install-hooks canonicalizes the data dir to a
-        // verbatim `\\?\C:\…` path; the baked `--data-dir` must be the plain
-        // form, or the native hook-spool write silently drops every event.
+        // Regression for #116: native hook commands must render a plain data dir.
         let cmd = hook_command(
             &PathBuf::from(
-                r"C:\Users\me\AppData\Local\ai-memory\hooks\claude-code\post-tool-use.sh",
+                r"C:/Users/me/AppData/Local/ai-memory/hooks/claude-code/post-tool-use.sh",
             ),
             "https://srv.example.com",
             None,
@@ -1400,6 +1356,7 @@ mod tests {
             cmd.contains(r#"--data-dir "C:\Users\me\AppData\Local\ai-memory""#),
             "plain data dir expected: {cmd}"
         );
+        assert!(cmd.contains("hook --event post-tool-use"), "{cmd}");
         assert!(
             !cmd.contains(r"\\?\"),
             "verbatim prefix must not leak into the hook command: {cmd}"

--- a/crates/ai-memory-cli/src/commands/render_shared.rs
+++ b/crates/ai-memory-cli/src/commands/render_shared.rs
@@ -685,11 +685,38 @@ enum NativeQuote {
     Windows,
 }
 
+/// Strip the Windows extended-length (verbatim) prefix from a path string so it
+/// can be safely embedded in a hook command line.
+///
+/// `install-hooks` canonicalizes the data dir (see `config.rs`), which on
+/// Windows yields a verbatim path — `\\?\C:\Users\…\ai-memory`, or
+/// `\\?\UNC\server\share` for a network location. Emitting that verbatim form
+/// into the native hook command silently breaks the hook-spool write at capture
+/// time, so every lifecycle event is dropped while each hook still exits 0
+/// (issue #116). Rendering the plain path avoids that. A no-op for any path
+/// without the prefix — including every POSIX path — so it is safe to apply
+/// before either quote style.
+pub(crate) fn strip_windows_verbatim_prefix(path: &str) -> Cow<'_, str> {
+    if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
+        // `\\?\UNC\server\share` → `\\server\share`
+        Cow::Owned(format!(r"\\{rest}"))
+    } else if let Some(rest) = path.strip_prefix(r"\\?\") {
+        // `\\?\C:\…` → `C:\…`
+        Cow::Borrowed(rest)
+    } else {
+        Cow::Borrowed(path)
+    }
+}
+
 fn native_data_dir_arg(data_dir: Option<&Path>, quote: NativeQuote) -> String {
     let Some(data_dir) = data_dir else {
         return String::new();
     };
-    let path = data_dir.to_string_lossy();
+    // A canonicalized data dir is verbatim on Windows (`\\?\C:\…`); emitting
+    // that into the hook command silently breaks the native hook-spool write
+    // (#116), so render the plain path. No-op for non-verbatim / POSIX paths.
+    let lossy = data_dir.to_string_lossy();
+    let path = strip_windows_verbatim_prefix(&lossy);
     match quote {
         NativeQuote::Posix => format!(" --data-dir {}", shell_quote(&path)),
         NativeQuote::Windows => format!(" --data-dir {}", win_double_quote(&path)),
@@ -1331,6 +1358,52 @@ mod tests {
             "{cmd}"
         );
         assert!(!cmd.contains("--auth-token"), "no token expected: {cmd}");
+    }
+
+    #[test]
+    fn strip_windows_verbatim_prefix_handles_disk_unc_and_plain() {
+        let strip = strip_windows_verbatim_prefix;
+        // Disk verbatim → plain drive path.
+        assert_eq!(
+            &*strip(r"\\?\C:\Users\me\AppData\Local\ai-memory"),
+            r"C:\Users\me\AppData\Local\ai-memory"
+        );
+        // UNC verbatim → plain UNC path.
+        assert_eq!(&*strip(r"\\?\UNC\server\share\m"), r"\\server\share\m");
+        // Already-plain Windows path is left untouched.
+        assert_eq!(&*strip(r"C:\Users\me\ai-memory"), r"C:\Users\me\ai-memory");
+        // POSIX path is left untouched.
+        assert_eq!(
+            &*strip("/home/alice/.local/share/ai-memory"),
+            "/home/alice/.local/share/ai-memory"
+        );
+    }
+
+    #[test]
+    fn windows_native_command_strips_verbatim_data_dir() {
+        // Regression for #116: install-hooks canonicalizes the data dir to a
+        // verbatim `\\?\C:\…` path; the baked `--data-dir` must be the plain
+        // form, or the native hook-spool write silently drops every event.
+        let cmd = hook_command(
+            &PathBuf::from(
+                r"C:\Users\me\AppData\Local\ai-memory\hooks\claude-code\post-tool-use.sh",
+            ),
+            "https://srv.example.com",
+            None,
+            HookCommandContext::new(
+                HookCommandPlatform::WindowsNative,
+                "claude-code",
+                Some(Path::new(r"\\?\C:\Users\me\AppData\Local\ai-memory")),
+            ),
+        );
+        assert!(
+            cmd.contains(r#"--data-dir "C:\Users\me\AppData\Local\ai-memory""#),
+            "plain data dir expected: {cmd}"
+        );
+        assert!(
+            !cmd.contains(r"\\?\"),
+            "verbatim prefix must not leak into the hook command: {cmd}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #116 — total silent capture loss on native Windows Claude Code installs.

On Windows, `install-hooks` canonicalizes the data dir, which yields a verbatim
extended-length path (`\\?\C:\…`). That prefix was rendered verbatim into the
`--data-dir` baked into every native hook command. At capture time the
hook-spool write under a `\\?\`-prefixed data dir never lands, and the enqueue
error is swallowed (`let _ = hook_spool::enqueue(...)`), so every
`UserPromptSubmit` / `PreToolUse` / `PostToolUse` / `PreCompact` / `Stop` /
`SessionEnd` event is dropped while each hook still exits `0`. Only
`SessionStart` (the handoff GET) keeps working, which masks the loss — retrieval
looks alive while nothing new is ever stored.

## Fix

Strip the verbatim prefix at the hook boundary (the issue's suggested surgical
fix #1), dependency-free:

- **Render side** (`render_shared.rs::native_data_dir_arg`): new installs emit a
  plain `--data-dir "C:\…"`.
- **Resolve side** (`hook.rs::resolve_data_dir`): an already-installed hook (with
  `\\?\` already baked into `settings.json`) recovers on the next session
  **without** re-running `install-hooks`.

Both go through one helper, `strip_windows_verbatim_prefix`, which handles
`\\?\C:\…` → `C:\…` and `\\?\UNC\server\share` → `\\server\share`, and is a
no-op for any non-verbatim path (including every POSIX path).

This intentionally does **not** touch the `let _ = enqueue(...)` error-swallowing
(the issue's fix #2) — that hardening is orthogonal and left for a separate
change.

## Tests

- `strip_windows_verbatim_prefix_handles_disk_unc_and_plain` — disk / UNC /
  already-plain / POSIX.
- `windows_native_command_strips_verbatim_data_dir` — render regression: the
  baked `--data-dir` is the plain path and `\\?\` never leaks into the command.
- `resolve_data_dir_strips_verbatim_prefix_from_baked_arg` +
  `resolve_data_dir_leaves_plain_path_untouched`.

Gates run locally (native Windows, Rust 1.95):

- `cargo fmt --all -- --check` ✅
- `cargo clippy -p ai-memory-cli --all-targets -- -D warnings` ✅
- `cargo test -p ai-memory-cli` — green except one **pre-existing**,
  platform-specific failure unrelated to this change:
  `grok_script_payload_uses_grok_bundle` asserts POSIX `/` separators and fails
  on native Windows `Path::join` (`grok\session-start.sh`). Confirmed failing on
  `main` without this patch too, so it is not a regression.

No dependencies added, so `cargo deny` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
