### PR TITLE
fix(opencode): listen to session.deleted and send session-end

### DIFF
--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -1370,6 +1370,12 @@ export const AiMemoryHooks: Plugin = async ({{ directory }}) => {{
         startSession(id, cwdFor(id, directory));
         postHook("stop", {{ sessionID: id, cwd: cwdFor(id, directory) }});
       }}
+      if (event?.type === "session.deleted") {{
+        const info = properties.info ?? {{}};
+        const id = properties.sessionID ?? info.id;
+        const cwd = info.directory ?? cwdFor(id, directory);
+        postHook("session-end", {{ sessionID: id, cwd }});
+      }}
       if (event?.type === "session.compacted") {{
         const id = properties.sessionID;
         postPreCompact(id, directory);
@@ -3243,6 +3249,8 @@ model = "gpt-5"
         assert!(plugin.contains("applyMarkerParams(url, cwd);"));
         assert!(plugin.contains("postPreCompact"));
         assert!(plugin.contains("postHook(\"session-start\""));
+        assert!(plugin.contains(r#""session.deleted")"#));
+        assert!(plugin.contains("postHook(\"session-end\""));
         assert!(plugin.contains("postHook(\"user-prompt\""));
         assert!(plugin.contains("Bearer ${TOKEN}"));
         assert!(plugin.contains("tok"));


### PR DESCRIPTION
## What changed

Added missing session lifecycle handler to the generated OpenCode plugin template (`build_opencode_plugin`):

1. **`session.deleted` event handler** — maps OpenCode's `session.deleted` bus event to `postHook("session-end", ...)`, closing the session in ai-memory when it ends.

## Why

OpenCode sessions were being started in ai-memory but never finished. The plugin listened for `session.created`, `session.idle`, and `session.compacted`, but not `session.deleted` — which is the event OpenCode's SDK fires when a session ends.

Every other agent already closes sessions properly:
- **Claude Code** has explicit `SessionEnd` + `Stop` hooks in `settings.json`
- **OMP** maps `session_shutdown` to `postHook("session-end")` (line 1981) — same pattern as this PR

## Test plan

- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes (new assertions in `opencode_plugin_uses_real_plugin_hooks`)
- [ ] Manual test: generated plugin is valid TypeScript, exported hooks match `@opencode-ai/plugin` 1.17.8 interface

## Notes for reviewers

The `HOOK_IMMEDIATE_EVENTS` set already included `"session-end"`, so the queued flush infrastructure was ready to handle this event — only the trigger was missing.