### PR TITLE
feat(hook): batched spool delivery via POST /hook/batch to amortize per-event RTT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default, receives proposal JSON on stdin, fails closed on command/timeout/JSON
   errors or insufficient score delta, and records eval failures as rejected
   candidates without running from hook paths.
+- Hook spool drains now use `POST /hook/batch` when the server supports it,
+  grouping compatible queued lifecycle events into bounded batches to amortize
+  remote request latency. Older servers fall back to the existing per-event
+  `POST /hook` path.
 
 ### Fixed
 - Auto-improvement eval gates now apply timeouts to the full child interaction,
@@ -35,7 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   aliases still prefix-match later events into the same project.
 - Updated `git2` to the patched 0.21 line to clear new RustSec unsoundness
   advisories in libgit2 bindings.
-<<<<<<< HEAD
 - Native Claude Code hooks now capture array-shaped `tool_response` content and
   recognize the native `user-prompt-submit` event token, restoring prompt text
   and tool output bodies for native installs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/ai-memory-cli/src/commands/hook_capture.rs
+++ b/crates/ai-memory-cli/src/commands/hook_capture.rs
@@ -177,6 +177,75 @@ pub async fn post_hook(
     }
 }
 
+/// Outcome of one `POST /hook/batch` request — many spooled events delivered in
+/// a single round-trip, so a draining client amortizes TLS + network RTT + the
+/// edge auth hop over the whole batch instead of paying it per event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BatchOutcome {
+    /// Server committed the leading `usize` items (contiguous prefix, oldest
+    /// first). Equals the request length on full success; a smaller value means
+    /// the server stopped on that item (fail-fast) — the caller deletes the
+    /// prefix and charges the next item a retry.
+    Accepted(usize),
+    /// `429` — ingest saturated; nothing was processed. Keep the whole batch and
+    /// retry it later WITHOUT bumping attempts (saturation isn't a failure).
+    Saturated,
+    /// `404`/`405` — the server has no `/hook/batch` (a pre-upgrade build). The
+    /// caller falls back to per-event `POST /hook` for the rest of the drain.
+    Unsupported,
+    /// Transport error or any other non-2xx: the batch didn't land. Treated as a
+    /// failed attempt for each item it carried (bounded by `MAX_ATTEMPTS`).
+    Failed,
+}
+
+/// POST a pre-serialized JSON array of `{url, body}` events to `<batch_url>`.
+/// `bearer` authenticates the whole batch (every item shares the drain's single
+/// identity). Best-effort: never errors. Reads `{"accepted": K}` from a 2xx
+/// body; a 2xx whose body can't be read is treated as `Failed` (re-send rather
+/// than risk dropping undelivered events).
+pub async fn post_batch(
+    client: &reqwest::Client,
+    batch_url: &str,
+    payload: &str,
+    token: Option<&str>,
+    timeout: Duration,
+) -> BatchOutcome {
+    let mut req = client
+        .post(batch_url)
+        .header("Content-Type", "application/json")
+        .timeout(timeout)
+        .body(payload.to_owned());
+    if let Some(t) = token {
+        req = req.bearer_auth(t);
+    }
+    match req.send().await {
+        Ok(resp) => {
+            let status = resp.status();
+            if status.is_success() {
+                match resp.json::<serde_json::Value>().await {
+                    Ok(v) => {
+                        let accepted = v
+                            .get("accepted")
+                            .and_then(serde_json::Value::as_u64)
+                            .unwrap_or(0) as usize;
+                        BatchOutcome::Accepted(accepted)
+                    }
+                    Err(_) => BatchOutcome::Failed,
+                }
+            } else if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                BatchOutcome::Saturated
+            } else if status == reqwest::StatusCode::NOT_FOUND
+                || status == reqwest::StatusCode::METHOD_NOT_ALLOWED
+            {
+                BatchOutcome::Unsupported
+            } else {
+                BatchOutcome::Failed
+            }
+        }
+        Err(_) => BatchOutcome::Failed,
+    }
+}
+
 /// GET the handoff text with a caller-chosen budget. Returns None on any error
 /// or an empty body. This is the one synchronous read on the agent's critical
 /// path (session-start injects it as context), so the budget is larger than a

--- a/crates/ai-memory-cli/src/commands/hook_capture.rs
+++ b/crates/ai-memory-cli/src/commands/hook_capture.rs
@@ -193,8 +193,9 @@ pub enum BatchOutcome {
     /// `404`/`405` — the server has no `/hook/batch` (a pre-upgrade build). The
     /// caller falls back to per-event `POST /hook` for the rest of the drain.
     Unsupported,
-    /// Transport error or any other non-2xx: the batch didn't land. Treated as a
-    /// failed attempt for each item it carried (bounded by `MAX_ATTEMPTS`).
+    /// Transport error or any other non-2xx: the batch outcome is unknown. The
+    /// drain charges conservatively so trailing events that may never have been
+    /// attempted do not burn retry budget.
     Failed,
 }
 

--- a/crates/ai-memory-cli/src/commands/hook_spool.rs
+++ b/crates/ai-memory-cli/src/commands/hook_spool.rs
@@ -269,7 +269,15 @@ pub async fn drain(
             }
 
             let payload = batch_payload(&items[idx..end]);
-            match post_batch(&client, &base, &payload, bearer.as_deref(), per_event_timeout).await {
+            match post_batch(
+                &client,
+                &base,
+                &payload,
+                bearer.as_deref(),
+                per_event_timeout,
+            )
+            .await
+            {
                 BatchOutcome::Accepted(k) => {
                     let k = k.min(end - idx);
                     for (path, _) in &items[idx..idx + k] {
@@ -774,7 +782,11 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let spool = spool_dir(tmp.path());
         for i in 0..3 {
-            write_spool_entry(&spool, &format!("evt-{i}.json"), format!("http://{addr}/hook?event=e{i}"));
+            write_spool_entry(
+                &spool,
+                &format!("evt-{i}.json"),
+                format!("http://{addr}/hook?event=e{i}"),
+            );
         }
 
         let r = drain(
@@ -803,7 +815,11 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let spool = spool_dir(tmp.path());
         for i in 0..2 {
-            write_spool_entry(&spool, &format!("evt-{i}.json"), format!("http://{addr}/hook?event=e{i}"));
+            write_spool_entry(
+                &spool,
+                &format!("evt-{i}.json"),
+                format!("http://{addr}/hook?event=e{i}"),
+            );
         }
 
         let r = drain(

--- a/crates/ai-memory-cli/src/commands/hook_spool.rs
+++ b/crates/ai-memory-cli/src/commands/hook_spool.rs
@@ -25,7 +25,7 @@ use ai_memory_llm::{OidcToken, refresh_access_token};
 use secrecy::ExposeSecret as _;
 use serde::{Deserialize, Serialize};
 
-use super::hook_capture::{PostOutcome, build_client, post_hook};
+use super::hook_capture::{BatchOutcome, PostOutcome, build_client, post_batch, post_hook};
 
 /// Drop a spooled event after this many failed drain passes — bounds retries of
 /// a permanently-undeliverable event (e.g. a server URL that never comes back).
@@ -39,6 +39,15 @@ const MAX_AGE_MS: u64 = 7 * 24 * 60 * 60 * 1000;
 const MAX_SPOOL_FILES: usize = 10_000;
 #[cfg(test)]
 const MAX_SPOOL_FILES: usize = 3;
+
+/// Max events per `POST /hook/batch` request (count bound; the byte bound below
+/// also applies). Caps the blast radius of a failed batch and keeps one request
+/// well under the server's body limit even with many small events.
+const MAX_BATCH_ITEMS: usize = 256;
+/// Soft byte budget for one `/hook/batch` body — stays under the server's 10 MiB
+/// `DefaultBodyLimit` with margin for JSON framing. A chunk always carries at
+/// least one event even if that event alone exceeds this.
+const MAX_BATCH_BYTES: usize = 8 * 1024 * 1024;
 
 /// How a spooled event authenticates to the server when drained.
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
@@ -55,7 +64,7 @@ pub enum AuthMode {
 }
 
 /// One spooled hook event: the full request plus how to authenticate it.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SpoolEntry {
     /// Full hook URL including the `?event=…&agent=…[&cwd&workspace&project]`
     /// query the agent's payload resolved to.
@@ -167,9 +176,21 @@ pub struct DrainResult {
     pub dropped: usize,
 }
 
-/// Drain the spool to the server, oldest-first, within `total_budget`. Each
-/// event that gets a 2xx is deleted; failures stay for the next boundary.
-/// OIDC bearer is resolved + refreshed at most once per drain and cached.
+/// Drain the spool to the server, oldest-first, within `total_budget`.
+///
+/// Events are delivered in **batches** via `POST /hook/batch`: one request
+/// carries many spooled events, so the per-request cost (TLS + network RTT + the
+/// edge auth hop) is amortized over the whole batch instead of paid per event.
+/// That is the throughput fix — a sequential per-event drain falls behind when
+/// many parallel sessions share one spool against a remote, gated server, and
+/// the spool then grows to its cap and evicts undelivered events. A server
+/// without `/hook/batch` (a pre-upgrade build) answers `404`/`405`, and the
+/// drain transparently falls back to per-event `POST /hook`.
+///
+/// A delivered event is deleted; a failed one is charged a retry attempt
+/// (dropped at `MAX_ATTEMPTS`); a `429` (saturation) is retried untouched so it
+/// never burns the retry budget. OIDC bearer is resolved + refreshed at most
+/// once per drain and cached.
 ///
 /// Best-effort: returns counts and never errors, so a session boundary is never
 /// blocked beyond the budget and never fails the agent.
@@ -190,74 +211,199 @@ pub async fn drain(
     let mut oidc_cache: Option<Option<String>> = None; // outer None = not yet resolved
     let mut result = DrainResult::default();
 
+    // Load entries oldest-first, dropping unparseable / too-old files up front
+    // (a long-dead instance must not keep the spool growing). The batch path
+    // then only ever sees live, parseable events.
+    let mut items: Vec<(PathBuf, SpoolEntry)> = Vec::with_capacity(files.len());
     for path in files {
-        if started.elapsed() >= total_budget {
-            result.remaining += 1;
-            continue;
-        }
         let Ok(bytes) = std::fs::read(&path) else {
             result.remaining += 1;
             continue;
         };
-        let Ok(mut entry) = serde_json::from_slice::<SpoolEntry>(&bytes) else {
+        let Ok(entry) = serde_json::from_slice::<SpoolEntry>(&bytes) else {
             // Unparseable spool file: drop it so it can't wedge the queue.
             let _ = std::fs::remove_file(&path);
             result.dropped += 1;
             continue;
         };
-
-        // Prune events too old to be worth retrying (a long-dead instance).
         if now_ms().saturating_sub(entry.created_ms) > MAX_AGE_MS {
             let _ = std::fs::remove_file(&path);
             result.dropped += 1;
             continue;
         }
+        items.push((path, entry));
+    }
 
-        let bearer: Option<String> = match entry.auth_mode {
-            AuthMode::Static => entry.token.clone(),
-            AuthMode::Anonymous => None,
-            AuthMode::Oidc => {
-                if oidc_cache.is_none() {
-                    oidc_cache = Some(resolve_oidc(&client, data_dir).await);
+    let mut idx = 0;
+    let mut batch_supported = true;
+    while idx < items.len() {
+        if started.elapsed() >= total_budget {
+            result.remaining += items.len() - idx;
+            break;
+        }
+
+        let bearer = entry_bearer(&items[idx].1, &client, data_dir, &mut oidc_cache).await;
+
+        if batch_supported {
+            // Extend the chunk over consecutive entries sharing the same batch
+            // endpoint AND bearer (one request carries one Authorization header),
+            // bounded by item count and body bytes.
+            let base = batch_endpoint(&items[idx].1.url);
+            let mut end = idx + 1;
+            let mut bytes = entry_wire_len(&items[idx].1);
+            while end < items.len() && end - idx < MAX_BATCH_ITEMS {
+                if batch_endpoint(&items[end].1.url) != base {
+                    break;
                 }
-                oidc_cache.clone().flatten()
+                let next_bearer =
+                    entry_bearer(&items[end].1, &client, data_dir, &mut oidc_cache).await;
+                if next_bearer != bearer {
+                    break;
+                }
+                let next_len = entry_wire_len(&items[end].1);
+                if bytes + next_len > MAX_BATCH_BYTES {
+                    break;
+                }
+                bytes += next_len;
+                end += 1;
             }
-        };
 
-        match post_hook(
-            &client,
-            &entry.url,
-            &entry.body,
-            bearer.as_deref(),
-            per_event_timeout,
-        )
-        .await
-        {
-            PostOutcome::Delivered => {
-                let _ = std::fs::remove_file(&path);
-                result.sent += 1;
+            let payload = batch_payload(&items[idx..end]);
+            match post_batch(&client, &base, &payload, bearer.as_deref(), per_event_timeout).await {
+                BatchOutcome::Accepted(k) => {
+                    let k = k.min(end - idx);
+                    for (path, _) in &items[idx..idx + k] {
+                        let _ = std::fs::remove_file(path);
+                    }
+                    result.sent += k;
+                    if idx + k < end {
+                        // The (idx+k)th event is the one the server stopped on
+                        // (fail-fast). Charge it a failed attempt and skip past it
+                        // so a single bad event can't wedge the rest — the
+                        // per-event loop also advances past a failed entry.
+                        bump_or_drop(&items[idx + k].0, &items[idx + k].1, &mut result);
+                        idx += k + 1;
+                    } else {
+                        idx = end;
+                    }
+                }
+                BatchOutcome::Saturated => {
+                    // Server ingest is full; further batches would 429 too. Leave
+                    // everything queued, no attempt bump (parity with per-event).
+                    result.remaining += items.len() - idx;
+                    break;
+                }
+                BatchOutcome::Unsupported => {
+                    // Pre-upgrade server with no /hook/batch: fall back to the
+                    // per-event path for the rest of the drain. Retry items[idx]
+                    // below (don't advance).
+                    batch_supported = false;
+                }
+                BatchOutcome::Failed => {
+                    // The batch didn't land (transport error / unexpected status).
+                    // Charge each item a failed attempt so a dead server still
+                    // bounds retries via MAX_ATTEMPTS, then move past the chunk.
+                    for (path, entry) in &items[idx..end] {
+                        bump_or_drop(path, entry, &mut result);
+                    }
+                    idx = end;
+                }
             }
-            // Transient server backpressure (429 `hook queue full`): the event
-            // was never processed, so leave it untouched — no attempt bump, no
-            // rewrite — and saturation never burns the entry's retry budget. It
-            // rides the next pass unchanged; `MAX_AGE_MS` still bounds it.
-            PostOutcome::Saturated => {
-                result.remaining += 1;
-            }
-            PostOutcome::Failed => {
-                entry.attempts = entry.attempts.saturating_add(1);
-                if entry.attempts >= MAX_ATTEMPTS {
-                    let _ = std::fs::remove_file(&path);
-                    result.dropped += 1;
-                } else {
-                    // Persist the bumped attempt count for the next boundary.
-                    let _ = note_retry_persist(rewrite_entry(&path, &entry));
+        } else {
+            // Per-event fallback (server without /hook/batch). Mirrors the
+            // original drain's per-entry semantics exactly.
+            let path = &items[idx].0;
+            let entry = &items[idx].1;
+            match post_hook(
+                &client,
+                &entry.url,
+                &entry.body,
+                bearer.as_deref(),
+                per_event_timeout,
+            )
+            .await
+            {
+                PostOutcome::Delivered => {
+                    let _ = std::fs::remove_file(path);
+                    result.sent += 1;
+                }
+                PostOutcome::Saturated => {
                     result.remaining += 1;
                 }
+                PostOutcome::Failed => {
+                    bump_or_drop(path, entry, &mut result);
+                }
             }
+            idx += 1;
         }
     }
     result
+}
+
+/// Resolve the bearer for a spooled entry at drain time: a `Static` token is
+/// stored inline; an `Oidc` entry resolves (and refreshes) the stored token
+/// once per drain via `oidc_cache`; `Anonymous` is None.
+async fn entry_bearer(
+    entry: &SpoolEntry,
+    client: &reqwest::Client,
+    data_dir: &Path,
+    oidc_cache: &mut Option<Option<String>>,
+) -> Option<String> {
+    match entry.auth_mode {
+        AuthMode::Static => entry.token.clone(),
+        AuthMode::Anonymous => None,
+        AuthMode::Oidc => {
+            if oidc_cache.is_none() {
+                *oidc_cache = Some(resolve_oidc(client, data_dir).await);
+            }
+            oidc_cache.clone().flatten()
+        }
+    }
+}
+
+/// The `/hook/batch` URL for a spooled per-event URL: strip the `?…` query and
+/// append `/batch` (a spooled URL ends in `…/hook` before its query). Entries
+/// whose endpoint string matches can ride one batch request.
+fn batch_endpoint(url: &str) -> String {
+    let path = url.split('?').next().unwrap_or(url);
+    format!("{path}/batch")
+}
+
+/// Rough wire size of one event inside a batch body (`{"url":…,"body":…}` plus
+/// framing) — used only to keep a chunk under [`MAX_BATCH_BYTES`].
+fn entry_wire_len(entry: &SpoolEntry) -> usize {
+    entry.url.len() + entry.body.len() + 32
+}
+
+/// Serialize a chunk of entries into the `/hook/batch` request body — a JSON
+/// array of `{url, body}`. Each `body` is re-parsed from its stored text so a
+/// malformed one becomes `null` (skipped server-side) instead of poisoning the
+/// whole batch.
+fn batch_payload(items: &[(PathBuf, SpoolEntry)]) -> String {
+    let arr: Vec<serde_json::Value> = items
+        .iter()
+        .map(|(_, e)| {
+            let body = serde_json::from_str::<serde_json::Value>(&e.body)
+                .unwrap_or(serde_json::Value::Null);
+            serde_json::json!({ "url": e.url, "body": body })
+        })
+        .collect();
+    serde_json::to_string(&arr).unwrap_or_else(|_| "[]".to_string())
+}
+
+/// Charge a spooled entry a failed delivery attempt: drop it once it reaches
+/// `MAX_ATTEMPTS`, else persist the bumped count for the next boundary. Updates
+/// `result.dropped` / `result.remaining` accordingly.
+fn bump_or_drop(path: &Path, entry: &SpoolEntry, result: &mut DrainResult) {
+    let mut bumped = entry.clone();
+    bumped.attempts = bumped.attempts.saturating_add(1);
+    if bumped.attempts >= MAX_ATTEMPTS {
+        let _ = std::fs::remove_file(path);
+        result.dropped += 1;
+    } else {
+        let _ = note_retry_persist(rewrite_entry(path, &bumped));
+        result.remaining += 1;
+    }
 }
 
 /// Overwrite a spool file in place with the updated entry (atomic temp+rename),
@@ -325,6 +471,14 @@ fn prune_spool_file_count(spool: &Path) {
         return;
     }
     files.sort();
+    // The spool is at its hard cap: the oldest events are about to be deleted
+    // WITHOUT ever reaching the server — silent capture loss otherwise. Surface
+    // it on stderr (never stdout, which carries the hook's JSON protocol output)
+    // so a sustained backlog dropping events is visible, not invisible.
+    eprintln!(
+        "ai-memory: hook-spool at capacity ({} > {MAX_SPOOL_FILES}); evicting {excess} oldest UNDELIVERED event(s)",
+        files.len()
+    );
     for path in files.into_iter().take(excess) {
         let _ = std::fs::remove_file(path);
     }
@@ -560,6 +714,124 @@ mod tests {
         let loaded: SpoolEntry =
             serde_json::from_slice(&std::fs::read(&files[0]).unwrap()).unwrap();
         assert_eq!(loaded.attempts, 0, "429 must not consume the retry budget");
+    }
+
+    /// A mock hook server: answers `200 {"accepted":N}` to `POST /hook/batch`
+    /// (N = array length in the body) and `202 queued` to a per-event
+    /// `POST /hook`. Counts every request so a test can assert batching. Reads
+    /// the whole request in one shot (small test payloads), mirroring the other
+    /// raw-TCP mocks in this module.
+    async fn serve_counting_hook(
+        req_count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        batch_status: &'static str,
+    ) -> String {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((mut s, _)) = listener.accept().await {
+                let rc = req_count.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0_u8; 65536];
+                    let n = s.read(&mut buf).await.unwrap_or(0);
+                    rc.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    let req = String::from_utf8_lossy(&buf[..n]);
+                    let is_batch = req
+                        .lines()
+                        .next()
+                        .is_some_and(|l| l.contains("/hook/batch"));
+                    let (status, body) = if is_batch {
+                        let payload = req.split("\r\n\r\n").nth(1).unwrap_or("");
+                        let accepted = serde_json::from_str::<serde_json::Value>(payload)
+                            .ok()
+                            .and_then(|v| v.as_array().map(Vec::len))
+                            .unwrap_or(0);
+                        (batch_status, format!("{{\"accepted\":{accepted}}}"))
+                    } else {
+                        ("202 Accepted", "queued".to_string())
+                    };
+                    let resp = format!(
+                        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = s.write_all(resp.as_bytes()).await;
+                });
+            }
+        });
+        addr.to_string()
+    }
+
+    fn write_spool_entry(spool: &Path, name: &str, url: String) {
+        std::fs::create_dir_all(spool).unwrap();
+        let e = entry_for(url, "{}".into(), None, false);
+        std::fs::write(spool.join(name), serde_json::to_vec(&e).unwrap()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn drain_delivers_all_events_in_one_batch() {
+        let req_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let addr = serve_counting_hook(req_count.clone(), "200 OK").await;
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        for i in 0..3 {
+            write_spool_entry(&spool, &format!("evt-{i}.json"), format!("http://{addr}/hook?event=e{i}"));
+        }
+
+        let r = drain(
+            &spool,
+            tmp.path(),
+            Duration::from_secs(5),
+            Duration::from_secs(2),
+        )
+        .await;
+
+        assert_eq!(r.sent, 3, "all three events delivered");
+        assert_eq!(r.remaining, 0);
+        assert!(list_entries(&spool).unwrap().is_empty(), "spool emptied");
+        assert_eq!(
+            req_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "three events ride ONE /hook/batch request (RTT amortized)"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_falls_back_to_per_event_when_batch_unsupported() {
+        // Pre-upgrade server: /hook/batch is 404, per-event /hook is 202.
+        let req_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let addr = serve_counting_hook(req_count.clone(), "404 Not Found").await;
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        for i in 0..2 {
+            write_spool_entry(&spool, &format!("evt-{i}.json"), format!("http://{addr}/hook?event=e{i}"));
+        }
+
+        let r = drain(
+            &spool,
+            tmp.path(),
+            Duration::from_secs(5),
+            Duration::from_secs(2),
+        )
+        .await;
+
+        assert_eq!(r.sent, 2, "both events delivered via per-event fallback");
+        assert_eq!(r.remaining, 0);
+        assert!(list_entries(&spool).unwrap().is_empty());
+        // 1 rejected batch probe + 2 per-event POSTs.
+        assert_eq!(
+            req_count.load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "one /hook/batch 404, then a per-event POST per remaining event"
+        );
+    }
+
+    #[test]
+    fn batch_endpoint_derives_from_event_url() {
+        assert_eq!(
+            batch_endpoint("https://h/hook?event=stop&agent=claude-code"),
+            "https://h/hook/batch"
+        );
+        assert_eq!(batch_endpoint("https://h/hook"), "https://h/hook/batch");
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/hook_spool.rs
+++ b/crates/ai-memory-cli/src/commands/hook_spool.rs
@@ -211,64 +211,75 @@ pub async fn drain(
     let mut oidc_cache: Option<Option<String>> = None; // outer None = not yet resolved
     let mut result = DrainResult::default();
 
-    // Load entries oldest-first, dropping unparseable / too-old files up front
-    // (a long-dead instance must not keep the spool growing). The batch path
-    // then only ever sees live, parseable events.
-    let mut items: Vec<(PathBuf, SpoolEntry)> = Vec::with_capacity(files.len());
-    for path in files {
-        let Ok(bytes) = std::fs::read(&path) else {
-            result.remaining += 1;
-            continue;
-        };
-        let Ok(entry) = serde_json::from_slice::<SpoolEntry>(&bytes) else {
-            // Unparseable spool file: drop it so it can't wedge the queue.
-            let _ = std::fs::remove_file(&path);
-            result.dropped += 1;
-            continue;
-        };
-        if now_ms().saturating_sub(entry.created_ms) > MAX_AGE_MS {
-            let _ = std::fs::remove_file(&path);
-            result.dropped += 1;
-            continue;
-        }
-        items.push((path, entry));
-    }
-
     let mut idx = 0;
     let mut batch_supported = true;
-    while idx < items.len() {
+    'drain: while idx < files.len() {
         if started.elapsed() >= total_budget {
-            result.remaining += items.len() - idx;
+            result.remaining += files.len() - idx;
             break;
         }
 
-        let bearer = entry_bearer(&items[idx].1, &client, data_dir, &mut oidc_cache).await;
+        let path = files[idx].clone();
+        idx += 1;
+        let Some(entry) = load_live_entry(&path, &mut result) else {
+            continue;
+        };
+        if body_is_malformed(&entry) {
+            bump_or_drop(&path, &entry, &mut result);
+            continue;
+        }
+
+        let bearer = entry_bearer(&entry, &client, data_dir, &mut oidc_cache).await;
 
         if batch_supported {
             // Extend the chunk over consecutive entries sharing the same batch
             // endpoint AND bearer (one request carries one Authorization header),
             // bounded by item count and body bytes.
-            let base = batch_endpoint(&items[idx].1.url);
-            let mut end = idx + 1;
-            let mut bytes = entry_wire_len(&items[idx].1);
-            while end < items.len() && end - idx < MAX_BATCH_ITEMS {
-                if batch_endpoint(&items[end].1.url) != base {
+            let base = batch_endpoint(&entry.url);
+            let mut bytes = entry_wire_len(&entry);
+            let mut chunk = Vec::with_capacity(MAX_BATCH_ITEMS.min(files.len() - idx + 1));
+            chunk.push((path, entry));
+            while idx < files.len() && chunk.len() < MAX_BATCH_ITEMS {
+                if started.elapsed() >= total_budget {
+                    break;
+                }
+                let next_path = files[idx].clone();
+                idx += 1;
+                let Some(next_entry) = load_live_entry(&next_path, &mut result) else {
+                    continue;
+                };
+                if body_is_malformed(&next_entry) {
+                    bump_or_drop(&next_path, &next_entry, &mut result);
+                    continue;
+                }
+                if batch_endpoint(&next_entry.url) != base {
+                    idx -= 1;
                     break;
                 }
                 let next_bearer =
-                    entry_bearer(&items[end].1, &client, data_dir, &mut oidc_cache).await;
+                    entry_bearer(&next_entry, &client, data_dir, &mut oidc_cache).await;
                 if next_bearer != bearer {
+                    idx -= 1;
                     break;
                 }
-                let next_len = entry_wire_len(&items[end].1);
+                let next_len = entry_wire_len(&next_entry);
                 if bytes + next_len > MAX_BATCH_BYTES {
+                    idx -= 1;
                     break;
                 }
                 bytes += next_len;
-                end += 1;
+                chunk.push((next_path, next_entry));
             }
 
-            let payload = batch_payload(&items[idx..end]);
+            let Some(payload) = batch_payload(&chunk) else {
+                bump_or_drop(&chunk[0].0, &chunk[0].1, &mut result);
+                result.remaining += chunk.len().saturating_sub(1) + files.len().saturating_sub(idx);
+                break;
+            };
+            if started.elapsed() >= total_budget {
+                result.remaining += chunk.len() + files.len().saturating_sub(idx);
+                break;
+            }
             match post_batch(
                 &client,
                 &base,
@@ -279,49 +290,80 @@ pub async fn drain(
             .await
             {
                 BatchOutcome::Accepted(k) => {
-                    let k = k.min(end - idx);
-                    for (path, _) in &items[idx..idx + k] {
+                    let k = k.min(chunk.len());
+                    for (path, _) in &chunk[..k] {
                         let _ = std::fs::remove_file(path);
                     }
                     result.sent += k;
-                    if idx + k < end {
+                    if k < chunk.len() {
                         // The (idx+k)th event is the one the server stopped on
                         // (fail-fast). Charge it a failed attempt and skip past it
                         // so a single bad event can't wedge the rest — the
                         // per-event loop also advances past a failed entry.
-                        bump_or_drop(&items[idx + k].0, &items[idx + k].1, &mut result);
-                        idx += k + 1;
-                    } else {
-                        idx = end;
+                        bump_or_drop(&chunk[k].0, &chunk[k].1, &mut result);
+                        result.remaining +=
+                            chunk.len().saturating_sub(k + 1) + files.len().saturating_sub(idx);
+                        break;
                     }
                 }
                 BatchOutcome::Saturated => {
                     // Server ingest is full; further batches would 429 too. Leave
                     // everything queued, no attempt bump (parity with per-event).
-                    result.remaining += items.len() - idx;
+                    result.remaining += chunk.len() + files.len().saturating_sub(idx);
                     break;
                 }
                 BatchOutcome::Unsupported => {
                     // Pre-upgrade server with no /hook/batch: fall back to the
-                    // per-event path for the rest of the drain. Retry items[idx]
-                    // below (don't advance).
+                    // per-event path for the current chunk and the rest of the
+                    // drain. Do not rewind: entries skipped while building this
+                    // chunk (unparseable/stale/malformed) have already been
+                    // handled locally and must not be charged twice.
                     batch_supported = false;
+                    for (pos, (path, entry)) in chunk.iter().enumerate() {
+                        if started.elapsed() >= total_budget {
+                            result.remaining += chunk.len() - pos + files.len().saturating_sub(idx);
+                            break 'drain;
+                        }
+                        let item_bearer =
+                            entry_bearer(entry, &client, data_dir, &mut oidc_cache).await;
+                        match post_hook(
+                            &client,
+                            &entry.url,
+                            &entry.body,
+                            item_bearer.as_deref(),
+                            per_event_timeout,
+                        )
+                        .await
+                        {
+                            PostOutcome::Delivered => {
+                                let _ = std::fs::remove_file(path);
+                                result.sent += 1;
+                            }
+                            PostOutcome::Saturated => {
+                                result.remaining += 1;
+                            }
+                            PostOutcome::Failed => {
+                                bump_or_drop(path, entry, &mut result);
+                            }
+                        }
+                    }
                 }
                 BatchOutcome::Failed => {
                     // The batch didn't land (transport error / unexpected status).
-                    // Charge each item a failed attempt so a dead server still
-                    // bounds retries via MAX_ATTEMPTS, then move past the chunk.
-                    for (path, entry) in &items[idx..end] {
-                        bump_or_drop(path, entry, &mut result);
-                    }
-                    idx = end;
+                    // The server may have processed none, some, or all items before
+                    // the client saw the failure. Charge only the first item
+                    // conservatively and leave the rest queued for a future pass so
+                    // a timeout cannot burn attempts for events that may never have
+                    // been attempted.
+                    bump_or_drop(&chunk[0].0, &chunk[0].1, &mut result);
+                    result.remaining +=
+                        chunk.len().saturating_sub(1) + files.len().saturating_sub(idx);
+                    break;
                 }
             }
         } else {
             // Per-event fallback (server without /hook/batch). Mirrors the
             // original drain's per-entry semantics exactly.
-            let path = &items[idx].0;
-            let entry = &items[idx].1;
             match post_hook(
                 &client,
                 &entry.url,
@@ -339,13 +381,35 @@ pub async fn drain(
                     result.remaining += 1;
                 }
                 PostOutcome::Failed => {
-                    bump_or_drop(path, entry, &mut result);
+                    bump_or_drop(&path, &entry, &mut result);
                 }
             }
-            idx += 1;
         }
     }
     result
+}
+
+fn load_live_entry(path: &Path, result: &mut DrainResult) -> Option<SpoolEntry> {
+    let Ok(bytes) = std::fs::read(path) else {
+        result.remaining += 1;
+        return None;
+    };
+    let Ok(entry) = serde_json::from_slice::<SpoolEntry>(&bytes) else {
+        // Unparseable spool file: drop it so it can't wedge the queue.
+        let _ = std::fs::remove_file(path);
+        result.dropped += 1;
+        return None;
+    };
+    if now_ms().saturating_sub(entry.created_ms) > MAX_AGE_MS {
+        let _ = std::fs::remove_file(path);
+        result.dropped += 1;
+        return None;
+    }
+    Some(entry)
+}
+
+fn body_is_malformed(entry: &SpoolEntry) -> bool {
+    serde_json::from_str::<serde_json::Value>(&entry.body).is_err()
 }
 
 /// Resolve the bearer for a spooled entry at drain time: a `Static` token is
@@ -384,19 +448,17 @@ fn entry_wire_len(entry: &SpoolEntry) -> usize {
 }
 
 /// Serialize a chunk of entries into the `/hook/batch` request body — a JSON
-/// array of `{url, body}`. Each `body` is re-parsed from its stored text so a
-/// malformed one becomes `null` (skipped server-side) instead of poisoning the
-/// whole batch.
-fn batch_payload(items: &[(PathBuf, SpoolEntry)]) -> String {
-    let arr: Vec<serde_json::Value> = items
+/// array of `{url, body}`. Each `body` is re-parsed from its stored text; a
+/// malformed body is a local retry/drop condition, never synthesized as `null`.
+fn batch_payload(items: &[(PathBuf, SpoolEntry)]) -> Option<String> {
+    let arr: Result<Vec<serde_json::Value>, serde_json::Error> = items
         .iter()
         .map(|(_, e)| {
-            let body = serde_json::from_str::<serde_json::Value>(&e.body)
-                .unwrap_or(serde_json::Value::Null);
-            serde_json::json!({ "url": e.url, "body": body })
+            let body = serde_json::from_str::<serde_json::Value>(&e.body)?;
+            Ok(serde_json::json!({ "url": e.url, "body": body }))
         })
         .collect();
-    serde_json::to_string(&arr).unwrap_or_else(|_| "[]".to_string())
+    serde_json::to_string(&arr.ok()?).ok()
 }
 
 /// Charge a spooled entry a failed delivery attempt: drop it once it reaches
@@ -733,12 +795,21 @@ mod tests {
         req_count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
         batch_status: &'static str,
     ) -> String {
+        serve_counting_hook_with_accept(req_count, batch_status, None).await
+    }
+
+    async fn serve_counting_hook_with_accept(
+        req_count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        batch_status: &'static str,
+        accepted_override: Option<usize>,
+    ) -> String {
         use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move {
             while let Ok((mut s, _)) = listener.accept().await {
                 let rc = req_count.clone();
+                let accepted_override = accepted_override;
                 tokio::spawn(async move {
                     let mut buf = vec![0_u8; 65536];
                     let n = s.read(&mut buf).await.unwrap_or(0);
@@ -750,10 +821,12 @@ mod tests {
                         .is_some_and(|l| l.contains("/hook/batch"));
                     let (status, body) = if is_batch {
                         let payload = req.split("\r\n\r\n").nth(1).unwrap_or("");
-                        let accepted = serde_json::from_str::<serde_json::Value>(payload)
-                            .ok()
-                            .and_then(|v| v.as_array().map(Vec::len))
-                            .unwrap_or(0);
+                        let accepted = accepted_override.unwrap_or_else(|| {
+                            serde_json::from_str::<serde_json::Value>(payload)
+                                .ok()
+                                .and_then(|v| v.as_array().map(Vec::len))
+                                .unwrap_or(0)
+                        });
                         (batch_status, format!("{{\"accepted\":{accepted}}}"))
                     } else {
                         ("202 Accepted", "queued".to_string())
@@ -770,9 +843,53 @@ mod tests {
     }
 
     fn write_spool_entry(spool: &Path, name: &str, url: String) {
+        write_spool_entry_with_body(spool, name, url, "{}".into());
+    }
+
+    fn write_spool_entry_with_body(spool: &Path, name: &str, url: String, body: String) {
         std::fs::create_dir_all(spool).unwrap();
-        let e = entry_for(url, "{}".into(), None, false);
+        let e = entry_for(url, body, None, false);
         std::fs::write(spool.join(name), serde_json::to_vec(&e).unwrap()).unwrap();
+    }
+
+    fn write_spool_entry_with_token(spool: &Path, name: &str, url: String, token: &str) {
+        std::fs::create_dir_all(spool).unwrap();
+        let e = entry_for(url, "{}".into(), Some(token), false);
+        std::fs::write(spool.join(name), serde_json::to_vec(&e).unwrap()).unwrap();
+    }
+
+    fn sorted_attempts(spool: &Path) -> Vec<u32> {
+        let mut files = list_entries(spool).unwrap();
+        files.sort();
+        files
+            .iter()
+            .map(|path| {
+                serde_json::from_slice::<SpoolEntry>(&std::fs::read(path).unwrap())
+                    .unwrap()
+                    .attempts
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn zero_budget_does_not_deserialize_or_drop_entries() {
+        let req_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let addr = serve_counting_hook(req_count.clone(), "200 OK").await;
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        write_spool_entry(&spool, "evt-0.json", format!("http://{addr}/hook?event=e0"));
+        std::fs::write(spool.join("evt-1.json"), b"not a spool entry").unwrap();
+
+        let r = drain(&spool, tmp.path(), Duration::ZERO, Duration::from_secs(2)).await;
+
+        assert_eq!(r.sent, 0);
+        assert_eq!(
+            r.dropped, 0,
+            "zero budget must not pre-parse and drop bad files"
+        );
+        assert_eq!(r.remaining, 2);
+        assert_eq!(req_count.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(list_entries(&spool).unwrap().len(), 2);
     }
 
     #[tokio::test]
@@ -839,6 +956,207 @@ mod tests {
             3,
             "one /hook/batch 404, then a per-event POST per remaining event"
         );
+    }
+
+    #[tokio::test]
+    async fn failed_batch_charges_only_first_item() {
+        let req_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let addr = serve_counting_hook(req_count.clone(), "500 Internal Server Error").await;
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        for i in 0..3 {
+            write_spool_entry(
+                &spool,
+                &format!("evt-{i}.json"),
+                format!("http://{addr}/hook?event=e{i}"),
+            );
+        }
+
+        let r = drain(
+            &spool,
+            tmp.path(),
+            Duration::from_secs(5),
+            Duration::from_secs(2),
+        )
+        .await;
+
+        assert_eq!(r.sent, 0);
+        assert_eq!(r.dropped, 0);
+        assert_eq!(r.remaining, 3);
+        assert_eq!(req_count.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        let mut files = list_entries(&spool).unwrap();
+        files.sort();
+        let attempts: Vec<u32> = files
+            .iter()
+            .map(|path| {
+                serde_json::from_slice::<SpoolEntry>(&std::fs::read(path).unwrap())
+                    .unwrap()
+                    .attempts
+            })
+            .collect();
+        assert_eq!(attempts, vec![1, 0, 0]);
+    }
+
+    #[tokio::test]
+    async fn partial_batch_ack_deletes_prefix_and_charges_only_failed_item() {
+        let req_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let addr = serve_counting_hook_with_accept(req_count.clone(), "200 OK", Some(1)).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        for i in 0..3 {
+            write_spool_entry(
+                &spool,
+                &format!("evt-{i}.json"),
+                format!("http://{addr}/hook?event=e{i}"),
+            );
+        }
+
+        let r = drain(
+            &spool,
+            tmp.path(),
+            Duration::from_secs(5),
+            Duration::from_secs(2),
+        )
+        .await;
+
+        assert_eq!(r.sent, 1);
+        assert_eq!(r.dropped, 0);
+        assert_eq!(r.remaining, 2);
+        assert_eq!(req_count.load(std::sync::atomic::Ordering::SeqCst), 1);
+        let mut files = list_entries(&spool).unwrap();
+        files.sort();
+        assert_eq!(files.len(), 2);
+        assert!(files[0].ends_with("evt-1.json"));
+        assert!(files[1].ends_with("evt-2.json"));
+        assert_eq!(sorted_attempts(&spool), vec![1, 0]);
+    }
+
+    #[tokio::test]
+    async fn endpoint_change_splits_batches_without_losing_rewound_entry() {
+        let req_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let addr = serve_counting_hook(req_count.clone(), "200 OK").await;
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        write_spool_entry(
+            &spool,
+            "evt-0.json",
+            format!("http://{addr}/a/hook?event=e0"),
+        );
+        write_spool_entry(
+            &spool,
+            "evt-1.json",
+            format!("http://{addr}/b/hook?event=e1"),
+        );
+        write_spool_entry(
+            &spool,
+            "evt-2.json",
+            format!("http://{addr}/a/hook?event=e2"),
+        );
+
+        let r = drain(
+            &spool,
+            tmp.path(),
+            Duration::from_secs(5),
+            Duration::from_secs(2),
+        )
+        .await;
+
+        assert_eq!(r.sent, 3);
+        assert_eq!(r.remaining, 0);
+        assert!(list_entries(&spool).unwrap().is_empty());
+        assert_eq!(
+            req_count.load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "each endpoint boundary should start a separate batch"
+        );
+    }
+
+    #[tokio::test]
+    async fn bearer_change_splits_batches_without_burning_attempts() {
+        let req_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let addr = serve_counting_hook(req_count.clone(), "200 OK").await;
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        write_spool_entry_with_token(
+            &spool,
+            "evt-0.json",
+            format!("http://{addr}/hook?event=e0"),
+            "token-a",
+        );
+        write_spool_entry_with_token(
+            &spool,
+            "evt-1.json",
+            format!("http://{addr}/hook?event=e1"),
+            "token-b",
+        );
+
+        let r = drain(
+            &spool,
+            tmp.path(),
+            Duration::from_secs(5),
+            Duration::from_secs(2),
+        )
+        .await;
+
+        assert_eq!(r.sent, 2);
+        assert_eq!(r.remaining, 0);
+        assert!(list_entries(&spool).unwrap().is_empty());
+        assert_eq!(
+            req_count.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "different bearer tokens require separate batch requests"
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_body_is_charged_locally_not_sent_as_null() {
+        let req_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let addr = serve_counting_hook(req_count.clone(), "200 OK").await;
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        write_spool_entry_with_body(
+            &spool,
+            "evt-0.json",
+            format!("http://{addr}/hook?event=e0"),
+            "{\"ok\":true}".into(),
+        );
+        write_spool_entry_with_body(
+            &spool,
+            "evt-1.json",
+            format!("http://{addr}/hook?event=e1"),
+            "not-json".into(),
+        );
+        write_spool_entry_with_body(
+            &spool,
+            "evt-2.json",
+            format!("http://{addr}/hook?event=e2"),
+            "{\"ok\":true}".into(),
+        );
+
+        let r = drain(
+            &spool,
+            tmp.path(),
+            Duration::from_secs(5),
+            Duration::from_secs(2),
+        )
+        .await;
+
+        assert_eq!(r.sent, 2);
+        assert_eq!(r.dropped, 0);
+        assert_eq!(r.remaining, 1);
+        assert_eq!(
+            req_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "only valid bodies are sent in the batch"
+        );
+
+        let files = list_entries(&spool).unwrap();
+        assert_eq!(files.len(), 1);
+        let remaining: SpoolEntry =
+            serde_json::from_slice(&std::fs::read(&files[0]).unwrap()).unwrap();
+        assert_eq!(remaining.body, "not-json");
+        assert_eq!(remaining.attempts, 1);
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/process_guard.rs
+++ b/crates/ai-memory-cli/src/process_guard.rs
@@ -14,6 +14,18 @@ pub const BIN_NAME: &str = "ai-memory";
 /// process and any threads of it).
 #[must_use]
 pub fn sibling_processes() -> Vec<sysinfo::Pid> {
+    // Test opt-out. The destructive-command tests would otherwise flake
+    // non-deterministically: a dev box (and a parallel test run) almost always
+    // has some *other* `ai-memory` process alive, which the real scan rightly
+    // refuses against. Two seams, neither reachable in a normal shipped run:
+    //   - `cfg!(test)` — the crate's own in-process unit tests (reset / reindex
+    //     / restore) skip the scan.
+    //   - `AI_MEMORY_TEST_NO_PROCESS_GUARD` — a spawned `ai-memory` a test
+    //     launches reads it from its env and skips. The dedicated, `#[ignore]`d
+    //     guard test launches WITHOUT it, so the guard itself stays covered.
+    if cfg!(test) || std::env::var_os("AI_MEMORY_TEST_NO_PROCESS_GUARD").is_some() {
+        return Vec::new();
+    }
     let mut sys = System::new();
     sys.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
     let me = sysinfo::Pid::from_u32(std::process::id());

--- a/crates/ai-memory-cli/tests/uninstall.rs
+++ b/crates/ai-memory-cli/tests/uninstall.rs
@@ -417,6 +417,10 @@ fn uninstall_purge_data_apply_wipes() {
         .args(["uninstall", "--apply", "--yes", "--purge-data"])
         .env("HOME", home.path())
         .env("AI_MEMORY_DATA_DIR", data.path())
+        // Exercises the WIPE, not the live-process guard; opt out so an
+        // unrelated `ai-memory` on the machine can't make it flake. The
+        // dedicated guard test below does NOT set this.
+        .env("AI_MEMORY_TEST_NO_PROCESS_GUARD", "1")
         .output()
         .unwrap();
     assert!(
@@ -451,6 +455,9 @@ fn uninstall_dry_run_previews_purge() {
         .args(["uninstall", "--purge-data"]) // dry-run: no --apply
         .env("HOME", home.path())
         .env("AI_MEMORY_DATA_DIR", data.path())
+        // Dry-run still hits the purge guard before previewing; opt out so an
+        // unrelated live `ai-memory` can't flake the preview.
+        .env("AI_MEMORY_TEST_NO_PROCESS_GUARD", "1")
         .output()
         .unwrap();
     assert!(out.status.success());

--- a/crates/ai-memory-hooks/Cargo.toml
+++ b/crates/ai-memory-hooks/Cargo.toml
@@ -17,6 +17,9 @@ anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+# Parse the per-event `?event=…` query of each spooled URL in `/hook/batch`,
+# the same crate (and version) axum's `Query` extractor uses for `/hook`.
+serde_urlencoded = "0.7"
 tokio.workspace = true
 tracing.workspace = true
 jiff.workspace = true

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -1648,7 +1648,11 @@ mod tests {
             .unwrap();
         let parent = state
             .writer
-            .get_or_create_project(ws, String::from("my_app"), Some(String::from("/repo/my_app")))
+            .get_or_create_project(
+                ws,
+                String::from("my_app"),
+                Some(String::from("/repo/my_app")),
+            )
             .await
             .unwrap();
 

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -1632,6 +1632,60 @@ mod tests {
         );
     }
 
+    /// A real `repo_path` containing a `_` must prefix-match its literal child
+    /// cwd (escaped, not rejected) AND must NOT match a path that differs only
+    /// where the `_` sits — proving `_` is literal, never a single-char
+    /// wildcard. Pre-fix, both the cwd `_` rejection and the repo_path `_`
+    /// rejection made any `my_app`-style project silently un-matchable.
+    #[tokio::test]
+    async fn resolve_matches_literal_underscore_repo_path() {
+        let tmp = TempDir::new().unwrap();
+        let state = make_state(&tmp).await;
+        let ws = state
+            .writer
+            .get_or_create_workspace(String::from(DEFAULT_WORKSPACE_NAME))
+            .await
+            .unwrap();
+        let parent = state
+            .writer
+            .get_or_create_project(ws, String::from("my_app"), Some(String::from("/repo/my_app")))
+            .await
+            .unwrap();
+
+        // Literal child → resolves to the existing `my_app` project.
+        let (_, resolved) = resolve_project_ids(
+            &state,
+            Some("/repo/my_app/src"),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            resolved, parent,
+            "a repo_path with `_` must prefix-match its literal child"
+        );
+
+        // `/repo/myXapp/...` must NOT match `/repo/my_app` (the `_` is literal,
+        // not a wildcard that would match the `X`).
+        let (_, other) = resolve_project_ids(
+            &state,
+            Some("/repo/myXapp/src"),
+            None,
+            None,
+            ProjectStrategy::Basename,
+            &ai_memory_core::ActorKey::default(),
+        )
+        .await
+        .unwrap();
+        assert_ne!(
+            other, parent,
+            "`_` must be literal, not a single-character LIKE wildcard"
+        );
+    }
+
     /// Cold-start preservation: when NO existing project's `repo_path`
     /// prefix-matches the cwd, the resolver must fall through to the
     /// previous create-by-basename behaviour. This is the "first time
@@ -2783,22 +2837,15 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let state = make_state(&tmp).await;
 
-        // Build the git repo under an underscore-free, canonicalized temp base.
-        // Two macOS-only traps otherwise break the sibling prefix-match below
-        // (Linux CI hits neither, so this test passes there): (1) the default
-        // `TempDir` resolves under `/var/folders/<hash>` whose hash contains a
-        // `_`, and `is_safe_cwd_for_prefix_match` rejects any cwd carrying a `_`
-        // LIKE-wildcard; (2) `/var` is a symlink to `/private/var`, but git2's
-        // repo discovery records the resolved `/private/var/...` path, so an
-        // unresolved sibling cwd wouldn't prefix-match it. `/tmp` (→
-        // `/private/tmp`) with a hyphenated prefix and tempfile's alphanumeric
-        // suffix yields an underscore-free path, and `canonicalize` resolves the
-        // symlink so both sides agree.
-        let repo_base = tempfile::Builder::new()
-            .prefix("ai-memory-reporoot-")
-            .tempdir_in("/tmp")
-            .unwrap();
-        let root = std::fs::canonicalize(repo_base.path()).unwrap();
+        // Canonicalize the temp root before deriving the repo paths. On macOS
+        // `TempDir` lives under `/var/folders/...`, a symlink to
+        // `/private/var/...`; git2's repo discovery records the resolved
+        // `/private/var/...` path, and the sibling cwd below is prefix-matched
+        // against it — so both sides must agree on the resolved form. (The `_`
+        // in the macOS temp hash no longer breaks the match:
+        // `find_project_by_cwd_prefix` now escapes `%`/`_` and matches them
+        // literally, so this also exercises that fix on macOS.)
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
         let main_dir = root.join("repo");
         init_repo_with_commit(&main_dir);
         let app_dir = main_dir.join("app");

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -26,7 +26,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use jiff::Timestamp;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -190,6 +190,7 @@ pub struct HookState {
 pub fn hook_router(state: HookState) -> Router {
     Router::new()
         .route("/hook", post(handle_hook))
+        .route("/hook/batch", post(handle_hook_batch))
         .route("/handoff", get(handle_handoff))
         .with_state(Arc::new(state))
 }
@@ -218,6 +219,84 @@ async fn handle_hook(
         process_envelope(state, env, actor_user).await;
     });
     (StatusCode::ACCEPTED, "queued")
+}
+
+/// One event in a `POST /hook/batch` request — the same `{url, body}` pair a
+/// single `POST /hook` would carry, so the server reuses the per-event query
+/// parsing instead of inventing a second wire shape.
+#[derive(Debug, Deserialize)]
+pub struct HookBatchItem {
+    /// Full hook URL including the `?event=…&agent=…` query (as the client
+    /// spooled it); only the query is read here — the host/path are the
+    /// client's record of where the event was bound.
+    pub url: String,
+    /// Raw JSON event payload.
+    #[serde(default)]
+    pub body: serde_json::Value,
+}
+
+/// Response to `POST /hook/batch`: the length of the contiguous leading prefix
+/// of items that committed (equals the request length on full success).
+#[derive(Debug, Serialize)]
+pub struct HookBatchAck {
+    /// Items committed, oldest-first. The client deletes exactly this many
+    /// spool entries and re-sends the rest next pass.
+    pub accepted: usize,
+}
+
+/// Batch sibling of [`handle_hook`]. Accepts many spooled events in ONE request
+/// so a draining client amortizes the per-request cost (TLS + network RTT + the
+/// edge auth hop) over the whole batch instead of paying it per event — the
+/// dominant cost when a backlog drains to a remote, gated server, and the reason
+/// a sequential per-event drain falls behind under parallel load.
+///
+/// Unlike `handle_hook` (which spawns and answers `202` immediately), the batch
+/// is processed INLINE and FAIL-FAST: items run in order and the first error
+/// stops the batch, returning `accepted = <committed prefix>`. Inline + fail-fast
+/// keeps every item's side effects (a SessionEnd writes a session page + a
+/// handoff) inside the response window, so a partially-applied batch never
+/// commits beyond what `accepted` reports — the client deletes only that prefix.
+async fn handle_hook_batch(
+    State(state): State<Arc<HookState>>,
+    actor_ext: Option<axum::Extension<ai_memory_core::ActorContext>>,
+    Json(items): Json<Vec<HookBatchItem>>,
+) -> impl IntoResponse {
+    // All items in a batch share the drain's single identity, so the actor is
+    // captured once from the batch request (mirrors `handle_hook`).
+    let actor_user = actor_ext
+        .map(|axum::Extension(ctx)| ctx.user)
+        .unwrap_or_default();
+    // One permit for the whole batch — it holds ingest capacity for its
+    // duration, exactly as a single in-flight `/hook` request would.
+    let Ok(permit) = state.ingest_semaphore.clone().try_acquire_owned() else {
+        warn!("hook batch ingest saturated; rejecting with 429");
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(HookBatchAck { accepted: 0 }),
+        );
+    };
+    let _permit = permit;
+    let mut accepted = 0usize;
+    for item in items {
+        let query = parse_hook_query(&item.url);
+        let env = HookEnvelope::from_query_and_body(query, item.body);
+        if let Err(e) = process(&state, env, actor_user.clone()).await {
+            warn!(error = %e, accepted, "hook batch item failed; stopping (fail-fast)");
+            break;
+        }
+        accepted += 1;
+    }
+    (StatusCode::OK, Json(HookBatchAck { accepted }))
+}
+
+/// Parse the `?event=…&agent=…` query of a spooled hook URL into [`HookQuery`],
+/// mirroring axum's `Query` extractor (both use `serde_urlencoded`). A URL with
+/// no query, or an unparseable one, yields the default (empty `event`) — which
+/// `from_query_and_body` maps to an unknown event that `process` skips, so a
+/// malformed item can't error the whole batch.
+fn parse_hook_query(url: &str) -> HookQuery {
+    let qs = url.split_once('?').map_or("", |(_, q)| q);
+    serde_urlencoded::from_str(qs).unwrap_or_default()
 }
 
 /// Query params for `GET /handoff`.
@@ -1112,6 +1191,64 @@ mod tests {
         .into_response();
 
         assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn handle_hook_batch_acks_processed_count() {
+        let tmp = TempDir::new().unwrap();
+        let state = make_state(&tmp).await;
+        // Two events sharing a session, carried in ONE batch request — the per
+        // event `?event=…&agent=…` query is parsed from each item's `url`.
+        let items = vec![
+            HookBatchItem {
+                url: "http://h/hook?event=session-start&agent=claude-code".into(),
+                body: serde_json::json!({ "session_id": "batch-s1" }),
+            },
+            HookBatchItem {
+                url: "http://h/hook?event=user-prompt-submit&agent=claude-code".into(),
+                body: serde_json::json!({ "session_id": "batch-s1", "prompt": "hello" }),
+            },
+        ];
+
+        let response = handle_hook_batch(State(Arc::new(state)), None, Json(items))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let ack: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(ack["accepted"], 2, "both events committed, oldest-first");
+    }
+
+    #[tokio::test]
+    async fn handle_hook_batch_returns_429_when_saturated() {
+        let tmp = TempDir::new().unwrap();
+        let mut state = make_state(&tmp).await;
+        state.ingest_semaphore = Arc::new(tokio::sync::Semaphore::new(0));
+
+        let response = handle_hook_batch(
+            State(Arc::new(state)),
+            None,
+            Json(vec![HookBatchItem {
+                url: "http://h/hook?event=session-start&agent=claude-code".into(),
+                body: serde_json::json!({}),
+            }]),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[test]
+    fn parse_hook_query_reads_event_and_agent() {
+        let q = parse_hook_query("http://h/hook?event=stop&agent=claude-code&cwd=%2Ftmp");
+        assert_eq!(q.event, "stop");
+        assert_eq!(q.agent.as_deref(), Some("claude-code"));
+        assert_eq!(q.cwd.as_deref(), Some("/tmp"));
+        // No query string at all → default (empty event), which `process` skips.
+        assert_eq!(parse_hook_query("http://h/hook").event, "");
     }
 
     /// An event without a cwd must fall back to the server defaults.

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -2783,7 +2783,23 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let state = make_state(&tmp).await;
 
-        let main_dir = tmp.path().join("repo");
+        // Build the git repo under an underscore-free, canonicalized temp base.
+        // Two macOS-only traps otherwise break the sibling prefix-match below
+        // (Linux CI hits neither, so this test passes there): (1) the default
+        // `TempDir` resolves under `/var/folders/<hash>` whose hash contains a
+        // `_`, and `is_safe_cwd_for_prefix_match` rejects any cwd carrying a `_`
+        // LIKE-wildcard; (2) `/var` is a symlink to `/private/var`, but git2's
+        // repo discovery records the resolved `/private/var/...` path, so an
+        // unresolved sibling cwd wouldn't prefix-match it. `/tmp` (→
+        // `/private/tmp`) with a hyphenated prefix and tempfile's alphanumeric
+        // suffix yields an underscore-free path, and `canonicalize` resolves the
+        // symlink so both sides agree.
+        let repo_base = tempfile::Builder::new()
+            .prefix("ai-memory-reporoot-")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let root = std::fs::canonicalize(repo_base.path()).unwrap();
+        let main_dir = root.join("repo");
         init_repo_with_commit(&main_dir);
         let app_dir = main_dir.join("app");
         let sibling_dir = main_dir.join("sibling");

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -41,6 +41,11 @@ use crate::synth::synthesize_session_page;
 /// callers can drop or retry instead of growing memory without bound.
 pub const DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT: usize = 1024;
 
+/// Maximum events accepted in one `POST /hook/batch` request. This matches the
+/// client drain cap so a single request cannot monopolize ingest capacity or
+/// allocate/process an unbounded vector of hook events.
+pub const MAX_HOOK_BATCH_ITEMS: usize = 256;
+
 /// Maximum cwd-resolution cache entries kept per server process. The cache is
 /// an optimization only; evicted entries are re-resolved through the writer.
 pub const DEFAULT_PROJECT_CACHE_MAX_ENTRIES: usize = 4096;
@@ -261,14 +266,31 @@ async fn handle_hook_batch(
     actor_ext: Option<axum::Extension<ai_memory_core::ActorContext>>,
     Json(items): Json<Vec<HookBatchItem>>,
 ) -> impl IntoResponse {
+    if items.len() > MAX_HOOK_BATCH_ITEMS {
+        warn!(
+            items = items.len(),
+            max = MAX_HOOK_BATCH_ITEMS,
+            "hook batch too large; rejecting before processing"
+        );
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(HookBatchAck { accepted: 0 }),
+        );
+    }
     // All items in a batch share the drain's single identity, so the actor is
     // captured once from the batch request (mirrors `handle_hook`).
     let actor_user = actor_ext
         .map(|axum::Extension(ctx)| ctx.user)
         .unwrap_or_default();
-    // One permit for the whole batch — it holds ingest capacity for its
-    // duration, exactly as a single in-flight `/hook` request would.
-    let Ok(permit) = state.ingest_semaphore.clone().try_acquire_owned() else {
+    // Hold capacity proportional to the batch size so batch ingress cannot
+    // exceed the same in-flight event bound as single `/hook` requests. Empty
+    // batches still acquire one permit to respect backpressure consistently.
+    let permits = u32::try_from(items.len().max(1)).unwrap_or(u32::MAX);
+    let Ok(permit) = state
+        .ingest_semaphore
+        .clone()
+        .try_acquire_many_owned(permits)
+    else {
         warn!("hook batch ingest saturated; rejecting with 429");
         return (
             StatusCode::TOO_MANY_REQUESTS,
@@ -1238,6 +1260,52 @@ mod tests {
         )
         .await
         .into_response();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn handle_hook_batch_rejects_over_client_item_cap() {
+        let tmp = TempDir::new().unwrap();
+        let state = make_state(&tmp).await;
+        let items: Vec<HookBatchItem> = (0..=MAX_HOOK_BATCH_ITEMS)
+            .map(|i| HookBatchItem {
+                url: format!("http://h/hook?event=user-prompt-submit&agent=claude-code&i={i}"),
+                body: serde_json::json!({ "session_id": "too-many", "prompt": "nope" }),
+            })
+            .collect();
+
+        let response = handle_hook_batch(State(Arc::new(state)), None, Json(items))
+            .await
+            .into_response();
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let ack: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(ack["accepted"], 0);
+    }
+
+    #[tokio::test]
+    async fn handle_hook_batch_acquires_capacity_per_item() {
+        let tmp = TempDir::new().unwrap();
+        let mut state = make_state(&tmp).await;
+        state.ingest_semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+        let items = vec![
+            HookBatchItem {
+                url: "http://h/hook?event=session-start&agent=claude-code".into(),
+                body: serde_json::json!({ "session_id": "bounded-batch" }),
+            },
+            HookBatchItem {
+                url: "http://h/hook?event=user-prompt-submit&agent=claude-code".into(),
+                body: serde_json::json!({ "session_id": "bounded-batch", "prompt": "hello" }),
+            },
+        ];
+
+        let response = handle_hook_batch(State(Arc::new(state)), None, Json(items))
+            .await
+            .into_response();
+
         assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 

--- a/crates/ai-memory-mcp/tests/autoscope_stress.rs
+++ b/crates/ai-memory-mcp/tests/autoscope_stress.rs
@@ -346,13 +346,29 @@ async fn fire_hook_and_settle(
     assert_eq!(resp.status(), StatusCode::ACCEPTED, "hook must accept");
     // Drain the response body before settling so the connection releases.
     let _ = response_body_text(resp).await;
-    // `process_envelope` is `tokio::spawn`-ed; give it a generous window
-    // to land the active_project write on a loaded machine. Empirically a
-    // single yield is enough; we go higher for headroom in CI.
-    for _ in 0..20 {
+    // `process_envelope` is `tokio::spawn`-ed; poll a read for THIS session
+    // until its write is actually visible, instead of guessing a fixed settle
+    // time. A fixed sleep races under heavy load — the observed flake was a
+    // loaded full-workspace run where a session's active-project write hadn't
+    // landed yet, so its read saw `{hits: []}`. Polling waits exactly as long
+    // as needed (normally one iteration), with a generous cap that only burns
+    // if the write genuinely never lands (a real bug the downstream assert
+    // then reports).
+    let expected = number_word(project_index);
+    for _ in 0..200 {
         tokio::task::yield_now().await;
+        let probe = router
+            .clone()
+            .oneshot(mcp_query_request(user, Some(session_id)))
+            .await
+            .expect("settle probe");
+        if probe.status() == StatusCode::OK
+            && extract_tool_text(&response_body_text(probe).await).contains(expected)
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
     }
-    tokio::time::sleep(Duration::from_millis(15)).await;
 }
 
 // ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Under heavy **parallel** load (many agent sessions sharing one `data_dir`/hook-spool) draining to a **remote, gated** server, the sequential per-event drain falls behind: each POST pays TLS + network RTT + the edge auth hop, and the 250 ms mid-session drain clears only a handful per pass. The spool grows to `MAX_SPOOL_FILES` and `prune_spool_file_count` evicts the **oldest entries at enqueue time without delivering them** — silent capture loss (the `attempts:0 / last_error:null` symptom).

This PR adds a **batched delivery path** that collapses N round-trips into 1, plus a few supporting fixes. It’s built on top of `v1.1.3`.

> Heads-up: this also turns the **two currently-red CI checks on `v1.1.3` green** — see “CI” below.

## The fix (batch delivery)

- **Server — `POST /hook/batch`** (`ai-memory-hooks`): accepts a JSON array of `{url, body}`, reuses `HookEnvelope::from_query_and_body` + `process()` per event, processed **inline and fail-fast** (stops on the first error, returns `{accepted: K}`). One ingest permit + one auth pass per batch. The per-event query is parsed from each item’s `url` via `serde_urlencoded` (the same crate axum’s `Query` extractor uses).
- **Client — batched drain** (`ai-memory-cli`): the drain groups consecutive entries sharing the same endpoint + bearer, bounded by count (256) and bytes (8 MiB), and deletes only the acked prefix. **Automatic fall-back to per-event `POST /hook` on 404/405**, so a new client stays compatible with an un-upgraded server during rollout. `/hook` is unchanged.
- **Observability**: `prune_spool_file_count` now warns on stderr when it evicts undelivered events at the cap, so sustained loss is visible instead of silent.

`drain()`’s signature is unchanged, so the `session-start`/`session-end`/incremental call sites are untouched.

### Why batch (not concurrency)
The dominant cost is **network round-trip per request**, not the auth itself (a JWKS-caching forwardAuth validates locally in ~ms). Batching amortizes RTT directly (1 request instead of N) and preserves attribution (one forwardAuth pass / one actor per drain). Idempotency (a `UNIQUE client_key` + `ON CONFLICT`) is a sensible follow-up that would close the duplicate-on-retry window a batch widens.

### Production validation
Deployed against a Keycloak-gated remote: a backlog of **2132 events drained in ~15 s (~140/s)**, spool 2574 → 442, **zero eviction**, zero error. The same backlog per-event would take ~8 min at the sequential ceiling (~4/s, TTFB ~228 ms) and typically hit the cap → loss. **≈35× throughput.**

## Supporting fixes (independent commits, easy to split if you prefer)

- **`fix(store)`: prefix-match `repo_path`/`cwd` with `_`/`%` literally.** `find_project_by_cwd_prefix` silently dropped any cwd/`repo_path` containing a LIKE wildcard (`is_safe_cwd_for_prefix_match` rejected the cwd; the SQL rejected the `repo_path`), so an agent in e.g. `/home/u/my_project/src` never matched its parent project. Now the stored `repo_path` is **escaped** in the LIKE pattern (literal match, never a wildcard) and the cwd `_`/`%` rejection is dropped. Adds a regression test.
- **`test`: robustness.** (1) `process_guard::sibling_processes` made the destructive-command tests flake (a dev box always has another `ai-memory` alive) — opt out under `cfg!(test)` / `AI_MEMORY_TEST_NO_PROCESS_GUARD`; the dedicated `#[ignore]`d guard test still covers it. (2) `autoscope_stress` replaced a fixed 15 ms settle with a poll. (3) the repo-root prefix-match test no longer fails on macOS (`/var`→`/private/var` + `_` in the temp path). `cargo test --workspace` now passes repeatedly.
- **`fix(deps)`: bump `git2` 0.20 → 0.21** to clear `RUSTSEC-2026-0184` (unsound `Blame::blame_buffer` advisory). Adjusts the three `Commit::summary()`/`body()` call sites for the new `Result<Option<&str>, _>` return.

## CI
The two failing checks on `v1.1.3` are fixed here:
- **`test (macos-latest)`** — failed on the repo-root prefix-match test (deterministic on macOS due to the `/var` symlink + the `_` in the temp dir hitting the prefix-match `_` rejection). Fixed by the prefix-match + test-robustness commits.
- **`cargo-deny`** — failed on `RUSTSEC-2026-0184` (`git2 0.20.4`). Fixed by the `git2` bump. `cargo deny check` is now fully green.

## Test plan
- New: `/hook/batch` round-trip, per-event fallback on 404/405, `handle_hook_batch` ack + 429 + query parse, literal-`_` prefix-match.
- `cargo test --workspace` green (incl. macOS); `cargo deny check` green; existing spool tests unchanged.
- End-to-end validated in production (numbers above).
