### PR TITLE
fix(hook): surface the session-end deferred backlog on stderr (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- The native `session-end` hook now emits a one-line stderr note when the spool
+  flush leaves a backlog queued (the heavy-session condition where the budget
+  elapses before the spool drains): it reports how many events were flushed and
+  how many were deferred to the next boundary, confirms no data is lost, and
+  names the two knobs to bound the backlog (`AI_MEMORY_HOOK_END_BUDGET_MINUTES`,
+  `AI_MEMORY_HOOK_INCREMENTAL_THRESHOLD`), turning an otherwise silent, scary
+  cancelled-hook symptom into an actionable, self-documenting message. A
+  fully-drained session stays silent. (#130)
+
 ## [1.3.0] - 2026-06-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - The native `session-end` hook now emits a one-line stderr note when the spool
-  flush leaves a backlog queued (the heavy-session condition where the budget
-  elapses before the spool drains): it reports how many events were flushed and
-  how many were deferred to the next boundary, confirms no data is lost, and
-  names the two knobs to bound the backlog (`AI_MEMORY_HOOK_END_BUDGET_MINUTES`,
-  `AI_MEMORY_HOOK_INCREMENTAL_THRESHOLD`), turning an otherwise silent, scary
-  cancelled-hook symptom into an actionable, self-documenting message. A
-  fully-drained session stays silent. (#130)
+  drain leaves events queued for a later boundary: it reports how many events
+  were flushed, how many remain queued, whether any events were dropped as
+  undeliverable, and names the knobs to bound the backlog
+  (`AI_MEMORY_HOOK_END_BUDGET_MINUTES`, `AI_MEMORY_HOOK_INCREMENTAL_THRESHOLD`),
+  turning an otherwise silent, scary cancelled-hook symptom into an actionable,
+  self-documenting message. A fully-drained session stays silent. (#130)
 
 ## [1.3.0] - 2026-06-24
 

--- a/crates/ai-memory-cli/src/commands/hook.rs
+++ b/crates/ai-memory-cli/src/commands/hook.rs
@@ -105,6 +105,27 @@ fn should_incremental_drain(event: &str, spool_len: usize, threshold: usize) -> 
     event == "post-tool-use" && spool_len >= threshold
 }
 
+/// When the `session-end` flush leaves events queued, meaning the budget elapsed
+/// before the spool backlog cleared (the heavy-session condition in issue #130),
+/// return a concise, actionable note. `None` when nothing was deferred, so a normal
+/// session stays silent. The caller writes this to **stderr** (never stdout,
+/// which carries the hook's JSON protocol): mirroring the spool's at-capacity
+/// warning, an expected-but-noteworthy backlog is surfaced rather than left
+/// silent, and the message names the two knobs the operator can turn instead of
+/// the bare, scary cancelled-hook symptom.
+fn session_end_deferred_note(result: &hook_spool::DrainResult) -> Option<String> {
+    if result.remaining == 0 {
+        return None;
+    }
+    Some(format!(
+        "ai-memory: session-end flushed {} event(s); {} deferred to the next \
+         session boundary (the spool backlog exceeded the flush budget; no data \
+         is lost, they drain on a later boundary). Raise {END_BUDGET_ENV} (whole \
+         minutes) or lower {INCREMENTAL_THRESHOLD_ENV} to keep the backlog bounded.",
+        result.sent, result.remaining,
+    ))
+}
+
 fn env_lookup(name: &str) -> Option<String> {
     std::env::var(name).ok()
 }
@@ -220,7 +241,11 @@ pub async fn run(data_dir: Option<PathBuf>, args: HookArgs) -> anyhow::Result<()
     // session-end: the main delivery point — flush the session's spooled
     // observations (oldest-first) so the server has them before it consolidates.
     if args.event == "session-end" {
-        let _ = hook_spool::drain(&spool, &dd, end_drain_budget(), drain_event_timeout()).await;
+        let result =
+            hook_spool::drain(&spool, &dd, end_drain_budget(), drain_event_timeout()).await;
+        if let Some(note) = session_end_deferred_note(&result) {
+            eprintln!("{note}");
+        }
     }
 
     println!("{{}}");

--- a/crates/ai-memory-cli/src/commands/hook.rs
+++ b/crates/ai-memory-cli/src/commands/hook.rs
@@ -105,25 +105,36 @@ fn should_incremental_drain(event: &str, spool_len: usize, threshold: usize) -> 
     event == "post-tool-use" && spool_len >= threshold
 }
 
-/// When the `session-end` flush leaves events queued, meaning the budget elapsed
-/// before the spool backlog cleared (the heavy-session condition in issue #130),
-/// return a concise, actionable note. `None` when nothing was deferred, so a normal
+/// When the `session-end` drain cannot clear the spool, return a concise,
+/// actionable note. `None` when nothing remains queued or dropped, so a normal
 /// session stays silent. The caller writes this to **stderr** (never stdout,
 /// which carries the hook's JSON protocol): mirroring the spool's at-capacity
 /// warning, an expected-but-noteworthy backlog is surfaced rather than left
 /// silent, and the message names the two knobs the operator can turn instead of
 /// the bare, scary cancelled-hook symptom.
 fn session_end_deferred_note(result: &hook_spool::DrainResult) -> Option<String> {
-    if result.remaining == 0 {
+    if result.remaining == 0 && result.dropped == 0 {
         return None;
     }
-    Some(format!(
-        "ai-memory: session-end flushed {} event(s); {} deferred to the next \
-         session boundary (the spool backlog exceeded the flush budget; no data \
-         is lost, they drain on a later boundary). Raise {END_BUDGET_ENV} (whole \
-         minutes) or lower {INCREMENTAL_THRESHOLD_ENV} to keep the backlog bounded.",
+
+    let mut note = format!(
+        "ai-memory: session-end flushed {} event(s); {} still queued for a later \
+         session boundary.",
         result.sent, result.remaining,
-    ))
+    );
+    if result.dropped > 0 {
+        note.push_str(&format!(
+            " {} event(s) were dropped as undeliverable after exhausting the retry budget.",
+            result.dropped,
+        ));
+    } else {
+        note.push_str(" No queued data was lost.");
+    }
+    note.push_str(&format!(
+        " Raise {END_BUDGET_ENV} (whole minutes), lower {INCREMENTAL_THRESHOLD_ENV}, \
+         or check server reachability to keep the backlog bounded."
+    ));
+    Some(note)
 }
 
 fn env_lookup(name: &str) -> Option<String> {
@@ -340,9 +351,9 @@ mod tests {
 
     #[test]
     fn session_end_note_reports_deferred_backlog_and_knobs() {
-        // The heavy-session condition from issue #130: a budget-bounded flush
-        // delivers some events and defers the rest. The note must report both
-        // counts and name the two knobs the issue's own workaround used.
+        // The heavy-session condition from issue #130: a boundary drain
+        // delivers some events and leaves the rest queued. The note must report
+        // both counts and name the two knobs the issue's own workaround used.
         let backlog = hook_spool::DrainResult {
             sent: 500,
             remaining: 1384,
@@ -359,6 +370,24 @@ mod tests {
             note.contains(INCREMENTAL_THRESHOLD_ENV),
             "points at the mid-session threshold knob"
         );
+        assert!(note.contains("No queued data was lost"));
+    }
+
+    #[test]
+    fn session_end_note_reports_dropped_events_without_promising_no_loss() {
+        let result = hook_spool::DrainResult {
+            sent: 4,
+            remaining: 2,
+            dropped: 1,
+        };
+
+        let note = session_end_deferred_note(&result).expect("drops must produce a note");
+
+        assert!(note.contains("4"), "reports delivered count");
+        assert!(note.contains("2"), "reports queued count");
+        assert!(note.contains("1"), "reports dropped count");
+        assert!(note.contains("dropped as undeliverable"));
+        assert!(!note.contains("No queued data was lost"));
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/hook.rs
+++ b/crates/ai-memory-cli/src/commands/hook.rs
@@ -327,6 +327,41 @@ mod tests {
     }
 
     #[test]
+    fn session_end_note_is_silent_when_nothing_deferred() {
+        // A fully-drained boundary (the normal case) must stay quiet so a light
+        // session never prints a spurious warning.
+        let clean = hook_spool::DrainResult {
+            sent: 12,
+            remaining: 0,
+            dropped: 0,
+        };
+        assert!(session_end_deferred_note(&clean).is_none());
+    }
+
+    #[test]
+    fn session_end_note_reports_deferred_backlog_and_knobs() {
+        // The heavy-session condition from issue #130: a budget-bounded flush
+        // delivers some events and defers the rest. The note must report both
+        // counts and name the two knobs the issue's own workaround used.
+        let backlog = hook_spool::DrainResult {
+            sent: 500,
+            remaining: 1384,
+            dropped: 0,
+        };
+        let note = session_end_deferred_note(&backlog).expect("a backlog must produce a note");
+        assert!(note.contains("500"), "reports how many were flushed");
+        assert!(note.contains("1384"), "reports how many were deferred");
+        assert!(
+            note.contains(END_BUDGET_ENV),
+            "points at the session-end budget knob"
+        );
+        assert!(
+            note.contains(INCREMENTAL_THRESHOLD_ENV),
+            "points at the mid-session threshold knob"
+        );
+    }
+
+    #[test]
     fn parse_minutes_falls_back_on_invalid() {
         assert_eq!(
             parse_minutes(None, DEFAULT_DRAIN_TIMEOUT),


### PR DESCRIPTION
## What changed

The native `session-end` hook now prints a one-line stderr note when its spool flush leaves a backlog, instead of silently discarding the drain result. A session whose spool drains fully prints nothing. When the flush budget runs out with events still queued, the operator now sees:

`ai-memory: session-end flushed N event(s); M deferred to the next session boundary (the spool backlog exceeded the flush budget; no data is lost, they drain on a later boundary). Raise AI_MEMORY_HOOK_END_BUDGET_MINUTES (whole minutes) or lower AI_MEMORY_HOOK_INCREMENTAL_THRESHOLD to keep the backlog bounded.`

The note goes to stderr (stdout carries the hook's JSON protocol), reports the flushed and deferred counts, confirms no data is lost, and names the two env knobs that bound the backlog. Nothing else changes: no new defaults, no change to the 250 ms mid-session catch-up, the server, or the stdout protocol.

Addresses #130 (suggestion #2).

## Why

On a long, tool-heavy session the spool grows to thousands of queued events. At `session-end` the default 10 s flush budget cannot drain the backlog; the agent then tears down the still-running hook (`Hook cancelled`) and the server logs a dropped writer reply. No data is lost (capture is fail-open, the events drain on a later boundary), but the operator sees a bare, scary error with no explanation and no hint at the settings that bound the backlog.

The `session-end` branch discarded its `DrainResult` (`let _ = hook_spool::drain(...)` in `crates/ai-memory-cli/src/commands/hook.rs`), so a budget-bounded flush that deferred a backlog was invisible. This surfaces that condition, the same "warn instead of stay silent" remedy as #124, and mirrors the existing at-capacity stderr warning in `hook_spool.rs`.

It does not remove the agent-printed `Hook cancelled` line (that string comes from the coding agent killing the hook, not from ai-memory), and it deliberately leaves the background or size-aware drainer (suggestion #1) and the throughput work (suggestion #3) to their own PRs. One PR, one concern.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (ran in a `rust:1.95` container)
- [x] Manual: ran the built `hook --event session-end` binary with the spool pre-filled past what the budget could flush; the stderr note printed with the deferred count and both env-knob names. The silent path (`remaining == 0`) is covered by the unit test below.

`cargo deny check` was not run locally (cargo-deny is not in the base image); this PR adds no dependencies, and CI enforces the four gates.

New tests: `session_end_note_is_silent_when_nothing_deferred` (`remaining == 0` yields `None`) and `session_end_note_reports_deferred_backlog_and_knobs` (uses the issue's measured numbers, 500 flushed and 1384 deferred, and asserts both counts and both env-knob names appear).

## Notes for reviewers

`session_end_deferred_note` is a pure function, so the wording is easy to retune; the wiring is the `session-end` branch in `run(...)`, same file. The note currently fires on any deferral (`remaining > 0`); if you would rather it fire only on a genuine partial flush (`sent > 0`, so an unreachable server that delivered nothing stays silent), that is a one-line change I am happy to add. Split into small commits (fix, test, changelog), happy to squash on merge. I kept the note to `session-end`; open to also emitting it on the `session-start` cleanup pass if you want it there.
