### PR TITLE
fix(hooks): warn instead of silently swallowing spool retry-count persist failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   aliases still prefix-match later events into the same project.
 - Updated `git2` to the patched 0.21 line to clear new RustSec unsoundness
   advisories in libgit2 bindings.
+<<<<<<< HEAD
 - Native Claude Code hooks now capture array-shaped `tool_response` content and
   recognize the native `user-prompt-submit` event token, restoring prompt text
   and tool output bodies for native installs.
+- The headless hook spool now warns (instead of silently swallowing) when it
+  cannot persist a bumped retry-attempt count back to disk, matching the v1.1.3
+  enqueue-failure fix. A failed atomic rewrite previously lost the in-memory
+  attempt bump, so a poison spool entry never reached `MAX_ATTEMPTS` and kept
+  retrying on every drain boundary with no operator signal until the 7-day
+  age-out pruned it. The warning is sanitized and carries no path (a raw spool
+  path can be a Windows verbatim `\\?\…` path).
 
 ## [1.1.3] - 2026-06-20
 

--- a/crates/ai-memory-cli/src/commands/hook_spool.rs
+++ b/crates/ai-memory-cli/src/commands/hook_spool.rs
@@ -271,11 +271,20 @@ fn rewrite_entry(path: &Path, entry: &SpoolEntry) -> std::io::Result<()> {
     std::fs::rename(&tmp, path)
 }
 
-/// Report whether persisting a bumped retry count landed. A seam so the
-/// persist-outcome handling (warn-vs-not) is unit-testable without provoking a
-/// real FS fault. Fire-and-forget: the returned bool is consumed only by tests.
+/// Report whether persisting a bumped retry count landed; on failure, emit a
+/// sanitized stderr warning (no path — a raw spool path can be a Windows verbatim
+/// `\\?\…` path) instead of swallowing it, so a poison entry can't retry
+/// invisibly until it ages out. Fire-and-forget: warns only, never panics or
+/// blocks; the returned bool is consumed only by tests.
 fn note_retry_persist(outcome: std::io::Result<()>) -> bool {
-    outcome.is_ok()
+    if outcome.is_err() {
+        eprintln!(
+            "ai-memory hook warning: failed to persist spool retry count; \
+             event may retry until it ages out"
+        );
+        return false;
+    }
+    true
 }
 
 /// Resolve the bearer for a synchronous request (the session-start handoff

--- a/crates/ai-memory-cli/src/commands/hook_spool.rs
+++ b/crates/ai-memory-cli/src/commands/hook_spool.rs
@@ -585,4 +585,68 @@ mod tests {
         }
         assert_eq!(spool_len(&spool), 3);
     }
+
+    #[test]
+    fn note_retry_persist_reports_failure() {
+        // Root-proof: feed a synthetic error so the warn / not-persisted branch is
+        // exercised without provoking a real FS fault (the Docker CI gate runs as
+        // root and ignores chmod-based read-only dirs).
+        let failed: std::io::Result<()> = Err(std::io::Error::other("simulated rewrite failure"));
+        assert!(
+            !note_retry_persist(failed),
+            "a failed persist is reported as not-persisted, not swallowed"
+        );
+    }
+
+    #[test]
+    fn note_retry_persist_reports_success() {
+        assert!(
+            note_retry_persist(Ok(())),
+            "a successful persist is reported as persisted"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_stays_robust_when_retry_count_cannot_persist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        let e = entry_for(
+            "http://127.0.0.1:1/hook?event=stuck".into(),
+            "{}".into(),
+            None,
+            false,
+        );
+        enqueue(&spool, &e).unwrap();
+
+        // Make the atomic rewrite fail in a way that survives root (the Docker gate
+        // runs as root, so a chmod read-only dir wouldn't fault): occupy the entry's
+        // `<name>.json.tmp` path with a directory, so `rewrite_entry`'s temp-file
+        // write (an `OpenOptions` create) can't be created. `list_entries` matches
+        // only `*.json`, so the `.json.tmp` directory is ignored by the drain.
+        let entry_path = list_entries(&spool).unwrap().into_iter().next().unwrap();
+        let mut blocker = entry_path.into_os_string();
+        blocker.push(".tmp");
+        std::fs::create_dir(PathBuf::from(blocker)).unwrap();
+
+        // The persist fails, but drain must stay fire-and-forget: no panic, the
+        // event is still counted as remaining, nothing dropped, the entry survives.
+        let r = drain(
+            &spool,
+            tmp.path(),
+            Duration::from_secs(2),
+            Duration::from_millis(100),
+        )
+        .await;
+        assert_eq!(r.sent, 0);
+        assert_eq!(r.dropped, 0, "a persist failure must not drop the event");
+        assert_eq!(
+            r.remaining, 1,
+            "the event stays queued for the next boundary"
+        );
+        assert_eq!(
+            list_entries(&spool).unwrap().len(),
+            1,
+            "the spool entry survives a failed rewrite"
+        );
+    }
 }

--- a/crates/ai-memory-cli/src/commands/hook_spool.rs
+++ b/crates/ai-memory-cli/src/commands/hook_spool.rs
@@ -251,7 +251,7 @@ pub async fn drain(
                     result.dropped += 1;
                 } else {
                     // Persist the bumped attempt count for the next boundary.
-                    let _ = rewrite_entry(&path, &entry);
+                    let _ = note_retry_persist(rewrite_entry(&path, &entry));
                     result.remaining += 1;
                 }
             }
@@ -269,6 +269,13 @@ fn rewrite_entry(path: &Path, entry: &SpoolEntry) -> std::io::Result<()> {
     let bytes = serde_json::to_vec(entry)?;
     write_private(&tmp, &bytes)?;
     std::fs::rename(&tmp, path)
+}
+
+/// Report whether persisting a bumped retry count landed. A seam so the
+/// persist-outcome handling (warn-vs-not) is unit-testable without provoking a
+/// real FS fault. Fire-and-forget: the returned bool is consumed only by tests.
+fn note_retry_persist(outcome: std::io::Result<()>) -> bool {
+    outcome.is_ok()
 }
 
 /// Resolve the bearer for a synchronous request (the session-start handoff


### PR DESCRIPTION
## What

The headless hook spool's drain loop bumps an event's retry-attempt counter on a
failed delivery and persists it back to disk via `rewrite_entry` (an atomic
temp-write + rename). That persist was swallowed:

```rust
// crates/ai-memory-cli/src/commands/hook_spool.rs — PostOutcome::Failed
let _ = rewrite_entry(&path, &entry);   // fallible write, error discarded
result.remaining += 1;
```

If the rewrite fails (disk full, a read-only dir, a permission change, or a
Windows `\\?\` verbatim-path write that never lands), the bumped `attempts` lives
only in memory and is lost. The on-disk entry keeps its old count, so it never
reaches `MAX_ATTEMPTS` (8) and retries on **every** drain boundary — with no
operator signal, and with `DrainResult` still reporting `remaining` as if nothing
were wrong — until the 7-day `MAX_AGE_MS` prune eventually drops it. The failure
is silent twice over.

## Why this fits the project's direction

This is the same bug class already fixed in **v1.1.3 (issue #116)**: the sibling
`let _ = enqueue(...)` swallow was changed to emit a sanitized stderr warning
(see that release's `### Fixed` block). This applies the identical remedy to the
one remaining `rewrite_entry` swallow. There is no separate tracking issue for
this one — the v1.1.3 precedent is the rationale.

## The change

- Route the persist through a small `note_retry_persist` seam that emits a
  sanitized stderr warning instead of swallowing the error, and reports whether
  the count was persisted.
- The warning carries **no path** — a raw spool path can be a Windows verbatim
  `\\?\…` path, exactly the leak class #116 was about. It mirrors the wording and
  style of the existing enqueue-failure warning.
- Strictly **fire-and-forget**: it only warns — never panics, returns, or blocks
  — so the hook binary still exits 0 and the drain loop keeps draining.
- CHANGELOG `### Fixed` entry under `[Unreleased]`.

## Tests

- `note_retry_persist_reports_failure` / `note_retry_persist_reports_success` —
  unit-test the warn-vs-not decision by feeding a synthetic `io::Result`. This is
  **root-proof**: CI runs as root, which ignores `chmod`, so a read-only-dir test
  would never actually fault.
- `drain_stays_robust_when_retry_count_cannot_persist` — end-to-end: forces a
  uid-independent rewrite failure (occupying the entry's `<name>.json.tmp` path
  with a directory so the atomic temp-write cannot be created) and asserts the
  drain stays robust — no panic, the event is still counted as `remaining`,
  nothing is dropped, and the entry survives for the next boundary.

---

Pushed as a few small, logically separate commits (refactor → fix + CHANGELOG →
tests); happy to squash on merge. The four CI gates apply — `cargo fmt --check`,
`cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`,
`cargo deny check` — and were run locally in a `rust:1.95` container.
