### PR TITLE
feat(install-hooks): add --project-strategy to bake a repo-root default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `install-hooks --project-strategy repo-root` bakes a default project strategy
+  into the generated hooks, so every session resolves its project from the main
+  git repo root (collapsing subdirectories and worktrees) without a per-repo
+  `.ai-memory.toml` marker — preventing a persistent `cd` into a subdirectory
+  from forking memory into a phantom project. A marker's own `project_strategy`
+  still takes precedence, and the default (`basename`) bakes nothing, so existing
+  installs are unchanged. Covers every delivery path: POSIX/PowerShell hook
+  scripts, the native `hook` command, and the OpenCode / OMP / OpenClaw
+  TypeScript integrations. (#128)
+
 ## [1.2.2] - 2026-06-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ other server / hook you have configured, and write a timestamped
 scripts are staged into `~/.local/share/ai-memory/hooks/<agent>/`
 automatically; re-running overwrites them so future image updates ship
 updated hooks. Drop `--apply` to print the snippet instead of mutating.
+If your agent often starts inside repository subdirectories or linked
+worktrees, add `--project-strategy repo-root` to `install-hooks` so captures
+collapse to the main git repo name; see [`docs/install.md`](docs/install.md)
+and [`docs/marker-file.md`](docs/marker-file.md) for details.
 
 The Docker wrapper also bridges thin-client commands such as
 `ai-memory status` and `ai-memory bootstrap` back to the host's

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -1079,8 +1079,8 @@ pub struct HookArgs {
     /// Default project strategy baked in by `install-hooks
     /// --project-strategy`. Applies only when a `.ai-memory.toml`
     /// marker does not pin its own `project_strategy`.
-    #[arg(long)]
-    pub project_strategy: Option<String>,
+    #[arg(long, value_enum)]
+    pub project_strategy: Option<ProjectStrategyArg>,
 }
 
 /// Arguments for `install-hooks`.
@@ -1623,6 +1623,26 @@ mod tests {
         assert!(
             result.is_err(),
             "an unknown --project-strategy value must be rejected by value_enum"
+        );
+    }
+
+    #[test]
+    fn hook_project_strategy_rejects_invalid_value() {
+        let result = Cli::try_parse_from([
+            "ai-memory",
+            "hook",
+            "--event",
+            "session-start",
+            "--agent",
+            "claude-code",
+            "--server-url",
+            "http://127.0.0.1:49374",
+            "--project-strategy",
+            "bogus",
+        ]);
+        assert!(
+            result.is_err(),
+            "an unknown hook --project-strategy value must be rejected by value_enum"
         );
     }
 

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -1032,6 +1032,35 @@ pub struct LlmTestArgs {
     pub api_key: Option<String>,
 }
 
+/// Project-resolution strategy to bake into installed hooks.
+///
+/// `basename` (the default) bakes nothing — generated hooks behave
+/// exactly as before. `repo-root` bakes a default so every session
+/// resolves its project from the main git repo root (collapsing
+/// subdirectories and worktrees) without a per-repo `.ai-memory.toml`
+/// marker. A marker's own `project_strategy` still wins.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum ProjectStrategyArg {
+    /// `project = basename(cwd)` — the default; bakes nothing.
+    Basename,
+    /// `project = basename(main git repo root)` — collapses subdirs/worktrees.
+    /// clap renders this value as `repo-root`.
+    RepoRoot,
+}
+
+impl ProjectStrategyArg {
+    /// Normalize to what the hook command should bake. `None` bakes
+    /// nothing (behavior unchanged); `Some("repo-root")` bakes the
+    /// repo-root default into the generated hooks.
+    #[must_use]
+    pub fn baked(self) -> Option<&'static str> {
+        match self {
+            Self::Basename => None,
+            Self::RepoRoot => Some("repo-root"),
+        }
+    }
+}
+
 /// Arguments for `hook` — emit one lifecycle event natively.
 #[derive(Debug, Args)]
 pub struct HookArgs {
@@ -1047,6 +1076,11 @@ pub struct HookArgs {
     /// Optional bearer token (`Authorization: Bearer <token>`).
     #[arg(long, hide_env_values = true)]
     pub auth_token: Option<String>,
+    /// Default project strategy baked in by `install-hooks
+    /// --project-strategy`. Applies only when a `.ai-memory.toml`
+    /// marker does not pin its own `project_strategy`.
+    #[arg(long)]
+    pub project_strategy: Option<String>,
 }
 
 /// Arguments for `install-hooks`.
@@ -1104,6 +1138,14 @@ pub struct InstallHooksArgs {
     /// For OpenClaw, this is the generated plugin package directory.
     #[arg(long)]
     pub config_file: Option<PathBuf>,
+    /// Default project strategy to bake into the installed hooks.
+    /// `repo-root` makes every session resolve its project from the main
+    /// git repo root (collapsing subdirectories and worktrees) without a
+    /// per-repo `.ai-memory.toml` marker. A marker's own `project_strategy`
+    /// still wins. Defaults to `basename`, which bakes nothing and is
+    /// identical to prior behavior.
+    #[arg(long, value_enum, default_value_t = ProjectStrategyArg::Basename)]
+    pub project_strategy: ProjectStrategyArg,
 }
 
 /// Arguments for `install-mcp`.

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -1582,6 +1582,51 @@ mod tests {
     }
 
     #[test]
+    fn install_hooks_project_strategy_repo_root_parses() {
+        let cli = Cli::try_parse_from([
+            "ai-memory",
+            "install-hooks",
+            "--agent",
+            "claude-code",
+            "--project-strategy",
+            "repo-root",
+        ])
+        .unwrap_or_else(|e| panic!("failed to parse --project-strategy repo-root: {e}"));
+        let Command::InstallHooks(args) = cli.command else {
+            panic!("expected install-hooks command");
+        };
+        assert!(matches!(
+            args.project_strategy,
+            ProjectStrategyArg::RepoRoot
+        ));
+        assert_eq!(args.project_strategy.baked(), Some("repo-root"));
+    }
+
+    #[test]
+    fn install_hooks_project_strategy_defaults_to_basename() {
+        let cli = Cli::try_parse_from(["ai-memory", "install-hooks", "--agent", "claude-code"])
+            .expect("install-hooks parses without --project-strategy");
+        let Command::InstallHooks(args) = cli.command else {
+            panic!("expected install-hooks command");
+        };
+        assert!(matches!(
+            args.project_strategy,
+            ProjectStrategyArg::Basename
+        ));
+        assert_eq!(args.project_strategy.baked(), None);
+    }
+
+    #[test]
+    fn install_hooks_project_strategy_rejects_invalid_value() {
+        let result =
+            Cli::try_parse_from(["ai-memory", "install-hooks", "--project-strategy", "bogus"]);
+        assert!(
+            result.is_err(),
+            "an unknown --project-strategy value must be rejected by value_enum"
+        );
+    }
+
+    #[test]
     fn vscode_copilot_aliases_parse_to_same_variant() {
         for alias in ["vscode-copilot", "copilot", "github-copilot"] {
             let cli = Cli::try_parse_from([

--- a/crates/ai-memory-cli/src/commands/hook.rs
+++ b/crates/ai-memory-cli/src/commands/hook.rs
@@ -142,7 +142,7 @@ pub async fn run(data_dir: Option<PathBuf>, args: HookArgs) -> anyhow::Result<()
     let json: serde_json::Value = serde_json::from_str(&payload).unwrap_or(serde_json::Value::Null);
 
     let qs = extract_cwd(&json)
-        .map(|cwd| marker_query_suffix(&cwd, args.project_strategy.as_deref()))
+        .map(|cwd| marker_query_suffix(&cwd, args.project_strategy.and_then(|s| s.baked())))
         .unwrap_or_default();
     let base = args.server_url.trim_end_matches('/');
     let dd = resolve_data_dir(data_dir.as_deref());

--- a/crates/ai-memory-cli/src/commands/hook.rs
+++ b/crates/ai-memory-cli/src/commands/hook.rs
@@ -142,7 +142,7 @@ pub async fn run(data_dir: Option<PathBuf>, args: HookArgs) -> anyhow::Result<()
     let json: serde_json::Value = serde_json::from_str(&payload).unwrap_or(serde_json::Value::Null);
 
     let qs = extract_cwd(&json)
-        .map(|cwd| marker_query_suffix(&cwd))
+        .map(|cwd| marker_query_suffix(&cwd, args.project_strategy.as_deref()))
         .unwrap_or_default();
     let base = args.server_url.trim_end_matches('/');
     let dd = resolve_data_dir(data_dir.as_deref());

--- a/crates/ai-memory-cli/src/commands/hook_capture.rs
+++ b/crates/ai-memory-cli/src/commands/hook_capture.rs
@@ -41,26 +41,35 @@ pub fn url_encode(s: &str) -> String {
 /// Build `&cwd=…[&workspace=…&project=…&project_strategy=…]`, mirroring
 /// `ai_memory_marker_qs`: always include cwd; append marker-declared
 /// fields when a `.ai-memory.toml` is found walking up toward $HOME.
-pub fn marker_query_suffix(cwd: &str) -> String {
+///
+/// `default_strategy` is the install-time default baked into the native hook
+/// command by `install-hooks --project-strategy` (passed via the `hook
+/// --project-strategy` flag). It fills `project_strategy` only when no marker
+/// pinned one — a marker's explicit `project` / `project_strategy` always win
+/// (§3.3). repo-root is resolved here, host-side, because a containerized
+/// server cannot see this checkout.
+pub fn marker_query_suffix(cwd: &str, default_strategy: Option<&str>) -> String {
     let mut qs = format!("&cwd={}", url_encode(cwd));
+    let (mut workspace, mut project, mut strategy) = (None, None, None);
     if let Some(marker) = find_marker(cwd) {
-        let workspace = parse_toml_key(&marker, "workspace");
-        let mut project = parse_toml_key(&marker, "project");
-        let project_strategy = parse_toml_key(&marker, "project_strategy");
-        if project.is_none()
-            && matches!(project_strategy.as_deref(), Some("repo-root" | "repo_root"))
-        {
-            project = repo_root_project(cwd);
-        }
-        if let Some(val) = workspace {
-            qs.push_str(&format!("&workspace={}", url_encode(&val)));
-        }
-        if let Some(val) = project {
-            qs.push_str(&format!("&project={}", url_encode(&val)));
-        }
-        if let Some(val) = project_strategy {
-            qs.push_str(&format!("&project_strategy={}", url_encode(&val)));
-        }
+        workspace = parse_toml_key(&marker, "workspace");
+        project = parse_toml_key(&marker, "project");
+        strategy = parse_toml_key(&marker, "project_strategy");
+    }
+    if strategy.is_none() {
+        strategy = default_strategy.map(str::to_owned);
+    }
+    if project.is_none() && matches!(strategy.as_deref(), Some("repo-root" | "repo_root")) {
+        project = repo_root_project(cwd);
+    }
+    if let Some(val) = workspace {
+        qs.push_str(&format!("&workspace={}", url_encode(&val)));
+    }
+    if let Some(val) = project {
+        qs.push_str(&format!("&project={}", url_encode(&val)));
+    }
+    if let Some(val) = strategy {
+        qs.push_str(&format!("&project_strategy={}", url_encode(&val)));
     }
     qs
 }
@@ -305,7 +314,7 @@ mod tests {
 
     #[test]
     fn query_suffix_without_marker_has_only_cwd() {
-        let qs = marker_query_suffix("/nonexistent/path/xyz");
+        let qs = marker_query_suffix("/nonexistent/path/xyz", None);
         assert_eq!(qs, "&cwd=%2Fnonexistent%2Fpath%2Fxyz");
     }
 
@@ -434,7 +443,7 @@ project_strategy = "repo-root"
         )
         .unwrap();
         let cwd = tmp.path().to_str().unwrap();
-        let qs = marker_query_suffix(cwd);
+        let qs = marker_query_suffix(cwd, None);
         // cwd is encoded first; marker fields follow in the iteration order
         // of the loop in `marker_query_suffix`.
         assert!(qs.contains("&workspace=acme%20corp"), "{qs}");
@@ -452,7 +461,7 @@ project_strategy = "repo-root"
         .unwrap();
         let child = tmp.path().join("plain-dir");
         std::fs::create_dir_all(&child).unwrap();
-        let qs = marker_query_suffix(child.to_str().unwrap());
+        let qs = marker_query_suffix(child.to_str().unwrap(), None);
         assert!(qs.contains("&workspace=oss"), "{qs}");
         assert!(!qs.contains("&project="), "{qs}");
         assert!(qs.contains("&project_strategy=repo-root"), "{qs}");
@@ -519,7 +528,7 @@ project_strategy = "repo-root"
             return;
         }
 
-        let qs = marker_query_suffix(wt.to_str().unwrap());
+        let qs = marker_query_suffix(wt.to_str().unwrap(), None);
         assert!(qs.contains("&workspace=oss"), "{qs}");
         assert!(qs.contains("&project=acme-api"), "{qs}");
         assert!(qs.contains("&project_strategy=repo-root"), "{qs}");

--- a/crates/ai-memory-cli/src/commands/hook_capture.rs
+++ b/crates/ai-memory-cli/src/commands/hook_capture.rs
@@ -533,4 +533,74 @@ project_strategy = "repo-root"
         assert!(qs.contains("&project=acme-api"), "{qs}");
         assert!(qs.contains("&project_strategy=repo-root"), "{qs}");
     }
+
+    // ── install-time default strategy (#128), no marker required ──────
+
+    #[test]
+    fn marker_query_suffix_default_repo_root_non_git_keeps_project_implicit() {
+        // Baked repo-root default, no marker, not a git tree: the strategy is
+        // forwarded but no project is derived (server falls back to basename).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let child = tmp.path().join("plain-dir");
+        std::fs::create_dir_all(&child).unwrap();
+        let qs = marker_query_suffix(child.to_str().unwrap(), Some("repo-root"));
+        assert!(!qs.contains("&project="), "{qs}");
+        assert!(qs.contains("&project_strategy=repo-root"), "{qs}");
+    }
+
+    #[test]
+    fn marker_query_suffix_default_repo_root_collapses_git_subdir() {
+        // Baked repo-root default, no marker, inside a git subdir: the project
+        // collapses to the repo-root basename.
+        if std::process::Command::new("git")
+            .arg("--version")
+            .status()
+            .is_err()
+        {
+            return;
+        }
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo = tmp.path().join("contentcreator");
+        std::fs::create_dir_all(&repo).unwrap();
+        assert!(
+            std::process::Command::new("git")
+                .args(["init", "-q"])
+                .arg(&repo)
+                .status()
+                .unwrap()
+                .success()
+        );
+        let sub = repo.join("transcripts");
+        std::fs::create_dir_all(&sub).unwrap();
+        let qs = marker_query_suffix(sub.to_str().unwrap(), Some("repo-root"));
+        assert!(qs.contains("&project=contentcreator"), "{qs}");
+        assert!(qs.contains("&project_strategy=repo-root"), "{qs}");
+    }
+
+    #[test]
+    fn marker_query_suffix_marker_strategy_overrides_default() {
+        // A marker that pins `project_strategy = "basename"` wins over the
+        // install-time repo-root default — no repo-root derivation happens.
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join(".ai-memory.toml"),
+            "project_strategy = \"basename\"\n",
+        )
+        .unwrap();
+        let qs = marker_query_suffix(tmp.path().to_str().unwrap(), Some("repo-root"));
+        assert!(qs.contains("&project_strategy=basename"), "{qs}");
+        assert!(!qs.contains("repo-root"), "{qs}");
+        assert!(!qs.contains("&project="), "{qs}");
+    }
+
+    #[test]
+    fn marker_query_suffix_marker_project_overrides_default_repo_root() {
+        // A marker's explicit `project` wins over repo-root derivation, while
+        // the baked default strategy is still forwarded.
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".ai-memory.toml"), "project = \"pinned\"\n").unwrap();
+        let qs = marker_query_suffix(tmp.path().to_str().unwrap(), Some("repo-root"));
+        assert!(qs.contains("&project=pinned"), "{qs}");
+        assert!(qs.contains("&project_strategy=repo-root"), "{qs}");
+    }
 }

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -183,19 +183,19 @@ pub fn run(config: &Config, args: InstallHooksArgs) -> Result<()> {
         }
         AgentChoice::Codex => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
-            render_agent("codex", &hooks_dir, &server_url, auth)
+            render_agent("codex", &hooks_dir, &server_url, auth, strategy)
         }
         AgentChoice::Cursor => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
-            render_agent("cursor", &hooks_dir, &server_url, auth)
+            render_agent("cursor", &hooks_dir, &server_url, auth, strategy)
         }
         AgentChoice::GeminiCli => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
-            render_agent("gemini-cli", &hooks_dir, &server_url, auth)
+            render_agent("gemini-cli", &hooks_dir, &server_url, auth, strategy)
         }
         AgentChoice::AntigravityCli => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
-            render_agent("antigravity-cli", &hooks_dir, &server_url, auth)
+            render_agent("antigravity-cli", &hooks_dir, &server_url, auth, strategy)
         }
         AgentChoice::Grok => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
@@ -1634,29 +1634,59 @@ fn render_agent(
     hooks_dir: &Path,
     server_url: &str,
     auth_token: Option<&str>,
+    project_strategy: Option<&str>,
 ) -> Result<()> {
-    println!("# {label} hook scripts (manual install — wire each to the matching event)");
-    println!("# Hook scripts: {}", hooks_dir.display());
-    println!("# AI-memory server URL: {server_url}");
+    print!(
+        "{}",
+        render_agent_output(label, hooks_dir, server_url, auth_token, project_strategy)?
+    );
+    Ok(())
+}
+
+fn render_agent_output(
+    label: &str,
+    hooks_dir: &Path,
+    server_url: &str,
+    auth_token: Option<&str>,
+    project_strategy: Option<&str>,
+) -> Result<String> {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# {label} hook scripts (manual install — wire each to the matching event)\n"
+    ));
+    out.push_str(&format!("# Hook scripts: {}\n", hooks_dir.display()));
+    out.push_str(&format!("# AI-memory server URL: {server_url}\n"));
     if auth_token.is_some() {
-        println!("# Auth: set AI_MEMORY_AUTH_TOKEN in each hook's environment to the");
-        println!("#       value passed via --auth-token (omitted from this printout).");
+        out.push_str("# Auth: set AI_MEMORY_AUTH_TOKEN in each hook's environment to the\n");
+        out.push_str("#       value passed via --auth-token (omitted from this printout).\n");
     } else {
-        println!("# Auth: server requires no bearer token. To require one, generate a");
-        println!("#       token with `ai-memory generate-auth-token` and pass it via");
-        println!("#       --auth-token here AND set AI_MEMORY_AUTH_TOKEN on the server.");
+        out.push_str("# Auth: server requires no bearer token. To require one, generate a\n");
+        out.push_str("#       token with `ai-memory generate-auth-token` and pass it via\n");
+        out.push_str("#       --auth-token here AND set AI_MEMORY_AUTH_TOKEN on the server.\n");
     }
-    println!();
+    out.push('\n');
     for entry in std::fs::read_dir(hooks_dir)? {
         let entry = entry?;
         let p = entry.path();
         if p.is_file() && p.extension().is_some_and(|e| e == hook_script_extension()) {
-            println!("- {}", p.display());
+            out.push_str(&format!("- {}\n", p.display()));
         }
     }
-    println!();
-    println!("Set AI_MEMORY_HOOK_URL in each hook's environment to override the default.");
-    Ok(())
+    out.push('\n');
+    out.push_str("Set AI_MEMORY_HOOK_URL in each hook's environment to override the default.\n");
+    if let Some(instruction) = manual_agent_project_strategy_instruction(project_strategy) {
+        out.push_str(&instruction);
+        out.push('\n');
+    }
+    Ok(out)
+}
+
+fn manual_agent_project_strategy_instruction(project_strategy: Option<&str>) -> Option<String> {
+    project_strategy.map(|strategy| {
+        format!(
+            "Set AI_MEMORY_PROJECT_STRATEGY={strategy} in each hook's environment to use the requested project strategy."
+        )
+    })
 }
 
 /// Copy the bundled hook scripts to a stable user-global location
@@ -2196,6 +2226,36 @@ mod tests {
     #[test]
     fn validate_as_user_passes_with_both_flags() {
         assert!(validate_as_user(Some("alice"), Some("some-token")).is_ok());
+    }
+
+    #[test]
+    fn manual_agent_render_mentions_repo_root_project_strategy() {
+        let temp = TempDir::new().unwrap();
+        stub_scripts(temp.path(), &["session-start.sh"]);
+        for agent in ["codex", "cursor", "gemini-cli", "antigravity-cli"] {
+            let output = render_agent_output(
+                agent,
+                temp.path(),
+                "http://127.0.0.1:49374",
+                None,
+                Some("repo-root"),
+            )
+            .unwrap_or_else(|err| panic!("failed to render {agent}: {err}"));
+            assert!(
+                output.contains("AI_MEMORY_PROJECT_STRATEGY=repo-root"),
+                "{agent} manual output must tell users to set the strategy env: {output}"
+            );
+        }
+    }
+
+    #[test]
+    fn manual_agent_render_omits_project_strategy_by_default() {
+        let temp = TempDir::new().unwrap();
+        stub_scripts(temp.path(), &["session-start.sh"]);
+        let output =
+            render_agent_output("codex", temp.path(), "http://127.0.0.1:49374", None, None)
+                .unwrap();
+        assert!(!output.contains("AI_MEMORY_PROJECT_STRATEGY"));
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -173,12 +173,13 @@ pub fn run(config: &Config, args: InstallHooksArgs) -> Result<()> {
             AgentChoice::Openclaw => openclaw_plugin::apply(&server_url, auth, &args),
         };
     }
+    let strategy = args.project_strategy.baked();
     match args.agent {
         AgentChoice::OpenCode => render_opencode_plugin(&server_url, auth),
         AgentChoice::Omp => render_omp_extension(&server_url, auth),
         AgentChoice::ClaudeCode => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
-            render_claude_code(&hooks_dir, &server_url, auth, &config.data_dir)
+            render_claude_code(&hooks_dir, &server_url, auth, &config.data_dir, strategy)
         }
         AgentChoice::Codex => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
@@ -198,7 +199,7 @@ pub fn run(config: &Config, args: InstallHooksArgs) -> Result<()> {
         }
         AgentChoice::Grok => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
-            render_grok(&hooks_dir, &server_url, auth, &config.data_dir)
+            render_grok(&hooks_dir, &server_url, auth, &config.data_dir, strategy)
         }
         AgentChoice::Openclaw => {
             openclaw_plugin::render(&server_url, auth);
@@ -467,11 +468,13 @@ fn apply_to_claude_code_settings(
     };
     let staged = stage_hook_scripts(hooks_dir, "claude-code")?;
     let command_dir = staged_command_dir(&staged, "claude-code");
+    let strategy = args.project_strategy.baked();
     let payload = build_claude_code_payload_with_data_dir(
         &command_dir,
         server_url,
         auth_token,
         Some(data_dir),
+        strategy,
     );
     let our_hooks = payload
         .get("hooks")
@@ -529,8 +532,14 @@ fn apply_to_grok_settings(
     };
     let staged = stage_hook_scripts(hooks_dir, "grok")?;
     let command_dir = staged_command_dir(&staged, "grok");
-    let payload =
-        build_grok_payload_with_data_dir(&command_dir, server_url, auth_token, Some(data_dir));
+    let strategy = args.project_strategy.baked();
+    let payload = build_grok_payload_with_data_dir(
+        &command_dir,
+        server_url,
+        auth_token,
+        Some(data_dir),
+        strategy,
+    );
     let our_hooks = payload
         .get("hooks")
         .and_then(|v| v.as_object())
@@ -598,7 +607,15 @@ fn apply_to_codex_settings(
     };
     let staged = stage_hook_scripts(hooks_dir, "codex")?;
     let command_dir = staged_command_dir(&staged, "codex");
-    let outcome = merge_codex_hooks(&command_dir, server_url, auth_token, data_dir, &path)?;
+    let strategy = args.project_strategy.baked();
+    let outcome = merge_codex_hooks(
+        &command_dir,
+        server_url,
+        auth_token,
+        data_dir,
+        strategy,
+        &path,
+    )?;
     println!(
         "✓ {} {} ({})",
         outcome.verb(),
@@ -628,6 +645,7 @@ fn merge_codex_hooks(
     server_url: &str,
     auth_token: Option<&str>,
     data_dir: &Path,
+    project_strategy: Option<&str>,
     config_path: &Path,
 ) -> Result<ApplyOutcome> {
     // Build the Codex-flavoured payload. The JSON shape is identical
@@ -640,6 +658,7 @@ fn merge_codex_hooks(
         auth_token,
         "codex",
         Some(data_dir),
+        project_strategy,
     );
     let our_hooks = payload
         .get("hooks")
@@ -699,7 +718,15 @@ fn apply_to_cursor_settings(
     };
     let staged = stage_hook_scripts(hooks_dir, "cursor")?;
     let command_dir = staged_command_dir(&staged, "cursor");
-    let outcome = merge_cursor_hooks(&command_dir, server_url, auth_token, data_dir, &path)?;
+    let strategy = args.project_strategy.baked();
+    let outcome = merge_cursor_hooks(
+        &command_dir,
+        server_url,
+        auth_token,
+        data_dir,
+        strategy,
+        &path,
+    )?;
     println!(
         "✓ {} {} ({})",
         outcome.verb(),
@@ -718,6 +745,7 @@ fn merge_cursor_hooks(
     server_url: &str,
     auth_token: Option<&str>,
     data_dir: &Path,
+    project_strategy: Option<&str>,
     config_path: &Path,
 ) -> Result<ApplyOutcome> {
     let payload = build_profile_payload_for_agent(
@@ -727,6 +755,7 @@ fn merge_cursor_hooks(
         auth_token,
         "cursor",
         Some(data_dir),
+        project_strategy,
     );
     let our_hooks = payload
         .get("hooks")
@@ -781,7 +810,15 @@ fn apply_to_gemini_settings(
     };
     let staged = stage_hook_scripts(hooks_dir, "gemini-cli")?;
     let command_dir = staged_command_dir(&staged, "gemini-cli");
-    let outcome = merge_gemini_hooks(&command_dir, server_url, auth_token, data_dir, &path)?;
+    let strategy = args.project_strategy.baked();
+    let outcome = merge_gemini_hooks(
+        &command_dir,
+        server_url,
+        auth_token,
+        data_dir,
+        strategy,
+        &path,
+    )?;
     println!(
         "✓ {} {} ({})",
         outcome.verb(),
@@ -800,6 +837,7 @@ fn merge_gemini_hooks(
     server_url: &str,
     auth_token: Option<&str>,
     data_dir: &Path,
+    project_strategy: Option<&str>,
     config_path: &Path,
 ) -> Result<ApplyOutcome> {
     let payload = build_profile_payload_for_agent(
@@ -809,6 +847,7 @@ fn merge_gemini_hooks(
         auth_token,
         "gemini-cli",
         Some(data_dir),
+        project_strategy,
     );
     let our_hooks = payload
         .get("hooks")
@@ -855,7 +894,15 @@ fn apply_to_antigravity_settings(
     };
     let staged = stage_hook_scripts(hooks_dir, "antigravity-cli")?;
     let command_dir = staged_command_dir(&staged, "antigravity-cli");
-    let outcome = merge_antigravity_hooks(&command_dir, server_url, auth_token, data_dir, &path)?;
+    let strategy = args.project_strategy.baked();
+    let outcome = merge_antigravity_hooks(
+        &command_dir,
+        server_url,
+        auth_token,
+        data_dir,
+        strategy,
+        &path,
+    )?;
     println!(
         "✓ {} {} ({})",
         outcome.verb(),
@@ -874,10 +921,16 @@ fn merge_antigravity_hooks(
     server_url: &str,
     auth_token: Option<&str>,
     data_dir: &Path,
+    project_strategy: Option<&str>,
     config_path: &Path,
 ) -> Result<ApplyOutcome> {
-    let payload =
-        build_antigravity_payload_with_data_dir(staged, server_url, auth_token, Some(data_dir));
+    let payload = build_antigravity_payload_with_data_dir(
+        staged,
+        server_url,
+        auth_token,
+        Some(data_dir),
+        project_strategy,
+    );
     let our_group = payload
         .get("ai-memory")
         .and_then(|v| v.as_object())
@@ -1846,6 +1899,7 @@ fn render_claude_code(
     server_url: &str,
     auth_token: Option<&str>,
     data_dir: &Path,
+    project_strategy: Option<&str>,
 ) -> Result<()> {
     // Soft check: warn (don't bail) if a script is missing. The user
     // may be running this command inside docker against a host path
@@ -1864,8 +1918,13 @@ fn render_claude_code(
             );
         }
     }
-    let payload =
-        build_claude_code_payload_with_data_dir(hooks_dir, server_url, auth_token, Some(data_dir));
+    let payload = build_claude_code_payload_with_data_dir(
+        hooks_dir,
+        server_url,
+        auth_token,
+        Some(data_dir),
+        project_strategy,
+    );
     let serialized =
         serde_json::to_string_pretty(&payload).context("serializing claude code hook config")?;
     println!("# Claude Code hook config — merge into ~/.claude/settings.json");
@@ -1885,6 +1944,7 @@ fn render_grok(
     server_url: &str,
     auth_token: Option<&str>,
     data_dir: &Path,
+    project_strategy: Option<&str>,
 ) -> Result<()> {
     // Soft check (same rationale as render_claude_code): warn, don't bail,
     // so the docker host-path flow still works.
@@ -1901,8 +1961,13 @@ fn render_grok(
             );
         }
     }
-    let payload =
-        build_grok_payload_with_data_dir(hooks_dir, server_url, auth_token, Some(data_dir));
+    let payload = build_grok_payload_with_data_dir(
+        hooks_dir,
+        server_url,
+        auth_token,
+        Some(data_dir),
+        project_strategy,
+    );
     let serialized =
         serde_json::to_string_pretty(&payload).context("serializing grok hook config")?;
     println!("# Grok Build CLI hook config — write to ~/.grok/hooks/ai-memory.json");
@@ -1923,6 +1988,7 @@ fn render_grok(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::ProjectStrategyArg;
     use std::collections::BTreeMap;
     use std::fs;
     #[cfg(unix)]
@@ -2034,6 +2100,7 @@ mod tests {
             as_user: None,
             apply: true,
             config_file: None,
+            project_strategy: ProjectStrategyArg::Basename,
         }
     }
 
@@ -2681,6 +2748,7 @@ model = "gpt-5"
             as_user: None,
             apply: true,
             config_file: Some(tmp.path().join("extensions").join("ai-memory.ts")),
+            project_strategy: ProjectStrategyArg::Basename,
         };
 
         let path = resolve_omp_extension_path(&args).unwrap();
@@ -2769,6 +2837,7 @@ model = "gpt-5"
             "http://127.0.0.1:49374",
             None,
             config_tmp.path(),
+            None,
             &config_path,
         )
         .unwrap();
@@ -2816,6 +2885,7 @@ model = "gpt-5"
             "http://127.0.0.1:49374",
             None,
             config_tmp.path(),
+            None,
             &config_path,
         )
         .unwrap();
@@ -2830,6 +2900,7 @@ model = "gpt-5"
             "http://127.0.0.1:49374",
             None,
             config_tmp.path(),
+            None,
             &config_path,
         )
         .unwrap();
@@ -2865,6 +2936,7 @@ model = "gpt-5"
             "http://127.0.0.1:49374",
             None,
             config_tmp.path(),
+            None,
             &config_path,
         )
         .unwrap();
@@ -2910,6 +2982,7 @@ model = "gpt-5"
             "http://127.0.0.1:49374",
             None,
             config_tmp.path(),
+            None,
             &config_path,
         )
         .unwrap();
@@ -2954,6 +3027,7 @@ model = "gpt-5"
             "http://127.0.0.1:49374",
             None,
             config_tmp.path(),
+            None,
             &config_path,
         )
         .unwrap();
@@ -3012,6 +3086,7 @@ model = "gpt-5"
             "http://127.0.0.1:49374",
             None,
             config_tmp.path(),
+            None,
             &config_path,
         )
         .unwrap();
@@ -3063,6 +3138,7 @@ model = "gpt-5"
             "http://127.0.0.1:49374",
             None,
             config_tmp.path(),
+            None,
             &config_path,
         )
         .unwrap();
@@ -3077,6 +3153,7 @@ model = "gpt-5"
             "http://127.0.0.1:49374",
             None,
             config_tmp.path(),
+            None,
             &config_path,
         )
         .unwrap();

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -175,8 +175,8 @@ pub fn run(config: &Config, args: InstallHooksArgs) -> Result<()> {
     }
     let strategy = args.project_strategy.baked();
     match args.agent {
-        AgentChoice::OpenCode => render_opencode_plugin(&server_url, auth),
-        AgentChoice::Omp => render_omp_extension(&server_url, auth),
+        AgentChoice::OpenCode => render_opencode_plugin(&server_url, auth, strategy),
+        AgentChoice::Omp => render_omp_extension(&server_url, auth, strategy),
         AgentChoice::ClaudeCode => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
             render_claude_code(&hooks_dir, &server_url, auth, &config.data_dir, strategy)
@@ -969,7 +969,8 @@ fn apply_to_opencode_plugin(
         Some(p) => p.clone(),
         None => opencode_plugin_path()?,
     };
-    let body = build_opencode_plugin(server_url, auth_token);
+    let strategy = args.project_strategy.baked();
+    let body = build_opencode_plugin(server_url, auth_token, strategy);
 
     let outcome = apply_atomic(&path, move |_existing| Ok(body.clone()))?;
     println!(
@@ -991,19 +992,94 @@ fn apply_to_opencode_plugin(
     Ok(())
 }
 
-fn render_opencode_plugin(server_url: &str, auth_token: Option<&str>) -> Result<()> {
+fn render_opencode_plugin(
+    server_url: &str,
+    auth_token: Option<&str>,
+    project_strategy: Option<&str>,
+) -> Result<()> {
     println!("// OpenCode plugin — write to ~/.config/opencode/plugins/ai-memory.ts");
     println!("// Or re-run with `--apply` to install it automatically.");
     println!("// Restart OpenCode after changing plugins; config is loaded at startup.");
     println!();
-    println!("{}", build_opencode_plugin(server_url, auth_token));
+    println!(
+        "{}",
+        build_opencode_plugin(server_url, auth_token, project_strategy)
+    );
     Ok(())
 }
 
-fn build_opencode_plugin(server_url: &str, auth_token: Option<&str>) -> String {
+/// Emit the `applyMarkerParams` TypeScript function shared verbatim by the
+/// OpenCode plugin and the OMP extension.
+///
+/// `None` reproduces the historical marker-only function byte-for-byte, so
+/// existing generated files and golden tests are unchanged. `Some(default)`
+/// prepends a `DEFAULT_PROJECT_STRATEGY` const and emits a variant that applies
+/// that install-time default when no marker pins a `project_strategy` (#128).
+/// A marker's own `project` / `project_strategy` still take precedence (§3.3),
+/// and repo-root is resolved host-side via `repoRootProject`.
+fn ts_apply_marker_params(default_strategy: Option<&str>) -> String {
+    let Some(default) = default_strategy else {
+        return r#"function applyMarkerParams(url: URL, cwd: string | undefined): void {
+  const marker = findMarker(cwd);
+  if (!marker || !cwd) return;
+  url.searchParams.set("cwd", cwd);
+  try {
+    const body = readFileSync(marker, "utf8");
+    const workspace = tomlKey(body, "workspace");
+    const project = tomlKey(body, "project");
+    const projectStrategy = tomlKey(body, "project_strategy");
+    if (workspace) url.searchParams.set("workspace", workspace);
+    if (project) url.searchParams.set("project", project);
+    if (projectStrategy) url.searchParams.set("project_strategy", projectStrategy);
+    if (!project && (projectStrategy === "repo-root" || projectStrategy === "repo_root")) {
+      const repoProject = repoRootProject(cwd);
+      if (repoProject) url.searchParams.set("project", repoProject);
+    }
+  } catch (_e) {
+  }
+}"#
+        .to_string();
+    };
+    let body = r#"function applyMarkerParams(url: URL, cwd: string | undefined): void {
+  if (!cwd) return;
+  url.searchParams.set("cwd", cwd);
+  let workspace: string | undefined;
+  let project: string | undefined;
+  let projectStrategy: string | undefined;
+  const marker = findMarker(cwd);
+  if (marker) {
+    try {
+      const body = readFileSync(marker, "utf8");
+      workspace = tomlKey(body, "workspace");
+      project = tomlKey(body, "project");
+      projectStrategy = tomlKey(body, "project_strategy");
+    } catch (_e) {
+    }
+  }
+  if (!projectStrategy) projectStrategy = DEFAULT_PROJECT_STRATEGY;
+  if (!project && (projectStrategy === "repo-root" || projectStrategy === "repo_root")) {
+    const repoProject = repoRootProject(cwd);
+    if (repoProject) project = repoProject;
+  }
+  if (workspace) url.searchParams.set("workspace", workspace);
+  if (project) url.searchParams.set("project", project);
+  if (projectStrategy) url.searchParams.set("project_strategy", projectStrategy);
+}"#;
+    format!(
+        "const DEFAULT_PROJECT_STRATEGY = {};\n{body}",
+        ts_string_literal(default)
+    )
+}
+
+fn build_opencode_plugin(
+    server_url: &str,
+    auth_token: Option<&str>,
+    project_strategy: Option<&str>,
+) -> String {
     let token_line = auth_token
         .map(|t| format!("const TOKEN: string | null = {};\n", ts_string_literal(t)))
         .unwrap_or_else(|| "const TOKEN: string | null = null;\n".to_string());
+    let apply_marker_params = ts_apply_marker_params(project_strategy);
     format!(
         r#"// Auto-generated by `ai-memory install-hooks --agent opencode --apply`.
 // Edit by re-running the command, not by hand — install-hooks
@@ -1073,25 +1149,7 @@ function repoRootProject(cwd: string | undefined): string | undefined {{
     return undefined;
   }}
 }}
-function applyMarkerParams(url: URL, cwd: string | undefined): void {{
-  const marker = findMarker(cwd);
-  if (!marker || !cwd) return;
-  url.searchParams.set("cwd", cwd);
-  try {{
-    const body = readFileSync(marker, "utf8");
-    const workspace = tomlKey(body, "workspace");
-    const project = tomlKey(body, "project");
-    const projectStrategy = tomlKey(body, "project_strategy");
-    if (workspace) url.searchParams.set("workspace", workspace);
-    if (project) url.searchParams.set("project", project);
-    if (projectStrategy) url.searchParams.set("project_strategy", projectStrategy);
-    if (!project && (projectStrategy === "repo-root" || projectStrategy === "repo_root")) {{
-      const repoProject = repoRootProject(cwd);
-      if (repoProject) url.searchParams.set("project", repoProject);
-    }}
-  }} catch (_e) {{
-  }}
-}}
+{apply_marker_params}
 
 function sessionID(input: unknown): string | undefined {{
   const value = input as any;
@@ -1271,7 +1329,8 @@ fn apply_to_omp_extension(
     args: &InstallHooksArgs,
 ) -> Result<()> {
     let path = resolve_omp_extension_path(args)?;
-    let body = build_omp_extension(server_url, auth_token);
+    let strategy = args.project_strategy.baked();
+    let body = build_omp_extension(server_url, auth_token, strategy);
 
     let outcome = apply_atomic(&path, move |_existing| Ok(body.clone()))?;
     println!(
@@ -1295,12 +1354,19 @@ fn apply_to_omp_extension(
     Ok(())
 }
 
-fn render_omp_extension(server_url: &str, auth_token: Option<&str>) -> Result<()> {
+fn render_omp_extension(
+    server_url: &str,
+    auth_token: Option<&str>,
+    project_strategy: Option<&str>,
+) -> Result<()> {
     println!("// Oh My Pi / OMP extension — write to ~/.omp/agent/extensions/ai-memory.ts");
     println!("// Or re-run with `--apply` to install it automatically.");
     println!("// Restart OMP after changing extensions; config is loaded at startup.");
     println!();
-    println!("{}", build_omp_extension(server_url, auth_token));
+    println!(
+        "{}",
+        build_omp_extension(server_url, auth_token, project_strategy)
+    );
     Ok(())
 }
 
@@ -1311,10 +1377,15 @@ fn resolve_omp_extension_path(args: &InstallHooksArgs) -> Result<PathBuf> {
     omp_extension_path()
 }
 
-fn build_omp_extension(server_url: &str, auth_token: Option<&str>) -> String {
+fn build_omp_extension(
+    server_url: &str,
+    auth_token: Option<&str>,
+    project_strategy: Option<&str>,
+) -> String {
     let token_line = auth_token
         .map(|t| format!("const TOKEN: string | null = {};\n", ts_string_literal(t)))
         .unwrap_or_else(|| "const TOKEN: string | null = null;\n".to_string());
+    let apply_marker_params = ts_apply_marker_params(project_strategy);
     format!(
         r#"// Auto-generated by `ai-memory install-hooks --agent omp --apply`.
 // Edit by re-running the command, not by hand — install-hooks
@@ -1383,25 +1454,7 @@ function repoRootProject(cwd: string | undefined): string | undefined {{
     return undefined;
   }}
 }}
-function applyMarkerParams(url: URL, cwd: string | undefined): void {{
-  const marker = findMarker(cwd);
-  if (!marker || !cwd) return;
-  url.searchParams.set("cwd", cwd);
-  try {{
-    const body = readFileSync(marker, "utf8");
-    const workspace = tomlKey(body, "workspace");
-    const project = tomlKey(body, "project");
-    const projectStrategy = tomlKey(body, "project_strategy");
-    if (workspace) url.searchParams.set("workspace", workspace);
-    if (project) url.searchParams.set("project", project);
-    if (projectStrategy) url.searchParams.set("project_strategy", projectStrategy);
-    if (!project && (projectStrategy === "repo-root" || projectStrategy === "repo_root")) {{
-      const repoProject = repoRootProject(cwd);
-      if (repoProject) url.searchParams.set("project", repoProject);
-    }}
-  }} catch (_e) {{
-  }}
-}}
+{apply_marker_params}
 
 function sessionID(ctx: any): string | undefined {{
   const id = ctx?.sessionManager?.getSessionId?.();
@@ -2638,7 +2691,7 @@ model = "gpt-5"
 
     #[test]
     fn opencode_plugin_uses_real_plugin_hooks() {
-        let plugin = build_opencode_plugin("http://127.0.0.1:49374", Some("tok"));
+        let plugin = build_opencode_plugin("http://127.0.0.1:49374", Some("tok"), None);
 
         assert!(plugin.contains("event: async (input)"));
         assert!(plugin.contains(r#""chat.message": async"#));
@@ -2680,7 +2733,7 @@ model = "gpt-5"
 
     #[test]
     fn opencode_plugin_normalizes_payloads_without_legacy_wrapper() {
-        let plugin = build_opencode_plugin("http://127.0.0.1:49374/", None);
+        let plugin = build_opencode_plugin("http://127.0.0.1:49374/", None, None);
 
         assert!(plugin.contains("const SERVER = \"http://127.0.0.1:49374/\".replace"));
         assert!(plugin.contains("const TOKEN: string | null = null;"));
@@ -2701,7 +2754,7 @@ model = "gpt-5"
 
     #[test]
     fn omp_extension_uses_native_lifecycle_events() {
-        let extension = build_omp_extension("http://127.0.0.1:49374", Some("tok"));
+        let extension = build_omp_extension("http://127.0.0.1:49374", Some("tok"), None);
 
         assert!(extension.contains("export default function AiMemoryExtension"));
         assert!(extension.contains("const AGENT = \"omp\";"));

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -2748,6 +2748,33 @@ model = "gpt-5"
         );
     }
 
+    #[test]
+    fn opencode_plugin_bakes_repo_root_default() {
+        let plugin =
+            build_opencode_plugin("http://127.0.0.1:49374", Some("tok"), Some("repo-root"));
+        assert!(
+            plugin.contains("const DEFAULT_PROJECT_STRATEGY = \"repo-root\";"),
+            "repo-root install default must bake the const: {plugin}"
+        );
+        assert!(
+            plugin.contains("if (!projectStrategy) projectStrategy = DEFAULT_PROJECT_STRATEGY;"),
+            "must apply the default when a marker pins no strategy: {plugin}"
+        );
+        assert!(
+            plugin.contains("if (repoProject) project = repoProject;"),
+            "{plugin}"
+        );
+    }
+
+    #[test]
+    fn opencode_plugin_default_omits_baked_strategy() {
+        let plugin = build_opencode_plugin("http://127.0.0.1:49374", Some("tok"), None);
+        assert!(
+            !plugin.contains("DEFAULT_PROJECT_STRATEGY"),
+            "basename default must bake no strategy: {plugin}"
+        );
+    }
+
     // ----------------------------------------------------------------
     // OMP tests
     // ----------------------------------------------------------------
@@ -2788,6 +2815,29 @@ model = "gpt-5"
                 .contains("projectStrategy === \"repo-root\" || projectStrategy === \"repo_root\"")
         );
         assert!(extension.contains("url.searchParams.set(\"project\", repoProject)"));
+    }
+
+    #[test]
+    fn omp_extension_bakes_repo_root_default() {
+        let extension =
+            build_omp_extension("http://127.0.0.1:49374", Some("tok"), Some("repo-root"));
+        assert!(
+            extension.contains("const DEFAULT_PROJECT_STRATEGY = \"repo-root\";"),
+            "repo-root install default must bake the const: {extension}"
+        );
+        assert!(
+            extension.contains("if (!projectStrategy) projectStrategy = DEFAULT_PROJECT_STRATEGY;"),
+            "{extension}"
+        );
+    }
+
+    #[test]
+    fn omp_extension_default_omits_baked_strategy() {
+        let extension = build_omp_extension("http://127.0.0.1:49374", Some("tok"), None);
+        assert!(
+            !extension.contains("DEFAULT_PROJECT_STRATEGY"),
+            "{extension}"
+        );
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -202,7 +202,7 @@ pub fn run(config: &Config, args: InstallHooksArgs) -> Result<()> {
             render_grok(&hooks_dir, &server_url, auth, &config.data_dir, strategy)
         }
         AgentChoice::Openclaw => {
-            openclaw_plugin::render(&server_url, auth);
+            openclaw_plugin::render(&server_url, auth, strategy);
             Ok(())
         }
     }

--- a/crates/ai-memory-cli/src/commands/openclaw_plugin.rs
+++ b/crates/ai-memory-cli/src/commands/openclaw_plugin.rs
@@ -541,6 +541,28 @@ mod tests {
     }
 
     #[test]
+    fn openclaw_plugin_bakes_repo_root_default() {
+        let plugin = build_plugin("http://127.0.0.1:49374", Some("tok"), Some("repo-root"));
+        assert!(
+            plugin.contains("const DEFAULT_PROJECT_STRATEGY = \"repo-root\";"),
+            "repo-root install default must bake the const: {plugin}"
+        );
+        assert!(
+            plugin.contains("if (!projectStrategy) projectStrategy = DEFAULT_PROJECT_STRATEGY;"),
+            "must apply the default when a marker pins no strategy: {plugin}"
+        );
+    }
+
+    #[test]
+    fn openclaw_plugin_default_omits_baked_strategy() {
+        let plugin = build_plugin("http://127.0.0.1:49374", Some("tok"), None);
+        assert!(
+            !plugin.contains("DEFAULT_PROJECT_STRATEGY"),
+            "basename default must bake no strategy: {plugin}"
+        );
+    }
+
+    #[test]
     fn package_writes_all_required_files() {
         let tmp = TempDir::new().unwrap();
         let outcomes = write_package(tmp.path(), "http://127.0.0.1:49374", None, None).unwrap();

--- a/crates/ai-memory-cli/src/commands/openclaw_plugin.rs
+++ b/crates/ai-memory-cli/src/commands/openclaw_plugin.rs
@@ -24,7 +24,8 @@ pub(crate) fn apply(
     args: &InstallHooksArgs,
 ) -> Result<()> {
     let plugin_dir = resolve_plugin_dir(args)?;
-    let outcomes = write_package(&plugin_dir, server_url, auth_token)?;
+    let strategy = args.project_strategy.baked();
+    let outcomes = write_package(&plugin_dir, server_url, auth_token, strategy)?;
     for (path, outcome) in &outcomes {
         println!(
             "✓ {} {} ({})",
@@ -59,7 +60,7 @@ pub(crate) fn apply(
 }
 
 /// Print the generated package for manual installation.
-pub(crate) fn render(server_url: &str, auth_token: Option<&str>) {
+pub(crate) fn render(server_url: &str, auth_token: Option<&str>, project_strategy: Option<&str>) {
     println!("# OpenClaw native plugin package");
     println!("# Re-run with `--apply` to write the package and call:");
     println!("#   openclaw plugins install --link <package-dir> --force");
@@ -71,7 +72,7 @@ pub(crate) fn render(server_url: &str, auth_token: Option<&str>) {
     println!("## {MANIFEST_JSON}");
     println!("{}", manifest_json());
     println!("## {ENTRYPOINT_TS}");
-    println!("{}", build_plugin(server_url, auth_token));
+    println!("{}", build_plugin(server_url, auth_token, project_strategy));
 }
 
 fn outcome_detail(outcome: ApplyOutcome) -> &'static str {
@@ -100,11 +101,15 @@ fn write_package(
     plugin_dir: &Path,
     server_url: &str,
     auth_token: Option<&str>,
+    project_strategy: Option<&str>,
 ) -> Result<Vec<(PathBuf, ApplyOutcome)>> {
     let files = [
         (PACKAGE_JSON, package_json()),
         (MANIFEST_JSON, manifest_json()),
-        (ENTRYPOINT_TS, build_plugin(server_url, auth_token)),
+        (
+            ENTRYPOINT_TS,
+            build_plugin(server_url, auth_token, project_strategy),
+        ),
     ];
     let mut outcomes = Vec::with_capacity(files.len());
     for (name, body) in files {
@@ -188,10 +193,78 @@ pub(crate) fn manifest_json() -> String {
         + "\n"
 }
 
-fn build_plugin(server_url: &str, auth_token: Option<&str>) -> String {
+/// Emit the OpenClaw plugin's `applyMarkerParams` TypeScript function.
+///
+/// `None` reproduces the historical marker-only function byte-for-byte (the
+/// OpenClaw variant always sets `cwd`, even with no marker). `Some(default)`
+/// prepends a `DEFAULT_PROJECT_STRATEGY` const and applies that install-time
+/// default when no marker pins a `project_strategy` (#128); a marker's own
+/// `project` / `project_strategy` still win (§3.3). Mirrors the opencode/omp
+/// `ts_apply_marker_params` in `install_hooks.rs`.
+fn apply_marker_params_ts(default_strategy: Option<&str>) -> String {
+    let Some(default) = default_strategy else {
+        return r#"function applyMarkerParams(url: URL, cwd: string | undefined): void {
+  if (!cwd) return;
+  url.searchParams.set("cwd", cwd);
+  const marker = findMarker(cwd);
+  if (!marker) return;
+  try {
+    const body = readFileSync(marker, "utf8");
+    const workspace = tomlKey(body, "workspace");
+    const project = tomlKey(body, "project");
+    const projectStrategy = tomlKey(body, "project_strategy");
+    if (workspace) url.searchParams.set("workspace", workspace);
+    if (project) url.searchParams.set("project", project);
+    if (projectStrategy) url.searchParams.set("project_strategy", projectStrategy);
+    if (!project && (projectStrategy === "repo-root" || projectStrategy === "repo_root")) {
+      const repoProject = repoRootProject(cwd);
+      if (repoProject) url.searchParams.set("project", repoProject);
+    }
+  } catch (_e) {
+  }
+}"#
+        .to_string();
+    };
+    let body = r#"function applyMarkerParams(url: URL, cwd: string | undefined): void {
+  if (!cwd) return;
+  url.searchParams.set("cwd", cwd);
+  let workspace: string | undefined;
+  let project: string | undefined;
+  let projectStrategy: string | undefined;
+  const marker = findMarker(cwd);
+  if (marker) {
+    try {
+      const body = readFileSync(marker, "utf8");
+      workspace = tomlKey(body, "workspace");
+      project = tomlKey(body, "project");
+      projectStrategy = tomlKey(body, "project_strategy");
+    } catch (_e) {
+    }
+  }
+  if (!projectStrategy) projectStrategy = DEFAULT_PROJECT_STRATEGY;
+  if (!project && (projectStrategy === "repo-root" || projectStrategy === "repo_root")) {
+    const repoProject = repoRootProject(cwd);
+    if (repoProject) project = repoProject;
+  }
+  if (workspace) url.searchParams.set("workspace", workspace);
+  if (project) url.searchParams.set("project", project);
+  if (projectStrategy) url.searchParams.set("project_strategy", projectStrategy);
+}"#;
+    format!(
+        "const DEFAULT_PROJECT_STRATEGY = {};\n{body}",
+        ts_string_literal(default)
+    )
+}
+
+fn build_plugin(
+    server_url: &str,
+    auth_token: Option<&str>,
+    project_strategy: Option<&str>,
+) -> String {
     let token_line = auth_token
         .map(|t| format!("const TOKEN: string | null = {};\n", ts_string_literal(t)))
         .unwrap_or_else(|| "const TOKEN: string | null = null;\n".to_string());
+    let apply_marker_params = apply_marker_params_ts(project_strategy);
     format!(
         r#"// Auto-generated by `ai-memory install-hooks --agent openclaw --apply`.
 // Edit by re-running the command, not by hand. install-hooks owns
@@ -260,26 +333,7 @@ function repoRootProject(cwd: string | undefined): string | undefined {{
     return undefined;
   }}
 }}
-function applyMarkerParams(url: URL, cwd: string | undefined): void {{
-  if (!cwd) return;
-  url.searchParams.set("cwd", cwd);
-  const marker = findMarker(cwd);
-  if (!marker) return;
-  try {{
-    const body = readFileSync(marker, "utf8");
-    const workspace = tomlKey(body, "workspace");
-    const project = tomlKey(body, "project");
-    const projectStrategy = tomlKey(body, "project_strategy");
-    if (workspace) url.searchParams.set("workspace", workspace);
-    if (project) url.searchParams.set("project", project);
-    if (projectStrategy) url.searchParams.set("project_strategy", projectStrategy);
-    if (!project && (projectStrategy === "repo-root" || projectStrategy === "repo_root")) {{
-      const repoProject = repoRootProject(cwd);
-      if (repoProject) url.searchParams.set("project", repoProject);
-    }}
-  }} catch (_e) {{
-  }}
-}}
+{apply_marker_params}
 
 function textFrom(value: unknown): string {{
   if (value === null || value === undefined) return "";
@@ -448,7 +502,7 @@ mod tests {
     fn package_has_manifest_and_hook_entrypoint() {
         let package = package_json();
         let manifest = manifest_json();
-        let plugin = build_plugin("http://127.0.0.1:49374", Some("tok"));
+        let plugin = build_plugin("http://127.0.0.1:49374", Some("tok"), None);
 
         assert!(package.contains(r#""extensions""#));
         assert!(package.contains(r#""./index.ts""#));
@@ -489,7 +543,7 @@ mod tests {
     #[test]
     fn package_writes_all_required_files() {
         let tmp = TempDir::new().unwrap();
-        let outcomes = write_package(tmp.path(), "http://127.0.0.1:49374", None).unwrap();
+        let outcomes = write_package(tmp.path(), "http://127.0.0.1:49374", None, None).unwrap();
 
         assert_eq!(outcomes.len(), 3);
         assert!(tmp.path().join(PACKAGE_JSON).is_file());

--- a/crates/ai-memory-cli/src/commands/render_shared.rs
+++ b/crates/ai-memory-cli/src/commands/render_shared.rs
@@ -109,6 +109,7 @@ pub(crate) fn build_claude_code_payload(
             HookCommandPlatform::for_bash_script_runner(),
             "claude-code",
             None,
+            None,
         ),
     )
 }
@@ -118,6 +119,7 @@ pub(crate) fn build_claude_code_payload_with_data_dir(
     server_url: &str,
     auth_token: Option<&str>,
     data_dir: Option<&Path>,
+    project_strategy: Option<&str>,
 ) -> serde_json::Value {
     build_hook_payload_for_platform(
         &CLAUDE_CODE_EVENTS,
@@ -129,6 +131,7 @@ pub(crate) fn build_claude_code_payload_with_data_dir(
             HookCommandPlatform::for_bash_runner(),
             "claude-code",
             data_dir,
+            project_strategy,
         ),
     )
 }
@@ -149,7 +152,12 @@ pub(crate) fn build_grok_payload(
         server_url,
         auth_token,
         HookShape::Nested,
-        HookCommandContext::new(HookCommandPlatform::for_bash_script_runner(), "grok", None),
+        HookCommandContext::new(
+            HookCommandPlatform::for_bash_script_runner(),
+            "grok",
+            None,
+            None,
+        ),
     )
 }
 
@@ -160,6 +168,7 @@ pub(crate) fn build_grok_payload_with_data_dir(
     server_url: &str,
     auth_token: Option<&str>,
     data_dir: Option<&Path>,
+    project_strategy: Option<&str>,
 ) -> serde_json::Value {
     build_hook_payload_for_platform(
         &CLAUDE_CODE_EVENTS,
@@ -167,7 +176,12 @@ pub(crate) fn build_grok_payload_with_data_dir(
         server_url,
         auth_token,
         HookShape::Nested,
-        HookCommandContext::new(HookCommandPlatform::for_bash_runner(), "grok", data_dir),
+        HookCommandContext::new(
+            HookCommandPlatform::for_bash_runner(),
+            "grok",
+            data_dir,
+            project_strategy,
+        ),
     )
 }
 
@@ -292,6 +306,7 @@ pub(crate) fn build_antigravity_payload_with_data_dir(
     server_url: &str,
     auth_token: Option<&str>,
     data_dir: Option<&Path>,
+    project_strategy: Option<&str>,
 ) -> serde_json::Value {
     build_antigravity_payload_for_platform(
         emit_root,
@@ -300,6 +315,7 @@ pub(crate) fn build_antigravity_payload_with_data_dir(
         HookCommandPlatform::current(),
         "antigravity-cli",
         data_dir,
+        project_strategy,
     )
 }
 
@@ -310,6 +326,7 @@ fn build_antigravity_payload_for_platform(
     platform: HookCommandPlatform,
     agent: &str,
     data_dir: Option<&Path>,
+    project_strategy: Option<&str>,
 ) -> serde_json::Value {
     let mut group = serde_json::Map::new();
 
@@ -321,7 +338,7 @@ fn build_antigravity_payload_for_platform(
             &abs,
             server_url,
             auth_token,
-            HookCommandContext::new(platform, agent, data_dir),
+            HookCommandContext::new(platform, agent, data_dir, project_strategy),
         );
         group.insert(
             (*event).to_string(),
@@ -343,7 +360,7 @@ fn build_antigravity_payload_for_platform(
             &abs,
             server_url,
             auth_token,
-            HookCommandContext::new(platform, agent, data_dir),
+            HookCommandContext::new(platform, agent, data_dir, project_strategy),
         );
         group.insert(
             (*event).to_string(),
@@ -375,6 +392,7 @@ pub(crate) fn build_profile_payload(
         auth_token,
         "claude-code",
         None,
+        None,
     )
 }
 
@@ -385,6 +403,7 @@ pub(crate) fn build_profile_payload_for_agent(
     auth_token: Option<&str>,
     agent: &str,
     data_dir: Option<&Path>,
+    project_strategy: Option<&str>,
 ) -> serde_json::Value {
     build_hook_payload(
         profile.events,
@@ -392,7 +411,12 @@ pub(crate) fn build_profile_payload_for_agent(
         server_url,
         auth_token,
         profile.shape,
-        HookCommandContext::new(HookCommandPlatform::current(), agent, data_dir),
+        HookCommandContext::new(
+            HookCommandPlatform::current(),
+            agent,
+            data_dir,
+            project_strategy,
+        ),
     )
 }
 
@@ -437,6 +461,9 @@ struct HookCommandContext<'a> {
     platform: HookCommandPlatform,
     agent: &'a str,
     data_dir: Option<&'a Path>,
+    /// Install-time default project strategy baked into the command
+    /// (`install-hooks --project-strategy`). `None` bakes nothing.
+    project_strategy: Option<&'a str>,
 }
 
 impl<'a> HookCommandContext<'a> {
@@ -444,11 +471,13 @@ impl<'a> HookCommandContext<'a> {
         platform: HookCommandPlatform,
         agent: &'a str,
         data_dir: Option<&'a Path>,
+        project_strategy: Option<&'a str>,
     ) -> Self {
         Self {
             platform,
             agent,
             data_dir,
+            project_strategy,
         }
     }
 }
@@ -599,6 +628,9 @@ fn hook_command(
             if let Some(t) = auth_token {
                 prefix.push_str(&format!("AI_MEMORY_AUTH_TOKEN={} ", shell_quote(t)));
             }
+            if let Some(s) = context.project_strategy {
+                prefix.push_str(&format!("AI_MEMORY_PROJECT_STRATEGY={} ", shell_quote(s)));
+            }
             format!("{prefix}{}", shell_quote(&script.to_string_lossy()))
         }
         HookCommandPlatform::Windows => {
@@ -607,6 +639,12 @@ fn hook_command(
                 setup.push_str(&format!(
                     "; $env:AI_MEMORY_AUTH_TOKEN={}",
                     powershell_quote(t)
+                ));
+            }
+            if let Some(s) = context.project_strategy {
+                setup.push_str(&format!(
+                    "; $env:AI_MEMORY_PROJECT_STRATEGY={}",
+                    powershell_quote(s)
                 ));
             }
             format!(
@@ -619,6 +657,9 @@ fn hook_command(
             let mut inner = format!("AI_MEMORY_HOOK_URL={} ", shell_quote(server_url));
             if let Some(t) = auth_token {
                 inner.push_str(&format!("AI_MEMORY_AUTH_TOKEN={} ", shell_quote(t)));
+            }
+            if let Some(s) = context.project_strategy {
+                inner.push_str(&format!("AI_MEMORY_PROJECT_STRATEGY={} ", shell_quote(s)));
             }
             inner.push_str(&shell_quote(&bash_path));
             format!("bash -c {}", shell_quote(&inner))
@@ -652,6 +693,10 @@ fn hook_command(
             if let Some(t) = auth_token {
                 cmd.push_str(&format!(" --auth-token {}", win_double_quote(t)));
             }
+            cmd.push_str(&native_project_strategy_arg(
+                context.project_strategy,
+                NativeQuote::Windows,
+            ));
             cmd
         }
         HookCommandPlatform::PosixNative => {
@@ -676,6 +721,10 @@ fn hook_command(
             if let Some(t) = auth_token {
                 cmd.push_str(&format!(" --auth-token {}", shell_quote(t)));
             }
+            cmd.push_str(&native_project_strategy_arg(
+                context.project_strategy,
+                NativeQuote::Posix,
+            ));
             cmd
         }
     }
@@ -697,6 +746,19 @@ fn native_data_dir_arg(data_dir: Option<&Path>, quote: NativeQuote) -> String {
     match quote {
         NativeQuote::Posix => format!(" --data-dir {}", shell_quote(&path)),
         NativeQuote::Windows => format!(" --data-dir {}", win_double_quote(&path)),
+    }
+}
+
+/// Append ` --project-strategy <value>` to a native hook command when an
+/// install-time default was baked in (`install-hooks --project-strategy`).
+/// `None` appends nothing, keeping the command byte-identical to before.
+fn native_project_strategy_arg(strategy: Option<&str>, quote: NativeQuote) -> String {
+    let Some(strategy) = strategy else {
+        return String::new();
+    };
+    match quote {
+        NativeQuote::Posix => format!(" --project-strategy {}", shell_quote(strategy)),
+        NativeQuote::Windows => format!(" --project-strategy {}", win_double_quote(strategy)),
     }
 }
 
@@ -763,7 +825,7 @@ mod tests {
             server_url,
             auth_token,
             shape,
-            HookCommandContext::new(HookCommandPlatform::Posix, "claude-code", None),
+            HookCommandContext::new(HookCommandPlatform::Posix, "claude-code", None, None),
         )
     }
 
@@ -798,7 +860,7 @@ mod tests {
             "http://localhost:49374",
             None,
             HookShape::Nested,
-            HookCommandContext::new(HookCommandPlatform::PosixNative, "grok", None),
+            HookCommandContext::new(HookCommandPlatform::PosixNative, "grok", None, None),
         );
         let command = v
             .pointer("/hooks/SessionStart/0/hooks/0/command")
@@ -817,7 +879,7 @@ mod tests {
             "http://localhost:49374",
             None,
             HookShape::Nested,
-            HookCommandContext::new(HookCommandPlatform::Posix, "grok", None),
+            HookCommandContext::new(HookCommandPlatform::Posix, "grok", None, None),
         );
         let command = v
             .pointer("/hooks/SessionStart/0/hooks/0/command")
@@ -1032,7 +1094,12 @@ mod tests {
             "http://h:49374",
             Some("tok"),
             HookShape::Nested,
-            HookCommandContext::new(HookCommandPlatform::WindowsNative, "claude-code", None),
+            HookCommandContext::new(
+                HookCommandPlatform::WindowsNative,
+                "claude-code",
+                None,
+                None,
+            ),
         );
         // Each native command must carry `hook --event <stem>` where <stem>
         // matches the .sh script the other platforms invoke — so the server
@@ -1089,7 +1156,7 @@ mod tests {
             &PathBuf::from("/tmp/hooks dir/session-start.sh"),
             "http://localhost:49374/mcp?x=1&y=2",
             Some("tok;rm -rf /"),
-            HookCommandContext::new(HookCommandPlatform::Posix, "claude-code", None),
+            HookCommandContext::new(HookCommandPlatform::Posix, "claude-code", None, None),
         );
 
         assert!(
@@ -1115,7 +1182,7 @@ mod tests {
             "http://localhost:49374",
             Some("tok'en"),
             HookShape::Nested,
-            HookCommandContext::new(HookCommandPlatform::Windows, "claude-code", None),
+            HookCommandContext::new(HookCommandPlatform::Windows, "claude-code", None, None),
         );
         let cmd = v
             .pointer("/hooks/SessionStart/0/hooks/0/command")
@@ -1143,6 +1210,7 @@ mod tests {
             Some("tok"),
             HookCommandPlatform::Posix,
             "antigravity-cli",
+            None,
             None,
         );
 
@@ -1246,7 +1314,7 @@ mod tests {
             ),
             "https://my-server.example.com",
             Some("tok123"),
-            HookCommandContext::new(HookCommandPlatform::WindowsBash, "claude-code", None),
+            HookCommandContext::new(HookCommandPlatform::WindowsBash, "claude-code", None, None),
         );
         assert!(
             cmd.starts_with("bash -c "),
@@ -1276,7 +1344,7 @@ mod tests {
             &PathBuf::from(r"C:\Users\alice\hooks\session-start.sh"),
             "http://localhost:49374",
             None,
-            HookCommandContext::new(HookCommandPlatform::WindowsBash, "claude-code", None),
+            HookCommandContext::new(HookCommandPlatform::WindowsBash, "claude-code", None, None),
         );
         assert!(cmd.starts_with("bash -c "));
         assert!(
@@ -1297,7 +1365,7 @@ mod tests {
             &PathBuf::from("/home/alice/.local/share/ai-memory/hooks/claude-code/session-start.sh"),
             "https://my-server.example.com",
             Some("tok123"),
-            HookCommandContext::new(HookCommandPlatform::PosixNative, "claude-code", None),
+            HookCommandContext::new(HookCommandPlatform::PosixNative, "claude-code", None, None),
         );
         assert!(
             cmd.contains("hook --event session-start"),
@@ -1326,6 +1394,7 @@ mod tests {
                 HookCommandPlatform::PosixNative,
                 "codex",
                 Some(Path::new("/home/alice/.local/share/custom memory")),
+                None,
             ),
         );
         assert!(cmd.contains("hook --event pre-tool-use"), "{cmd}");
@@ -1350,6 +1419,7 @@ mod tests {
                 HookCommandPlatform::WindowsNative,
                 "claude-code",
                 Some(Path::new(r"\\?\C:\Users\me\AppData\Local\ai-memory")),
+                None,
             ),
         );
         assert!(
@@ -1372,7 +1442,7 @@ mod tests {
             "https://my-server.example.com",
             Some("tok123"),
             HookShape::Nested,
-            HookCommandContext::new(HookCommandPlatform::WindowsBash, "claude-code", None),
+            HookCommandContext::new(HookCommandPlatform::WindowsBash, "claude-code", None, None),
         );
         let cmd = v
             .pointer("/hooks/SessionStart/0/hooks/0/command")

--- a/crates/ai-memory-cli/src/commands/render_shared.rs
+++ b/crates/ai-memory-cli/src/commands/render_shared.rs
@@ -1359,6 +1359,86 @@ mod tests {
         assert_eq!(s, "session-start.sh");
     }
 
+    // ── install-time --project-strategy baking (#128) ────────────────
+    // A baked `Some("repo-root")` must surface in every command arm; the
+    // default `None` must leave every arm byte-identical (no strategy).
+
+    fn strategy_cmd(platform: HookCommandPlatform, strategy: Option<&str>) -> String {
+        hook_command(
+            &PathBuf::from("/tmp/hooks/claude-code/session-start.sh"),
+            "http://localhost:49374",
+            None,
+            HookCommandContext::new(platform, "claude-code", None, strategy),
+        )
+    }
+
+    #[test]
+    fn posix_hook_command_bakes_project_strategy_env() {
+        let cmd = strategy_cmd(HookCommandPlatform::Posix, Some("repo-root"));
+        assert!(
+            cmd.contains("AI_MEMORY_PROJECT_STRATEGY=repo-root"),
+            "posix must bake the strategy env: {cmd}"
+        );
+    }
+
+    #[test]
+    fn windows_ps_hook_command_bakes_project_strategy_env() {
+        let cmd = strategy_cmd(HookCommandPlatform::Windows, Some("repo-root"));
+        assert!(
+            cmd.contains("$env:AI_MEMORY_PROJECT_STRATEGY='repo-root'"),
+            "powershell must bake the strategy env: {cmd}"
+        );
+    }
+
+    #[test]
+    fn windows_bash_hook_command_bakes_project_strategy_env() {
+        let cmd = strategy_cmd(HookCommandPlatform::WindowsBash, Some("repo-root"));
+        assert!(cmd.starts_with("bash -c "), "{cmd}");
+        assert!(
+            cmd.contains("AI_MEMORY_PROJECT_STRATEGY=repo-root"),
+            "windows-bash must bake the strategy env inside bash -c: {cmd}"
+        );
+    }
+
+    #[test]
+    fn posix_native_hook_command_passes_project_strategy_flag() {
+        let cmd = strategy_cmd(HookCommandPlatform::PosixNative, Some("repo-root"));
+        assert!(
+            cmd.contains("--project-strategy repo-root"),
+            "posix-native must pass the strategy flag: {cmd}"
+        );
+    }
+
+    #[test]
+    fn windows_native_hook_command_passes_project_strategy_flag() {
+        let cmd = strategy_cmd(HookCommandPlatform::WindowsNative, Some("repo-root"));
+        assert!(
+            cmd.contains(r#"--project-strategy "repo-root""#),
+            "windows-native must pass the strategy flag (double-quoted): {cmd}"
+        );
+    }
+
+    #[test]
+    fn hook_command_omits_project_strategy_when_none() {
+        for platform in [
+            HookCommandPlatform::Posix,
+            HookCommandPlatform::Windows,
+            HookCommandPlatform::WindowsBash,
+            HookCommandPlatform::PosixNative,
+            HookCommandPlatform::WindowsNative,
+        ] {
+            let cmd = strategy_cmd(platform, None);
+            assert!(
+                !cmd.contains("AI_MEMORY_PROJECT_STRATEGY"),
+                "{platform:?}: no strategy env when None: {cmd}"
+            );
+            assert!(
+                !cmd.contains("--project-strategy"),
+                "{platform:?}: no strategy flag when None: {cmd}"
+            );
+        }
+    }
+
     #[test]
     fn posix_native_hook_command_invokes_binary_directly() {
         let cmd = hook_command(

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -204,6 +204,8 @@ Lesson from basic-memory's v0.20 trauma: `(workspace, project, page_path)`. Even
 
 Project resolution chain: explicit param → server's default → cwd-based heuristic (match repo root) → error.
 
+**Install-time `project_strategy` default (#128).** `basename(cwd)` stays the v1 default, but an agent shell that `cd`s into a subdirectory and stays there silently forks the rest of the session into a phantom project named after the subdir. A `.ai-memory.toml` marker with `project_strategy = "repo-root"` fixes this (#16, #23, #111) but needs a marker in (or above) every repo; a runtime env-var fallback that the *user* sets was deliberately rejected in #16. `install-hooks --project-strategy repo-root` instead **bakes** the strategy into the generated hook command (and the OpenCode / OMP / OpenClaw plugins) at install time — the same status as the already-baked `AI_MEMORY_AUTH_TOKEN` / `AI_MEMORY_HOOK_URL` / `--data-dir`, not a user runtime override. This is a client/install-time-only change: the server already parses `project_strategy=repo-root`. A marker's own `project_strategy` / `project` still win, and the default stays `basename` (baking nothing) so existing installs are byte-identical.
+
 ## 12. Operability
 
 - **Single binary**, statically-linked where possible. Distroless Docker image. **Absolute data path** by default (`dirs::data_local_dir().join("ai-memory")`); log it loudly on startup (agentmemory #303 lesson).

--- a/docs/install.md
+++ b/docs/install.md
@@ -114,6 +114,25 @@ pointed at the same server instead of falling back to loopback.
 `init`, `serve`, and `generate-auth-token` do not need these env vars because
 they either create local files or start the server itself.
 
+### Default project resolution (`--project-strategy`)
+
+By default each session files memory under `basename(cwd)`. Because an agent
+shell keeps its working directory between tool calls, a single
+`mkdir sub && cd sub` reparents the rest of the session into a phantom project
+named `sub`. To make every session for an install resolve its project from the
+git repo root instead — collapsing subdirectories and worktrees — bake the
+strategy into the hooks:
+
+```bash
+ai-memory install-hooks --apply --agent claude-code --project-strategy repo-root
+```
+
+`--project-strategy` accepts `basename` (the default; bakes nothing, so existing
+installs are unchanged) or `repo-root`. It works for every agent and delivery
+path. A per-repo `.ai-memory.toml` marker's own `project_strategy` / `project`
+still take precedence — see
+[the marker-file reference](marker-file.md#install-wide-default-no-marker).
+
 ---
 
 ## Arch Linux native packages (AUR)

--- a/docs/marker-file.md
+++ b/docs/marker-file.md
@@ -150,15 +150,43 @@ ai-memory rename-project \
     --new-workspace movvia
 ```
 
+## Install-wide default (no marker)
+
+`project_strategy = "repo-root"` normally lives in a marker, which means
+dropping a `.ai-memory.toml` in (or above) every repo. To get the same
+repo-root resolution for a whole install **without** a per-repo marker, bake
+it into the generated hooks at install time:
+
+```sh
+ai-memory install-hooks --apply --agent claude-code --project-strategy repo-root
+```
+
+Every session for that install then resolves its project from the main git
+repo root — so an agent that runs `mkdir sub && cd sub` and stays there no
+longer forks the rest of the session into a phantom project named `sub`.
+
+This is **install-time config**, written into the agent's hook command (and
+the generated OpenCode / OMP / OpenClaw plugins) — the same status as the
+`AI_MEMORY_AUTH_TOKEN` / `AI_MEMORY_HOOK_URL` it sits beside, *not* a user-set
+runtime override (which was deliberately rejected in #16). The flag accepts
+`basename` (the default — bakes nothing, behavior unchanged) or `repo-root`.
+
+Precedence is unchanged: a marker's explicit `project_strategy` or `project`
+still wins over the install default.
+
 ## What the marker file does NOT do
 
 - ❌ No glob patterns. Walk-up by literal ancestry only.
 - ❌ No merge of ancestor markers. Closest wins.
 - ❌ No automatic migration of `default`-workspace projects.
 - ❌ No automatic repo-root collapsing. Worktrees and subdirectories only
-  share a project when `project_strategy = "repo-root"` is explicitly set.
-- ❌ No env / auth / hook-url override. Use the existing env vars
-  (`AI_MEMORY_AUTH_TOKEN`, `AI_MEMORY_HOOK_URL`) for those.
+  share a project when `project_strategy = "repo-root"` is explicitly set
+  (per marker, or baked install-wide — see above).
+- ❌ No user-set env / auth / hook-url override. Use the existing env vars
+  (`AI_MEMORY_AUTH_TOKEN`, `AI_MEMORY_HOOK_URL`) for those. (A repo-root
+  *default* can still be baked into an install without a marker via
+  `install-hooks --project-strategy repo-root`, but that is install-time
+  config, not a runtime override the user sets in their shell.)
 
 ## Troubleshooting
 

--- a/hooks/_lib.sh
+++ b/hooks/_lib.sh
@@ -101,15 +101,25 @@ ai_memory_marker_qs() {
     cwd="$1"
     [ -z "$cwd" ] && return 0
     qs="&cwd=$(ai_memory_url_encode "$cwd")"
+    ws=""
+    pr=""
+    st=""
     marker=$(ai_memory_find_marker "$cwd")
-    [ -z "$marker" ] && { printf '%s' "$qs"; return 0; }
-    ws=$(ai_memory_parse_toml_key "$marker" workspace)
-    pr=$(ai_memory_parse_toml_key "$marker" project)
-    st=$(ai_memory_parse_toml_key "$marker" project_strategy)
+    if [ -n "$marker" ]; then
+        ws=$(ai_memory_parse_toml_key "$marker" workspace)
+        pr=$(ai_memory_parse_toml_key "$marker" project)
+        st=$(ai_memory_parse_toml_key "$marker" project_strategy)
+    fi
+    # Install-time default baked into the hook command by
+    # `install-hooks --project-strategy` fills the strategy only when no marker
+    # pinned one. A marker's explicit project / project_strategy still win.
+    if [ -z "$st" ] && [ -n "${AI_MEMORY_PROJECT_STRATEGY:-}" ]; then
+        st="$AI_MEMORY_PROJECT_STRATEGY"
+    fi
     # The repo-root strategy must be resolved here, on the host: a containerized
     # server cannot see this checkout, so its own libgit2 discovery fails and
-    # falls back to basename(cwd). When the marker selects repo-root and pins no
-    # explicit project, derive the main repo name now and send it as an explicit
+    # falls back to basename(cwd). When repo-root is selected and no explicit
+    # project is pinned, derive the main repo name now and send it as an explicit
     # `project` override. `project_strategy` is still forwarded so native servers
     # keep their existing resolution path.
     if [ -z "$pr" ]; then

--- a/hooks/lib/ai-memory-hook.ps1
+++ b/hooks/lib/ai-memory-hook.ps1
@@ -68,17 +68,27 @@ function Get-AiMemoryMarkerQuery {
     param([string] $Cwd)
     if (-not $Cwd) { return "" }
     $qs = "&cwd=$([uri]::EscapeDataString($Cwd))"
+    $ws = $null
+    $proj = $null
+    $strategy = $null
     $marker = Get-AiMemoryMarkerToml -Cwd $Cwd
-    if (-not $marker) { return $qs }
-    $ws = Get-AiMemoryTomlKey -File $marker -Key "workspace"
-    if ($ws) { $qs += "&workspace=$([uri]::EscapeDataString($ws))" }
-    $proj = Get-AiMemoryTomlKey -File $marker -Key "project"
-    $strategy = Get-AiMemoryTomlKey -File $marker -Key "project_strategy"
+    if ($marker) {
+        $ws = Get-AiMemoryTomlKey -File $marker -Key "workspace"
+        $proj = Get-AiMemoryTomlKey -File $marker -Key "project"
+        $strategy = Get-AiMemoryTomlKey -File $marker -Key "project_strategy"
+    }
+    # Install-time default baked into the hook command by
+    # `install-hooks --project-strategy` fills the strategy only when no marker
+    # pinned one. A marker's explicit project / project_strategy still win.
+    if (-not $strategy -and $env:AI_MEMORY_PROJECT_STRATEGY) {
+        $strategy = $env:AI_MEMORY_PROJECT_STRATEGY
+    }
     # repo-root must be resolved host-side (the server may not see this checkout);
     # only when no explicit project is pinned. Explicit project always wins.
     if (-not $proj -and ($strategy -eq "repo-root" -or $strategy -eq "repo_root")) {
         $proj = Get-AiMemoryRepoRootProject -Cwd $Cwd
     }
+    if ($ws) { $qs += "&workspace=$([uri]::EscapeDataString($ws))" }
     if ($proj) { $qs += "&project=$([uri]::EscapeDataString($proj))" }
     if ($strategy) { $qs += "&project_strategy=$([uri]::EscapeDataString($strategy))" }
     return $qs

--- a/tests/hooks/test_lib.sh
+++ b/tests/hooks/test_lib.sh
@@ -102,6 +102,24 @@ if command -v git >/dev/null 2>&1; then
         "&cwd=$REPO/crates/cli&workspace=oss&project=acme-api&project_strategy=repo-root" \
         "$QSR"
 
+    rm -f "$REPO/.ai-memory.toml"
+    AI_MEMORY_PROJECT_STRATEGY=repo-root
+    export AI_MEMORY_PROJECT_STRATEGY
+    QSE=$(ai_memory_marker_qs "$REPO/crates/cli")
+    assert_eq "repo-root env: no marker resolves to repo basename" \
+        "&cwd=$REPO/crates/cli&project=acme-api&project_strategy=repo-root" \
+        "$QSE"
+
+    printf 'workspace = "oss"\nproject = "pinned"\nproject_strategy = "basename"\n' \
+        >"$REPO/.ai-memory.toml"
+    QSO=$(ai_memory_marker_qs "$REPO/crates/cli")
+    assert_eq "marker project strategy overrides env default" \
+        "&cwd=$REPO/crates/cli&workspace=oss&project=pinned&project_strategy=basename" \
+        "$QSO"
+    unset AI_MEMORY_PROJECT_STRATEGY
+
+    printf 'workspace = "oss"\nproject_strategy = "repo-root"\n' >"$REPO/.ai-memory.toml"
+
     # A linked worktree whose directory lives OUTSIDE the main repo tree
     # (a common layout: tools that keep worktrees in a separate directory)
     # has no .ai-memory.toml ancestor of its own, yet still collapses to the


### PR DESCRIPTION
## What changed

`install-hooks` gets a `--project-strategy <basename|repo-root>` flag. With `repo-root` it makes every session for that install resolve its project from the git repo root, so an agent that `cd`s into a subdirectory stops forking its memory into a phantom project named after that subdir. `basename` stays the default and bakes nothing, so existing installs come out byte for byte the same.

The value is written into the generated hook config at install time: an `AI_MEMORY_PROJECT_STRATEGY` env on the shell and PowerShell commands, a `--project-strategy` flag on the native `hook` command, and a `DEFAULT_PROJECT_STRATEGY` const in the OpenCode, OMP and OpenClaw plugins. A `.ai-memory.toml` marker still wins over the baked default.

Closes #128.

## Why

`basename(cwd)` is easy to trip because an agent shell keeps its cwd between tool calls, so one `mkdir sub && cd sub` reparents the rest of the session. The reporter lost about 211 observations to a `default/transcripts` phantom instead of his `contentcreator` repo.

A marker with `project_strategy = "repo-root"` already fixes this (#16, #23, #111) but needs a marker in every repo, and the runtime env var some people reach for was rejected in #16. This flag is install-time config instead, the same status as the auth token and `--data-dir` that install-hooks already bakes. The server is untouched, `ProjectStrategy::parse` already understands `repo-root`.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (ran in a `rust:1.95` container)
- [x] Manual: `install-hooks --apply --agent claude-code --project-strategy repo-root` bakes `AI_MEMORY_PROJECT_STRATEGY=repo-root` into the session-start command, the native and opencode paths bake their own forms, and nothing is baked without the flag. With the env set, `ai_memory_marker_qs` resolves a git subdir to the repo basename, and emits just `&cwd` when it is unset.

New tests cover every command arm, the native `marker_query_suffix` precedence (a marker beats the install default), the three plugin generators, and CLI parsing.

## Notes for reviewers

The main thing worth a second opinion is the #16 framing. I read that issue as rejecting a fallback the user sets in their own shell, not config that `install-hooks` writes for them. If you see it differently I can drop the env path for the shell hooks and keep only the native flag and the plugin const.

The default path threads `None` everywhere and emits the old output, which is why the existing golden command and plugin tests pass unchanged.

One gap: I could not run the PowerShell hook locally (no pwsh on hand), so that one is a line for line mirror of the POSIX `_lib.sh` change rather than something I exercised.

Split into small commits by area (cli, render, each generator, native, shell, ps, then tests and docs), happy to squash on merge.
