### PR TITLE
feat(hooks): drop_subagent_captures with subagent-session tail tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Per-project `drop_subagent_captures` opt-in. A project sets
+  `drop_subagent_captures = "true"` in its `.ai-memory.toml`; the host-side hook
+  forwards it (as the `drop_subagent` query flag, alongside the existing
+  `workspace`/`project`/`project_strategy` marker fields) so the ingest router
+  **accepts but does not persist** that project's subagent-session captures,
+  keeping only top-level sessions. A multi-agent harness fans one goal out to
+  many subagent sessions, each firing lifecycle hooks; on a small shared
+  instance that flood can saturate ingest and bloat the store. Scoping the
+  opt-in to the project that asked for it avoids a server-global switch that
+  would shed subagent captures for every project on the instance. Captures are
+  accepted (HTTP 202 / counted in the `/hook/batch` ack) so clients do not retry
+  or spool them, but they are not stored. Detection combines a per-event marker
+  (`subagentType` for grok, `agent_type`/`agent_id` for Claude Code) with
+  stateful, bounded tracking of subagent session ids: the router seeds the set
+  from any marked event and from the newly registered
+  `SubagentStart`/`SubagentStop` lifecycle hooks (claude-code and grok), and
+  clears it on `SubagentStop`, so the unmarked tail of a subagent session (its
+  `user_prompt_submit`/`stop`/`session_end`, which carry no marker) is dropped
+  too — not just the marker-bearing tool-use events.
+
 ## [1.4.1] - 2026-06-28
 
 ## [1.4.0] - 2026-06-26

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "askama"

--- a/crates/ai-memory-cli/src/commands/hook_capture.rs
+++ b/crates/ai-memory-cli/src/commands/hook_capture.rs
@@ -50,11 +50,12 @@ pub fn url_encode(s: &str) -> String {
 /// server cannot see this checkout.
 pub fn marker_query_suffix(cwd: &str, default_strategy: Option<&str>) -> String {
     let mut qs = format!("&cwd={}", url_encode(cwd));
-    let (mut workspace, mut project, mut strategy) = (None, None, None);
+    let (mut workspace, mut project, mut strategy, mut drop_subagent) = (None, None, None, None);
     if let Some(marker) = find_marker(cwd) {
         workspace = parse_toml_key(&marker, "workspace");
         project = parse_toml_key(&marker, "project");
         strategy = parse_toml_key(&marker, "project_strategy");
+        drop_subagent = parse_toml_key(&marker, "drop_subagent_captures");
     }
     if strategy.is_none() {
         strategy = default_strategy.map(str::to_owned);
@@ -70,6 +71,12 @@ pub fn marker_query_suffix(cwd: &str, default_strategy: Option<&str>) -> String 
     }
     if let Some(val) = strategy {
         qs.push_str(&format!("&project_strategy={}", url_encode(&val)));
+    }
+    // Per-project `drop_subagent_captures` opt-in: forward the marker's value as
+    // the `drop_subagent` flag so the server scopes the drop to this project.
+    // The server interprets truthiness (`1`/`true`/…).
+    if let Some(val) = drop_subagent.filter(|v| !v.is_empty()) {
+        qs.push_str(&format!("&drop_subagent={}", url_encode(&val)));
     }
     qs
 }
@@ -427,8 +434,8 @@ project = "infra" # this is fine
     }
 
     /// `marker_query_suffix` appends `&workspace=…&project=…` (and
-    /// `&project_strategy=…`) when the marker declares them. Each value is
-    /// URL-encoded, so a workspace with a space round-trips as `%20`.
+    /// `&project_strategy=…`, `&drop_subagent=…`) when the marker declares them.
+    /// Each value is URL-encoded, so a workspace with a space round-trips as `%20`.
     #[test]
     fn marker_query_suffix_appends_marker_fields() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -439,6 +446,7 @@ project = "infra" # this is fine
 workspace = "acme corp"
 project = "infra"
 project_strategy = "repo-root"
+drop_subagent_captures = "true"
 "#,
         )
         .unwrap();
@@ -449,6 +457,21 @@ project_strategy = "repo-root"
         assert!(qs.contains("&workspace=acme%20corp"), "{qs}");
         assert!(qs.contains("&project=infra"), "{qs}");
         assert!(qs.contains("&project_strategy=repo-root"), "{qs}");
+        assert!(qs.contains("&drop_subagent=true"), "{qs}");
+    }
+
+    /// A marker WITHOUT `drop_subagent_captures` does not forward the flag, so
+    /// the server keeps that project's subagent captures (opt-in only).
+    #[test]
+    fn marker_query_suffix_omits_drop_subagent_when_unset() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join(".ai-memory.toml"),
+            "workspace = \"acme\"\nproject = \"infra\"\n",
+        )
+        .unwrap();
+        let qs = marker_query_suffix(tmp.path().to_str().unwrap(), None);
+        assert!(!qs.contains("drop_subagent"), "{qs}");
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/hook_capture.rs
+++ b/crates/ai-memory-cli/src/commands/hook_capture.rs
@@ -205,9 +205,10 @@ pub enum BatchOutcome {
     /// the server stopped on that item (fail-fast) — the caller deletes the
     /// prefix and charges the next item a retry.
     Accepted(usize),
-    /// `429` — ingest saturated; nothing was processed. Keep the whole batch and
-    /// retry it later WITHOUT bumping attempts (saturation isn't a failure).
-    Saturated,
+    /// `429` — ingest saturated after committing this many leading items. The
+    /// caller deletes that prefix and retries the rest later WITHOUT bumping
+    /// attempts (saturation isn't a failure).
+    Saturated(usize),
     /// `404`/`405` — the server has no `/hook/batch` (a pre-upgrade build). The
     /// caller falls back to per-event `POST /hook` for the rest of the drain.
     Unsupported,
@@ -252,7 +253,13 @@ pub async fn post_batch(
                     Err(_) => BatchOutcome::Failed,
                 }
             } else if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                BatchOutcome::Saturated
+                let accepted = resp
+                    .json::<serde_json::Value>()
+                    .await
+                    .ok()
+                    .and_then(|v| v.get("accepted").and_then(serde_json::Value::as_u64))
+                    .unwrap_or(0) as usize;
+                BatchOutcome::Saturated(accepted)
             } else if status == reqwest::StatusCode::NOT_FOUND
                 || status == reqwest::StatusCode::METHOD_NOT_ALLOWED
             {

--- a/crates/ai-memory-cli/src/commands/hook_spool.rs
+++ b/crates/ai-memory-cli/src/commands/hook_spool.rs
@@ -195,9 +195,10 @@ pub struct DrainResult {
 /// drain transparently falls back to per-event `POST /hook`.
 ///
 /// A delivered event is deleted; a failed one is charged a retry attempt
-/// (dropped at `MAX_ATTEMPTS`); a `429` (saturation) is retried untouched so it
-/// never burns the retry budget. OIDC bearer is resolved + refreshed at most
-/// once per drain and cached.
+/// (dropped at `MAX_ATTEMPTS`); a `429` (saturation) deletes any accepted prefix
+/// the server reports, then retries the rest untouched so it never burns the
+/// retry budget. OIDC bearer is resolved + refreshed at most once per drain and
+/// cached.
 ///
 /// Best-effort: returns counts and never errors, so a session boundary is never
 /// blocked beyond the budget and never fails the agent.
@@ -307,10 +308,18 @@ pub async fn drain(
                         break;
                     }
                 }
-                BatchOutcome::Saturated => {
-                    // Server ingest is full; further batches would 429 too. Leave
-                    // everything queued, no attempt bump (parity with per-event).
-                    result.remaining += chunk.len() + files.len().saturating_sub(idx);
+                BatchOutcome::Saturated(k) => {
+                    // Server ingest filled after committing a leading prefix.
+                    // Delete only that prefix; leave the saturated item and all
+                    // later entries queued without bumping attempts (parity with
+                    // per-event 429 handling).
+                    let k = k.min(chunk.len());
+                    for (path, _) in &chunk[..k] {
+                        let _ = std::fs::remove_file(path);
+                    }
+                    result.sent += k;
+                    result.remaining +=
+                        chunk.len().saturating_sub(k) + files.len().saturating_sub(idx);
                     break;
                 }
                 BatchOutcome::Unsupported => {
@@ -806,6 +815,46 @@ mod tests {
         let loaded: SpoolEntry =
             serde_json::from_slice(&std::fs::read(&files[0]).unwrap()).unwrap();
         assert_eq!(loaded.attempts, 0, "429 must not consume the retry budget");
+    }
+
+    #[tokio::test]
+    async fn partial_429_deletes_prefix_without_bumping_saturated_item() {
+        let req_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let addr =
+            serve_counting_hook_with_accept(req_count.clone(), "429 Too Many Requests", Some(1))
+                .await;
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        for i in 0..3 {
+            write_spool_entry(
+                &spool,
+                &format!("evt-{i}.json"),
+                format!("http://{addr}/hook?event=e{i}"),
+            );
+        }
+
+        let r = drain(
+            &spool,
+            tmp.path(),
+            Duration::from_secs(5),
+            Duration::from_secs(2),
+        )
+        .await;
+
+        assert_eq!(r.sent, 1);
+        assert_eq!(r.dropped, 0);
+        assert_eq!(r.remaining, 2);
+        assert_eq!(req_count.load(std::sync::atomic::Ordering::SeqCst), 1);
+        let mut files = list_entries(&spool).unwrap();
+        files.sort();
+        assert_eq!(files.len(), 2);
+        assert!(files[0].ends_with("evt-1.json"));
+        assert!(files[1].ends_with("evt-2.json"));
+        assert_eq!(
+            sorted_attempts(&spool),
+            vec![0, 0],
+            "saturation must not bump retry attempts for the first unaccepted item"
+        );
     }
 
     /// A mock hook server: answers `200 {"accepted":N}` to `POST /hook/batch`

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -452,9 +452,9 @@ fn overlay_event_hooks(
     map.insert(event.to_string(), serde_json::Value::Array(entries));
 }
 
-/// Mutate `~/.claude/settings.json` in place: replace the seven hook
-/// entries ai-memory cares about; preserve every other hook the user
-/// has wired up to other tools.
+/// Mutate `~/.claude/settings.json` in place: replace the hook entries
+/// ai-memory cares about (`CLAUDE_CODE_EVENTS`); preserve every other hook the
+/// user has wired up to other tools.
 fn apply_to_claude_code_settings(
     hooks_dir: &Path,
     server_url: &str,
@@ -514,7 +514,7 @@ fn apply_to_claude_code_settings(
 
 /// Mutate `~/.grok/hooks/ai-memory.json` so Grok Build CLI fires the ai-memory
 /// lifecycle hooks. Grok's hook config is structurally identical to Claude
-/// Code's nested hook JSON and uses the same seven CamelCase event names, but
+/// Code's nested hook JSON and uses the same CamelCase event names, but
 /// its script bundle carries `agent=grok` and skips destructive SessionStart
 /// handoff fetches. We merge into a dedicated `ai-memory.json` (Grok discovers
 /// every `~/.grok/hooks/*.json`), so a pre-existing third-party hook file is

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -25,7 +25,8 @@ use crate::commands::install_mcp;
 use crate::commands::openclaw_plugin;
 use crate::commands::path_util::home_dir;
 use crate::commands::render_shared::{
-    CURSOR_PROFILE, GEMINI_PROFILE, build_antigravity_payload_with_data_dir,
+    ANTIGRAVITY_LIFECYCLE_EVENTS, ANTIGRAVITY_TOOL_EVENTS, CODEX_PROFILE, CURSOR_PROFILE,
+    GEMINI_PROFILE, build_antigravity_payload_with_data_dir,
     build_claude_code_payload_with_data_dir, build_grok_payload_with_data_dir,
     build_profile_payload_for_agent, hook_script_for_claude_code, hook_script_for_current_platform,
     ts_string_literal,
@@ -184,19 +185,47 @@ pub fn run(config: &Config, args: InstallHooksArgs) -> Result<()> {
         }
         AgentChoice::Codex => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
-            render_agent("codex", &hooks_dir, &server_url, auth, strategy)
+            render_agent(
+                "codex",
+                &hooks_dir,
+                &server_url,
+                auth,
+                strategy,
+                &[CODEX_PROFILE.events],
+            )
         }
         AgentChoice::Cursor => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
-            render_agent("cursor", &hooks_dir, &server_url, auth, strategy)
+            render_agent(
+                "cursor",
+                &hooks_dir,
+                &server_url,
+                auth,
+                strategy,
+                &[CURSOR_PROFILE.events],
+            )
         }
         AgentChoice::GeminiCli => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
-            render_agent("gemini-cli", &hooks_dir, &server_url, auth, strategy)
+            render_agent(
+                "gemini-cli",
+                &hooks_dir,
+                &server_url,
+                auth,
+                strategy,
+                &[GEMINI_PROFILE.events],
+            )
         }
         AgentChoice::AntigravityCli => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
-            render_agent("antigravity-cli", &hooks_dir, &server_url, auth, strategy)
+            render_agent(
+                "antigravity-cli",
+                &hooks_dir,
+                &server_url,
+                auth,
+                strategy,
+                &[&ANTIGRAVITY_TOOL_EVENTS, &ANTIGRAVITY_LIFECYCLE_EVENTS],
+            )
         }
         AgentChoice::Grok => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
@@ -1029,9 +1058,11 @@ fn ts_apply_marker_params(default_strategy: Option<&str>) -> String {
     const workspace = tomlKey(body, "workspace");
     const project = tomlKey(body, "project");
     const projectStrategy = tomlKey(body, "project_strategy");
+    const dropSubagent = tomlKey(body, "drop_subagent_captures");
     if (workspace) url.searchParams.set("workspace", workspace);
     if (project) url.searchParams.set("project", project);
     if (projectStrategy) url.searchParams.set("project_strategy", projectStrategy);
+    if (dropSubagent) url.searchParams.set("drop_subagent", dropSubagent);
     if (!project && (projectStrategy === "repo-root" || projectStrategy === "repo_root")) {
       const repoProject = repoRootProject(cwd);
       if (repoProject) url.searchParams.set("project", repoProject);
@@ -1047,6 +1078,7 @@ fn ts_apply_marker_params(default_strategy: Option<&str>) -> String {
   let workspace: string | undefined;
   let project: string | undefined;
   let projectStrategy: string | undefined;
+  let dropSubagent: string | undefined;
   const marker = findMarker(cwd);
   if (marker) {
     try {
@@ -1054,6 +1086,7 @@ fn ts_apply_marker_params(default_strategy: Option<&str>) -> String {
       workspace = tomlKey(body, "workspace");
       project = tomlKey(body, "project");
       projectStrategy = tomlKey(body, "project_strategy");
+      dropSubagent = tomlKey(body, "drop_subagent_captures");
     } catch (_e) {
     }
   }
@@ -1065,6 +1098,7 @@ fn ts_apply_marker_params(default_strategy: Option<&str>) -> String {
   if (workspace) url.searchParams.set("workspace", workspace);
   if (project) url.searchParams.set("project", project);
   if (projectStrategy) url.searchParams.set("project_strategy", projectStrategy);
+  if (dropSubagent) url.searchParams.set("drop_subagent", dropSubagent);
 }"#;
     format!(
         "const DEFAULT_PROJECT_STRATEGY = {};\n{body}",
@@ -1636,10 +1670,18 @@ fn render_agent(
     server_url: &str,
     auth_token: Option<&str>,
     project_strategy: Option<&str>,
+    event_lists: &[&[(&str, &str)]],
 ) -> Result<()> {
     print!(
         "{}",
-        render_agent_output(label, hooks_dir, server_url, auth_token, project_strategy)?
+        render_agent_output(
+            label,
+            hooks_dir,
+            server_url,
+            auth_token,
+            project_strategy,
+            event_lists,
+        )
     );
     Ok(())
 }
@@ -1650,7 +1692,8 @@ fn render_agent_output(
     server_url: &str,
     auth_token: Option<&str>,
     project_strategy: Option<&str>,
-) -> Result<String> {
+    event_lists: &[&[(&str, &str)]],
+) -> String {
     let mut out = String::new();
     out.push_str(&format!(
         "# {label} hook scripts (manual install — wire each to the matching event)\n"
@@ -1666,11 +1709,13 @@ fn render_agent_output(
         out.push_str("#       --auth-token here AND set AI_MEMORY_AUTH_TOKEN on the server.\n");
     }
     out.push('\n');
-    for entry in std::fs::read_dir(hooks_dir)? {
-        let entry = entry?;
-        let p = entry.path();
-        if p.is_file() && p.extension().is_some_and(|e| e == hook_script_extension()) {
-            out.push_str(&format!("- {}\n", p.display()));
+    for events in event_lists {
+        for (_, script) in *events {
+            let script = hook_script_for_current_platform(script);
+            out.push_str(&format!(
+                "- {}\n",
+                hooks_dir.join(script.as_ref()).display()
+            ));
         }
     }
     out.push('\n');
@@ -1679,7 +1724,7 @@ fn render_agent_output(
         out.push_str(&instruction);
         out.push('\n');
     }
-    Ok(out)
+    out
 }
 
 fn manual_agent_project_strategy_instruction(project_strategy: Option<&str>) -> Option<String> {
@@ -1875,14 +1920,6 @@ fn staged_command_dir(staged: &Path, agent_label: &str) -> PathBuf {
     match std::env::var("AI_MEMORY_HOOKS_HOST_ROOT") {
         Ok(root) if !root.trim().is_empty() => PathBuf::from(root).join(agent_label),
         _ => staged.to_path_buf(),
-    }
-}
-
-fn hook_script_extension() -> &'static str {
-    if hook_script_for_current_platform("x.sh").ends_with(".ps1") {
-        "ps1"
-    } else {
-        "sh"
     }
 }
 
@@ -2269,8 +2306,8 @@ mod tests {
                 "http://127.0.0.1:49374",
                 None,
                 Some("repo-root"),
-            )
-            .unwrap_or_else(|err| panic!("failed to render {agent}: {err}"));
+                &[CODEX_PROFILE.events],
+            );
             assert!(
                 output.contains("AI_MEMORY_PROJECT_STRATEGY=repo-root"),
                 "{agent} manual output must tell users to set the strategy env: {output}"
@@ -2282,10 +2319,62 @@ mod tests {
     fn manual_agent_render_omits_project_strategy_by_default() {
         let temp = TempDir::new().unwrap();
         stub_scripts(temp.path(), &["session-start.sh"]);
-        let output =
-            render_agent_output("codex", temp.path(), "http://127.0.0.1:49374", None, None)
-                .unwrap();
+        let output = render_agent_output(
+            "codex",
+            temp.path(),
+            "http://127.0.0.1:49374",
+            None,
+            None,
+            &[CODEX_PROFILE.events],
+        );
         assert!(!output.contains("AI_MEMORY_PROJECT_STRATEGY"));
+    }
+
+    #[test]
+    fn manual_agent_render_uses_agent_profile_not_physical_bundle_listing() {
+        let temp = TempDir::new().unwrap();
+        stub_scripts(
+            temp.path(),
+            &[
+                "session-start.sh",
+                "session-end.sh",
+                "user-prompt-submit.sh",
+                "stop.sh",
+                "subagent-start.sh",
+                "subagent-stop.sh",
+            ],
+        );
+
+        let gemini = render_agent_output(
+            "gemini-cli",
+            temp.path(),
+            "http://127.0.0.1:49374",
+            None,
+            None,
+            &[GEMINI_PROFILE.events],
+        );
+        assert!(gemini.contains("session-start"));
+        assert!(gemini.contains("session-end"));
+        assert!(
+            !gemini.contains("user-prompt-submit")
+                && !gemini.contains("subagent-start")
+                && !gemini.contains("subagent-stop"),
+            "Gemini manual output must omit scripts outside Gemini's hook vocabulary: {gemini}"
+        );
+
+        let codex = render_agent_output(
+            "codex",
+            temp.path(),
+            "http://127.0.0.1:49374",
+            None,
+            None,
+            &[CODEX_PROFILE.events],
+        );
+        assert!(codex.contains("stop"));
+        assert!(
+            !codex.contains("session-end") && !codex.contains("subagent-start"),
+            "Codex manual output must omit scripts outside Codex's hook vocabulary: {codex}"
+        );
     }
 
     #[test]
@@ -2499,6 +2588,7 @@ model = "gpt-5"
             "codex",
             "cursor",
             "gemini-cli",
+            "grok",
             "opencode",
             "antigravity-cli",
         ] {
@@ -2796,7 +2886,9 @@ model = "gpt-5"
         assert!(plugin.contains("readFileSync(marker, \"utf8\")"));
         assert!(plugin.contains("text.split(/\\r?\\n/)"));
         assert!(plugin.contains("tomlKey(body, \"project_strategy\")"));
+        assert!(plugin.contains("tomlKey(body, \"drop_subagent_captures\")"));
         assert!(plugin.contains("url.searchParams.set(\"project_strategy\", projectStrategy)"));
+        assert!(plugin.contains("url.searchParams.set(\"drop_subagent\", dropSubagent)"));
         assert!(plugin.contains(
             "applyMarkerParams(url, typeof payload.cwd === \"string\" ? payload.cwd : undefined);"
         ));
@@ -2887,7 +2979,9 @@ model = "gpt-5"
         assert!(extension.contains("readFileSync(marker, \"utf8\")"));
         assert!(extension.contains("text.split(/\\r?\\n/)"));
         assert!(extension.contains("tomlKey(body, \"project_strategy\")"));
+        assert!(extension.contains("tomlKey(body, \"drop_subagent_captures\")"));
         assert!(extension.contains("url.searchParams.set(\"project_strategy\", projectStrategy)"));
+        assert!(extension.contains("url.searchParams.set(\"drop_subagent\", dropSubagent)"));
         assert!(extension.contains(
             "applyMarkerParams(url, typeof payload.cwd === \"string\" ? payload.cwd : undefined);"
         ));

--- a/crates/ai-memory-cli/src/commands/openclaw_plugin.rs
+++ b/crates/ai-memory-cli/src/commands/openclaw_plugin.rs
@@ -213,9 +213,11 @@ fn apply_marker_params_ts(default_strategy: Option<&str>) -> String {
     const workspace = tomlKey(body, "workspace");
     const project = tomlKey(body, "project");
     const projectStrategy = tomlKey(body, "project_strategy");
+    const dropSubagent = tomlKey(body, "drop_subagent_captures");
     if (workspace) url.searchParams.set("workspace", workspace);
     if (project) url.searchParams.set("project", project);
     if (projectStrategy) url.searchParams.set("project_strategy", projectStrategy);
+    if (dropSubagent) url.searchParams.set("drop_subagent", dropSubagent);
     if (!project && (projectStrategy === "repo-root" || projectStrategy === "repo_root")) {
       const repoProject = repoRootProject(cwd);
       if (repoProject) url.searchParams.set("project", repoProject);
@@ -231,6 +233,7 @@ fn apply_marker_params_ts(default_strategy: Option<&str>) -> String {
   let workspace: string | undefined;
   let project: string | undefined;
   let projectStrategy: string | undefined;
+  let dropSubagent: string | undefined;
   const marker = findMarker(cwd);
   if (marker) {
     try {
@@ -238,6 +241,7 @@ fn apply_marker_params_ts(default_strategy: Option<&str>) -> String {
       workspace = tomlKey(body, "workspace");
       project = tomlKey(body, "project");
       projectStrategy = tomlKey(body, "project_strategy");
+      dropSubagent = tomlKey(body, "drop_subagent_captures");
     } catch (_e) {
     }
   }
@@ -249,6 +253,7 @@ fn apply_marker_params_ts(default_strategy: Option<&str>) -> String {
   if (workspace) url.searchParams.set("workspace", workspace);
   if (project) url.searchParams.set("project", project);
   if (projectStrategy) url.searchParams.set("project_strategy", projectStrategy);
+  if (dropSubagent) url.searchParams.set("drop_subagent", dropSubagent);
 }"#;
     format!(
         "const DEFAULT_PROJECT_STRATEGY = {};\n{body}",
@@ -521,6 +526,8 @@ mod tests {
         assert!(plugin.contains("postHook(\"user-prompt\""));
         assert!(plugin.contains("function applyMarkerParams"));
         assert!(plugin.contains("tomlKey(body, \"project_strategy\")"));
+        assert!(plugin.contains("tomlKey(body, \"drop_subagent_captures\")"));
+        assert!(plugin.contains("url.searchParams.set(\"drop_subagent\", dropSubagent)"));
         assert!(plugin.contains("import { execFileSync } from \"node:child_process\";"));
         assert!(plugin.contains("import { basename, dirname, join, resolve } from \"node:path\";"));
         assert!(plugin.contains("function repoRootProject"));

--- a/crates/ai-memory-cli/src/commands/render_shared.rs
+++ b/crates/ai-memory-cli/src/commands/render_shared.rs
@@ -4,9 +4,9 @@
 //! `setup-agent`) all emit configuration snippets that share two
 //! pieces of state:
 //!
-//! 1. The seven Claude Code lifecycle-hook events ai-memory wires
-//!    up — kept in sync between hook-bundle generation (setup-agent)
-//!    and JSON-config rendering (install-hooks).
+//! 1. The Claude Code lifecycle-hook events ai-memory wires up
+//!    (see `CLAUDE_CODE_EVENTS`) — kept in sync between hook-bundle
+//!    generation (setup-agent) and JSON-config rendering (install-hooks).
 //! 2. The optional `Authorization: Bearer <token>` header used by
 //!    both MCP client configs (install-mcp) and hook env blocks
 //!    (install-hooks / setup-agent).
@@ -30,7 +30,7 @@ use crate::commands::path_util::strip_windows_verbatim_prefix;
 /// matching `.sh` and `.ps1` files under
 /// `hooks/{claude-code,codex,cursor,gemini-cli,grok,opencode}/`. The
 /// install-hooks parity test fails if the bundle drifts.
-pub(crate) const CLAUDE_CODE_EVENTS: [(&str, &str); 7] = [
+pub(crate) const CLAUDE_CODE_EVENTS: [(&str, &str); 9] = [
     ("SessionStart", "session-start.sh"),
     ("UserPromptSubmit", "user-prompt-submit.sh"),
     ("PreToolUse", "pre-tool-use.sh"),
@@ -38,6 +38,11 @@ pub(crate) const CLAUDE_CODE_EVENTS: [(&str, &str); 7] = [
     ("PreCompact", "pre-compact.sh"),
     ("Stop", "stop.sh"),
     ("SessionEnd", "session-end.sh"),
+    // Subagent boundaries — let the server seed/forget a subagent session id so
+    // `drop_subagent_captures` can drop the whole nested session (Claude Code +
+    // grok both emit these; other agents keep their own event lists).
+    ("SubagentStart", "subagent-start.sh"),
+    ("SubagentStop", "subagent-stop.sh"),
 ];
 
 /// Format an `Authorization: Bearer <token>` header value, or `None`
@@ -77,7 +82,7 @@ pub(crate) fn ts_string_literal(s: &str) -> String {
 }
 
 /// Build the Claude Code `settings.json` fragment that wires the
-/// seven hooks. Used by both:
+/// lifecycle hooks (`CLAUDE_CODE_EVENTS`). Used by both:
 /// - `install-hooks --agent claude-code` (script paths are
 ///   wherever the user told us via `--hooks-dir`)
 /// - `setup-agent --agent claude-code` (script paths are where
@@ -841,11 +846,11 @@ mod tests {
     }
 
     #[test]
-    fn claude_code_payload_has_seven_events() {
+    fn claude_code_payload_has_all_events() {
         let root = PathBuf::from("/host/hooks/claude-code");
         let v = build_claude_code_payload(&root, "http://localhost:49374", None);
         let hooks = v.get("hooks").and_then(|h| h.as_object()).unwrap();
-        assert_eq!(hooks.len(), 7);
+        assert_eq!(hooks.len(), CLAUDE_CODE_EVENTS.len());
         for (event, _) in CLAUDE_CODE_EVENTS {
             assert!(hooks.contains_key(event), "missing event {event}");
         }

--- a/crates/ai-memory-cli/src/commands/render_shared.rs
+++ b/crates/ai-memory-cli/src/commands/render_shared.rs
@@ -4,9 +4,11 @@
 //! `setup-agent`) all emit configuration snippets that share two
 //! pieces of state:
 //!
-//! 1. The Claude Code lifecycle-hook events ai-memory wires up
-//!    (see `CLAUDE_CODE_EVENTS`) — kept in sync between hook-bundle
-//!    generation (setup-agent) and JSON-config rendering (install-hooks).
+//! 1. The per-agent lifecycle-hook event lists ai-memory wires up
+//!    (Claude/Grok share `CLAUDE_CODE_EVENTS`; Codex, Cursor, Gemini,
+//!    and Antigravity define their own profiles) — kept in sync between
+//!    hook-bundle generation (setup-agent) and config rendering
+//!    (install-hooks).
 //! 2. The optional `Authorization: Bearer <token>` header used by
 //!    both MCP client configs (install-mcp) and hook env blocks
 //!    (install-hooks / setup-agent).
@@ -26,10 +28,10 @@ use crate::commands::path_util::strip_windows_verbatim_prefix;
 /// Claude Code lifecycle events ai-memory hooks. Each pair is
 /// `(event-name-in-Claude-Code-settings, POSIX hook-script-filename)`.
 ///
-/// Adding a hook event means updating this list AND adding the
-/// matching `.sh` and `.ps1` files under
-/// `hooks/{claude-code,codex,cursor,gemini-cli,grok,opencode}/`. The
-/// install-hooks parity test fails if the bundle drifts.
+/// Adding a hook event means updating this list AND adding the matching `.sh`
+/// and `.ps1` files under the agents that use this profile (`claude-code` and
+/// `grok`). Agents with different vocabularies keep their own event arrays
+/// below. The install-hooks parity test fails if a bundle drifts.
 pub(crate) const CLAUDE_CODE_EVENTS: [(&str, &str); 9] = [
     ("SessionStart", "session-start.sh"),
     ("UserPromptSubmit", "user-prompt-submit.sh"),

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -286,6 +286,9 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
                     DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT,
                 )),
                 consolidate_on_session_end: config.consolidate_on_session_end,
+                subagent_sessions: std::sync::Arc::new(tokio::sync::Mutex::new(
+                    ai_memory_hooks::SubagentSessionSet::default(),
+                )),
                 home_dir: config.home_dir.clone(),
             });
             let admin = admin_router(AdminState {

--- a/crates/ai-memory-cli/src/commands/setup_agent.rs
+++ b/crates/ai-memory-cli/src/commands/setup_agent.rs
@@ -36,7 +36,8 @@ use anyhow::{Context, Result, bail};
 
 use crate::cli::{AgentChoice, SetupAgentArgs};
 use crate::commands::render_shared::{
-    CLAUDE_CODE_EVENTS, build_claude_code_payload, build_grok_payload,
+    ANTIGRAVITY_LIFECYCLE_EVENTS, ANTIGRAVITY_TOOL_EVENTS, CODEX_PROFILE, CURSOR_PROFILE,
+    GEMINI_PROFILE, build_claude_code_payload, build_grok_payload,
     hook_script_for_current_platform,
 };
 use crate::config::{Config, DEFAULT_SERVER_URL};
@@ -130,12 +131,17 @@ pub fn run(config: &Config, args: SetupAgentArgs) -> Result<()> {
     match args.agent {
         AgentChoice::ClaudeCode => emit_claude_code(&emit_root, &args)?,
         AgentChoice::Grok => emit_grok(&emit_root, &args)?,
-        AgentChoice::Codex
-        | AgentChoice::Cursor
-        | AgentChoice::GeminiCli
-        | AgentChoice::AntigravityCli => {
-            emit_other(&emit_root, agent_sub, &args);
+        AgentChoice::Codex => emit_other(&emit_root, agent_sub, &args, &[CODEX_PROFILE.events]),
+        AgentChoice::Cursor => emit_other(&emit_root, agent_sub, &args, &[CURSOR_PROFILE.events]),
+        AgentChoice::GeminiCli => {
+            emit_other(&emit_root, agent_sub, &args, &[GEMINI_PROFILE.events]);
         }
+        AgentChoice::AntigravityCli => emit_other(
+            &emit_root,
+            agent_sub,
+            &args,
+            &[&ANTIGRAVITY_TOOL_EVENTS, &ANTIGRAVITY_LIFECYCLE_EVENTS],
+        ),
         AgentChoice::OpenCode => unreachable!("opencode handled above"),
         AgentChoice::Omp => unreachable!("omp handled above"),
         AgentChoice::Openclaw => {
@@ -226,7 +232,12 @@ fn emit_grok(emit_root: &Path, args: &SetupAgentArgs) -> Result<()> {
     Ok(())
 }
 
-fn emit_other(emit_root: &Path, label: &str, args: &SetupAgentArgs) {
+fn emit_other(
+    emit_root: &Path,
+    label: &str,
+    args: &SetupAgentArgs,
+    event_lists: &[&[(&str, &str)]],
+) {
     // These clients have hook surfaces, but their print-mode config
     // snippets are intentionally conservative: apply-mode owns the
     // exact merge/plugin generation where ai-memory knows the format.
@@ -238,13 +249,23 @@ fn emit_other(emit_root: &Path, label: &str, args: &SetupAgentArgs) {
         println!("#       value you passed via --auth-token (not echoed).");
     }
     println!();
-    for (_, script) in CLAUDE_CODE_EVENTS {
-        let script = hook_script_for_current_platform(script);
-        println!("- {}", emit_root.join(script.as_ref()).display());
+    for path in event_script_paths(emit_root, event_lists) {
+        println!("- {}", path.display());
     }
     println!();
     println!("Set AI_MEMORY_HOOK_URL in each hook's environment to override the default.");
     println!("Also run `ai-memory install-mcp --client {label}` to wire MCP separately.");
+}
+
+fn event_script_paths(emit_root: &Path, event_lists: &[&[(&str, &str)]]) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for events in event_lists {
+        for (_, script) in *events {
+            let script = hook_script_for_current_platform(script);
+            paths.push(emit_root.join(script.as_ref()));
+        }
+    }
+    paths
 }
 
 fn is_hook_script_file(path: &Path) -> bool {
@@ -378,5 +399,30 @@ mod tests {
     fn source_candidates_honour_explicit_override() {
         let candidates = source_candidates(Some(Path::new("/custom/src")), "codex", None);
         assert_eq!(candidates, vec![PathBuf::from("/custom/src/codex")]);
+    }
+
+    #[test]
+    fn manual_script_paths_use_agent_specific_events() {
+        let root = Path::new("/hooks/gemini-cli");
+        let paths = event_script_paths(root, &[GEMINI_PROFILE.events]);
+        let rendered = paths
+            .iter()
+            .map(|path| path.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("session-start"));
+        assert!(rendered.contains("session-end"));
+        assert!(rendered.contains("pre-tool-use"));
+        assert!(rendered.contains("post-tool-use"));
+        assert!(rendered.contains("pre-compact"));
+        assert!(
+            !rendered.contains("user-prompt-submit"),
+            "Gemini has no UserPromptSubmit hook; setup-agent must not print Claude-only scripts"
+        );
+        assert!(
+            !rendered.contains("subagent-start") && !rendered.contains("subagent-stop"),
+            "Gemini has no subagent hook events; setup-agent must not print nonexistent scripts"
+        );
     }
 }

--- a/crates/ai-memory-hooks/src/lib.rs
+++ b/crates/ai-memory-hooks/src/lib.rs
@@ -29,6 +29,6 @@ pub use ai_memory_core::{SanitizeConfig, Sanitized, Sanitizer};
 pub use payload::{HookEnvelope, HookEvent};
 pub use router::{
     DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT, DEFAULT_PROJECT_CACHE_MAX_ENTRIES, HookState, ProjectCache,
-    ProjectCacheStore, hook_router,
+    ProjectCacheStore, SubagentSessionSet, SubagentSessions, hook_router,
 };
 pub use synth::synthesize_session_page;

--- a/crates/ai-memory-hooks/src/log.rs
+++ b/crates/ai-memory-hooks/src/log.rs
@@ -92,6 +92,8 @@ fn format_line(when: Timestamp, event: HookEvent, title: &str) -> String {
         HookEvent::Notification => "notification",
         HookEvent::Stop => "stop",
         HookEvent::SessionEnd => "session-end",
+        HookEvent::SubagentStart => "subagent-start",
+        HookEvent::SubagentStop => "subagent-stop",
         HookEvent::Other => "other",
     };
     let one_line: String = title

--- a/crates/ai-memory-hooks/src/payload.rs
+++ b/crates/ai-memory-hooks/src/payload.rs
@@ -34,6 +34,13 @@ pub struct HookQuery {
     /// When omitted and `extension` is present, unknown `event` values
     /// are preserved as the source event.
     pub source_event: Option<String>,
+    /// Per-project opt-in for `drop_subagent_captures`, forwarded by the
+    /// host-side hook from a project's `.ai-memory.toml`. A truthy value
+    /// (`1`/`true`/…) makes the server accept-but-drop this project's subagent
+    /// captures; absent/falsy leaves them stored. Scoping the drop to the
+    /// project that asked for it avoids a server-global switch that would shed
+    /// subagent captures for every project on a shared instance.
+    pub drop_subagent: Option<String>,
 }
 
 /// Coalesced view of an incoming hook event after light parsing of the
@@ -58,6 +65,11 @@ pub struct HookEnvelope {
     pub project_override: Option<String>,
     /// Project derivation strategy declared by the hook marker.
     pub project_strategy: ProjectStrategy,
+    /// Whether this project opted into `drop_subagent_captures` via its
+    /// `.ai-memory.toml` (forwarded as the `drop_subagent` query flag). The
+    /// ingest router consults this per-event so the drop is scoped to the
+    /// project that asked for it.
+    pub drop_subagent_requested: bool,
     /// Optional third-party extension namespace.
     pub extension: Option<String>,
     /// Optional source event name from the extension vocabulary.
@@ -68,6 +80,36 @@ pub struct HookEnvelope {
     pub body_excerpt: Option<String>,
     /// The agent's raw JSON, kept for forensics.
     pub raw: serde_json::Value,
+}
+
+/// Keys by which agent harnesses tag a hook event as belonging to a SUBAGENT
+/// (a nested/spawned agent session) rather than the top-level session. Grok
+/// sets `subagentType` (on its tool-use events); Claude Code sets `agent_type`
+/// and `agent_id` (on its `SubagentStart`/`SubagentStop` and subagent tool
+/// events). The set is a union so one check covers every harness that signals
+/// subagent-ness; a harness that does not signal it simply never matches.
+const SUBAGENT_MARKER_KEYS: &[&str] = &["subagentType", "agent_type", "agent_id"];
+
+/// True when the raw hook payload carries a non-empty subagent marker — i.e.
+/// the event originates from a spawned subagent session. The ingest router
+/// consults this to optionally drop subagent captures (the
+/// `drop_subagent_captures` setting). Only top-level string keys are inspected.
+pub(crate) fn body_is_subagent(raw: &serde_json::Value) -> bool {
+    SUBAGENT_MARKER_KEYS.iter().any(|key| {
+        raw.get(*key)
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    })
+}
+
+/// Truthy interpretation of a query-string flag (`1`/`true`/`yes`/`on`,
+/// case-insensitive). Used for the per-project `drop_subagent` opt-in the
+/// host-side hook forwards from a project's `.ai-memory.toml`.
+fn query_flag_truthy(value: Option<&str>) -> bool {
+    matches!(
+        value.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
 }
 
 /// How the hook router derives a project name when no explicit
@@ -123,6 +165,10 @@ pub enum HookEvent {
     Stop,
     /// Session ended (final).
     SessionEnd,
+    /// A subagent (nested/spawned child session) started.
+    SubagentStart,
+    /// A subagent finished.
+    SubagentStop,
     /// Anything else.
     Other,
 }
@@ -148,6 +194,11 @@ impl HookEvent {
             "notification" | "Notification" => Self::Notification,
             "stop" | "Stop" => Self::Stop,
             "session-end" | "session_end" | "SessionEnd" | "sessionEnd" => Self::SessionEnd,
+            "subagent-start" | "subagent_start" | "SubagentStart" | "subagentStart" => {
+                Self::SubagentStart
+            }
+            "subagent-stop" | "subagent_stop" | "SubagentStop" | "subagentStop"
+            | "subagent-end" | "SubagentEnd" => Self::SubagentStop,
             _ => Self::Other,
         }
     }
@@ -164,6 +215,9 @@ impl HookEvent {
             Self::Notification => ObservationKind::Notification,
             Self::Stop => ObservationKind::Stop,
             Self::SessionEnd => ObservationKind::SessionEnd,
+            // Subagent lifecycle events are normally dropped (drop_subagent_captures);
+            // bucket as Other for the flag-off path rather than growing ObservationKind.
+            Self::SubagentStart | Self::SubagentStop => ObservationKind::Other,
             Self::Other => ObservationKind::Other,
         }
     }
@@ -238,6 +292,7 @@ impl HookEnvelope {
         let workspace_override = query.workspace.filter(|s| !s.is_empty());
         let project_override = query.project.filter(|s| !s.is_empty());
         let project_strategy = ProjectStrategy::parse(query.project_strategy.as_deref());
+        let drop_subagent_requested = query_flag_truthy(query.drop_subagent.as_deref());
         let extension = normalize_extension_name(query.extension.as_deref());
         let source_event = extension.as_ref().and_then(|_| {
             let raw_source = query
@@ -269,6 +324,7 @@ impl HookEnvelope {
             workspace_override,
             project_override,
             project_strategy,
+            drop_subagent_requested,
             extension,
             source_event,
             title_hint,
@@ -545,6 +601,40 @@ fn normalize_token(value: &str, max_len: usize) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn body_is_subagent_detects_harness_markers() {
+        // grok tags subagent tool-use events with `subagentType`.
+        assert!(body_is_subagent(
+            &serde_json::json!({ "sessionId": "s", "subagentType": "general-purpose" })
+        ));
+        // Claude Code tags its subagent events with `agent_type` / `agent_id`.
+        assert!(body_is_subagent(
+            &serde_json::json!({ "session_id": "s", "agent_type": "workflow-subagent" })
+        ));
+        assert!(body_is_subagent(
+            &serde_json::json!({ "agent_id": "agent-abc123" })
+        ));
+    }
+
+    #[test]
+    fn body_is_subagent_false_for_top_level_and_empty_markers() {
+        // A normal top-level event carries no marker.
+        assert!(!body_is_subagent(
+            &serde_json::json!({ "session_id": "s", "tool_name": "Write" })
+        ));
+        // An empty / blank or non-string marker does not count as a subagent.
+        assert!(!body_is_subagent(
+            &serde_json::json!({ "subagentType": "" })
+        ));
+        assert!(!body_is_subagent(
+            &serde_json::json!({ "subagentType": "   " })
+        ));
+        assert!(!body_is_subagent(
+            &serde_json::json!({ "agent_type": null })
+        ));
+        assert!(!body_is_subagent(&serde_json::json!({})));
+    }
 
     #[test]
     fn parses_known_events() {

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -8,7 +8,7 @@
 //! basic-memory #763). The agent never blocks on us thanks to the
 //! fire-and-forget client side.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -31,7 +31,9 @@ use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::log;
-use crate::payload::{HookEnvelope, HookEvent, HookQuery, ProjectStrategy, parse_agent};
+use crate::payload::{
+    HookEnvelope, HookEvent, HookQuery, ProjectStrategy, body_is_subagent, parse_agent,
+};
 use crate::synth::synthesize_session_page;
 
 /// Default maximum number of hook events allowed to be processing at once.
@@ -49,6 +51,11 @@ pub const MAX_HOOK_BATCH_ITEMS: usize = 256;
 /// Maximum cwd-resolution cache entries kept per server process. The cache is
 /// an optimization only; evicted entries are re-resolved through the writer.
 pub const DEFAULT_PROJECT_CACHE_MAX_ENTRIES: usize = 4096;
+
+/// Cap on session ids tracked as subagents for the `drop_subagent_captures`
+/// tail-drop. Bounded LRU: a missed `SubagentStop` can never grow it without
+/// bound — the oldest id evicts once the cap is hit.
+const SUBAGENT_SESSIONS_MAX: usize = 4096;
 
 /// Resolved-project cache key:
 /// `(cwd, workspace_override, project_override, project_strategy)`.
@@ -141,6 +148,62 @@ impl ProjectCacheStore {
     }
 }
 
+/// Shared bounded set of session ids known to belong to a SUBAGENT.
+pub type SubagentSessions = Arc<tokio::sync::Mutex<SubagentSessionSet>>;
+
+/// Tracks the session ids of subagent (nested/spawned) sessions so that the
+/// `drop_subagent_captures` gate can also drop the **unmarked tail** of those
+/// sessions (`user_prompt_submit` / `stop` / `session_end`), which the
+/// per-event marker (`subagentType` / `agent_type`) does not cover. A session
+/// is seeded when a `SubagentStart` or any marker-bearing event arrives, and
+/// forgotten on `SubagentStop`. Bounded LRU so a missed stop cannot leak memory.
+#[derive(Debug)]
+pub struct SubagentSessionSet {
+    ids: HashSet<SessionId>,
+    order: VecDeque<SessionId>,
+    max: usize,
+}
+
+impl Default for SubagentSessionSet {
+    fn default() -> Self {
+        Self {
+            ids: HashSet::new(),
+            order: VecDeque::new(),
+            max: SUBAGENT_SESSIONS_MAX,
+        }
+    }
+}
+
+impl SubagentSessionSet {
+    /// Mark a session id as a subagent (idempotent). Evicts the oldest id once
+    /// the cap is exceeded.
+    fn insert(&mut self, id: SessionId) {
+        if self.ids.insert(id) {
+            self.order.push_back(id);
+            while self.ids.len() > self.max {
+                if let Some(oldest) = self.order.pop_front() {
+                    self.ids.remove(&oldest);
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Whether this session id is a known subagent.
+    #[must_use]
+    fn contains(&self, id: &SessionId) -> bool {
+        self.ids.contains(id)
+    }
+
+    /// Forget a session id (on `SubagentStop`).
+    fn remove(&mut self, id: &SessionId) {
+        if self.ids.remove(id) {
+            self.order.retain(|k| k != id);
+        }
+    }
+}
+
 /// Shared state passed to the hook handler.
 #[derive(Clone)]
 pub struct HookState {
@@ -183,6 +246,13 @@ pub struct HookState {
     /// session close stays cheap; the LLM checkpoint otherwise happens on
     /// PreCompact and via manual `memory_consolidate`.
     pub consolidate_on_session_end: bool,
+    /// Session ids known to be subagents (seeded by `SubagentStart` / any
+    /// marker-bearing event). For a project that opted into
+    /// `drop_subagent_captures` (via its `.ai-memory.toml`, forwarded as the
+    /// per-event `drop_subagent` flag), every event of a tracked session is
+    /// dropped — closing the unmarked tail
+    /// (`user_prompt_submit`/`stop`/`session_end`) the per-event marker misses.
+    pub subagent_sessions: SubagentSessions,
     /// Operator home directory, sourced from `Config` once at startup. The
     /// cwd->project resolver never prefix-matches a stored `repo_path` equal
     /// to this, so `$HOME` cannot become a catch-all (issue #103). `None`
@@ -207,6 +277,13 @@ async fn handle_hook(
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     let env = HookEnvelope::from_query_and_body(query, body);
+    // Accept-but-drop subagent captures (incl. the unmarked tail of tracked
+    // subagent sessions) when the operator opts in. Returning 202 (not an error)
+    // means the client treats the event as delivered and never retries/spools
+    // it. Runs before the semaphore so a dropped event consumes no capacity.
+    if should_drop_subagent(&state, &env).await {
+        return (StatusCode::ACCEPTED, "subagent capture dropped");
+    }
     // The auth middleware in front of `/hook` injects the request's
     // [`ActorContext`] (rung 1 root, rung 2 DB user, or anonymous). We
     // capture its `user` field NOW — before the spawn drops the request
@@ -302,6 +379,13 @@ async fn handle_hook_batch(
     for item in items {
         let query = parse_hook_query(&item.url);
         let env = HookEnvelope::from_query_and_body(query, item.body);
+        // Accept-but-drop subagent captures (see `handle_hook`): count the item
+        // as committed so the client clears it from its spool, but do not store
+        // it. Keeps the contiguous-prefix ack contract intact.
+        if should_drop_subagent(&state, &env).await {
+            accepted += 1;
+            continue;
+        }
         if let Err(e) = process(&state, env, actor_user.clone()).await {
             warn!(error = %e, accepted, "hook batch item failed; stopping (fail-fast)");
             break;
@@ -309,6 +393,45 @@ async fn handle_hook_batch(
         accepted += 1;
     }
     (StatusCode::OK, Json(HookBatchAck { accepted }))
+}
+
+/// Decide whether to accept-but-drop this event under `drop_subagent_captures`,
+/// maintaining the subagent-session set. Returns `true` to drop. Seeds the
+/// session on `SubagentStart` and on any marker-bearing event; forgets it on
+/// `SubagentStop`; and drops the **unmarked tail** (`user_prompt_submit` /
+/// `stop` / `session_end`) of a session already known to be a subagent. No-op
+/// (returns `false`) unless this event's project opted in via the per-event
+/// `drop_subagent` flag (sourced from its `.ai-memory.toml`).
+async fn should_drop_subagent(state: &HookState, env: &HookEnvelope) -> bool {
+    if !env.drop_subagent_requested {
+        return false;
+    }
+    let sid = resolve_session_id(env).ok();
+    match env.event {
+        HookEvent::SubagentStop => {
+            if let Some(s) = sid {
+                state.subagent_sessions.lock().await.remove(&s);
+            }
+            true
+        }
+        HookEvent::SubagentStart => {
+            if let Some(s) = sid {
+                state.subagent_sessions.lock().await.insert(s);
+            }
+            true
+        }
+        _ if body_is_subagent(&env.raw) => {
+            if let Some(s) = sid {
+                state.subagent_sessions.lock().await.insert(s);
+            }
+            true
+        }
+        // Unmarked event: drop only when its session is a known subagent (tail).
+        _ => match sid {
+            Some(s) => state.subagent_sessions.lock().await.contains(&s),
+            None => false,
+        },
+    }
 }
 
 /// Parse the `?event=…&agent=…` query of a spooled hook URL into [`HookQuery`],
@@ -1086,7 +1209,10 @@ const fn importance_for(event: HookEvent) -> u8 {
         HookEvent::UserPrompt => 8,
         HookEvent::PostToolUse | HookEvent::PreToolUse => 5,
         HookEvent::Stop | HookEvent::PreCompact => 6,
-        HookEvent::Notification | HookEvent::Other => 3,
+        HookEvent::Notification
+        | HookEvent::Other
+        | HookEvent::SubagentStart
+        | HookEvent::SubagentStop => 3,
     }
 }
 
@@ -1128,6 +1254,7 @@ mod tests {
             project_cache: Arc::new(tokio::sync::Mutex::new(ProjectCacheStore::default())),
             active_project: ActiveProject::new(),
             consolidate_on_session_end: false,
+            subagent_sessions: Arc::new(tokio::sync::Mutex::new(SubagentSessionSet::default())),
             home_dir: None,
             ingest_semaphore: Arc::new(tokio::sync::Semaphore::new(
                 DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT,
@@ -1241,6 +1368,231 @@ mod tests {
             .unwrap();
         let ack: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(ack["accepted"], 2, "both events committed, oldest-first");
+    }
+
+    /// `pre-tool-use` query+agent for building an env to recompute a SessionId.
+    fn grok_tool_query() -> HookQuery {
+        HookQuery {
+            event: "pre-tool-use".into(),
+            agent: Some("grok".into()),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_hook_batch_drops_subagent_events_when_enabled() {
+        let tmp = TempDir::new().unwrap();
+        let state = Arc::new(make_state(&tmp).await);
+
+        // A grok subagent tool-use event (carries `subagentType`) alongside a
+        // top-level event (no marker), in ONE batch.
+        let sub_body = serde_json::json!({
+            "sessionId": "sub-s1", "subagentType": "general-purpose", "toolName": "x"
+        });
+        let top_body = serde_json::json!({ "sessionId": "top-s1", "toolName": "x" });
+        // The project opted in (`.ai-memory.toml` → `drop_subagent=1`), so every
+        // event carries the flag; only the actual subagent capture is dropped.
+        let items = vec![
+            HookBatchItem {
+                url: "http://h/hook?event=pre-tool-use&agent=grok&drop_subagent=1".into(),
+                body: sub_body.clone(),
+            },
+            HookBatchItem {
+                url: "http://h/hook?event=pre-tool-use&agent=grok&drop_subagent=1".into(),
+                body: top_body.clone(),
+            },
+        ];
+
+        let response = handle_hook_batch(State(state.clone()), None, Json(items))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let ack: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        // Accept-but-drop: BOTH are acked so the client clears its spool…
+        assert_eq!(
+            ack["accepted"], 2,
+            "both acked so the client clears its spool"
+        );
+
+        // …but only the top-level event was persisted; the subagent left nothing.
+        let sub_sid = resolve_session_id(&HookEnvelope::from_query_and_body(
+            grok_tool_query(),
+            sub_body,
+        ))
+        .unwrap();
+        let top_sid = resolve_session_id(&HookEnvelope::from_query_and_body(
+            grok_tool_query(),
+            top_body,
+        ))
+        .unwrap();
+        assert!(
+            state
+                .reader
+                .observations_for_session(sub_sid)
+                .await
+                .unwrap()
+                .is_empty(),
+            "subagent capture must not be persisted"
+        );
+        assert_eq!(
+            state
+                .reader
+                .observations_for_session(top_sid)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "top-level capture is persisted as usual"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_hook_batch_keeps_subagent_events_when_disabled() {
+        let tmp = TempDir::new().unwrap();
+        let state = Arc::new(make_state(&tmp).await);
+
+        // No `drop_subagent` flag on the request → the project did not opt in,
+        // so its subagent captures are stored as usual.
+        let sub_body = serde_json::json!({
+            "sessionId": "sub-s2", "subagentType": "general-purpose", "toolName": "x"
+        });
+        let items = vec![HookBatchItem {
+            url: "http://h/hook?event=pre-tool-use&agent=grok".into(),
+            body: sub_body.clone(),
+        }];
+
+        let response = handle_hook_batch(State(state.clone()), None, Json(items))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let sub_sid = resolve_session_id(&HookEnvelope::from_query_and_body(
+            grok_tool_query(),
+            sub_body,
+        ))
+        .unwrap();
+        assert_eq!(
+            state
+                .reader
+                .observations_for_session(sub_sid)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "without the per-project opt-in, subagent captures are stored (default behavior)"
+        );
+    }
+
+    #[tokio::test]
+    async fn drop_subagent_captures_drops_unmarked_tail_of_tracked_session() {
+        let tmp = TempDir::new().unwrap();
+        let state = Arc::new(make_state(&tmp).await);
+
+        // (1) marked subagent event seeds session "sub" (and is dropped);
+        // (2) a later UNMARKED event on "sub" is the tail → dropped via tracking;
+        // (3) an UNMARKED event on a never-seeded session "top" → kept.
+        let marked = serde_json::json!({
+            "sessionId": "sub", "subagentType": "general-purpose", "toolName": "x"
+        });
+        let tail = serde_json::json!({ "sessionId": "sub", "toolName": "y" });
+        let top = serde_json::json!({ "sessionId": "top", "toolName": "z" });
+        let items = vec![
+            HookBatchItem {
+                url: "http://h/hook?event=pre-tool-use&agent=grok&drop_subagent=1".into(),
+                body: marked,
+            },
+            HookBatchItem {
+                url: "http://h/hook?event=pre-tool-use&agent=grok&drop_subagent=1".into(),
+                body: tail.clone(),
+            },
+            HookBatchItem {
+                url: "http://h/hook?event=pre-tool-use&agent=grok&drop_subagent=1".into(),
+                body: top.clone(),
+            },
+        ];
+
+        let response = handle_hook_batch(State(state.clone()), None, Json(items))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let ack: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(ack["accepted"], 3, "all acked: 2 dropped + 1 processed");
+
+        let sub_sid =
+            resolve_session_id(&HookEnvelope::from_query_and_body(grok_tool_query(), tail))
+                .unwrap();
+        let top_sid =
+            resolve_session_id(&HookEnvelope::from_query_and_body(grok_tool_query(), top)).unwrap();
+        assert!(
+            state
+                .reader
+                .observations_for_session(sub_sid)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the unmarked tail of a tracked subagent session is dropped"
+        );
+        assert_eq!(
+            state
+                .reader
+                .observations_for_session(top_sid)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "an unmarked event on a non-subagent session is kept"
+        );
+    }
+
+    #[tokio::test]
+    async fn subagent_start_event_seeds_the_session_so_its_tail_drops() {
+        let tmp = TempDir::new().unwrap();
+        let state = Arc::new(make_state(&tmp).await);
+
+        // SubagentStart seeds session "ss" BEFORE its first content event, so even
+        // the leading unmarked user_prompt_submit is dropped.
+        let start = serde_json::json!({ "sessionId": "ss" });
+        let lead = serde_json::json!({ "sessionId": "ss", "prompt": "go" });
+        let items = vec![
+            HookBatchItem {
+                url: "http://h/hook?event=subagent-start&agent=grok&drop_subagent=1".into(),
+                body: start,
+            },
+            HookBatchItem {
+                url: "http://h/hook?event=user-prompt-submit&agent=grok&drop_subagent=1".into(),
+                body: lead.clone(),
+            },
+        ];
+
+        let response = handle_hook_batch(State(state.clone()), None, Json(items))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let sid = resolve_session_id(&HookEnvelope::from_query_and_body(
+            HookQuery {
+                event: "user-prompt-submit".into(),
+                agent: Some("grok".into()),
+                ..Default::default()
+            },
+            lead,
+        ))
+        .unwrap();
+        assert!(
+            state
+                .reader
+                .observations_for_session(sid)
+                .await
+                .unwrap()
+                .is_empty(),
+            "SubagentStart seeds the session so the leading unmarked event drops too"
+        );
     }
 
     #[tokio::test]

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -14,8 +14,9 @@ use std::sync::Arc;
 
 use ai_memory_consolidate::Consolidator;
 use ai_memory_core::{
-    ActiveProject, AgentKind, DEFAULT_WORKSPACE_NAME, Handoff, NewHandoff, NewObservation,
-    NewSession, ObservationKind, ProjectId, Sanitized, Sanitizer, SessionId, WorkspaceId,
+    ActiveProject, ActorKey, AgentKind, DEFAULT_WORKSPACE_NAME, Handoff, NewHandoff,
+    NewObservation, NewSession, ObservationKind, ProjectId, Sanitized, Sanitizer, SessionId,
+    WorkspaceId,
 };
 use ai_memory_store::WriterHandle;
 use ai_memory_wiki::Wiki;
@@ -52,9 +53,10 @@ pub const MAX_HOOK_BATCH_ITEMS: usize = 256;
 /// an optimization only; evicted entries are re-resolved through the writer.
 pub const DEFAULT_PROJECT_CACHE_MAX_ENTRIES: usize = 4096;
 
-/// Cap on session ids tracked as subagents for the `drop_subagent_captures`
-/// tail-drop. Bounded LRU: a missed `SubagentStop` can never grow it without
-/// bound — the oldest id evicts once the cap is hit.
+/// Cap on scoped session ids tracked as subagents for the
+/// `drop_subagent_captures` tail-drop. Mirrors the project-cache order of
+/// magnitude: enough for high fan-out harnesses, still bounded if a client never
+/// sends a terminal `SessionEnd`.
 const SUBAGENT_SESSIONS_MAX: usize = 4096;
 
 /// Resolved-project cache key:
@@ -148,19 +150,27 @@ impl ProjectCacheStore {
     }
 }
 
-/// Shared bounded set of session ids known to belong to a SUBAGENT.
+/// Shared bounded set of scoped session keys known to belong to a SUBAGENT.
 pub type SubagentSessions = Arc<tokio::sync::Mutex<SubagentSessionSet>>;
 
-/// Tracks the session ids of subagent (nested/spawned) sessions so that the
-/// `drop_subagent_captures` gate can also drop the **unmarked tail** of those
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct SubagentSessionKey {
+    workspace_id: WorkspaceId,
+    project_id: ProjectId,
+    session_id: SessionId,
+}
+
+/// Tracks the scoped session keys of subagent (nested/spawned) sessions so that
+/// the `drop_subagent_captures` gate can also drop the **unmarked tail** of those
 /// sessions (`user_prompt_submit` / `stop` / `session_end`), which the
 /// per-event marker (`subagentType` / `agent_type`) does not cover. A session
 /// is seeded when a `SubagentStart` or any marker-bearing event arrives, and
-/// forgotten on `SubagentStop`. Bounded LRU so a missed stop cannot leak memory.
+/// forgotten on `SessionEnd` after the tail has been dropped. Bounded LRU so a
+/// missed terminal event cannot leak memory.
 #[derive(Debug)]
 pub struct SubagentSessionSet {
-    ids: HashSet<SessionId>,
-    order: VecDeque<SessionId>,
+    ids: HashSet<SubagentSessionKey>,
+    order: VecDeque<SubagentSessionKey>,
     max: usize,
 }
 
@@ -175,32 +185,40 @@ impl Default for SubagentSessionSet {
 }
 
 impl SubagentSessionSet {
-    /// Mark a session id as a subagent (idempotent). Evicts the oldest id once
-    /// the cap is exceeded.
-    fn insert(&mut self, id: SessionId) {
-        if self.ids.insert(id) {
-            self.order.push_back(id);
-            while self.ids.len() > self.max {
-                if let Some(oldest) = self.order.pop_front() {
-                    self.ids.remove(&oldest);
-                } else {
-                    break;
-                }
+    /// Mark a scoped session id as a subagent (idempotent). Refreshes recency
+    /// and evicts the oldest id once the cap is exceeded.
+    fn insert(&mut self, key: SubagentSessionKey) {
+        if self.ids.contains(&key) {
+            self.touch(&key);
+            return;
+        }
+        self.ids.insert(key);
+        self.order.push_back(key);
+        while self.ids.len() > self.max {
+            if let Some(oldest) = self.order.pop_front() {
+                self.ids.remove(&oldest);
+            } else {
+                break;
             }
         }
     }
 
-    /// Whether this session id is a known subagent.
+    /// Whether this scoped session id is a known subagent.
     #[must_use]
-    fn contains(&self, id: &SessionId) -> bool {
-        self.ids.contains(id)
+    fn contains(&self, key: &SubagentSessionKey) -> bool {
+        self.ids.contains(key)
     }
 
-    /// Forget a session id (on `SubagentStop`).
-    fn remove(&mut self, id: &SessionId) {
-        if self.ids.remove(id) {
-            self.order.retain(|k| k != id);
+    /// Forget a scoped session id (after `SessionEnd`).
+    fn remove(&mut self, key: &SubagentSessionKey) {
+        if self.ids.remove(key) {
+            self.order.retain(|k| k != key);
         }
+    }
+
+    fn touch(&mut self, key: &SubagentSessionKey) {
+        self.order.retain(|k| k != key);
+        self.order.push_back(*key);
     }
 }
 
@@ -246,7 +264,7 @@ pub struct HookState {
     /// session close stays cheap; the LLM checkpoint otherwise happens on
     /// PreCompact and via manual `memory_consolidate`.
     pub consolidate_on_session_end: bool,
-    /// Session ids known to be subagents (seeded by `SubagentStart` / any
+    /// Scoped session keys known to be subagents (seeded by `SubagentStart` / any
     /// marker-bearing event). For a project that opted into
     /// `drop_subagent_captures` (via its `.ai-memory.toml`, forwarded as the
     /// per-event `drop_subagent` flag), every event of a tracked session is
@@ -281,9 +299,6 @@ async fn handle_hook(
     // subagent sessions) when the operator opts in. Returning 202 (not an error)
     // means the client treats the event as delivered and never retries/spools
     // it. Runs before the semaphore so a dropped event consumes no capacity.
-    if should_drop_subagent(&state, &env).await {
-        return (StatusCode::ACCEPTED, "subagent capture dropped");
-    }
     // The auth middleware in front of `/hook` injects the request's
     // [`ActorContext`] (rung 1 root, rung 2 DB user, or anonymous). We
     // capture its `user` field NOW — before the spawn drops the request
@@ -292,6 +307,13 @@ async fn handle_hook(
     let actor_user = actor_ext
         .map(|axum::Extension(ctx)| ctx.user)
         .unwrap_or_default();
+    let actor_key = ActorKey {
+        user: actor_user.clone(),
+        session_id: env.session_id.clone(),
+    };
+    if should_drop_subagent(&state, &env, &actor_key).await {
+        return (StatusCode::ACCEPTED, "subagent capture dropped");
+    }
     let Ok(permit) = state.ingest_semaphore.clone().try_acquire_owned() else {
         warn!("hook ingest saturated; dropping event with 429");
         return (StatusCode::TOO_MANY_REQUESTS, "hook queue full");
@@ -359,33 +381,34 @@ async fn handle_hook_batch(
     let actor_user = actor_ext
         .map(|axum::Extension(ctx)| ctx.user)
         .unwrap_or_default();
-    // Hold capacity proportional to the batch size so batch ingress cannot
-    // exceed the same in-flight event bound as single `/hook` requests. Empty
-    // batches still acquire one permit to respect backpressure consistently.
-    let permits = u32::try_from(items.len().max(1)).unwrap_or(u32::MAX);
-    let Ok(permit) = state
-        .ingest_semaphore
-        .clone()
-        .try_acquire_many_owned(permits)
-    else {
-        warn!("hook batch ingest saturated; rejecting with 429");
-        return (
-            StatusCode::TOO_MANY_REQUESTS,
-            Json(HookBatchAck { accepted: 0 }),
-        );
-    };
-    let _permit = permit;
     let mut accepted = 0usize;
     for item in items {
         let query = parse_hook_query(&item.url);
         let env = HookEnvelope::from_query_and_body(query, item.body);
+        let actor_key = ActorKey {
+            user: actor_user.clone(),
+            session_id: env.session_id.clone(),
+        };
         // Accept-but-drop subagent captures (see `handle_hook`): count the item
         // as committed so the client clears it from its spool, but do not store
         // it. Keeps the contiguous-prefix ack contract intact.
-        if should_drop_subagent(&state, &env).await {
+        if should_drop_subagent(&state, &env, &actor_key).await {
             accepted += 1;
             continue;
         }
+        // Mirror single `/hook`: subagent drops consume no ingest capacity, and
+        // only events we will actually process acquire a permit. The batch loop
+        // is sequential, so one permit held across this item preserves the
+        // server-wide in-flight bound without making all-droppable batches 429
+        // under saturation.
+        let Ok(permit) = state.ingest_semaphore.clone().try_acquire_owned() else {
+            warn!(accepted, "hook batch ingest saturated; rejecting with 429");
+            return (
+                StatusCode::TOO_MANY_REQUESTS,
+                Json(HookBatchAck { accepted }),
+            );
+        };
+        let _permit = permit;
         if let Err(e) = process(&state, env, actor_user.clone()).await {
             warn!(error = %e, accepted, "hook batch item failed; stopping (fail-fast)");
             break;
@@ -397,41 +420,50 @@ async fn handle_hook_batch(
 
 /// Decide whether to accept-but-drop this event under `drop_subagent_captures`,
 /// maintaining the subagent-session set. Returns `true` to drop. Seeds the
-/// session on `SubagentStart` and on any marker-bearing event; forgets it on
+/// session on `SubagentStart` and on any marker-bearing event; keeps it through
 /// `SubagentStop`; and drops the **unmarked tail** (`user_prompt_submit` /
 /// `stop` / `session_end`) of a session already known to be a subagent. No-op
 /// (returns `false`) unless this event's project opted in via the per-event
 /// `drop_subagent` flag (sourced from its `.ai-memory.toml`).
-async fn should_drop_subagent(state: &HookState, env: &HookEnvelope) -> bool {
+async fn should_drop_subagent(state: &HookState, env: &HookEnvelope, actor: &ActorKey) -> bool {
     if !env.drop_subagent_requested {
         return false;
     }
-    let sid = resolve_session_id(env).ok();
-    match env.event {
-        HookEvent::SubagentStop => {
-            if let Some(s) = sid {
-                state.subagent_sessions.lock().await.remove(&s);
-            }
-            true
-        }
-        HookEvent::SubagentStart => {
-            if let Some(s) = sid {
-                state.subagent_sessions.lock().await.insert(s);
-            }
-            true
-        }
-        _ if body_is_subagent(&env.raw) => {
-            if let Some(s) = sid {
-                state.subagent_sessions.lock().await.insert(s);
-            }
-            true
-        }
-        // Unmarked event: drop only when its session is a known subagent (tail).
-        _ => match sid {
-            Some(s) => state.subagent_sessions.lock().await.contains(&s),
-            None => false,
-        },
+    let Ok(session_id) = resolve_session_id(env) else {
+        return false;
+    };
+    let Ok((workspace_id, project_id)) = resolve_project_ids(
+        state,
+        env.cwd.as_deref(),
+        env.workspace_override.as_deref(),
+        env.project_override.as_deref(),
+        env.project_strategy,
+        actor,
+    )
+    .await
+    else {
+        return false;
+    };
+    let key = SubagentSessionKey {
+        workspace_id,
+        project_id,
+        session_id,
+    };
+    let marked = matches!(
+        env.event,
+        HookEvent::SubagentStart | HookEvent::SubagentStop
+    ) || body_is_subagent(&env.raw);
+
+    if marked {
+        state.subagent_sessions.lock().await.insert(key);
+        return true;
     }
+
+    let tracked = state.subagent_sessions.lock().await.contains(&key);
+    if tracked && matches!(env.event, HookEvent::SessionEnd) {
+        state.subagent_sessions.lock().await.remove(&key);
+    }
+    tracked
 }
 
 /// Parse the `?event=…&agent=…` query of a spooled hook URL into [`HookQuery`],
@@ -1677,6 +1709,111 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn drop_subagent_tracking_is_scoped_by_project() {
+        let tmp = TempDir::new().unwrap();
+        let state = make_state(&tmp).await;
+        let actor = ai_memory_core::ActorKey::default();
+
+        let marked_project_a = HookEnvelope::from_query_and_body(
+            HookQuery {
+                event: "pre-tool-use".into(),
+                agent: Some("grok".into()),
+                project: Some("project-a".into()),
+                drop_subagent: Some("1".into()),
+                ..Default::default()
+            },
+            serde_json::json!({
+                "sessionId": "shared-session", "subagentType": "general-purpose"
+            }),
+        );
+        assert!(should_drop_subagent(&state, &marked_project_a, &actor).await);
+
+        let unmarked_project_b = HookEnvelope::from_query_and_body(
+            HookQuery {
+                event: "pre-tool-use".into(),
+                agent: Some("grok".into()),
+                project: Some("project-b".into()),
+                drop_subagent: Some("1".into()),
+                ..Default::default()
+            },
+            serde_json::json!({ "sessionId": "shared-session", "toolName": "kept" }),
+        );
+        assert!(
+            !should_drop_subagent(&state, &unmarked_project_b, &actor).await,
+            "a subagent session tracked in project-a must not drop same-id events in project-b"
+        );
+
+        let unmarked_project_a = HookEnvelope::from_query_and_body(
+            HookQuery {
+                event: "pre-tool-use".into(),
+                agent: Some("grok".into()),
+                project: Some("project-a".into()),
+                drop_subagent: Some("1".into()),
+                ..Default::default()
+            },
+            serde_json::json!({ "sessionId": "shared-session", "toolName": "dropped" }),
+        );
+        assert!(
+            should_drop_subagent(&state, &unmarked_project_a, &actor).await,
+            "the originally tracked project's unmarked tail still drops"
+        );
+    }
+
+    #[tokio::test]
+    async fn subagent_stop_keeps_session_tracked_until_session_end_tail_drops() {
+        let tmp = TempDir::new().unwrap();
+        let state = make_state(&tmp).await;
+        let actor = ai_memory_core::ActorKey::default();
+
+        let query = |event: &str| HookQuery {
+            event: event.into(),
+            agent: Some("grok".into()),
+            project: Some("tail-project".into()),
+            drop_subagent: Some("1".into()),
+            ..Default::default()
+        };
+
+        let start = HookEnvelope::from_query_and_body(
+            query("subagent-start"),
+            serde_json::json!({ "sessionId": "tail-session" }),
+        );
+        assert!(should_drop_subagent(&state, &start, &actor).await);
+
+        let subagent_stop = HookEnvelope::from_query_and_body(
+            query("subagent-stop"),
+            serde_json::json!({ "sessionId": "tail-session" }),
+        );
+        assert!(should_drop_subagent(&state, &subagent_stop, &actor).await);
+
+        let unmarked_stop_tail = HookEnvelope::from_query_and_body(
+            query("stop"),
+            serde_json::json!({ "sessionId": "tail-session" }),
+        );
+        assert!(
+            should_drop_subagent(&state, &unmarked_stop_tail, &actor).await,
+            "SubagentStop must not clear tracking before the unmarked stop tail"
+        );
+
+        let session_end_tail = HookEnvelope::from_query_and_body(
+            query("session-end"),
+            serde_json::json!({ "sessionId": "tail-session" }),
+        );
+        assert!(
+            should_drop_subagent(&state, &session_end_tail, &actor).await,
+            "SessionEnd tail is dropped and then clears tracking"
+        );
+
+        let after_session_end = HookEnvelope::from_query_and_body(
+            query("pre-tool-use"),
+            serde_json::json!({ "sessionId": "tail-session", "toolName": "kept" }),
+        );
+        assert!(
+            !should_drop_subagent(&state, &after_session_end, &actor).await,
+            "SessionEnd clears tracking for that scoped session"
+        );
+    }
+
+    #[tokio::test]
     async fn handle_hook_batch_returns_429_when_saturated() {
         let tmp = TempDir::new().unwrap();
         let mut state = make_state(&tmp).await;
@@ -1693,6 +1830,69 @@ mod tests {
         .await
         .into_response();
         assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn handle_hook_batch_drops_subagent_events_before_capacity_check() {
+        let tmp = TempDir::new().unwrap();
+        let mut state = make_state(&tmp).await;
+        state.ingest_semaphore = Arc::new(tokio::sync::Semaphore::new(0));
+
+        let response = handle_hook_batch(
+            State(Arc::new(state)),
+            None,
+            Json(vec![HookBatchItem {
+                url: "http://h/hook?event=pre-tool-use&agent=grok&drop_subagent=1".into(),
+                body: serde_json::json!({
+                    "sessionId": "saturated-subagent", "subagentType": "general-purpose"
+                }),
+            }]),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let ack: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            ack["accepted"], 1,
+            "droppable subagent batch items should clear the spool even when ingest capacity is saturated"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_hook_batch_saturated_after_prefix_reports_accepted_prefix() {
+        let tmp = TempDir::new().unwrap();
+        let mut state = make_state(&tmp).await;
+        state.ingest_semaphore = Arc::new(tokio::sync::Semaphore::new(0));
+
+        let response = handle_hook_batch(
+            State(Arc::new(state)),
+            None,
+            Json(vec![
+                HookBatchItem {
+                    url: "http://h/hook?event=pre-tool-use&agent=grok&drop_subagent=1".into(),
+                    body: serde_json::json!({
+                        "sessionId": "saturated-prefix", "subagentType": "general-purpose"
+                    }),
+                },
+                HookBatchItem {
+                    url: "http://h/hook?event=user-prompt-submit&agent=grok".into(),
+                    body: serde_json::json!({
+                        "sessionId": "saturated-prefix", "prompt": "retry later"
+                    }),
+                },
+            ]),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let ack: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(ack["accepted"], 1, "429 still reports the committed prefix");
     }
 
     #[tokio::test]
@@ -1719,7 +1919,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_hook_batch_acquires_capacity_per_item() {
+    async fn handle_hook_batch_processes_sequentially_with_one_permit() {
         let tmp = TempDir::new().unwrap();
         let mut state = make_state(&tmp).await;
         state.ingest_semaphore = Arc::new(tokio::sync::Semaphore::new(1));
@@ -1738,7 +1938,15 @@ mod tests {
             .await
             .into_response();
 
-        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let ack: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            ack["accepted"], 2,
+            "batch processing is sequential, so one permit is enough for processed items"
+        );
     }
 
     #[test]

--- a/crates/ai-memory-mcp/tests/autoscope_multiuser.rs
+++ b/crates/ai-memory-mcp/tests/autoscope_multiuser.rs
@@ -19,7 +19,8 @@
 
 use ai_memory_core::{ActiveProject, ActiveProjectMode, ActorContext, NewUser, Tier};
 use ai_memory_hooks::{
-    DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT, HookState, ProjectCacheStore, hook_router,
+    DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT, HookState, ProjectCacheStore, SubagentSessionSet,
+    hook_router,
 };
 use ai_memory_mcp::AiMemoryServer;
 use ai_memory_store::{Store, TokenPepper, generate_token, hash_token};
@@ -157,6 +158,7 @@ impl MultiUserHarness {
                 DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT,
             )),
             consolidate_on_session_end: false,
+            subagent_sessions: Arc::new(tokio::sync::Mutex::new(SubagentSessionSet::default())),
             home_dir: None,
         });
 

--- a/crates/ai-memory-mcp/tests/autoscope_stress.rs
+++ b/crates/ai-memory-mcp/tests/autoscope_stress.rs
@@ -19,7 +19,8 @@
 
 use ai_memory_core::{ActiveProject, ActiveProjectMode, ActorContext};
 use ai_memory_hooks::{
-    DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT, HookState, ProjectCacheStore, hook_router,
+    DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT, HookState, ProjectCacheStore, SubagentSessionSet,
+    hook_router,
 };
 use ai_memory_mcp::AiMemoryServer;
 use ai_memory_store::Store;
@@ -156,6 +157,7 @@ impl Harness {
                 DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT,
             )),
             consolidate_on_session_end: false,
+            subagent_sessions: Arc::new(tokio::sync::Mutex::new(SubagentSessionSet::default())),
             home_dir: None,
         });
 

--- a/docs/marker-file.md
+++ b/docs/marker-file.md
@@ -33,7 +33,8 @@ handoff lookups.
 The marker path is shared by the POSIX/PowerShell hook scripts and the
 generated OpenCode / OMP / OpenClaw TypeScript integrations. In all cases,
 hook capture and handoff lookup send the same `cwd`, `workspace`, `project`,
-and `project_strategy` query params to the server when a marker is present;
+`project_strategy`, and `drop_subagent` query params to the server when a
+marker is present;
 handoff lookup also sends `cwd` when no marker exists so the default
 `project = basename(cwd)` route works consistently.
 
@@ -53,6 +54,14 @@ project = "pe-portais"
 # linked worktrees and subdirectories share one project. Ignored when
 # `project` is present.
 project_strategy = "repo-root"
+
+# Optional. Opt this project into drop_subagent_captures: set it to "true"
+# and the server accepts but does NOT store this project's subagent-session
+# captures. A multi-agent harness fans one goal out to many subagent
+# sessions whose per-event captures can flood a small instance; scoping the
+# opt-in here keeps the drop from affecting other projects on the same
+# server. Off by default (absent / "false").
+drop_subagent_captures = "true"
 ```
 
 **Naming rules** for `workspace` and `project`, validated server-side:
@@ -66,6 +75,13 @@ defensively but the server's regex is the source of truth.
 
 `project_strategy` accepts `repo-root` (or `repo_root`) only. Unknown
 values are ignored and behave like the default `basename(cwd)` strategy.
+
+`drop_subagent_captures` accepts a truthy string (`"true"` / `"1"` /
+`"yes"` / `"on"`); any other value, or its absence, leaves this project's
+subagent captures stored as usual. Top-level (non-subagent) sessions are
+always stored regardless. This is per-project on purpose: there is no
+server-global switch, so opting one noisy project in never sheds subagent
+captures for the others on a shared instance.
 
 ## Four canonical examples
 

--- a/hooks/_lib.sh
+++ b/hooks/_lib.sh
@@ -104,11 +104,13 @@ ai_memory_marker_qs() {
     ws=""
     pr=""
     st=""
+    ds=""
     marker=$(ai_memory_find_marker "$cwd")
     if [ -n "$marker" ]; then
         ws=$(ai_memory_parse_toml_key "$marker" workspace)
         pr=$(ai_memory_parse_toml_key "$marker" project)
         st=$(ai_memory_parse_toml_key "$marker" project_strategy)
+        ds=$(ai_memory_parse_toml_key "$marker" drop_subagent_captures)
     fi
     # Install-time default baked into the hook command by
     # `install-hooks --project-strategy` fills the strategy only when no marker
@@ -130,6 +132,9 @@ ai_memory_marker_qs() {
     [ -n "$ws" ] && qs="${qs}&workspace=$(ai_memory_url_encode "$ws")"
     [ -n "$pr" ] && qs="${qs}&project=$(ai_memory_url_encode "$pr")"
     [ -n "$st" ] && qs="${qs}&project_strategy=$(ai_memory_url_encode "$st")"
+    # Per-project drop_subagent_captures opt-in: forward to the server, which
+    # interprets truthiness (1/true/...) and scopes the drop to this project.
+    [ -n "$ds" ] && qs="${qs}&drop_subagent=$(ai_memory_url_encode "$ds")"
     printf '%s' "$qs"
 }
 

--- a/hooks/claude-code/subagent-start.ps1
+++ b/hooks/claude-code/subagent-start.ps1
@@ -1,0 +1,3 @@
+. "$PSScriptRoot\..\lib\ai-memory-hook.ps1"
+Invoke-AiMemoryHook -Event "subagent-start" -Agent "claude-code"
+exit 0

--- a/hooks/claude-code/subagent-start.sh
+++ b/hooks/claude-code/subagent-start.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Claude Code subagent-start hook — forwards the event so the server can seed
+# the subagent's session id for drop_subagent_captures (so the whole nested
+# session, incl. the unmarked tail, is dropped). Mirrors stop.sh.
+_lib_dir="$(dirname "$0")"
+[ -f "$_lib_dir/_lib.sh" ] || _lib_dir="$_lib_dir/.."
+. "$_lib_dir/_lib.sh"
+
+SERVER="${AI_MEMORY_HOOK_URL:-http://127.0.0.1:49374}"
+PAYLOAD=$(cat)
+CWD=$(ai_memory_extract_cwd "$PAYLOAD")
+QS=$(ai_memory_marker_qs "$CWD")
+
+printf '%s' "$PAYLOAD" \
+    | ai_memory_post_hook "$SERVER/hook?event=subagent-start&agent=claude-code${QS}" >/dev/null 2>&1 || true
+printf '{}\n'
+exit 0

--- a/hooks/claude-code/subagent-stop.ps1
+++ b/hooks/claude-code/subagent-stop.ps1
@@ -1,0 +1,3 @@
+. "$PSScriptRoot\..\lib\ai-memory-hook.ps1"
+Invoke-AiMemoryHook -Event "subagent-stop" -Agent "claude-code"
+exit 0

--- a/hooks/claude-code/subagent-stop.sh
+++ b/hooks/claude-code/subagent-stop.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Claude Code subagent-stop hook — forwards the event so the server can forget
+# the subagent's session id (drop_subagent_captures). Mirrors stop.sh.
+_lib_dir="$(dirname "$0")"
+[ -f "$_lib_dir/_lib.sh" ] || _lib_dir="$_lib_dir/.."
+. "$_lib_dir/_lib.sh"
+
+SERVER="${AI_MEMORY_HOOK_URL:-http://127.0.0.1:49374}"
+PAYLOAD=$(cat)
+CWD=$(ai_memory_extract_cwd "$PAYLOAD")
+QS=$(ai_memory_marker_qs "$CWD")
+
+printf '%s' "$PAYLOAD" \
+    | ai_memory_post_hook "$SERVER/hook?event=subagent-stop&agent=claude-code${QS}" >/dev/null 2>&1 || true
+printf '{}\n'
+exit 0

--- a/hooks/grok/subagent-start.ps1
+++ b/hooks/grok/subagent-start.ps1
@@ -1,0 +1,3 @@
+. "$PSScriptRoot\..\lib\ai-memory-hook.ps1"
+Invoke-AiMemoryHook -Event "subagent-start" -Agent "grok"
+exit 0

--- a/hooks/grok/subagent-start.sh
+++ b/hooks/grok/subagent-start.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Grok Build CLI subagent-start hook — forwards the event so the server can seed
+# the subagent's session id for drop_subagent_captures (so the whole nested
+# session, incl. the unmarked tail, is dropped). Mirrors stop.sh.
+_lib_dir="$(dirname "$0")"
+[ -f "$_lib_dir/_lib.sh" ] || _lib_dir="$_lib_dir/.."
+. "$_lib_dir/_lib.sh"
+
+SERVER="${AI_MEMORY_HOOK_URL:-http://127.0.0.1:49374}"
+PAYLOAD=$(cat)
+CWD=$(ai_memory_extract_cwd "$PAYLOAD")
+QS=$(ai_memory_marker_qs "$CWD")
+
+printf '%s' "$PAYLOAD" \
+    | ai_memory_post_hook "$SERVER/hook?event=subagent-start&agent=grok${QS}" >/dev/null 2>&1 || true
+printf '{}\n'
+exit 0

--- a/hooks/grok/subagent-stop.ps1
+++ b/hooks/grok/subagent-stop.ps1
@@ -1,0 +1,3 @@
+. "$PSScriptRoot\..\lib\ai-memory-hook.ps1"
+Invoke-AiMemoryHook -Event "subagent-stop" -Agent "grok"
+exit 0

--- a/hooks/grok/subagent-stop.sh
+++ b/hooks/grok/subagent-stop.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Grok Build CLI subagent-stop hook — forwards the event so the server can forget
+# the subagent's session id (drop_subagent_captures). Mirrors stop.sh.
+_lib_dir="$(dirname "$0")"
+[ -f "$_lib_dir/_lib.sh" ] || _lib_dir="$_lib_dir/.."
+. "$_lib_dir/_lib.sh"
+
+SERVER="${AI_MEMORY_HOOK_URL:-http://127.0.0.1:49374}"
+PAYLOAD=$(cat)
+CWD=$(ai_memory_extract_cwd "$PAYLOAD")
+QS=$(ai_memory_marker_qs "$CWD")
+
+printf '%s' "$PAYLOAD" \
+    | ai_memory_post_hook "$SERVER/hook?event=subagent-stop&agent=grok${QS}" >/dev/null 2>&1 || true
+printf '{}\n'
+exit 0

--- a/hooks/lib/ai-memory-hook.ps1
+++ b/hooks/lib/ai-memory-hook.ps1
@@ -71,11 +71,13 @@ function Get-AiMemoryMarkerQuery {
     $ws = $null
     $proj = $null
     $strategy = $null
+    $dropSubagent = $null
     $marker = Get-AiMemoryMarkerToml -Cwd $Cwd
     if ($marker) {
         $ws = Get-AiMemoryTomlKey -File $marker -Key "workspace"
         $proj = Get-AiMemoryTomlKey -File $marker -Key "project"
         $strategy = Get-AiMemoryTomlKey -File $marker -Key "project_strategy"
+        $dropSubagent = Get-AiMemoryTomlKey -File $marker -Key "drop_subagent_captures"
     }
     # Install-time default baked into the hook command by
     # `install-hooks --project-strategy` fills the strategy only when no marker
@@ -91,6 +93,9 @@ function Get-AiMemoryMarkerQuery {
     if ($ws) { $qs += "&workspace=$([uri]::EscapeDataString($ws))" }
     if ($proj) { $qs += "&project=$([uri]::EscapeDataString($proj))" }
     if ($strategy) { $qs += "&project_strategy=$([uri]::EscapeDataString($strategy))" }
+    # Per-project drop_subagent_captures opt-in: forward to the server, which
+    # interprets truthiness (1/true/...) and scopes the drop to this project.
+    if ($dropSubagent) { $qs += "&drop_subagent=$([uri]::EscapeDataString($dropSubagent))" }
     return $qs
 }
 


### PR DESCRIPTION
## Summary

A **per-project, opt-in** control for the hook ingest path, for high-fan-out agent workloads. A multi-agent harness (e.g. Claude Code's Task tool, grok subagents) fans one goal out to many independent subagent sessions, each firing the full lifecycle hook stream. On a small shared instance that flood can saturate ingest and bloat the store with low-value captures. The opt-in is **scoped to the project that asks for it** — there is no server-global switch, so enabling it for a noisy project never sheds subagent captures for every other project on the instance.

## How it works

A project enables the drop in its `.ai-memory.toml`:

```toml
drop_subagent_captures = "true"
```

The host-side hook already walks up to the nearest `.ai-memory.toml` and forwards `workspace` / `project` / `project_strategy` as query parameters on each event; this adds `drop_subagent` to that set (POSIX and PowerShell hook libs). The server then, **for that project's events only**:

- **Accepts but does not persist** subagent-session captures, keeping only top-level sessions. Captures are accepted (HTTP 202, and they count toward the `/hook/batch` contiguous-prefix ack) so clients do not retry or spool them.
- **Detection** — a per-event marker (`subagentType` for grok; `agent_type` / `agent_id` for Claude Code) plus stateful, bounded tracking of subagent session ids. The marker only rides tool-use events, so the session-level tail (`user_prompt_submit` / `stop` / `session_end`) carries no marker and would otherwise leak through. The router seeds a capped LRU set of subagent session ids from any marked event and from the newly registered `SubagentStart` / `SubagentStop` lifecycle hooks, drops every event of a tracked session, and clears the id on `SubagentStop`.
- **Hooks** — `install-hooks` registers `subagent-start` / `subagent-stop` for claude-code and grok (POSIX + PowerShell templates; other agents unchanged).

## Notes

- Only the ingest/hook layer is touched — the observation store / retention path is untouched. The server stays authoritative: the marker file only forwards the project's opt-in declaration (exactly like `workspace`/`project`), and the server makes every drop decision.
- The ingest semaphore (HTTP 429 on saturation) remains the load backstop; this flag sheds the store/embed/synthesis cost of a project's subagent captures, it is not a rate limiter.
- Tests: router unit tests for accept-but-drop, the unmarked-tail drop, `SubagentStart` seeding, and that a project without the opt-in keeps its captures; host-side tests that the marker forwards (and omits) the `drop_subagent` flag; the bundled POSIX/PowerShell hook parity test covers the new templates.
