### PR TITLE
fix(hooks): capture array tool_response and the native user-prompt-submit event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   aliases still prefix-match later events into the same project.
 - Updated `git2` to the patched 0.21 line to clear new RustSec unsoundness
   advisories in libgit2 bindings.
+- Native Claude Code hooks now capture array-shaped `tool_response` content and
+  recognize the native `user-prompt-submit` event token, restoring prompt text
+  and tool output bodies for native installs.
 
 ## [1.1.3] - 2026-06-20
 

--- a/crates/ai-memory-hooks/src/payload.rs
+++ b/crates/ai-memory-hooks/src/payload.rs
@@ -135,9 +135,8 @@ impl HookEvent {
             "session-start" | "session_start" | "SessionStart" | "sessionStart" => {
                 Self::SessionStart
             }
-            "user-prompt" | "user_prompt" | "UserPromptSubmit" | "beforeSubmitPrompt" => {
-                Self::UserPrompt
-            }
+            "user-prompt" | "user_prompt" | "user-prompt-submit" | "user_prompt_submit"
+            | "UserPromptSubmit" | "beforeSubmitPrompt" => Self::UserPrompt,
             "pre-tool-use" | "pre_tool_use" | "PreToolUse" | "preToolUse" | "BeforeTool" => {
                 Self::PreToolUse
             }
@@ -418,21 +417,72 @@ fn extension_body_excerpt(raw: &serde_json::Value) -> Option<String> {
     .map(|s| truncate_excerpt(&s))
 }
 
+/// Extract human-readable text content for an observation body, accepting the
+/// shapes agents actually send: a plain string, an **array of content blocks**
+/// (`[{ "type": "text", "text": "…" }]` — the shape Claude Code uses for
+/// `tool_response`), or a structured object (rendered as compact JSON). Unlike
+/// [`extract_string`], which only matches a JSON string and silently drops
+/// everything else, this keeps tool outputs / inputs that arrive as
+/// arrays/objects.
+fn extract_content(value: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    for key in keys {
+        for candidate in extraction_candidates(value) {
+            if let Some(found) = candidate.get(*key).and_then(value_to_text)
+                && !found.is_empty()
+            {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+/// Flatten a JSON value into text. Strings pass through; arrays concatenate
+/// their flattened items (one per line); objects prefer a `text` / `content`
+/// field and otherwise fall back to compact JSON. `null` yields `None`.
+fn value_to_text(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => (!s.is_empty()).then(|| s.clone()),
+        serde_json::Value::Array(items) => {
+            let joined = items
+                .iter()
+                .filter_map(value_to_text)
+                .collect::<Vec<_>>()
+                .join("\n");
+            (!joined.is_empty()).then_some(joined)
+        }
+        serde_json::Value::Object(_) => value
+            .get("text")
+            .and_then(serde_json::Value::as_str)
+            .map(ToString::to_string)
+            .or_else(|| value.get("content").and_then(value_to_text))
+            .or_else(|| {
+                serde_json::to_string(value)
+                    .ok()
+                    .filter(|s| s != "{}" && s != "null")
+            }),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        serde_json::Value::Null => None,
+    }
+}
+
 fn best_body_excerpt(event: HookEvent, raw: &serde_json::Value) -> Option<String> {
     match event {
-        HookEvent::UserPrompt => extract_string(raw, &["prompt", "message", "text"]),
+        HookEvent::UserPrompt => extract_content(raw, &["prompt", "message", "text"]),
         HookEvent::PostToolUse => {
             let tool = extract_string(raw, &["tool", "tool_name", "name"])
                 .or_else(|| extract_string_path(raw, &[&["toolCall", "name"]]))
                 .or_else(|| {
                     extract_scalar_string(raw, &["stepIdx"]).map(|step| format!("step {step}"))
                 })?;
-            let result = extract_string(raw, &["tool_response", "tool_output", "output", "result"])
-                .or_else(|| extract_string(raw, &["error"]))
-                .unwrap_or_else(|| "(no output captured)".into());
+            let result =
+                extract_content(raw, &["tool_response", "tool_output", "output", "result"])
+                    .or_else(|| extract_content(raw, &["error"]))
+                    .unwrap_or_else(|| "(no output captured)".into());
             Some(format!("tool: {tool}\n---\n{}", truncate_excerpt(&result)))
         }
-        HookEvent::Notification => extract_string(raw, &["message", "text"]),
+        HookEvent::Notification => extract_content(raw, &["message", "text"]),
         _ => None,
     }
 }
@@ -891,5 +941,90 @@ mod tests {
         let excerpt = env.body_excerpt.unwrap();
         assert!(excerpt.ends_with('…'));
         assert!(excerpt.starts_with("tool: bash\n---\n"));
+    }
+
+    /// Regression: the native-binary hook command sends the script stem
+    /// `user-prompt-submit` as the event token (rendered by `render_shared.rs`,
+    /// forwarded verbatim by `ai-memory hook`). The parser must map it to
+    /// `UserPrompt`; otherwise native installs (the Windows / posix-native
+    /// default) bucket every prompt as `Other` and drop its text.
+    #[test]
+    fn parses_native_user_prompt_submit_event_token() {
+        assert_eq!(
+            HookEvent::parse("user-prompt-submit"),
+            HookEvent::UserPrompt
+        );
+        assert_eq!(
+            HookEvent::parse("user_prompt_submit"),
+            HookEvent::UserPrompt
+        );
+    }
+
+    /// Claude Code sends `tool_response` as an array of content blocks
+    /// (`[{ "type": "text", "text": "…" }]`). The body excerpt must capture
+    /// that text instead of falling back to "(no output captured)".
+    #[test]
+    fn post_tool_excerpt_captures_array_tool_response() {
+        let q = HookQuery {
+            event: "post-tool-use".into(),
+            agent: Some("claude-code".into()),
+            ..Default::default()
+        };
+        let env = HookEnvelope::from_query_and_body(
+            q,
+            serde_json::json!({
+                "tool_name": "Bash",
+                "tool_response": [{"type": "text", "text": "MARKER_OUTPUT_123"}],
+            }),
+        );
+        let body = env.body_excerpt.expect("post-tool body");
+        assert!(
+            body.contains("MARKER_OUTPUT_123"),
+            "array tool_response text should be captured: {body:?}"
+        );
+        assert!(
+            !body.contains("(no output captured)"),
+            "should not fall back when output is present: {body:?}"
+        );
+    }
+
+    /// An object-shaped `tool_response` is serialized into the body rather than
+    /// dropped.
+    #[test]
+    fn post_tool_excerpt_captures_object_tool_response() {
+        let q = HookQuery {
+            event: "post-tool-use".into(),
+            agent: Some("claude-code".into()),
+            ..Default::default()
+        };
+        let env = HookEnvelope::from_query_and_body(
+            q,
+            serde_json::json!({
+                "tool_name": "Read",
+                "tool_response": {"stdout": "MARKER_OBJ_456"},
+            }),
+        );
+        let body = env.body_excerpt.expect("post-tool body");
+        assert!(
+            body.contains("MARKER_OBJ_456"),
+            "object tool_response should be serialized into the body: {body:?}"
+        );
+    }
+
+    /// End-to-end: a native-hook user prompt (`event=user-prompt-submit`,
+    /// string `prompt`) maps to `UserPrompt` and keeps its body text.
+    #[test]
+    fn native_user_prompt_submit_keeps_prompt_body() {
+        let q = HookQuery {
+            event: "user-prompt-submit".into(),
+            agent: Some("claude-code".into()),
+            ..Default::default()
+        };
+        let env = HookEnvelope::from_query_and_body(
+            q,
+            serde_json::json!({ "session_id": "s1", "prompt": "MARKER_PROMPT_789" }),
+        );
+        assert_eq!(env.event, HookEvent::UserPrompt);
+        assert_eq!(env.body_excerpt.as_deref(), Some("MARKER_PROMPT_789"));
     }
 }


### PR DESCRIPTION
## Summary

On **native** Claude Code installs (the default on Windows via `windows-native`, and `posix-native`), consolidated memory comes out metadata-only — tool-call counts with no prompt text and no tool output. I traced it to two bugs in `crates/ai-memory-hooks/src/payload.rs`. Full report + `curl` repro in #120.

### Bug A — array `tool_response` is never captured (all Claude Code installs)
`best_body_excerpt` read `tool_response` via `extract_string`, which only matches a JSON **string** (`as_str()`). Claude Code sends `tool_response` as an **array of content blocks** (`[{"type":"text","text":"…"}]`), so extraction always failed and the body became `"(no output captured)"`.

Fix: add `extract_content` / `value_to_text`, which flatten a JSON value into text — strings pass through, arrays of content blocks concatenate their `text`, objects fall back to a `text`/`content` field or compact JSON — and use them for the `prompt` / `tool_response` / `error` / `message` bodies. `extract_string` is unchanged (still used for ids, tool names, cwd, …).

### Bug B — native hook event token `user-prompt-submit` is unrecognized
The native-binary command renders the script **stem** as the event token (`render_shared.rs`), and `ai-memory hook` forwards it verbatim (`…/hook?event=user-prompt-submit`). But `HookEvent::parse` accepted `user-prompt` / `UserPromptSubmit` — **not `user-prompt-submit`** — so prompts fell through to `Other` and their text was dropped. The `.sh`/`.ps1` hooks send `user-prompt`, so only the native path was affected; of the 7 Claude Code events, `user-prompt-submit` is the only stem the parser didn't accept.

Fix: accept `user-prompt-submit` / `user_prompt_submit` in `HookEvent::parse` — this also recovers already-installed native hooks without a reinstall.

## Reproduction (from #120)
Direct `curl` to `/hook` (no client), then `memory_consolidate`: an array `tool_response` yields `"(no output captured)"`, and an `event=user-prompt-submit` prompt is stored as `kind=other` with its text dropped. Re-running with `event=user-prompt` captures the prompt — confirming Bug B.

## Tests
Adds 4 `payload` regression tests (array & object `tool_response` capture; native `user-prompt-submit` parsing + end-to-end prompt body).

- `cargo test -p ai-memory-hooks` — payload tests pass, no regressions.
- `cargo clippy -p ai-memory-hooks` — clean.
- `cargo fmt` — applied.

> Note: one pre-existing, unrelated test — `router::tests::host_resolved_repo_root_override_records_repo_path_when_visible` — also fails on a clean checkout on my Windows machine (git repo-root detection in a temp dir); it is independent of this change.

Fixes #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
