### PR TITLE
Windows follow-up: harden Git Bash paths and fix flaky MCP test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   1 MiB (previous contents move to `hook-drain.log.old`), so an agent
   pointed at a chronically unreachable server can no longer grow the log
   without bound.
+- Windows hook-spool drain locks now treat native lock-violation responses as
+  expected lock contention, so overlapping background drains skip cleanly
+  instead of failing the single-flight guard.
+- Windows wiki checkpoints now fall back to the Git CLI for native libgit2
+  path-resolution failures when reopening freshly initialised repos, keeping
+  delete and purge operations usable under dot-prefixed temp or wrapper paths.
 
 ### Changed
 - Post-audit cleanup, no behavior change: the `AI_MEMORY_HOOK_PLATFORM`

--- a/crates/ai-memory-cli/src/commands/hook_drain_process.rs
+++ b/crates/ai-memory-cli/src/commands/hook_drain_process.rs
@@ -193,9 +193,8 @@ fn detach_config(try_breakaway: bool) -> DetachConfig {
 #[cfg(windows)]
 fn apply_detach_flags(command: &mut Command, detach: &DetachConfig) {
     use std::os::windows::process::CommandExt as _;
-    if let DetachConfig::WindowsCreationFlags(flags) = detach {
-        command.creation_flags(*flags);
-    }
+    let DetachConfig::WindowsCreationFlags(flags) = detach;
+    command.creation_flags(*flags);
 }
 
 #[cfg(windows)]
@@ -311,15 +310,9 @@ mod tests {
     fn windows_spawn_config_uses_expected_flags_and_breakaway_toggle() {
         let tmp = tempfile::tempdir().unwrap();
         let spec = command_spec(tmp.path()).unwrap();
-        let DetachConfig::WindowsCreationFlags(with_breakaway) = spawn_config(&spec, true).detach
-        else {
-            panic!("windows flags")
-        };
+        let DetachConfig::WindowsCreationFlags(with_breakaway) = spawn_config(&spec, true).detach;
         let DetachConfig::WindowsCreationFlags(without_breakaway) =
-            spawn_config(&spec, false).detach
-        else {
-            panic!("windows flags")
-        };
+            spawn_config(&spec, false).detach;
         assert_ne!(with_breakaway, without_breakaway);
     }
 }

--- a/crates/ai-memory-cli/src/commands/hook_spool.rs
+++ b/crates/ai-memory-cli/src/commands/hook_spool.rs
@@ -201,6 +201,24 @@ pub struct DrainLock {
     _file: File,
 }
 
+fn is_drain_lock_busy_error(err: &std::io::Error) -> bool {
+    if err.kind() == std::io::ErrorKind::WouldBlock {
+        return true;
+    }
+
+    #[cfg(windows)]
+    {
+        // Windows can report a contended fs2 byte-range lock as the native
+        // ERROR_LOCK_VIOLATION code instead of mapping it to WouldBlock.
+        const ERROR_LOCK_VIOLATION: i32 = 33;
+        if err.raw_os_error() == Some(ERROR_LOCK_VIOLATION) {
+            return true;
+        }
+    }
+
+    false
+}
+
 /// Outcome for lock-aware drain wrappers.
 #[derive(Debug, PartialEq, Eq)]
 pub enum LockedDrainResult {
@@ -224,7 +242,7 @@ pub fn acquire_drain_lock(spool: &Path, wait: DrainLockWait) -> std::io::Result<
     loop {
         match file.try_lock_exclusive() {
             Ok(()) => return Ok(Some(DrainLock { _file: file })),
-            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => match wait {
+            Err(err) if is_drain_lock_busy_error(&err) => match wait {
                 DrainLockWait::NoWait => return Ok(None),
                 DrainLockWait::Bounded(limit) if started.elapsed() >= limit => return Ok(None),
                 DrainLockWait::Bounded(limit) => {
@@ -888,6 +906,26 @@ mod tests {
                 .is_some(),
             "lock should release on drop"
         );
+    }
+
+    #[test]
+    fn would_block_lock_error_is_lock_busy() {
+        let err = std::io::Error::from(std::io::ErrorKind::WouldBlock);
+        assert!(is_drain_lock_busy_error(&err));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_lock_violation_error_is_lock_busy() {
+        const ERROR_LOCK_VIOLATION: i32 = 33;
+        let err = std::io::Error::from_raw_os_error(ERROR_LOCK_VIOLATION);
+        assert!(is_drain_lock_busy_error(&err));
+    }
+
+    #[test]
+    fn unrelated_lock_error_is_not_lock_busy() {
+        let err = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+        assert!(!is_drain_lock_busy_error(&err));
     }
 
     #[tokio::test]

--- a/crates/ai-memory-mcp/tests/autoscope_stress.rs
+++ b/crates/ai-memory-mcp/tests/autoscope_stress.rs
@@ -1060,10 +1060,21 @@ async fn fire_raw_hook_and_settle(
         "agent-shape hook must accept"
     );
     let _ = response_body_text(resp).await;
-    for _ in 0..20 {
+    let expected = number_word(project_index);
+    for _ in 0..200 {
         tokio::task::yield_now().await;
+        let probe = router
+            .clone()
+            .oneshot(mcp_query_request(None, Some(session_id)))
+            .await
+            .expect("agent-shape settle probe");
+        if probe.status() == StatusCode::OK
+            && extract_tool_text(&response_body_text(probe).await).contains(expected)
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
     }
-    tokio::time::sleep(Duration::from_millis(15)).await;
 }
 
 async fn read_session_marker(router: &Router, session_id: &str) -> String {

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -3224,12 +3224,12 @@ mod tests {
         );
         assert_eq!(
             read_repo_path(&conn, &git_proj),
-            Some(git_path),
+            Some(normalize_repo_path_key(&git_path)),
             "real git work-tree root must be preserved"
         );
         assert_eq!(
             read_repo_path(&conn, &gone_proj),
-            Some(gone_path),
+            Some(normalize_repo_path_key(&gone_path)),
             "path absent on this host must be preserved (multi-user/unmounted safety)"
         );
     }

--- a/crates/ai-memory-wiki/src/git.rs
+++ b/crates/ai-memory-wiki/src/git.rs
@@ -263,7 +263,25 @@ fn commit_all_fallback(
 }
 
 fn should_try_commit_cli_fallback(error: &git2::Error) -> bool {
-    matches!(error.code(), ErrorCode::NotFound)
+    if matches!(error.code(), ErrorCode::NotFound) {
+        return true;
+    }
+
+    #[cfg(windows)]
+    {
+        // On native Windows, libgit2 can fail to reopen a freshly initialised
+        // wiki repo under dot-prefixed temp dirs with an OS path-resolution
+        // error. The fallback still runs only for Repository::open failures;
+        // real permission or repo corruption errors must also pass through the
+        // Git CLI before they are treated as recoverable.
+        if matches!(error.class(), git2::ErrorClass::Os)
+            && error.message().contains("failed to resolve path")
+        {
+            return true;
+        }
+    }
+
+    false
 }
 
 #[cfg(windows)]
@@ -469,6 +487,18 @@ mod tests {
         let oid = adapter.commit_all("remove a").unwrap();
         assert!(oid.is_some());
         assert_eq!(adapter.commit_count(), 2);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn commit_all_handles_windows_dot_prefixed_temp_roots() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("wiki");
+        let adapter = GitAdapter::open_or_init(&root).unwrap();
+
+        std::fs::write(root.join("foo.md"), "hello").unwrap();
+        assert!(adapter.commit_all("add foo").unwrap().is_some());
+        assert_eq!(adapter.commit_count(), 1);
     }
 
     #[test]

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -167,10 +167,26 @@ target\debug\ai-memory.exe init
 target\debug\ai-memory.exe serve --transport http --bind 127.0.0.1:49374
 ```
 
+For release validation from Git Bash on native Windows, use the same checkout
+with the Rust MSVC toolchain active:
+
+```bash
+cargo test --workspace
+cargo build --locked --release -p ai-memory-cli
+./target/release/ai-memory.exe --version
+```
+
+The version output should match the package version for the checkout.
+
 The Tailwind build step supports the pinned
 `tailwindcss-windows-x64.exe` binary and falls back to PowerShell
 `Invoke-WebRequest` when `curl`/`wget` are unavailable. You should not
 need `TAILWIND_SKIP=1` for normal Windows builds.
+
+Keep Git for Windows' `git.exe` on `PATH` for native builds and hook runs. When
+libgit2 hits a Windows path-resolution error while opening a newly initialized
+wiki repository, ai-memory falls back to the Git CLI instead of treating that
+specific condition as fatal.
 
 From another PowerShell window in the repo:
 
@@ -260,6 +276,12 @@ incremental threshold is a positive event count; invalid values fall back to 32.
 The session-start budget caps how long the hook may block before handoff fetch;
 the background budget caps detached cleanup after session-end and does not keep
 the agent waiting.
+
+On Windows, a contended drain lock can be reported as the native
+`ERROR_LOCK_VIOLATION` code instead of Rust's `WouldBlock` error kind.
+ai-memory treats both as normal lock-busy states, so concurrent drains wait,
+skip, or expire according to the same spool timing rules instead of failing the
+hook.
 
 ## Current Harness Caveats
 


### PR DESCRIPTION
Follow-up to d4675ee. Two regressions surfaced after that PR landed when validating on a real Windows 11 + Git Bash machine.

## Problems

**`fix(windows): harden git bash native paths` (82b1b84)**

Two issues missed by the initial pass:

- The drain-lock guard in `hook_spool` only checked `WouldBlock` to detect a busy lock. On Windows, `fs2` byte-range locks can also surface as native `ERROR_LOCK_VIOLATION` (code 33), so the single-flight guard was raising an error instead of skipping cleanly when a background drain was already running.
- `libgit2` can fail to reopen a freshly initialised wiki repo on native Windows when the path contains a dot-prefixed segment (common under `tempfile`). The `should_try_commit_cli_fallback` check only matched `ErrorCode::NotFound`; `ErrorClass::Os` path-resolution failures were left unhandled, breaking wiki checkpoints during delete and purge operations under those paths.

A test assertion in `ai-memory-store` also needed to account for path normalisation already applied when reading back a stored repo path key.

**`test(mcp): wait for raw hook routing to settle` (d1ad7cd)**

`fire_raw_hook_and_settle` in the autoscope stress test used a fixed 15 ms sleep after 20 yield points. On slower or loaded machines this was not enough for the hook to be reflected in the router state, causing intermittent failures. The fixed sleep was replaced with an active polling loop (up to 200 × 5 ms) that probes the router and returns as soon as the expected content is visible.

## Changes

- Added `is_drain_lock_busy_error()` in `hook_spool` to also match `ERROR_LOCK_VIOLATION` on Windows alongside `WouldBlock`.
- Extended `should_try_commit_cli_fallback` in `ai-memory-wiki/git.rs` to trigger on `ErrorClass::Os` / "failed to resolve path" errors on Windows.
- Corrected test assertions in `ai-memory-store/ops.rs` to normalise the expected path key before comparison.
- Simplified irrefutable `let` destructures in `hook_drain_process` (clippy suggestion from the Windows build).
- Replaced the fixed sleep in `autoscope_stress::fire_raw_hook_and_settle` with a condition-based poll loop.

No new dependencies. Unix paths unchanged.

## Tests

Validated on Windows 11 + Git Bash and an Arch Linux container:

- [x] `cargo fmt --check`
- [x] `git diff --check`
- [x] `cargo deny check`
- [x] `TAILWIND_SKIP=1 cargo test --workspace --locked --all-targets`
- [x] `TAILWIND_SKIP=1 cargo clippy --workspace --locked --all-targets -- -D warnings`
- [x] `TAILWIND_SKIP=1 cargo build --locked --release -p ai-memory-cli`
- [x] `./target/release/ai-memory[.exe] --version` → `ai-memory 1.7.1`