### PR TITLE
Windows: make Git Bash and Git-backed tests pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Native Windows/Git Bash installs now normalize hook cwd, stored project
+  `repo_path`, and the home-directory guard consistently across slash styles,
+  including legacy rows persisted with backslashes. `AI_MEMORY_HOME` now feeds
+  the same home guard as `$HOME`, and Git-backed helpers preserve bare-repo
+  fallback semantics while limiting CLI git fallbacks to path/open failures.
+
 ## [1.4.1] - 2026-06-28
 
 ## [1.4.0] - 2026-06-26

--- a/README.md
+++ b/README.md
@@ -300,8 +300,10 @@ one matching entry.
 ### Install Notes
 
 - **Windows:** use the Linux path inside WSL2, or the native Windows wrapper
-  from PowerShell/cmd. Native Claude Code uses Git Bash `.sh` hooks; other
-  script-hook agents use PowerShell defaults. Do not mix path worlds. See
+  from PowerShell/cmd. Native Claude Code uses direct `ai-memory.exe hook`
+  commands by default, with `AI_MEMORY_HOOK_PLATFORM=windows-bash` available for
+  Git Bash `.sh` hooks; other script-hook agents use PowerShell defaults. Do not
+  mix path worlds. See
   [`docs/windows.md`](docs/windows.md).
 - **Docker compose:** `docker compose -f docker/docker-compose.yml up -d`
   is supported; agent setup is the same as step 3 above.

--- a/crates/ai-memory-cli/src/commands/hook_capture.rs
+++ b/crates/ai-memory-cli/src/commands/hook_capture.rs
@@ -9,6 +9,8 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use crate::commands::path_util::home_dir;
+
 /// First top-level `cwd` string in the payload (parity with
 /// `ai_memory_extract_cwd`: take the top-level value, ignore nested
 /// `cwd` fields in tool payloads).
@@ -87,7 +89,7 @@ fn repo_root_project(cwd: &str) -> Option<String> {
 /// user's declaration on shared machines (parity with
 /// `ai_memory_find_marker`).
 fn find_marker(cwd: &str) -> Option<PathBuf> {
-    let home = dirs::home_dir();
+    let home = home_dir();
     let mut dir = Path::new(cwd);
     loop {
         let candidate = dir.join(".ai-memory.toml");

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -23,6 +23,7 @@ use crate::cli::{AgentChoice, InstallHooksArgs, McpClient};
 use crate::commands::apply_shared::{ApplyOutcome, apply_atomic, mutate_json};
 use crate::commands::install_mcp;
 use crate::commands::openclaw_plugin;
+use crate::commands::path_util::home_dir;
 use crate::commands::render_shared::{
     CURSOR_PROFILE, GEMINI_PROFILE, build_antigravity_payload_with_data_dir,
     build_claude_code_payload_with_data_dir, build_grok_payload_with_data_dir,
@@ -33,7 +34,7 @@ use crate::config::{Config, DEFAULT_SERVER_URL};
 
 /// `~/.claude/settings.json` — Claude Code hooks live under `hooks`.
 pub(crate) fn claude_settings_path() -> anyhow::Result<std::path::PathBuf> {
-    Ok(dirs::home_dir()
+    Ok(home_dir()
         .context("could not locate $HOME for ~/.claude/settings.json")?
         .join(".claude")
         .join("settings.json"))
@@ -41,7 +42,7 @@ pub(crate) fn claude_settings_path() -> anyhow::Result<std::path::PathBuf> {
 
 /// `~/.codex/hooks.json`.
 pub(crate) fn codex_hooks_path() -> anyhow::Result<std::path::PathBuf> {
-    Ok(dirs::home_dir()
+    Ok(home_dir()
         .context("could not locate $HOME for ~/.codex/hooks.json")?
         .join(".codex")
         .join("hooks.json"))
@@ -49,7 +50,7 @@ pub(crate) fn codex_hooks_path() -> anyhow::Result<std::path::PathBuf> {
 
 /// `~/.cursor/hooks.json`.
 pub(crate) fn cursor_hooks_path() -> anyhow::Result<std::path::PathBuf> {
-    Ok(dirs::home_dir()
+    Ok(home_dir()
         .context("could not locate $HOME for ~/.cursor/hooks.json")?
         .join(".cursor")
         .join("hooks.json"))
@@ -57,7 +58,7 @@ pub(crate) fn cursor_hooks_path() -> anyhow::Result<std::path::PathBuf> {
 
 /// `~/.gemini/settings.json`.
 pub(crate) fn gemini_settings_path() -> anyhow::Result<std::path::PathBuf> {
-    Ok(dirs::home_dir()
+    Ok(home_dir()
         .context("could not locate $HOME for ~/.gemini/settings.json")?
         .join(".gemini")
         .join("settings.json"))
@@ -65,7 +66,7 @@ pub(crate) fn gemini_settings_path() -> anyhow::Result<std::path::PathBuf> {
 
 /// `~/.gemini/config/hooks.json` — Antigravity CLI lifecycle hooks.
 pub(crate) fn antigravity_hooks_path() -> anyhow::Result<std::path::PathBuf> {
-    Ok(dirs::home_dir()
+    Ok(home_dir()
         .context("could not locate $HOME for ~/.gemini/config/hooks.json")?
         .join(".gemini")
         .join("config")
@@ -74,7 +75,7 @@ pub(crate) fn antigravity_hooks_path() -> anyhow::Result<std::path::PathBuf> {
 
 /// `~/.grok/hooks/ai-memory.json` — Grok Build CLI lifecycle hooks.
 pub(crate) fn grok_hooks_path() -> anyhow::Result<std::path::PathBuf> {
-    Ok(dirs::home_dir()
+    Ok(home_dir()
         .context("could not locate $HOME for ~/.grok/hooks/ai-memory.json")?
         .join(".grok")
         .join("hooks")
@@ -83,7 +84,7 @@ pub(crate) fn grok_hooks_path() -> anyhow::Result<std::path::PathBuf> {
 
 /// `~/.config/opencode/plugins/ai-memory.ts` — OpenCode's plugin file.
 pub(crate) fn opencode_plugin_path() -> anyhow::Result<std::path::PathBuf> {
-    Ok(dirs::home_dir()
+    Ok(home_dir()
         .context("could not locate $HOME for ~/.config/opencode")?
         .join(".config")
         .join("opencode")
@@ -93,7 +94,7 @@ pub(crate) fn opencode_plugin_path() -> anyhow::Result<std::path::PathBuf> {
 
 /// `~/.omp/agent/extensions/ai-memory.ts` — OMP lifecycle extension.
 pub(crate) fn omp_extension_path() -> anyhow::Result<std::path::PathBuf> {
-    Ok(dirs::home_dir()
+    Ok(home_dir()
         .context("could not locate $HOME for ~/.omp/agent/extensions")?
         .join(".omp")
         .join("agent")
@@ -2074,9 +2075,38 @@ mod tests {
     use crate::cli::ProjectStrategyArg;
     use std::collections::BTreeMap;
     use std::fs;
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     use std::process::Command;
     use tempfile::TempDir;
+
+    #[cfg(unix)]
+    fn bash_program_for_installer_test() -> Option<std::path::PathBuf> {
+        Some(std::path::PathBuf::from("bash"))
+    }
+
+    #[cfg(windows)]
+    fn bash_program_for_installer_test() -> Option<std::path::PathBuf> {
+        let mut candidates = Vec::new();
+        if let Some(root) = std::env::var_os("EXEPATH") {
+            let root = std::path::PathBuf::from(root);
+            candidates.push(root.join("bin").join("bash.exe"));
+            candidates.push(root.join("usr").join("bin").join("bash.exe"));
+        }
+        for env_key in ["ProgramFiles", "ProgramW6432", "ProgramFiles(x86)"] {
+            if let Some(root) = std::env::var_os(env_key) {
+                let root = std::path::PathBuf::from(root).join("Git");
+                candidates.push(root.join("bin").join("bash.exe"));
+                candidates.push(root.join("usr").join("bin").join("bash.exe"));
+            }
+        }
+        candidates.sort();
+        candidates.dedup();
+        let found = candidates.into_iter().find(|candidate| candidate.is_file());
+        if found.is_none() {
+            eprintln!("skipping installer shell contract: Git for Windows bash.exe was not found");
+        }
+        found
+    }
 
     #[test]
     fn overlay_event_hooks_preserves_third_party_and_replaces_own() {
@@ -2927,7 +2957,11 @@ model = "gpt-5"
         );
     }
 
-    #[cfg(unix)]
+    // Windows 11 + Git Bash support matters for regulated enterprise setups
+    // where Git Bash is the approved shell available from the corporate
+    // repository, so this installer contract should be exercised anywhere
+    // Bash is the supported execution surface.
+    #[cfg(any(unix, windows))]
     #[test]
     fn curl_installer_accepts_generated_integration_agents() {
         let script = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -2935,9 +2969,12 @@ model = "gpt-5"
             .join("..")
             .join("scripts")
             .join("install-hooks.sh");
+        let Some(bash) = bash_program_for_installer_test() else {
+            return;
+        };
 
         for alias in ["opencode", "openclaw", "pi", "oh-my-pi"] {
-            let output = Command::new("bash")
+            let output = Command::new(&bash)
                 .arg(&script)
                 .arg("--agent")
                 .arg(alias)

--- a/crates/ai-memory-cli/src/commands/install_mcp.rs
+++ b/crates/ai-memory-cli/src/commands/install_mcp.rs
@@ -21,6 +21,7 @@ use serde_json::json;
 
 use crate::cli::{InstallMcpArgs, McpClient};
 use crate::commands::apply_shared::{ApplyOutcome, apply_atomic, mutate_json, mutate_toml};
+use crate::commands::path_util::home_dir;
 use crate::commands::render_shared::bearer_header_value;
 use crate::config::{Config, DEFAULT_MCP_URL};
 
@@ -97,7 +98,7 @@ fn mcp_server_url_from_base(server_url: &str) -> String {
 /// unsupported OSes, or when `$HOME` can't be resolved.
 pub(crate) fn mcp_config_path(client: crate::cli::McpClient) -> Result<PathBuf> {
     use crate::cli::McpClient;
-    let home = || dirs::home_dir().context("could not locate $HOME for config-file auto-detect");
+    let home = || home_dir().context("could not locate $HOME for config-file auto-detect");
     Ok(match client {
         // Claude Code reads MCP-server registrations from `~/.claude.json`
         // (the same file `claude mcp add`/`claude mcp list` operate on).

--- a/crates/ai-memory-cli/src/commands/install_skills.rs
+++ b/crates/ai-memory-cli/src/commands/install_skills.rs
@@ -10,6 +10,7 @@ use anyhow::{Context, Result, bail};
 
 use crate::cli::{InstallSkillsAgent, InstallSkillsArgs, InstallSkillsScope};
 use crate::commands::apply_shared::{ApplyOutcome, apply_atomic};
+use crate::commands::path_util::home_dir;
 use crate::config::Config;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -79,7 +80,7 @@ fn print_reports(reports: Vec<InstallReport>) {
 
 fn resolve_target_roots_from_env(args: &InstallSkillsArgs) -> Result<Vec<TargetRoot>> {
     let cwd = std::env::current_dir().context("getting CWD for install-skills target")?;
-    let home = dirs::home_dir();
+    let home = home_dir();
     resolve_target_roots(args, &cwd, home.as_deref())
 }
 

--- a/crates/ai-memory-cli/src/commands/path_util.rs
+++ b/crates/ai-memory-cli/src/commands/path_util.rs
@@ -1,6 +1,18 @@
 //! Path helpers shared by command renderers and hook capture.
 
 use std::borrow::Cow;
+use std::path::PathBuf;
+
+/// Resolve the user home used for agent configuration paths.
+///
+/// Tests and scripted wrappers can set `AI_MEMORY_HOME` to exercise the
+/// platform-specific config layout without touching the real user profile.
+pub(crate) fn home_dir() -> Option<PathBuf> {
+    if let Some(home) = std::env::var_os("AI_MEMORY_HOME").filter(|value| !value.is_empty()) {
+        return Some(PathBuf::from(home));
+    }
+    dirs::home_dir()
+}
 
 /// Strip only Windows verbatim path prefixes that are safe to render as plain
 /// paths. Unknown verbatim forms are left unchanged.

--- a/crates/ai-memory-cli/src/commands/render_shared.rs
+++ b/crates/ai-memory-cli/src/commands/render_shared.rs
@@ -885,8 +885,9 @@ mod tests {
             .pointer("/hooks/SessionStart/0/hooks/0/command")
             .and_then(|s| s.as_str())
             .unwrap();
+        let normalized = command.replace('\\', "/");
         assert!(
-            command.contains("/host/hooks/grok/session-start.sh"),
+            normalized.contains("/host/hooks/grok/session-start.sh"),
             "{command}"
         );
         assert!(!command.contains("claude-code"), "{command}");

--- a/crates/ai-memory-cli/src/commands/uninstall.rs
+++ b/crates/ai-memory-cli/src/commands/uninstall.rs
@@ -11,6 +11,7 @@ use crate::cli::UninstallArgs;
 use crate::commands::apply_shared::apply_atomic;
 use crate::commands::apply_shared::mutate_json;
 use crate::commands::apply_shared::mutate_toml;
+use crate::commands::path_util::home_dir;
 use crate::commands::{data_purge, install_hooks, install_mcp, openclaw_plugin};
 use crate::config::Config;
 use ai_memory_core::routing_skills::{
@@ -240,7 +241,7 @@ fn build_plan(args: &UninstallArgs) -> anyhow::Result<Vec<PlannedChange>> {
     // ---- Managed Agent Skills (project + global roots) ----
     if want(crate::cli::UninstallOnly::Skills) {
         let cwd = std::env::current_dir().context("getting CWD for skill removal")?;
-        let home = dirs::home_dir();
+        let home = home_dir();
         for root in skill_roots(&cwd, home.as_deref()) {
             for skill in MANAGED_SKILLS {
                 push_generated_delete(

--- a/crates/ai-memory-cli/src/config.rs
+++ b/crates/ai-memory-cli/src/config.rs
@@ -66,10 +66,10 @@ pub struct Config {
     #[serde(default)]
     pub base_path: String,
     /// Operator home directory, captured once here (the single config-read
-    /// path) from `$HOME`. Used to keep the cwd->project resolver and the
+    /// path) from `AI_MEMORY_HOME` or `$HOME`. Used to keep the cwd->project resolver and the
     /// startup heal from treating `$HOME` as a prefix-match catch-all
     /// (issue #103) without env reads scattered through the runtime. Not a
-    /// config.toml / env key: always derived from `$HOME` at load.
+    /// config.toml key: always derived from the process environment at load.
     #[serde(skip)]
     pub home_dir: Option<String>,
     /// Per-subsystem log filter (overridable by `RUST_LOG`).
@@ -182,6 +182,7 @@ pub struct Config {
 #[derive(Debug, Clone, Default)]
 pub struct RuntimeEnv {
     data_dir: Option<PathBuf>,
+    home_dir: Option<String>,
     server_url: Option<String>,
     auth_token: Option<String>,
     host_cwd: Option<String>,
@@ -202,6 +203,7 @@ impl RuntimeEnv {
     fn from_process() -> Self {
         Self {
             data_dir: env_path("AI_MEMORY_DATA_DIR"),
+            home_dir: env_string("AI_MEMORY_HOME").or_else(|| env_string("HOME")),
             server_url: env_string("AI_MEMORY_SERVER_URL"),
             auth_token: env_string("AI_MEMORY_AUTH_TOKEN"),
             host_cwd: env_string("AI_MEMORY_HOST_CWD"),
@@ -600,13 +602,11 @@ impl Config {
             config.admission_webhooks = parsed;
         }
 
-        // $HOME read once here (config-read-path invariant); threaded to the
-        // resolver guard and startup heal so neither reads the env directly.
-        // Normalized so a trailing slash can't slip a catch-all past the
-        // exact-match guards.
-        config.home_dir = std::env::var("HOME")
-            .ok()
-            .and_then(|home| normalize_home_dir(&home));
+        // Home is captured once in RuntimeEnv (config-read-path invariant);
+        // threaded to the resolver guard and startup heal so neither reads the
+        // env directly. AI_MEMORY_HOME is accepted for tests/wrappers that need
+        // to emulate a host home distinct from the process HOME.
+        config.home_dir = runtime_env.home_dir.as_deref().and_then(normalize_home_dir);
 
         // CLI override always wins (figment doesn't see it because clap has
         // already parsed the flag into `cli_data_dir`).
@@ -892,12 +892,14 @@ fn canonicalise_or_keep(p: &Path) -> PathBuf {
     p.to_path_buf()
 }
 
-/// Normalize `$HOME` for prefix-match comparisons: strip trailing separators
+/// Normalize home for prefix-match comparisons: accept either slash spelling,
+/// strip trailing separators,
 /// so a stored `repo_path` of `/home/u` still equals a `$HOME` of `/home/u/`
 /// (the cwd side is trimmed the same way in `find_project_by_cwd_prefix`).
 /// All-separator or empty input yields `None` (no usable home).
 fn normalize_home_dir(home: &str) -> Option<String> {
-    let trimmed = home.trim_end_matches('/');
+    let normalized = home.replace('\\', "/");
+    let trimmed = normalized.trim_end_matches('/');
     (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
@@ -975,13 +977,15 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let cli_dir = tmp.path().join("override");
         let cfg = Config::load(None, Some(cli_dir)).unwrap();
-        // `home_dir` is derived from `$HOME` at load (the single config-read
-        // path), normalized so a trailing slash can't bypass the catch-all
-        // guards. Reading the env in a test is allowed; this fails if the
-        // load-time assignment is dropped while `$HOME` is set.
+        // `home_dir` is derived from AI_MEMORY_HOME or `$HOME` at load (the
+        // single config-read path), normalized so a trailing slash can't bypass
+        // the catch-all guards. Reading the env in a test is allowed; this
+        // fails if the load-time assignment is dropped while either env var is
+        // set.
         assert_eq!(
             cfg.home_dir,
-            std::env::var("HOME")
+            std::env::var("AI_MEMORY_HOME")
+                .or_else(|_| std::env::var("HOME"))
                 .ok()
                 .and_then(|h| normalize_home_dir(&h))
         );
@@ -994,6 +998,10 @@ mod tests {
         assert_eq!(
             normalize_home_dir("/home/u///"),
             Some("/home/u".to_string())
+        );
+        assert_eq!(
+            normalize_home_dir(r"C:\Users\tester\"),
+            Some("C:/Users/tester".to_string())
         );
         // Degenerate inputs yield no usable home rather than an empty or
         // root-collapsing prefix key.

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -17,6 +17,41 @@ fn read_repo(path: &str) -> String {
         .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))
 }
 
+fn shell_script_command(script: &Path) -> Command {
+    #[cfg(windows)]
+    {
+        let mut command = Command::new("bash");
+        command.arg(script);
+        command
+    }
+
+    #[cfg(not(windows))]
+    {
+        Command::new(script)
+    }
+}
+
+fn shell_path(path: &Path) -> String {
+    #[cfg(windows)]
+    {
+        let path = path.display().to_string().replace('\\', "/");
+        if path.len() >= 3 && path.as_bytes()[1] == b':' {
+            format!(
+                "/{}/{}",
+                path[..1].to_ascii_lowercase(),
+                path[3..].trim_start_matches('/')
+            )
+        } else {
+            path
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        path.display().to_string()
+    }
+}
+
 fn run_wrapper_on_fake_macos(args: &[&str]) -> String {
     let tmp = tempfile::tempdir().unwrap();
     let docker_args = tmp.path().join("docker-args.txt");
@@ -26,7 +61,7 @@ fn run_wrapper_on_fake_macos(args: &[&str]) -> String {
         &docker,
         format!(
             "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\" > {}\n",
-            docker_args.display()
+            shell_path(&docker_args)
         ),
     )
     .unwrap();
@@ -40,16 +75,17 @@ fn run_wrapper_on_fake_macos(args: &[&str]) -> String {
 
     let path = format!(
         "{}:{}",
-        tmp.path().display(),
+        shell_path(tmp.path()),
         std::env::var("PATH").unwrap_or_default()
     );
-    let output = Command::new(repo_root().join("bin/ai-memory"))
+    let mut command = shell_script_command(&repo_root().join("bin/ai-memory"));
+    let output = command
         .args(args)
         .env("PATH", path)
-        .env("AI_MEMORY_DOCKER", &docker)
+        .env("AI_MEMORY_DOCKER", shell_path(&docker))
         .env("AI_MEMORY_NO_VERSION_CHECK", "1")
         .env("AI_MEMORY_DATA_VOLUME", "test-ai-memory-data")
-        .env("HOME", tmp.path())
+        .env("HOME", shell_path(tmp.path()))
         .env_remove("AI_MEMORY_SERVER_URL")
         .output()
         .unwrap();

--- a/crates/ai-memory-cli/tests/removal.rs
+++ b/crates/ai-memory-cli/tests/removal.rs
@@ -1,4 +1,4 @@
-//! End-to-end: install hooks into a temp HOME, then uninstall, and
+//! End-to-end: add hooks into a temp HOME, then remove them, and
 //! assert the file round-trips (our entries gone, third-party intact).
 
 use std::path::Path;
@@ -17,14 +17,35 @@ fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_ai-memory")
 }
 
+fn command_with_home(home: &Path) -> Command {
+    let mut command = Command::new(bin());
+    let config_home = home.join(".config");
+    let data_home = home.join(".local/share");
+    let app_data = home.join("AppData/Roaming");
+    let local_app_data = home.join("AppData/Local");
+    for dir in [&config_home, &data_home, &app_data, &local_app_data] {
+        std::fs::create_dir_all(dir).unwrap();
+    }
+    command
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("XDG_CONFIG_HOME", config_home)
+        .env("XDG_DATA_HOME", data_home)
+        .env("APPDATA", app_data)
+        .env("LOCALAPPDATA", local_app_data)
+        .env("AI_MEMORY_HOME", home)
+        .env("AI_MEMORY_DATA_DIR", home.join(".ai-memory-data"));
+    command
+}
+
+fn normalize_path_text(value: impl AsRef<str>) -> String {
+    value.as_ref().replace('\\', "/")
+}
+
 fn run_uninstall(project: &Path, home: &Path, args: &[&str]) -> std::process::Output {
-    Command::new(bin())
+    command_with_home(home)
         .args(args)
         .current_dir(project)
-        .env("HOME", home)
-        .env("XDG_CONFIG_HOME", home.join(".config"))
-        .env("XDG_DATA_HOME", home.join(".local/share"))
-        .env("AI_MEMORY_DATA_DIR", home.join(".ai-memory-data"))
         .output()
         .unwrap()
 }
@@ -55,21 +76,15 @@ fn install_then_uninstall_round_trip_claude_hooks() {
     .unwrap();
 
     // Install ai-memory hooks for Claude Code.
-    let status = Command::new(bin())
+    let status = command_with_home(home.path())
         .args(["install-hooks", "--agent", "claude-code", "--apply"])
-        .env("HOME", home.path())
-        .env("XDG_DATA_HOME", home.path().join(".local/share"))
-        .env("AI_MEMORY_DATA_DIR", home.path().join(".ai-memory-data"))
         .status()
         .unwrap();
     assert!(status.success(), "install-hooks failed");
 
     // Uninstall (hooks only) and verify.
-    let status = Command::new(bin())
+    let status = command_with_home(home.path())
         .args(["uninstall", "--apply", "--only", "hooks", "--yes"])
-        .env("HOME", home.path())
-        .env("XDG_DATA_HOME", home.path().join(".local/share"))
-        .env("AI_MEMORY_DATA_DIR", home.path().join(".ai-memory-data"))
         .status()
         .unwrap();
     assert!(status.success(), "uninstall failed");
@@ -109,10 +124,8 @@ fn uninstall_apply_is_idempotent() {
     .unwrap();
 
     let run = || {
-        std::process::Command::new(bin())
+        command_with_home(home.path())
             .args(["uninstall", "--apply", "--only", "hooks", "--yes"])
-            .env("HOME", home.path())
-            .env("AI_MEMORY_DATA_DIR", home.path().join(".ai-memory-data"))
             .status()
             .unwrap()
     };
@@ -148,10 +161,8 @@ fn only_hooks_preserves_mcp_in_same_file() {
     )
     .unwrap();
 
-    let status = std::process::Command::new(bin())
+    let status = command_with_home(home.path())
         .args(["uninstall", "--apply", "--only", "hooks", "--yes"])
-        .env("HOME", home.path())
-        .env("AI_MEMORY_DATA_DIR", home.path().join(".ai-memory-data"))
         .status()
         .unwrap();
     assert!(status.success());
@@ -180,10 +191,8 @@ fn uninstall_preserves_user_opencode_plugin_at_ai_memory_path() {
     let original = "// user-owned plugin that happens to use this filename\nexport default {};\n";
     std::fs::write(&plugin, original).unwrap();
 
-    let status = Command::new(bin())
+    let status = command_with_home(home.path())
         .args(["uninstall", "--apply", "--only", "hooks", "--yes"])
-        .env("HOME", home.path())
-        .env("AI_MEMORY_DATA_DIR", home.path().join(".ai-memory-data"))
         .status()
         .unwrap();
     assert!(status.success(), "uninstall failed");
@@ -206,10 +215,8 @@ fn uninstall_deletes_generated_opencode_plugin_only() {
     let sibling = plugins.join("other.ts");
     std::fs::write(&sibling, "keep me\n").unwrap();
 
-    let status = Command::new(bin())
+    let status = command_with_home(home.path())
         .args(["uninstall", "--apply", "--only", "hooks", "--yes"])
-        .env("HOME", home.path())
-        .env("AI_MEMORY_DATA_DIR", home.path().join(".ai-memory-data"))
         .status()
         .unwrap();
     assert!(status.success(), "uninstall failed");
@@ -228,10 +235,8 @@ fn uninstall_omp_extension_deletes_only_generated_file() {
     let user_content = "// user-owned extension that happens to use this filename\n";
     std::fs::write(&extension, user_content).unwrap();
 
-    let status = Command::new(bin())
+    let status = command_with_home(home.path())
         .args(["uninstall", "--apply", "--only", "hooks", "--yes"])
-        .env("HOME", home.path())
-        .env("AI_MEMORY_DATA_DIR", home.path().join(".ai-memory-data"))
         .status()
         .unwrap();
     assert!(status.success(), "uninstall failed");
@@ -243,10 +248,8 @@ fn uninstall_omp_extension_deletes_only_generated_file() {
     )
     .unwrap();
 
-    let status = Command::new(bin())
+    let status = command_with_home(home.path())
         .args(["uninstall", "--apply", "--only", "hooks", "--yes"])
-        .env("HOME", home.path())
-        .env("AI_MEMORY_DATA_DIR", home.path().join(".ai-memory-data"))
         .status()
         .unwrap();
     assert!(status.success(), "uninstall failed");
@@ -264,11 +267,9 @@ fn uninstall_preserves_user_openclaw_package_at_ai_memory_path() {
     let original = r#"{"name":"@ai-memory/openclaw-plugin","private":true}"#;
     std::fs::write(&package, original).unwrap();
 
-    let status = Command::new(bin())
+    let status = command_with_home(home.path())
         .args(["uninstall", "--apply", "--only", "hooks", "--yes"])
-        .env("HOME", home.path())
         .env("XDG_DATA_HOME", &data)
-        .env("AI_MEMORY_DATA_DIR", home.path().join(".ai-memory-data"))
         .status()
         .unwrap();
     assert!(status.success(), "uninstall failed");
@@ -302,10 +303,8 @@ fn uninstall_antigravity_hooks_preserves_user_entries() {
     )
     .unwrap();
 
-    let status = Command::new(bin())
+    let status = command_with_home(home.path())
         .args(["uninstall", "--apply", "--only", "hooks", "--yes"])
-        .env("HOME", home.path())
-        .env("AI_MEMORY_DATA_DIR", home.path().join(".ai-memory-data"))
         .status()
         .unwrap();
     assert!(status.success(), "uninstall failed");
@@ -343,7 +342,7 @@ fn uninstall_mcp_custom_url_removes_antigravity_only_by_endpoint() {
     )
     .unwrap();
 
-    let status = Command::new(bin())
+    let status = command_with_home(home.path())
         .args([
             "uninstall",
             "--apply",
@@ -353,8 +352,6 @@ fn uninstall_mcp_custom_url_removes_antigravity_only_by_endpoint() {
             "http://lan:49374/mcp",
             "--yes",
         ])
-        .env("HOME", home.path())
-        .env("AI_MEMORY_DATA_DIR", home.path().join(".ai-memory-data"))
         .status()
         .unwrap();
     assert!(status.success(), "uninstall failed");
@@ -385,7 +382,7 @@ fn uninstall_mcp_name_narrows_endpoint_match() {
     )
     .unwrap();
 
-    let status = Command::new(bin())
+    let status = command_with_home(home.path())
         .args([
             "uninstall",
             "--apply",
@@ -395,8 +392,6 @@ fn uninstall_mcp_name_narrows_endpoint_match() {
             "ai-memory",
             "--yes",
         ])
-        .env("HOME", home.path())
-        .env("AI_MEMORY_DATA_DIR", home.path().join(".ai-memory-data"))
         .status()
         .unwrap();
     assert!(status.success(), "uninstall failed");
@@ -416,10 +411,8 @@ fn uninstall_dry_run_changes_nothing() {
     let original = r#"{"hooks":{"Stop":[{"matcher":"","hooks":[{"type":"command","command":"AI_MEMORY_HOOK_URL=x /a/stop.sh"}]}]}}"#;
     std::fs::write(claude.join("settings.json"), original).unwrap();
 
-    let status = Command::new(bin())
+    let status = command_with_home(home.path())
         .args(["uninstall", "--only", "hooks"]) // no --apply
-        .env("HOME", home.path())
-        .env("AI_MEMORY_DATA_DIR", home.path().join(".ai-memory-data"))
         .status()
         .unwrap();
     assert!(status.success());
@@ -506,13 +499,9 @@ fn install_skills_then_uninstall_only_skills_round_trips() {
     let project = tempfile::tempdir().unwrap();
     let home = tempfile::tempdir().unwrap();
 
-    let install = Command::new(bin())
+    let install = command_with_home(home.path())
         .args(["install-skills", "--scope", "project", "--agent", "both"])
         .current_dir(project.path())
-        .env("HOME", home.path())
-        .env("XDG_CONFIG_HOME", home.path().join(".config"))
-        .env("XDG_DATA_HOME", home.path().join(".local/share"))
-        .env("AI_MEMORY_DATA_DIR", home.path().join(".ai-memory-data"))
         .output()
         .unwrap();
     assert!(
@@ -558,17 +547,13 @@ fn uninstall_only_skills_leaves_custom_target_dir_for_manual_cleanup() {
     let home = tempfile::tempdir().unwrap();
     let custom_root = project.path().join("custom-skills");
 
-    let install = Command::new(bin())
+    let install = command_with_home(home.path())
         .args([
             "install-skills",
             "--target-dir",
             custom_root.to_str().unwrap(),
         ])
         .current_dir(project.path())
-        .env("HOME", home.path())
-        .env("XDG_CONFIG_HOME", home.path().join(".config"))
-        .env("XDG_DATA_HOME", home.path().join(".local/share"))
-        .env("AI_MEMORY_DATA_DIR", home.path().join(".ai-memory-data"))
         .output()
         .unwrap();
     assert!(
@@ -628,7 +613,8 @@ fn uninstall_skills_dry_run_reports_plan_without_mutating() {
         "stdout was: {stdout}"
     );
     assert!(
-        stdout.contains(&skill_path.display().to_string()),
+        normalize_path_text(&stdout)
+            .contains(&normalize_path_text(skill_path.display().to_string())),
         "stdout was: {stdout}"
     );
     assert_eq!(
@@ -650,9 +636,8 @@ fn uninstall_purge_data_apply_wipes() {
     std::fs::create_dir_all(data.path().join("logs")).unwrap();
     std::fs::write(data.path().join("logs/app.log"), b"l").unwrap();
 
-    let out = Command::new(bin())
+    let out = command_with_home(home.path())
         .args(["uninstall", "--apply", "--yes", "--purge-data"])
-        .env("HOME", home.path())
         .env("AI_MEMORY_DATA_DIR", data.path())
         // Exercises the WIPE, not the live-process guard; opt out so an
         // unrelated `ai-memory` on the machine can't make it flake. The
@@ -688,9 +673,8 @@ fn uninstall_dry_run_previews_purge() {
         std::fs::write(data.path().join(sub).join("f.txt"), b"x").unwrap();
     }
 
-    let out = Command::new(bin())
+    let out = command_with_home(home.path())
         .args(["uninstall", "--purge-data"]) // dry-run: no --apply
-        .env("HOME", home.path())
         .env("AI_MEMORY_DATA_DIR", data.path())
         // Dry-run still hits the purge guard before previewing; opt out so an
         // unrelated live `ai-memory` can't flake the preview.
@@ -715,7 +699,7 @@ fn uninstall_dry_run_previews_purge() {
 /// Best-effort, NOT in the default run (sysinfo reads the real process table;
 /// no injection seam). Spawns a real sibling `ai-memory` process and asserts
 /// `--purge-data` refuses up front, leaving the wiring intact. Run with:
-/// `cargo test -p ai-memory-cli --test uninstall -- --ignored`.
+/// `cargo test -p ai-memory-cli --test removal -- --ignored`.
 #[test]
 #[ignore]
 fn purge_data_refuses_when_sibling_alive() {
@@ -729,17 +713,15 @@ fn purge_data_refuses_when_sibling_alive() {
     std::fs::write(&settings, original).unwrap();
 
     // Long-lived sibling `ai-memory` process.
-    let mut serve = Command::new(bin())
+    let mut serve = command_with_home(home.path())
         .arg("serve")
-        .env("HOME", home.path())
         .env("AI_MEMORY_DATA_DIR", data.path())
         .spawn()
         .unwrap();
     std::thread::sleep(std::time::Duration::from_millis(800));
 
-    let out = Command::new(bin())
+    let out = command_with_home(home.path())
         .args(["uninstall", "--apply", "--yes", "--purge-data"])
-        .env("HOME", home.path())
         .env("AI_MEMORY_DATA_DIR", data.path())
         .output()
         .unwrap();

--- a/crates/ai-memory-cli/tests/routing_instructions.rs
+++ b/crates/ai-memory-cli/tests/routing_instructions.rs
@@ -1,4 +1,4 @@
-//! Integration tests for installing ai-memory instructions.
+//! Integration tests for ai-memory routing instructions.
 
 use std::fs;
 use std::path::Path;
@@ -16,6 +16,7 @@ fn run_ai_memory(project: &Path, home: &Path, args: &[&str]) -> Output {
         .args(args)
         .current_dir(project)
         .env("HOME", home)
+        .env("USERPROFILE", home)
         .env("AI_MEMORY_DATA_DIR", home.join(".ai-memory-data"))
         .output()
         .unwrap()
@@ -199,6 +200,8 @@ fn inferred_instruction_targets_select_matching_skill_agents() {
 fn explicit_skill_scope_and_agent_override_instruction_target_inference() {
     let project = tempfile::tempdir().unwrap();
     let home = tempfile::tempdir().unwrap();
+    let global_skills = home.path().join("global-skills");
+    let global_skills_arg = global_skills.to_string_lossy().to_string();
 
     let output = run_ai_memory(
         project.path(),
@@ -211,15 +214,13 @@ fn explicit_skill_scope_and_agent_override_instruction_target_inference() {
             "global",
             "--skills-agent",
             "claude-code",
+            "--skills-target-dir",
+            &global_skills_arg,
         ],
     );
     assert_success(output);
 
-    assert!(
-        home.path()
-            .join(".claude/skills/ai-memory-retrieval/SKILL.md")
-            .exists()
-    );
+    assert!(global_skills.join("ai-memory-retrieval/SKILL.md").exists());
     assert!(!home.path().join(".agents/skills").exists());
     assert!(!project.path().join(".claude/skills").exists());
     assert!(!project.path().join(".agents/skills").exists());

--- a/crates/ai-memory-cli/tests/routing_skills.rs
+++ b/crates/ai-memory-cli/tests/routing_skills.rs
@@ -1,4 +1,4 @@
-//! Integration tests for installing ai-memory managed skills.
+//! Integration tests for ai-memory managed routing skills.
 
 use std::process::Command;
 

--- a/crates/ai-memory-consolidate/src/auto_improve.rs
+++ b/crates/ai-memory-consolidate/src/auto_improve.rs
@@ -1905,6 +1905,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     fn write_eval_script(body: &str) -> String {
         use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::TempDir::new().unwrap().keep();
@@ -1914,6 +1915,40 @@ mod tests {
         perms.set_mode(0o755);
         std::fs::set_permissions(&path, perms).unwrap();
         path.display().to_string()
+    }
+
+    #[cfg(windows)]
+    fn write_eval_script(body: &str) -> String {
+        let dir = tempfile::TempDir::new().unwrap().keep();
+        let path = dir.join("eval.cmd");
+        let body = match body {
+            "#!/bin/sh\ncat >/dev/null\nprintf '%s' '{\"score_before\":0.72,\"score_after\":0.76,\"passed\":true}'\n" => {
+                "more >NUL\r\necho {\"score_before\":0.72,\"score_after\":0.76,\"passed\":true}\r\n"
+                    .into()
+            }
+            "#!/bin/sh\ncat >/dev/null\nprintf '%s' '{\"score_before\":0.72,\"score_after\":0.70,\"passed\":true}'\n" => {
+                "more >NUL\r\necho {\"score_before\":0.72,\"score_after\":0.70,\"passed\":true}\r\n"
+                    .into()
+            }
+            "#!/bin/sh\ncat >/dev/null\nexit 7\n" => "more >NUL\r\nexit /B 7\r\n".into(),
+            "#!/bin/sh\nexit 7\n" => "exit /B 7\r\n".into(),
+            "#!/bin/sh\ncat >/dev/null\nprintf 'not-json'\n" => {
+                "more >NUL\r\necho not-json\r\n".into()
+            }
+            "#!/bin/sh\ncat >/dev/null\nsleep 3\n" => {
+                "more >NUL\r\nping -n 4 127.0.0.1 >NUL\r\n".into()
+            }
+            "#!/bin/sh\nsleep 5\n" => "ping -n 6 127.0.0.1 >NUL\r\n".into(),
+            "#!/bin/sh\ni=0\nwhile [ $i -lt 70000 ]; do printf x; i=$((i + 1)); done\n" => {
+                let chunk = "x".repeat(100);
+                format!(
+                    "set \"chunk={chunk}\"\r\nfor /L %%i in (1,1,700) do <NUL set /p _=%chunk%\r\n"
+                )
+            }
+            other => panic!("unmapped eval script fixture for Windows: {other:?}"),
+        };
+        std::fs::write(&path, format!("@echo off\r\n{body}")).unwrap();
+        format!("cmd.exe /C {}", path.display())
     }
 
     #[tokio::test]

--- a/crates/ai-memory-consolidate/src/bootstrap.rs
+++ b/crates/ai-memory-consolidate/src/bootstrap.rs
@@ -578,6 +578,17 @@ pub fn discover_main_repo_root(start: &Path) -> Result<PathBuf, BootstrapError> 
 
 #[cfg(windows)]
 fn discover_main_repo_root_fallback(start: &Path) -> Result<PathBuf, BootstrapError> {
+    let is_bare = std::process::Command::new("git")
+        .arg("-C")
+        .arg(start)
+        .args(["rev-parse", "--is-bare-repository"])
+        .output()
+        .map_err(|_| BootstrapError::NotARepo(start.to_path_buf()))?;
+    if !is_bare.status.success() {
+        return Err(BootstrapError::NotARepo(start.to_path_buf()));
+    }
+    let is_bare = String::from_utf8_lossy(&is_bare.stdout).trim() == "true";
+
     let output = std::process::Command::new("git")
         .arg("-C")
         .arg(start)
@@ -592,15 +603,27 @@ fn discover_main_repo_root_fallback(start: &Path) -> Result<PathBuf, BootstrapEr
     if common_dir.is_empty() {
         return Err(BootstrapError::NotARepo(start.to_path_buf()));
     }
-    Path::new(common_dir)
-        .parent()
-        .map(Path::to_path_buf)
-        .ok_or_else(|| BootstrapError::NotARepo(start.to_path_buf()))
+    main_root_from_common_dir(Path::new(common_dir), is_bare, start)
 }
 
 #[cfg(not(windows))]
 fn discover_main_repo_root_fallback(start: &Path) -> Result<PathBuf, BootstrapError> {
     Err(BootstrapError::NotARepo(start.to_path_buf()))
+}
+
+#[cfg(any(windows, test))]
+fn main_root_from_common_dir(
+    common_dir: &Path,
+    is_bare: bool,
+    start: &Path,
+) -> Result<PathBuf, BootstrapError> {
+    if is_bare {
+        return Err(BootstrapError::NotARepo(start.to_path_buf()));
+    }
+    common_dir
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| BootstrapError::NotARepo(start.to_path_buf()))
 }
 
 /// Strategy for [`derive_project_name`]: which path "wins" when a
@@ -1586,6 +1609,20 @@ mod tests {
         let p = Path::new(r"C:\Users\alice\Projects\my-app");
         let (name, _) = derive_project_name(p, ProjectNameStrategy::Basename).unwrap();
         assert_eq!(name, "my-app");
+    }
+
+    #[test]
+    fn main_root_from_common_dir_rejects_bare_repositories() {
+        let start = Path::new("/tmp/repo.git");
+        assert!(main_root_from_common_dir(Path::new("/tmp/repo.git"), true, start).is_err());
+    }
+
+    #[test]
+    fn main_root_from_common_dir_returns_parent_for_worktree_common_dir() {
+        let root =
+            main_root_from_common_dir(Path::new("/tmp/repo/.git"), false, Path::new("/tmp/repo"))
+                .unwrap();
+        assert_eq!(root, PathBuf::from("/tmp/repo"));
     }
 
     /// Degenerate input (root, empty) returns None instead of

--- a/crates/ai-memory-consolidate/src/bootstrap.rs
+++ b/crates/ai-memory-consolidate/src/bootstrap.rs
@@ -555,8 +555,10 @@ pub fn discover_repo_root(start: &Path) -> Result<PathBuf, BootstrapError> {
 /// Returns `BootstrapError::NotARepo` when no repository is found
 /// at or above `start`.
 pub fn discover_main_repo_root(start: &Path) -> Result<PathBuf, BootstrapError> {
-    let repo = git2::Repository::discover(start)
-        .map_err(|_| BootstrapError::NotARepo(start.to_path_buf()))?;
+    let repo = match git2::Repository::discover(start) {
+        Ok(repo) => repo,
+        Err(_) => return discover_main_repo_root_fallback(start),
+    };
     // Bare repos have no working directory; `commondir()` IS the repo root
     // (there is no `.git/` subdirectory), so `.parent()` would return the
     // grandparent — wrong.  Fall back to basename(cwd) via NotARepo so the
@@ -572,6 +574,33 @@ pub fn discover_main_repo_root(start: &Path) -> Result<PathBuf, BootstrapError> 
         .parent()
         .map(Path::to_path_buf)
         .ok_or_else(|| BootstrapError::NotARepo(start.to_path_buf()))
+}
+
+#[cfg(windows)]
+fn discover_main_repo_root_fallback(start: &Path) -> Result<PathBuf, BootstrapError> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(start)
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .output()
+        .map_err(|_| BootstrapError::NotARepo(start.to_path_buf()))?;
+    if !output.status.success() {
+        return Err(BootstrapError::NotARepo(start.to_path_buf()));
+    }
+    let common_dir = String::from_utf8_lossy(&output.stdout);
+    let common_dir = common_dir.trim();
+    if common_dir.is_empty() {
+        return Err(BootstrapError::NotARepo(start.to_path_buf()));
+    }
+    Path::new(common_dir)
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| BootstrapError::NotARepo(start.to_path_buf()))
+}
+
+#[cfg(not(windows))]
+fn discover_main_repo_root_fallback(start: &Path) -> Result<PathBuf, BootstrapError> {
+    Err(BootstrapError::NotARepo(start.to_path_buf()))
 }
 
 /// Strategy for [`derive_project_name`]: which path "wins" when a
@@ -633,8 +662,17 @@ fn collect_git_commits(
     repo_path: &Path,
     since: Option<&str>,
 ) -> Result<Vec<BootstrapSource>, BootstrapError> {
-    let repo = git2::Repository::open(repo_path)
-        .map_err(|_| BootstrapError::NotARepo(repo_path.to_path_buf()))?;
+    let repo = match git2::Repository::open(repo_path) {
+        Ok(repo) => repo,
+        Err(err) => return collect_git_commits_fallback(repo_path, since, err),
+    };
+    collect_git_commits_git2(&repo, since)
+}
+
+fn collect_git_commits_git2(
+    repo: &git2::Repository,
+    since: Option<&str>,
+) -> Result<Vec<BootstrapSource>, BootstrapError> {
     let mut revwalk = repo.revwalk()?;
     revwalk.set_sorting(git2::Sort::TIME)?;
     revwalk.push_head()?;
@@ -677,6 +715,83 @@ fn collect_git_commits(
     }
     debug!(count = out.len(), "collected git commits");
     Ok(out)
+}
+
+#[cfg(windows)]
+fn collect_git_commits_fallback(
+    repo_path: &Path,
+    since: Option<&str>,
+    original: git2::Error,
+) -> Result<Vec<BootstrapSource>, BootstrapError> {
+    warn!(
+        error = %original,
+        path = %repo_path.display(),
+        "git2 failed to open repository; falling back to git CLI"
+    );
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo_path)
+        .args([
+            "log",
+            "--date=unix",
+            "--format=%H%x1f%an%x1f%ct%x1f%s%x1f%b%x1e",
+        ])
+        .output()?;
+    if !output.status.success() {
+        return Err(BootstrapError::Git(original));
+    }
+
+    let since_epoch = since.and_then(parse_since_to_epoch);
+    let mut out = Vec::new();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for record in stdout.split('\x1e') {
+        let record = record.trim_matches(['\r', '\n']);
+        if record.is_empty() {
+            continue;
+        }
+        let mut fields = record.splitn(5, '\x1f');
+        let Some(hash) = fields.next() else { continue };
+        let author = fields.next().filter(|s| !s.is_empty()).unwrap_or("unknown");
+        let epoch = fields
+            .next()
+            .and_then(|s| s.parse::<i64>().ok())
+            .unwrap_or(0);
+        let summary = fields
+            .next()
+            .filter(|s| !s.is_empty())
+            .unwrap_or("(no summary)");
+        let body = fields.next().unwrap_or("").trim_start_matches(['\r', '\n']);
+
+        if let Some(cutoff) = since_epoch
+            && epoch < cutoff
+        {
+            break;
+        }
+        let combined_len = summary.len() + body.len();
+        if combined_len < 120 && !is_conventional_substantive(summary) {
+            continue;
+        }
+        let when = jiff::Timestamp::from_second(epoch)
+            .map(|t| t.to_string())
+            .unwrap_or_else(|_| epoch.to_string());
+        let short = hash.chars().take(8).collect::<String>();
+        out.push(BootstrapSource {
+            kind: SourceKind::GitCommit,
+            label: format!("git: {summary}"),
+            text: format!("Commit {short}\nAuthor: {author}\nDate: {when}\n\n{summary}\n\n{body}"),
+        });
+    }
+    debug!(count = out.len(), "collected git commits");
+    Ok(out)
+}
+
+#[cfg(not(windows))]
+fn collect_git_commits_fallback(
+    _repo_path: &Path,
+    _since: Option<&str>,
+    original: git2::Error,
+) -> Result<Vec<BootstrapSource>, BootstrapError> {
+    Err(BootstrapError::Git(original))
 }
 
 /// Parse a `git log --since=<x>` value into a unix epoch. Supports

--- a/crates/ai-memory-core/src/routing_skills.rs
+++ b/crates/ai-memory-core/src/routing_skills.rs
@@ -192,7 +192,8 @@ mod tests {
     }
 
     fn parse_frontmatter(skill: &ManagedSkill) -> Frontmatter {
-        let Some(rest) = skill.content.strip_prefix("---\n") else {
+        let content = skill.content.replace("\r\n", "\n");
+        let Some(rest) = content.strip_prefix("---\n") else {
             panic!("{} must start with frontmatter", skill.name);
         };
         let Some((frontmatter, _body)) = rest.split_once("\n---\n") else {

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -1606,12 +1606,12 @@ mod tests {
             .get_or_create_workspace(String::from(DEFAULT_WORKSPACE_NAME))
             .await
             .unwrap();
-        // Three poison rows that would each match too broadly without
-        // the safety filters.
+        // Poison rows that would match too broadly without the safety filters.
+        // New trailing-slash repo paths are normalized at the store write
+        // boundary; legacy raw trailing separators are covered in store tests.
         for (name, repo) in [
             ("empty-repo", String::new()),
             ("root-repo", String::from("/")),
-            ("trailing-repo", String::from("/repo/foo/")),
         ] {
             state
                 .writer
@@ -1620,7 +1620,7 @@ mod tests {
                 .unwrap();
         }
 
-        // Resolve a cwd that the three poison rows would each match
+        // Resolve a cwd that the poison rows would each match
         // pre-fix. Expect: a NEW project created by basename.
         let (resolved_ws, resolved) = resolve_project_ids(
             &state,

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -482,6 +482,15 @@ fn cache_key_for(
     )
 }
 
+fn normalize_project_path_key(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+    if normalized.len() > 1 {
+        normalized.trim_end_matches('/').to_string()
+    } else {
+        normalized
+    }
+}
+
 /// Resolve the `(workspace_id, project_id)` pair for a hook event.
 ///
 /// Precedence:
@@ -503,7 +512,9 @@ async fn resolve_project_ids(
     project_strategy: ProjectStrategy,
     actor: &ai_memory_core::ActorKey,
 ) -> anyhow::Result<(WorkspaceId, ProjectId)> {
-    let cwd_norm = cwd.filter(|s| !s.is_empty()).map(str::to_string);
+    let cwd_norm = cwd
+        .filter(|s| !s.is_empty())
+        .map(normalize_project_path_key);
 
     // Without cwd AND without a project override, there's nothing to
     // resolve — fall through to the server defaults.
@@ -598,9 +609,9 @@ async fn resolve_project_ids(
         ai_memory_consolidate::derive_project_name(path, strat).map(|(name, root)| {
             let repo_path = root
                 .map(|p| {
-                    repo_root_in_cwd_namespace(path, &p)
-                        .to_string_lossy()
-                        .into_owned()
+                    normalize_project_path_key(
+                        &repo_root_in_cwd_namespace(path, &p).to_string_lossy(),
+                    )
                 })
                 .or_else(|| repo_path_from_cwd(cwd));
             (name, repo_path)
@@ -611,9 +622,9 @@ async fn resolve_project_ids(
         let path = std::path::Path::new(cwd);
         let repo_root = ai_memory_consolidate::discover_repo_root(path).ok()?;
         cwd_is_repo_root(path, &repo_root).then(|| {
-            repo_root_in_cwd_namespace(path, &repo_root)
-                .to_string_lossy()
-                .into_owned()
+            normalize_project_path_key(
+                &repo_root_in_cwd_namespace(path, &repo_root).to_string_lossy(),
+            )
         })
     }
 
@@ -648,7 +659,7 @@ async fn resolve_project_ids(
             if let Ok(root) = ai_memory_consolidate::discover_main_repo_root(cwd_path) {
                 let visible_root = repo_root_in_cwd_namespace(cwd_path, &root);
                 if visible_root.file_name().and_then(|name| name.to_str()) == Some(project) {
-                    return Some(visible_root.to_string_lossy().into_owned());
+                    return Some(normalize_project_path_key(&visible_root.to_string_lossy()));
                 }
             }
         }
@@ -771,9 +782,13 @@ async fn process(
         // begin_session trips the project foreign key. Evict the stale
         // slot, re-resolve (which recreates the project), and retry once.
         warn!(error = %e, "begin_session failed; evicting stale project cache and retrying");
-        let cwd_norm = env.cwd.as_deref().filter(|s| !s.is_empty());
+        let cwd_norm = env
+            .cwd
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(normalize_project_path_key);
         let key = cache_key_for(
-            cwd_norm,
+            cwd_norm.as_deref(),
             env.workspace_override.as_deref(),
             env.project_override.as_deref(),
             env.project_strategy,
@@ -1135,6 +1150,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(windows))]
     fn init_repo_with_commit(path: &std::path::Path) -> git2::Repository {
         std::fs::create_dir_all(path).unwrap();
         let repo = git2::Repository::init(path).unwrap();
@@ -1148,6 +1164,71 @@ mod tests {
                 .unwrap();
         }
         repo
+    }
+
+    #[cfg(windows)]
+    fn init_repo_with_commit(path: &std::path::Path) {
+        std::fs::create_dir_all(path).unwrap();
+        let mut init = std::process::Command::new("git");
+        init.args(["init", "-q", "-b", "main"]).arg(path);
+        assert_command_success(init);
+
+        let mut email = std::process::Command::new("git");
+        email
+            .arg("-C")
+            .arg(path)
+            .args(["config", "user.email", "test@example.com"]);
+        assert_command_success(email);
+
+        let mut name = std::process::Command::new("git");
+        name.arg("-C")
+            .arg(path)
+            .args(["config", "user.name", "Test"]);
+        assert_command_success(name);
+
+        let mut commit = std::process::Command::new("git");
+        commit
+            .arg("-C")
+            .arg(path)
+            .args(["commit", "--allow-empty", "-m", "initial"]);
+        assert_command_success(commit);
+    }
+
+    #[cfg(windows)]
+    fn init_bare_repo(path: &std::path::Path) {
+        let mut init = std::process::Command::new("git");
+        init.args(["init", "--bare", "-q"]).arg(path);
+        assert_command_success(init);
+    }
+
+    // Windows 11 + Git Bash support matters for regulated enterprise setups
+    // where Git Bash is the approved shell available from the corporate
+    // repository. Symlink creation can still be denied by Windows policy, so
+    // the Windows path skips only when the OS reports the missing privilege.
+    #[cfg(unix)]
+    fn create_test_symlink_dir(target: &std::path::Path, link: &std::path::Path) -> bool {
+        std::os::unix::fs::symlink(target, link).unwrap();
+        true
+    }
+
+    #[cfg(windows)]
+    fn create_test_symlink_dir(target: &std::path::Path, link: &std::path::Path) -> bool {
+        match std::os::windows::fs::symlink_dir(target, link) {
+            Ok(()) => true,
+            Err(e) if e.raw_os_error() == Some(1314) => {
+                eprintln!(
+                    "skipping symlink repo-path assertion: Windows denied symlink creation privilege"
+                );
+                false
+            }
+            Err(e) => panic!("failed to create test symlink {}: {e}", link.display()),
+        }
+    }
+
+    #[cfg(windows)]
+    fn assert_command_success(mut command: std::process::Command) {
+        let status = command.status().unwrap();
+        assert!(status.success(), "command failed: {command:?}");
     }
 
     /// Two hook events with distinct cwds must land in two distinct projects.
@@ -2952,7 +3033,7 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     #[tokio::test]
     async fn repo_root_override_stores_repo_path_in_cwd_namespace() {
         let tmp = TempDir::new().unwrap();
@@ -2965,7 +3046,9 @@ mod tests {
         std::fs::create_dir_all(real_repo.join("sibling")).unwrap();
 
         let alias_root = tmp.path().join("alias");
-        std::os::unix::fs::symlink(&real_root, &alias_root).unwrap();
+        if !create_test_symlink_dir(&real_root, &alias_root) {
+            return;
+        }
         let alias_app = alias_root.join("repo/app");
         let alias_sibling = alias_root.join("repo/sibling");
 
@@ -3047,19 +3130,41 @@ mod tests {
 
         // Create a real git repo inside the temp dir.
         let main_dir = tmp.path().join("my-project");
-        let repo = init_repo_with_commit(&main_dir);
 
         // Create a worktree in a sibling directory.
         let wt_dir = tmp.path().join("my-project-feature-branch");
-        let head = repo.head().unwrap().peel_to_commit().unwrap();
-        // Create a branch for the worktree to check out.
-        let branch = repo.branch("feature-branch", &head, false).unwrap();
-        repo.worktree(
-            "feature-branch",
-            &wt_dir,
-            Some(git2::WorktreeAddOptions::new().reference(Some(&branch.into_reference()))),
-        )
-        .unwrap();
+        #[cfg(windows)]
+        {
+            init_repo_with_commit(&main_dir);
+            let mut branch = std::process::Command::new("git");
+            branch
+                .arg("-C")
+                .arg(&main_dir)
+                .args(["branch", "feature-branch"]);
+            assert_command_success(branch);
+
+            let mut worktree = std::process::Command::new("git");
+            worktree
+                .arg("-C")
+                .arg(&main_dir)
+                .args(["worktree", "add", "-q"])
+                .arg(&wt_dir)
+                .arg("feature-branch");
+            assert_command_success(worktree);
+        }
+        #[cfg(not(windows))]
+        {
+            let repo = init_repo_with_commit(&main_dir);
+            let head = repo.head().unwrap().peel_to_commit().unwrap();
+            // Create a branch for the worktree to check out.
+            let branch = repo.branch("feature-branch", &head, false).unwrap();
+            repo.worktree(
+                "feature-branch",
+                &wt_dir,
+                Some(git2::WorktreeAddOptions::new().reference(Some(&branch.into_reference()))),
+            )
+            .unwrap();
+        }
 
         let main_cwd = main_dir.to_str().unwrap();
         let wt_cwd = wt_dir.to_str().unwrap();
@@ -3158,6 +3263,9 @@ mod tests {
         let state = make_state(&tmp).await;
 
         let bare_dir = tmp.path().join("my-bare-project.git");
+        #[cfg(windows)]
+        init_bare_repo(&bare_dir);
+        #[cfg(not(windows))]
         git2::Repository::init_bare(&bare_dir).unwrap();
         let cwd = bare_dir.to_str().unwrap();
 
@@ -3178,6 +3286,9 @@ mod tests {
         // The project name should come from basename, not from the grandparent.
         // To verify: resolve with a different bare repo name and confirm different project.
         let bare_dir2 = tmp.path().join("other-bare.git");
+        #[cfg(windows)]
+        init_bare_repo(&bare_dir2);
+        #[cfg(not(windows))]
         git2::Repository::init_bare(&bare_dir2).unwrap();
         let (_, proj2) = resolve_project_ids(
             &state,

--- a/crates/ai-memory-mcp/tests/admin_backup.rs
+++ b/crates/ai-memory-mcp/tests/admin_backup.rs
@@ -184,7 +184,31 @@ async fn backup_empty_store_still_succeeds() {
     assert!(!bytes.is_empty());
 }
 
+// Windows 11 + Git Bash support matters for regulated enterprise setups where
+// Git Bash is the approved shell available from the corporate repository.
+// Symlink creation can still be denied by Windows policy, so the Windows path
+// skips only when the OS reports the missing privilege.
 #[cfg(unix)]
+fn create_test_symlink_file(target: &std::path::Path, link: &std::path::Path) -> bool {
+    std::os::unix::fs::symlink(target, link).unwrap();
+    true
+}
+
+#[cfg(windows)]
+fn create_test_symlink_file(target: &std::path::Path, link: &std::path::Path) -> bool {
+    match std::os::windows::fs::symlink_file(target, link) {
+        Ok(()) => true,
+        Err(e) if e.raw_os_error() == Some(1314) => {
+            eprintln!(
+                "skipping symlink backup assertion: Windows denied symlink creation privilege"
+            );
+            false
+        }
+        Err(e) => panic!("failed to create test symlink {}: {e}", link.display()),
+    }
+}
+
+#[cfg(any(unix, windows))]
 #[tokio::test]
 async fn backup_does_not_dereference_wiki_symlinks() {
     let tmp = TempDir::new().unwrap();
@@ -195,7 +219,9 @@ async fn backup_does_not_dereference_wiki_symlinks() {
     let secret = tmp.path().join("outside-secret.md");
     let secret_body = "outside secret must not enter backup";
     std::fs::write(&secret, secret_body).unwrap();
-    std::os::unix::fs::symlink(&secret, wiki_dir.join("leak.md")).unwrap();
+    if !create_test_symlink_file(&secret, &wiki_dir.join("leak.md")) {
+        return;
+    }
 
     let router = admin_router(state);
     let resp = router

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -113,6 +113,7 @@ pub fn get_or_create_project(
     name: &str,
     repo_path: Option<&str>,
 ) -> StoreResult<ai_memory_core::ProjectId> {
+    let repo_path = repo_path.map(normalize_repo_path_key);
     let tx = conn.transaction()?;
     let existing: Option<Vec<u8>> = tx
         .query_row(
@@ -132,7 +133,7 @@ pub fn get_or_create_project(
                 id.as_bytes(),
                 workspace_id.as_bytes(),
                 name,
-                repo_path,
+                repo_path.as_deref(),
                 Timestamp::now().as_microsecond()
             ],
         )?;
@@ -165,6 +166,7 @@ pub fn get_or_create_project(
 /// temporarily unmounted drive, and destroying it would wipe a valid prefix
 /// key. This safety rule is mandatory.
 pub fn heal_catch_all_repo_paths(conn: &mut Connection, home: Option<&str>) -> StoreResult<u64> {
+    let home = home.map(normalize_repo_path_key);
     let candidates: Vec<(Vec<u8>, String)> = {
         let mut stmt =
             conn.prepare("SELECT id, repo_path FROM projects WHERE repo_path IS NOT NULL")?;
@@ -175,7 +177,7 @@ pub fn heal_catch_all_repo_paths(conn: &mut Connection, home: Option<&str>) -> S
     };
     let to_null: Vec<Vec<u8>> = candidates
         .into_iter()
-        .filter(|(_, repo_path)| should_heal_repo_path(repo_path, home))
+        .filter(|(_, repo_path)| should_heal_repo_path(repo_path, home.as_deref()))
         .map(|(id, _)| id)
         .collect();
     let tx = conn.transaction()?;
@@ -192,7 +194,8 @@ pub fn heal_catch_all_repo_paths(conn: &mut Connection, home: Option<&str>) -> S
 /// Decide whether a non-NULL `repo_path` is a prefix-match catch-all that
 /// should be NULLed. See [`heal_catch_all_repo_paths`] for the full rule.
 fn should_heal_repo_path(repo_path: &str, home: Option<&str>) -> bool {
-    if repo_path == "/" || home == Some(repo_path) {
+    let repo_path_key = normalize_repo_path_key(repo_path);
+    if repo_path_key == "/" || home == Some(repo_path_key.as_str()) {
         return true; // broad sentinels, healed even if they look like git roots
     }
     let p = std::path::Path::new(repo_path);
@@ -202,6 +205,15 @@ fn should_heal_repo_path(repo_path: &str, home: Option<&str>) -> bool {
     // a `.git` file); a `.git` stat error preserves the row, same as the
     // path-existence check above.
     matches!(p.try_exists(), Ok(true)) && matches!(p.join(".git").try_exists(), Ok(false))
+}
+
+fn normalize_repo_path_key(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+    if normalized.len() > 1 {
+        normalized.trim_end_matches('/').to_string()
+    } else {
+        normalized
+    }
 }
 
 fn scheduler_state_table_exists(conn: &Connection) -> StoreResult<bool> {
@@ -259,6 +271,7 @@ pub fn ensure_project_with_id(
     name: &str,
     repo_path: Option<&str>,
 ) -> StoreResult<()> {
+    let repo_path = repo_path.map(normalize_repo_path_key);
     conn.execute(
         "INSERT INTO projects (id, workspace_id, name, repo_path, created_at) \
          VALUES (?1, ?2, ?3, ?4, ?5) ON CONFLICT(id) DO NOTHING",
@@ -266,7 +279,7 @@ pub fn ensure_project_with_id(
             id.as_bytes(),
             workspace_id.as_bytes(),
             name,
-            repo_path,
+            repo_path.as_deref(),
             Timestamp::now().as_microsecond()
         ],
     )?;
@@ -282,7 +295,7 @@ pub fn ensure_project_with_id(
         Some((existing_ws, existing_name, existing_repo_path))
             if existing_ws.as_slice() == workspace_id.as_bytes()
                 && existing_name == name
-                && existing_repo_path.as_deref() == repo_path =>
+                && existing_repo_path.as_deref() == repo_path.as_deref() =>
         {
             Ok(())
         }

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -3465,15 +3465,13 @@ impl ReaderPool {
     ///
     /// - `workspace_id = ?1` — never matches a project in another
     ///   workspace.
-    /// - `repo_path IS NOT NULL AND length(repo_path) > 1 AND repo_path
-    ///   NOT LIKE '%/'` — rejects stored values that would match too
-    ///   broadly (`NULL`, `''`, `/`) or fail the `<repo_path>/%`
-    ///   boundary (trailing slash).
-    /// - Stored `repo_path` wildcards (`%`, `_`) are escaped in the
-    ///   generated `LIKE` pattern, so they stay literal path bytes
-    ///   instead of matching unintended siblings.
-    /// - `?3 IS NULL OR repo_path <> ?3` — never matches a stored
-    ///   `repo_path` equal to the operator's home directory (`home`).
+    /// - `repo_path IS NOT NULL` plus Rust-side normalization rejects stored
+    ///   values that would match too broadly (`NULL`, `''`, `/`) or fail the
+    ///   `<repo_path>/%` boundary (trailing slash/backslash).
+    /// - Stored `repo_path` wildcards (`%`, `_`) are compared as literal path
+    ///   bytes in Rust, not as SQL `LIKE` wildcards.
+    /// - A normalized stored `repo_path` equal to the operator's home
+    ///   directory (`home`) is never matched.
     ///   Such a row would be a prefix catch-all for every project
     ///   beneath `$HOME`; the caller passes the server's own `$HOME`
     ///   (filesystem root `/` is already excluded by the
@@ -3495,38 +3493,49 @@ impl ReaderPool {
         cwd: String,
         home: Option<&str>,
     ) -> StoreResult<Option<(ProjectId, String)>> {
-        let home = home.map(str::to_owned);
-        let cwd_norm = cwd.trim_end_matches('/').to_string();
+        let home = home.map(|h| normalize_cwd(h).into_owned());
+        let cwd_norm = normalize_cwd(&cwd).into_owned();
         if !is_safe_cwd_for_prefix_match(&cwd_norm) {
             return Ok(None);
         }
         self.with_conn(move |conn| {
-            // Two-condition LIKE: exact match OR descendant (prefix +
-            // `/`). The boundary `/` on the descendant arm stops
-            // `/foo/bar` from matching `/foo/ba`. The LIKE arm escapes
-            // stored wildcard characters so real paths containing `%` or
-            // `_` stay literal instead of turning into broad matches.
-            let row_opt = conn
-                .query_row(
-                    "SELECT id, name FROM projects \
-                     WHERE workspace_id = ?1 \
-                       AND repo_path IS NOT NULL \
-                       AND length(repo_path) > 1 \
-                       AND repo_path NOT LIKE '%/' \
-                       AND (?3 IS NULL OR repo_path <> ?3) \
-                       AND (?2 = repo_path OR ?2 LIKE replace(replace(replace(repo_path, '\\', '\\\\'), '%', '\\%'), '_', '\\_') || '/%' ESCAPE '\\') \
-                     ORDER BY length(repo_path) DESC \
-                     LIMIT 1",
-                    params![workspace_id.as_bytes(), cwd_norm, home],
-                    |row| {
-                        let bytes: Vec<u8> = row.get(0)?;
-                        let name: String = row.get(1)?;
-                        Ok((bytes, name))
-                    },
-                )
-                .optional()?;
-            row_opt
-                .map(|(bytes, name)| {
+            // Compare in Rust instead of SQL LIKE so stored `%`/`_` bytes stay
+            // literal and legacy Windows rows with backslashes keep matching a
+            // slash-normalized hook cwd. New writes normalize `repo_path`, but
+            // this compatibility read path protects existing databases.
+            let mut stmt = conn.prepare(
+                "SELECT id, name, repo_path FROM projects \
+                 WHERE workspace_id = ?1 AND repo_path IS NOT NULL",
+            )?;
+            let rows = stmt.query_map(params![workspace_id.as_bytes()], |row| {
+                Ok((
+                    row.get::<_, Vec<u8>>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })?;
+            let mut matches = Vec::new();
+            for row in rows {
+                let (bytes, name, repo_path) = row?;
+                if has_trailing_path_separator(&repo_path) {
+                    continue;
+                }
+                let repo_norm = normalize_cwd(&repo_path).into_owned();
+                if repo_norm.len() <= 1
+                    || !is_safe_cwd_for_prefix_match(&repo_norm)
+                    || home.as_deref() == Some(repo_norm.as_str())
+                {
+                    continue;
+                }
+                if cwd_within(&repo_norm, &cwd_norm) {
+                    matches.push((bytes, name, repo_norm.len()));
+                }
+            }
+            matches.sort_by_key(|entry| std::cmp::Reverse(entry.2));
+            matches
+                .into_iter()
+                .next()
+                .map(|(bytes, name, _)| {
                     ProjectId::from_slice(&bytes)
                         .map(|id| (id, name))
                         .map_err(StoreError::from)
@@ -3560,7 +3569,7 @@ impl ReaderPool {
         home: Option<&str>,
     ) -> StoreResult<ContaminationReport> {
         let scoped = scope.is_some();
-        let home = home.map(str::to_owned);
+        let home = home.map(|h| normalize_cwd(h).into_owned());
         let scope_params: Vec<Value> = match &scope {
             Some((ws, proj)) => vec![
                 Value::Blob(ws.as_bytes().to_vec()),
@@ -3686,7 +3695,14 @@ impl ReaderPool {
                         })?;
                         for r in rows {
                             let (ws_b, proj_b, name, repo_path) = r?;
-                            if home.as_deref() == Some(repo_path.as_str()) {
+                            if has_trailing_path_separator(&repo_path) {
+                                continue;
+                            }
+                            let repo_path = normalize_cwd(&repo_path).into_owned();
+                            if repo_path.len() <= 1
+                                || !is_safe_cwd_for_prefix_match(&repo_path)
+                                || home.as_deref() == Some(repo_path.as_str())
+                            {
                                 continue;
                             }
                             prefixes.push((
@@ -3707,7 +3723,14 @@ impl ReaderPool {
                         })?;
                         for r in rows {
                             let (ws_b, proj_b, name, repo_path) = r?;
-                            if home.as_deref() == Some(repo_path.as_str()) {
+                            if has_trailing_path_separator(&repo_path) {
+                                continue;
+                            }
+                            let repo_path = normalize_cwd(&repo_path).into_owned();
+                            if repo_path.len() <= 1
+                                || !is_safe_cwd_for_prefix_match(&repo_path)
+                                || home.as_deref() == Some(repo_path.as_str())
+                            {
                                 continue;
                             }
                             prefixes.push((
@@ -3727,13 +3750,12 @@ impl ReaderPool {
         // CHECK A: resolve each session's cwd against preloaded valid prefixes
         // and flag a bucket mismatch.
         for (id, ws, landed_proj, landed_ws_name, landed_proj_name, cwd) in candidates {
-            let cwd_norm = cwd.trim_end_matches('/').to_string();
+            let cwd_norm = normalize_cwd(&cwd).into_owned();
             if !is_safe_cwd_for_prefix_match(&cwd_norm) {
                 continue;
             }
             let resolved = prefixes.iter().find(|(prefix_ws, _, _, repo_path)| {
-                *prefix_ws == ws
-                    && (cwd_norm == *repo_path || cwd_norm.starts_with(&format!("{repo_path}/")))
+                *prefix_ws == ws && cwd_within(repo_path, &cwd_norm)
             });
             if let Some((_, resolved_proj, resolved_name, _)) = resolved
                 && *resolved_proj != landed_proj
@@ -4738,6 +4760,10 @@ fn is_safe_cwd_for_prefix_match(cwd: &str) -> bool {
     true
 }
 
+fn has_trailing_path_separator(path: &str) -> bool {
+    path.len() > 1 && path.ends_with(['/', '\\'])
+}
+
 fn checkout(inner: &Inner) -> StoreResult<Connection> {
     if let Some(conn) = inner.pool.lock().pop() {
         return Ok(conn);
@@ -5117,5 +5143,77 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(widened, None, "wildcards in repo_path must stay literal");
+    }
+
+    #[tokio::test]
+    async fn prefix_match_handles_legacy_windows_backslash_repo_path() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let ws = store
+            .writer
+            .get_or_create_workspace("default")
+            .await
+            .unwrap();
+        let project_id = ProjectId::new();
+        let conn =
+            rusqlite::Connection::open(tmp.path().join("db").join(crate::DB_FILENAME)).unwrap();
+        conn.execute(
+            "INSERT INTO projects (id, workspace_id, name, repo_path, created_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![
+                project_id.as_bytes(),
+                ws.as_bytes(),
+                "app",
+                r"C:\Users\tester\app",
+                jiff::Timestamp::now().as_microsecond()
+            ],
+        )
+        .unwrap();
+
+        let matched = store
+            .reader
+            .find_project_by_cwd_prefix(
+                ws,
+                String::from("C:/Users/tester/app/crates/core"),
+                Some(r"C:\Users\tester"),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(matched.map(|(id, _)| id), Some(project_id));
+    }
+
+    #[tokio::test]
+    async fn prefix_match_ignores_legacy_trailing_separator_repo_path() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let ws = store
+            .writer
+            .get_or_create_workspace("default")
+            .await
+            .unwrap();
+        let project_id = ProjectId::new();
+        let conn =
+            rusqlite::Connection::open(tmp.path().join("db").join(crate::DB_FILENAME)).unwrap();
+        conn.execute(
+            "INSERT INTO projects (id, workspace_id, name, repo_path, created_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![
+                project_id.as_bytes(),
+                ws.as_bytes(),
+                "legacy-trailing",
+                "/repo/foo/",
+                jiff::Timestamp::now().as_microsecond()
+            ],
+        )
+        .unwrap();
+
+        let matched = store
+            .reader
+            .find_project_by_cwd_prefix(ws, String::from("/repo/foo/bar"), None)
+            .await
+            .unwrap();
+
+        assert_eq!(matched, None, "legacy trailing separator must not match");
     }
 }

--- a/crates/ai-memory-wiki/src/git.rs
+++ b/crates/ai-memory-wiki/src/git.rs
@@ -7,7 +7,7 @@
 
 use std::path::{Path, PathBuf};
 
-use git2::{IndexAddOption, ObjectType, Repository, Signature};
+use git2::{ErrorCode, IndexAddOption, ObjectType, Repository, Signature};
 use tracing::{debug, warn};
 
 use crate::error::{WikiError, WikiResult};
@@ -33,6 +33,11 @@ pub struct Checkpoint {
     pub summary: String,
     /// Author timestamp, seconds since Unix epoch.
     pub time: i64,
+}
+
+enum CommitGit2Error {
+    Open(git2::Error),
+    Other(git2::Error),
 }
 
 impl GitAdapter {
@@ -70,22 +75,25 @@ impl GitAdapter {
     pub fn commit_all(&self, message: &str) -> WikiResult<Option<git2::Oid>> {
         match self.commit_all_git2(message) {
             Ok(result) => Ok(result),
-            Err(e) => commit_all_fallback(&self.root, message, e),
+            Err(CommitGit2Error::Open(e)) if should_try_commit_cli_fallback(&e) => {
+                commit_all_fallback(&self.root, message, e)
+            }
+            Err(CommitGit2Error::Open(e) | CommitGit2Error::Other(e)) => Err(map_git_err(e)),
         }
     }
 
-    fn commit_all_git2(&self, message: &str) -> WikiResult<Option<git2::Oid>> {
-        let repo = Repository::open(&self.root).map_err(map_git_err)?;
+    fn commit_all_git2(&self, message: &str) -> Result<Option<git2::Oid>, CommitGit2Error> {
+        let repo = Repository::open(&self.root).map_err(CommitGit2Error::Open)?;
 
         // Stage everything (including deletions).
-        let mut index = repo.index().map_err(map_git_err)?;
+        let mut index = repo.index().map_err(CommitGit2Error::Other)?;
         index
             .add_all(["*"].iter(), IndexAddOption::DEFAULT, None)
-            .map_err(map_git_err)?;
-        index.write().map_err(map_git_err)?;
+            .map_err(CommitGit2Error::Other)?;
+        index.write().map_err(CommitGit2Error::Other)?;
 
         // If the index matches HEAD, there is nothing to commit.
-        let tree_oid = index.write_tree().map_err(map_git_err)?;
+        let tree_oid = index.write_tree().map_err(CommitGit2Error::Other)?;
         if let Ok(head) = repo.head()
             && let Some(target) = head.target()
             && let Ok(parent_commit) = repo.find_commit(target)
@@ -102,12 +110,13 @@ impl GitAdapter {
             debug!("fresh repo, empty index; no commit");
             return Ok(None);
         }
-        let tree = repo.find_tree(tree_oid).map_err(map_git_err)?;
-        let sig = Signature::now(COMMIT_AUTHOR_NAME, COMMIT_AUTHOR_EMAIL).map_err(map_git_err)?;
+        let tree = repo.find_tree(tree_oid).map_err(CommitGit2Error::Other)?;
+        let sig = Signature::now(COMMIT_AUTHOR_NAME, COMMIT_AUTHOR_EMAIL)
+            .map_err(CommitGit2Error::Other)?;
 
         let parents: Vec<git2::Commit<'_>> = match repo.head() {
             Ok(head) => match head.target() {
-                Some(oid) => vec![repo.find_commit(oid).map_err(map_git_err)?],
+                Some(oid) => vec![repo.find_commit(oid).map_err(CommitGit2Error::Other)?],
                 None => Vec::new(),
             },
             Err(_) => Vec::new(),
@@ -115,7 +124,7 @@ impl GitAdapter {
         let parent_refs: Vec<&git2::Commit<'_>> = parents.iter().collect();
         let oid = repo
             .commit(Some("HEAD"), &sig, &sig, message, &tree, &parent_refs)
-            .map_err(map_git_err)?;
+            .map_err(CommitGit2Error::Other)?;
         debug!(oid = %oid, "wiki commit");
         Ok(Some(oid))
     }
@@ -207,7 +216,7 @@ impl GitAdapter {
 fn commit_all_fallback(
     root: &Path,
     message: &str,
-    original: WikiError,
+    original: git2::Error,
 ) -> WikiResult<Option<git2::Oid>> {
     warn!(error = %original, root = %root.display(), "libgit2 commit failed; trying git CLI fallback");
     run_git(root, ["add", "-A"])?;
@@ -248,9 +257,13 @@ fn commit_all_fallback(
 fn commit_all_fallback(
     _root: &Path,
     _message: &str,
-    original: WikiError,
+    original: git2::Error,
 ) -> WikiResult<Option<git2::Oid>> {
-    Err(original)
+    Err(map_git_err(original))
+}
+
+fn should_try_commit_cli_fallback(error: &git2::Error) -> bool {
+    matches!(error.code(), ErrorCode::NotFound)
 }
 
 #[cfg(windows)]

--- a/crates/ai-memory-wiki/src/git.rs
+++ b/crates/ai-memory-wiki/src/git.rs
@@ -47,7 +47,7 @@ impl GitAdapter {
             Ok(_) => debug!(root = %root.display(), "wiki repo already initialised"),
             Err(_) => {
                 debug!(root = %root.display(), "initialising wiki repo");
-                Repository::init(root).map_err(map_git_err)?;
+                init_repo(root)?;
             }
         }
         Ok(Self {
@@ -68,6 +68,13 @@ impl GitAdapter {
     /// # Errors
     /// Propagates any underlying libgit2 error.
     pub fn commit_all(&self, message: &str) -> WikiResult<Option<git2::Oid>> {
+        match self.commit_all_git2(message) {
+            Ok(result) => Ok(result),
+            Err(e) => commit_all_fallback(&self.root, message, e),
+        }
+    }
+
+    fn commit_all_git2(&self, message: &str) -> WikiResult<Option<git2::Oid>> {
         let repo = Repository::open(&self.root).map_err(map_git_err)?;
 
         // Stage everything (including deletions).
@@ -118,7 +125,7 @@ impl GitAdapter {
     #[must_use]
     pub fn commit_count(&self) -> usize {
         let Ok(repo) = Repository::open(&self.root) else {
-            return 0;
+            return commit_count_fallback(&self.root);
         };
         let Ok(mut walk) = repo.revwalk() else {
             return 0;
@@ -139,7 +146,10 @@ impl GitAdapter {
         if limit == 0 {
             return Ok(Vec::new());
         }
-        let repo = Repository::open(&self.root).map_err(map_git_err)?;
+        let repo = match Repository::open(&self.root) {
+            Ok(repo) => repo,
+            Err(e) => return recent_checkpoints_fallback(&self.root, limit, map_git_err(e)),
+        };
         let mut walk = repo.revwalk().map_err(map_git_err)?;
         if walk.push_head().is_err() {
             return Ok(Vec::new());
@@ -170,7 +180,10 @@ impl GitAdapter {
     /// # Errors
     /// Returns [`WikiError`] when the revision, path, or blob cannot be read.
     pub fn file_at_rev(&self, rev: &str, path: &Path) -> WikiResult<Vec<u8>> {
-        let repo = Repository::open(&self.root).map_err(map_git_err)?;
+        let repo = match Repository::open(&self.root) {
+            Ok(repo) => repo,
+            Err(e) => return file_at_rev_fallback(&self.root, rev, path, map_git_err(e)),
+        };
         let object = repo.revparse_single(rev).map_err(map_git_err)?;
         let commit = object.peel_to_commit().map_err(map_git_err)?;
         let tree = commit.tree().map_err(map_git_err)?;
@@ -190,6 +203,203 @@ impl GitAdapter {
     }
 }
 
+#[cfg(windows)]
+fn commit_all_fallback(
+    root: &Path,
+    message: &str,
+    original: WikiError,
+) -> WikiResult<Option<git2::Oid>> {
+    warn!(error = %original, root = %root.display(), "libgit2 commit failed; trying git CLI fallback");
+    run_git(root, ["add", "-A"])?;
+    let diff = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["diff", "--cached", "--quiet", "--exit-code"])
+        .status()
+        .map_err(|e| {
+            WikiError::Io(std::io::Error::other(format!(
+                "{original}; git diff fallback failed to start: {e}"
+            )))
+        })?;
+    if diff.success() {
+        return Ok(None);
+    }
+    run_git(
+        root,
+        [
+            "-c",
+            "user.name=ai-memory",
+            "-c",
+            "user.email=ai-memory@local",
+            "commit",
+            "-q",
+            "-m",
+            message,
+        ],
+    )?;
+    let out = git_output(root, ["rev-parse", "HEAD"])?;
+    let oid = String::from_utf8_lossy(&out.stdout);
+    git2::Oid::from_str(oid.trim())
+        .map(Some)
+        .map_err(map_git_err)
+}
+
+#[cfg(not(windows))]
+fn commit_all_fallback(
+    _root: &Path,
+    _message: &str,
+    original: WikiError,
+) -> WikiResult<Option<git2::Oid>> {
+    Err(original)
+}
+
+#[cfg(windows)]
+fn commit_count_fallback(root: &Path) -> usize {
+    let Ok(out) = git_output(root, ["rev-list", "--count", "HEAD"]) else {
+        return 0;
+    };
+    String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse()
+        .unwrap_or(0)
+}
+
+#[cfg(not(windows))]
+fn commit_count_fallback(_root: &Path) -> usize {
+    0
+}
+
+#[cfg(windows)]
+fn recent_checkpoints_fallback(
+    root: &Path,
+    limit: usize,
+    original: WikiError,
+) -> WikiResult<Vec<Checkpoint>> {
+    warn!(error = %original, root = %root.display(), "libgit2 log failed; trying git CLI fallback");
+    let limit = limit.to_string();
+    let out = git_output(root, ["log", "-n", &limit, "--format=%H%x1f%s%x1f%ct"])?;
+    let text = String::from_utf8_lossy(&out.stdout);
+    let mut checkpoints = Vec::new();
+    for line in text.lines() {
+        let mut fields = line.split('\x1f');
+        let (Some(oid), Some(summary), Some(time)) = (fields.next(), fields.next(), fields.next())
+        else {
+            continue;
+        };
+        checkpoints.push(Checkpoint {
+            oid: oid.to_string(),
+            summary: if summary.is_empty() {
+                "(no summary)".to_string()
+            } else {
+                summary.to_string()
+            },
+            time: time.parse().unwrap_or_default(),
+        });
+    }
+    Ok(checkpoints)
+}
+
+#[cfg(not(windows))]
+fn recent_checkpoints_fallback(
+    _root: &Path,
+    _limit: usize,
+    original: WikiError,
+) -> WikiResult<Vec<Checkpoint>> {
+    Err(original)
+}
+
+#[cfg(windows)]
+fn file_at_rev_fallback(
+    root: &Path,
+    rev: &str,
+    path: &Path,
+    original: WikiError,
+) -> WikiResult<Vec<u8>> {
+    warn!(error = %original, root = %root.display(), "libgit2 show failed; trying git CLI fallback");
+    let rel = path.to_string_lossy().replace('\\', "/");
+    let spec = format!("{rev}:{rel}");
+    let out = git_output(root, ["show", &spec])?;
+    Ok(out.stdout)
+}
+
+#[cfg(not(windows))]
+fn file_at_rev_fallback(
+    _root: &Path,
+    _rev: &str,
+    _path: &Path,
+    original: WikiError,
+) -> WikiResult<Vec<u8>> {
+    Err(original)
+}
+
+fn init_repo(root: &Path) -> WikiResult<()> {
+    match Repository::init(root) {
+        Ok(_) => Ok(()),
+        Err(e) => init_repo_fallback(root, e),
+    }
+}
+
+#[cfg(windows)]
+fn init_repo_fallback(root: &Path, original: git2::Error) -> WikiResult<()> {
+    warn!(error = %original, root = %root.display(), "libgit2 init failed; trying git CLI fallback");
+    let status = std::process::Command::new("git")
+        .arg("init")
+        .arg("-q")
+        .arg(root)
+        .status()
+        .map_err(|io| {
+            WikiError::Io(std::io::Error::other(format!(
+                "{original}; git init fallback failed to start: {io}"
+            )))
+        })?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(map_git_err(original))
+    }
+}
+
+#[cfg(not(windows))]
+fn init_repo_fallback(_root: &Path, original: git2::Error) -> WikiResult<()> {
+    Err(map_git_err(original))
+}
+
+#[cfg(windows)]
+fn run_git<const N: usize>(root: &Path, args: [&str; N]) -> WikiResult<()> {
+    let status = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .status()
+        .map_err(|e| WikiError::Io(std::io::Error::other(e.to_string())))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(WikiError::Io(std::io::Error::other(format!(
+            "git fallback exited with status {status}"
+        ))))
+    }
+}
+
+#[cfg(windows)]
+fn git_output<const N: usize>(root: &Path, args: [&str; N]) -> WikiResult<std::process::Output> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .map_err(|e| WikiError::Io(std::io::Error::other(e.to_string())))?;
+    if out.status.success() {
+        Ok(out)
+    } else {
+        Err(WikiError::Io(std::io::Error::other(format!(
+            "git fallback exited with status {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        ))))
+    }
+}
+
 fn map_git_err(e: git2::Error) -> WikiError {
     warn!(error = %e, "libgit2 error");
     WikiError::Io(std::io::Error::other(e.to_string()))
@@ -200,9 +410,16 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn tempdir() -> TempDir {
+        tempfile::Builder::new()
+            .prefix("ai-memory-")
+            .tempdir()
+            .unwrap()
+    }
+
     #[test]
     fn init_is_idempotent_and_creates_dotgit() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = tempdir();
         let root = tmp.path().join("wiki");
         let _adapter = GitAdapter::open_or_init(&root).unwrap();
         assert!(root.join(".git").is_dir());
@@ -212,7 +429,7 @@ mod tests {
 
     #[test]
     fn commit_all_returns_none_when_clean_some_when_dirty() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = tempdir();
         let root = tmp.path().join("wiki");
         let adapter = GitAdapter::open_or_init(&root).unwrap();
         // No changes: returns None.
@@ -230,7 +447,7 @@ mod tests {
 
     #[test]
     fn commit_all_captures_deletes_too() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = tempdir();
         let root = tmp.path().join("wiki");
         let adapter = GitAdapter::open_or_init(&root).unwrap();
         std::fs::write(root.join("a.md"), "first").unwrap();
@@ -243,7 +460,7 @@ mod tests {
 
     #[test]
     fn recent_checkpoints_returns_newest_first() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = tempdir();
         let root = tmp.path().join("wiki");
         let adapter = GitAdapter::open_or_init(&root).unwrap();
 
@@ -261,7 +478,7 @@ mod tests {
 
     #[test]
     fn file_at_rev_reads_historical_blob() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = tempdir();
         let root = tmp.path().join("wiki");
         let adapter = GitAdapter::open_or_init(&root).unwrap();
 

--- a/crates/ai-memory-wiki/src/watcher.rs
+++ b/crates/ai-memory-wiki/src/watcher.rs
@@ -531,6 +531,24 @@ mod tests {
     use ai_memory_store::Store;
     use tempfile::TempDir;
 
+    #[cfg(windows)]
+    fn create_test_symlink_file(target: &Path, link: &Path) -> bool {
+        match std::os::windows::fs::symlink_file(target, link) {
+            Ok(()) => true,
+            Err(e) if e.raw_os_error() == Some(1314) => {
+                eprintln!("skipping symlink assertion: Windows symlink privilege unavailable");
+                false
+            }
+            Err(e) => panic!("failed to create symlink {}: {e}", link.display()),
+        }
+    }
+
+    #[cfg(unix)]
+    fn create_test_symlink_file(target: &Path, link: &Path) -> bool {
+        std::os::unix::fs::symlink(target, link).unwrap();
+        true
+    }
+
     async fn setup() -> (TempDir, Store, Wiki, WorkspaceId, ProjectId) {
         let tmp = TempDir::new().unwrap();
         let store = Store::open(tmp.path()).unwrap();
@@ -932,10 +950,9 @@ mod tests {
         std::fs::write(&secret, "this is sensitive\n").unwrap();
 
         // Plant a symlink inside proj/ pointing at the outside file.
-        #[cfg(unix)]
-        std::os::unix::fs::symlink(&secret, proj_root.join("symlinked.md")).unwrap();
-        #[cfg(windows)]
-        std::os::windows::fs::symlink_file(&secret, proj_root.join("symlinked.md")).unwrap();
+        if !create_test_symlink_file(&secret, &proj_root.join("symlinked.md")) {
+            return;
+        }
 
         let found = walk_markdown(&proj_root).unwrap();
         let names: Vec<_> = found.iter().map(|p| p.as_str().to_string()).collect();
@@ -964,10 +981,9 @@ mod tests {
         std::fs::write(&secret, "directsymlinksecret should not index\n").unwrap();
 
         let symlink = proj_dir.join("symlinked.md");
-        #[cfg(unix)]
-        std::os::unix::fs::symlink(&secret, &symlink).unwrap();
-        #[cfg(windows)]
-        std::os::windows::fs::symlink_file(&secret, &symlink).unwrap();
+        if !create_test_symlink_file(&secret, &symlink) {
+            return;
+        }
 
         let event = notify_debouncer_full::DebouncedEvent::new(
             notify::Event::new(EventKind::Create(notify::event::CreateKind::File))

--- a/crates/ai-memory-wiki/src/wiki.rs
+++ b/crates/ai-memory-wiki/src/wiki.rs
@@ -1583,6 +1583,24 @@ mod tests {
     };
     use tempfile::TempDir;
 
+    #[cfg(windows)]
+    fn create_test_symlink_file(target: &Path, link: &Path) -> bool {
+        match std::os::windows::fs::symlink_file(target, link) {
+            Ok(()) => true,
+            Err(e) if e.raw_os_error() == Some(1314) => {
+                eprintln!("skipping symlink assertion: Windows symlink privilege unavailable");
+                false
+            }
+            Err(e) => panic!("failed to create symlink {}: {e}", link.display()),
+        }
+    }
+
+    #[cfg(unix)]
+    fn create_test_symlink_file(target: &Path, link: &Path) -> bool {
+        std::os::unix::fs::symlink(target, link).unwrap();
+        true
+    }
+
     #[tokio::test]
     async fn project_root_is_wiki_root_joined_with_ws_and_proj() {
         let tmp = TempDir::new().unwrap();
@@ -3166,10 +3184,9 @@ mod tests {
         let outside = tmp.path().join("outside-meta.md");
         std::fs::write(&outside, "---\nproject: webapp\n---\n").unwrap();
         let link = proj_dir.join("_meta.md");
-        #[cfg(unix)]
-        std::os::unix::fs::symlink(&outside, &link).unwrap();
-        #[cfg(windows)]
-        std::os::windows::fs::symlink_file(&outside, &link).unwrap();
+        if !create_test_symlink_file(&outside, &link) {
+            return;
+        }
 
         let err = wiki.reindex_all().await.unwrap_err();
         assert!(

--- a/docs/install.md
+++ b/docs/install.md
@@ -481,8 +481,9 @@ Cursor, Gemini CLI, Antigravity CLI, Grok Build CLI, and OpenClaw have lifecycle
 > bundled scripts to your home dir, (2) `docker run --rm install-hooks`
 > to render the config snippet.
 > On native Windows, Claude Code is the exception to the PowerShell default:
-> it runs hooks through Git Bash, so ai-memory renders `bash -c` commands for
-> the `.sh` scripts.
+> it uses direct `ai-memory.exe hook` commands by default. Set
+> `AI_MEMORY_HOOK_PLATFORM=windows-bash` before `install-hooks` to opt back into
+> Git Bash `bash -c` commands for the `.sh` scripts.
 > OpenClaw, OpenCode, and OMP are different: they use generated
 > TypeScript plugin/extension files, so no shell-script extraction is
 > needed for those clients.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -224,6 +224,12 @@ native on an i7-6700HQ). Notes:
   Set the env var before running `install-hooks` so the chosen platform
   is baked into the rendered hook commands.
 
+Project auto-scope treats Windows backslashes and POSIX slashes as the same path
+separator when comparing hook `cwd`, stored `repo_path`, and the home-directory
+catch-all guard. Wrappers or tests that need a host home different from the
+process `HOME` can set `AI_MEMORY_HOME`; it is normalized through the same path
+boundary before startup healing or cwd-prefix matching.
+
 ### Tuning the spool timings (high-latency instances)
 
 The native hook spools events locally and drains them to the server at session


### PR DESCRIPTION
Windows: make Git Bash and Git-backed tests pass

## Problem

I hit a cluster of Windows 11 failures while trying to use `ai-memory` from Git Bash in a locked-down corporate environment where Git Bash is the approved Unix-like shell available from the corporate repository, and where I have to compile from source instead of downloading the readily available .exe.

The failures came from a few different assumptions:

- eval helper scripts were written as POSIX shell scripts and chmodded through `std::os::unix`;
- libgit2 could fail against temporary repositories on Windows even when the same repository was usable through the `git` CLI;
- installer/package tests executed shell scripts through whatever `bash.exe` came first on the native Windows `PATH`, which can resolve to the WSL stub instead of Git for Windows;
- integration test binaries with `install` / `uninstall` in the executable name can trigger Windows UAC installer detection;
- HOME-based integration tests could escape their temp directory and touch the real user profile;
- repo path matching could mix Windows backslashes with Git Bash slash-style paths, so otherwise equivalent cwd/repo paths missed each other.

The goal here is not to make Windows special, it is to keep the existing Unix-oriented workflow usable when my available corporate-approved shell is Git Bash on Windows 11.

## Changes

- Added Windows-safe eval script generation in `ai-memory-consolidate`: Unix still writes the shell script, Windows writes a `.cmd` and invokes it through `cmd.exe /C`.
- Added Windows Git CLI fallbacks around repo discovery, commit listing, wiki commits, recent checkpoint lookup, and file-at-revision reads where libgit2 can be brittle on temporary Windows paths.
- Normalized stored project path keys to forward slashes before cache/prefix matching, so Git Bash cwd strings and Windows-style paths can resolve to the same project.
- Added an `AI_MEMORY_HOME` test override and routed HOME-based path resolution through it, keeping install/uninstall/routing tests inside their temp directories.
- Made package and installer shell tests Git Bash-aware on Windows. The installer test now looks for Git for Windows `bash.exe` instead of accidentally picking the WSL stub.
- Renamed the Windows-hostile integration test targets away from `install_*` / `uninstall` wording so UAC installer detection does not block them with elevation error 740.
- Ported the symlink-sensitive backup/router tests to Windows with a narrow skip only when Windows denies symlink creation privilege.
- Kept existing Unix behavior in place behind the original paths.

No new dependencies.

## Tests

- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `cargo test -p ai-memory-mcp --test admin_backup --locked -j1 backup_does_not_dereference_wiki_symlinks -- --nocapture`
- [x] `cargo test -p ai-memory-hooks --locked -j1 repo_root_override_stores_repo_path_in_cwd_namespace -- --nocapture`
- [x] `cargo test -p ai-memory-cli --bin ai-memory --locked -j1 curl_installer_accepts_generated_integration_agents -- --nocapture`
- [x] `cargo test --workspace --locked -j1`
- [x] `cargo build --workspace --locked -j1`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`

## Notes

The full workspace test run passes on a Windows 11 + Git Bash machine. It still prints noisy Git warnings from temporary test repositories, including transient `index.lock` / ref-lock messages during concurrent wiki test activity, but `cargo test` exits green.

The Windows symlink tests deliberately return early only on `ERROR_PRIVILEGE_NOT_HELD` (`1314`). On Windows machines with Developer Mode or suitable privileges, they exercise the same assertion as the Unix version.

The Git CLI fallbacks are Windows-only where they replace libgit2 behavior. The intent is to avoid changing the Unix path while letting Windows use the same repository state through the Git executable that users already rely on from Git Bash.