### PR TITLE
fix(llm): normalize Gemini schema `type` arrays to `nullable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   provider blocks ([#147]).
 
 ### Fixed
+- Gemini structured output no longer fails with `400 INVALID_ARGUMENT …
+  "type" … Proto field is not repeating, cannot start list` when a schema
+  contains an optional field. `prepare_schema_for_gemini` now collapses
+  schemars' Draft-2020-12 `type` arrays (e.g. `["string", "null"]` for
+  `Option<T>`) into Gemini's single `type` + `nullable: true` form, so
+  consolidation / auto-improve work again with `gemini-2.5-pro` and other
+  Gemini models.
 - The detached drainer's `logs/hook-drain.log` now rotates once it exceeds
   1 MiB (previous contents move to `hook-drain.log.old`), so an agent
   pointed at a chronically unreachable server can no longer grow the log

--- a/crates/ai-memory-llm/src/gemini.rs
+++ b/crates/ai-memory-llm/src/gemini.rs
@@ -577,6 +577,15 @@ mod tests {
     }
 
     #[test]
+    fn prepare_schema_null_only_type_array_drops_type_keeps_nullable() {
+        let schema = json!({ "type": ["null"] });
+        let prepared = prepare_schema_for_gemini(schema).unwrap();
+        assert!(prepared.get("type").is_none());
+        assert!(prepared.get("anyOf").is_none());
+        assert_eq!(prepared.get("nullable").unwrap(), &json!(true));
+    }
+
+    #[test]
     fn build_request_disables_default_thinking_for_25_flash() {
         let provider =
             GeminiProvider::new(SecretString::from("test-key"), "gemini-2.5-flash").unwrap();

--- a/crates/ai-memory-llm/src/gemini.rs
+++ b/crates/ai-memory-llm/src/gemini.rs
@@ -278,6 +278,11 @@ fn first_text(response: &GeminiResponse) -> Option<String> {
 /// Gemini won't accept. `anyOf` is preserved (the only composition
 /// keyword Gemini accepts).
 ///
+/// Finally we normalise `type` *arrays* (schemars emits `["string",
+/// "null"]` for `Option<T>`) into a single `type` plus `nullable: true`,
+/// which is the shape Gemini's OpenAPI-3 subset expects — see
+/// [`normalize_nullable_types`].
+///
 /// # Errors
 /// Returns [`LlmError::Schema`] if a `$ref` can't be resolved or the
 /// schema's reference graph exceeds a safety depth (16).
@@ -285,6 +290,7 @@ pub fn prepare_schema_for_gemini(mut schema: serde_json::Value) -> LlmResult<ser
     let defs = extract_defs(&mut schema);
     inline_refs(&mut schema, &defs, 0)?;
     strip_unsupported(&mut schema);
+    normalize_nullable_types(&mut schema);
     Ok(schema)
 }
 
@@ -380,6 +386,67 @@ fn strip_unsupported(value: &mut serde_json::Value) {
     }
 }
 
+/// Rewrite JSON-Schema `type` *arrays* into the single-value form Gemini
+/// requires.
+///
+/// schemars encodes `Option<T>` as `type: ["<t>", "null"]` (Draft 2020-12).
+/// Gemini's `responseSchema` only accepts a single `type` string, so it
+/// rejects the array with `400 INVALID_ARGUMENT … "type" … Proto field is
+/// not repeating, cannot start list`. We collapse each such array:
+///
+/// - `["<t>", "null"]` → `type: "<t>"`, `nullable: true`
+/// - `["null"]` (or empty) → drop `type`, keep `nullable: true`
+/// - a genuine multi-type union → `anyOf` of single-`type` schemas
+///   (plus `nullable: true` when `"null"` was present)
+///
+/// `anyOf` is the only composition keyword Gemini accepts, so the union
+/// fallback stays within the supported subset.
+fn normalize_nullable_types(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(serde_json::Value::Array(variants)) = map.get("type").cloned() {
+                let mut non_null: Vec<String> = Vec::new();
+                let mut nullable = false;
+                for variant in &variants {
+                    match variant.as_str() {
+                        Some("null") => nullable = true,
+                        Some(other) => non_null.push(other.to_string()),
+                        None => {}
+                    }
+                }
+                match non_null.as_slice() {
+                    [single] => {
+                        map.insert("type".into(), serde_json::Value::String(single.clone()));
+                    }
+                    [] => {
+                        map.remove("type");
+                    }
+                    _ => {
+                        map.remove("type");
+                        let any_of = non_null
+                            .iter()
+                            .map(|t| serde_json::json!({ "type": t }))
+                            .collect();
+                        map.insert("anyOf".into(), serde_json::Value::Array(any_of));
+                    }
+                }
+                if nullable {
+                    map.insert("nullable".into(), serde_json::Value::Bool(true));
+                }
+            }
+            for v in map.values_mut() {
+                normalize_nullable_types(v);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for v in items {
+                normalize_nullable_types(v);
+            }
+        }
+        _ => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -458,6 +525,55 @@ mod tests {
         });
         let prepared = prepare_schema_for_gemini(schema.clone()).unwrap();
         assert_eq!(prepared, schema);
+    }
+
+    #[test]
+    fn prepare_schema_collapses_nullable_type_array() {
+        // schemars emits `["string", "null"]` for `Option<String>`; Gemini
+        // rejects the array and wants `type: "string", nullable: true`.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "title": { "type": ["string", "null"] },
+                "count": { "type": "integer" }
+            },
+            "required": ["title"]
+        });
+        let prepared = prepare_schema_for_gemini(schema).unwrap();
+        let title = prepared.pointer("/properties/title").unwrap();
+        assert_eq!(title.get("type").unwrap(), &json!("string"));
+        assert_eq!(title.get("nullable").unwrap(), &json!(true));
+        // non-nullable siblings are untouched.
+        let count = prepared.pointer("/properties/count").unwrap();
+        assert_eq!(count, &json!({ "type": "integer" }));
+    }
+
+    #[test]
+    fn prepare_schema_collapses_nested_nullable_in_array_items() {
+        let schema = json!({
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": { "note": { "type": ["string", "null"] } }
+            }
+        });
+        let prepared = prepare_schema_for_gemini(schema).unwrap();
+        let note = prepared.pointer("/items/properties/note").unwrap();
+        assert_eq!(note.get("type").unwrap(), &json!("string"));
+        assert_eq!(note.get("nullable").unwrap(), &json!(true));
+    }
+
+    #[test]
+    fn prepare_schema_multi_type_union_becomes_any_of() {
+        let schema = json!({ "type": ["string", "integer", "null"] });
+        let prepared = prepare_schema_for_gemini(schema).unwrap();
+        assert!(prepared.get("type").is_none());
+        assert_eq!(prepared.get("nullable").unwrap(), &json!(true));
+        let any_of = prepared.get("anyOf").unwrap().as_array().unwrap();
+        assert_eq!(
+            any_of,
+            &vec![json!({ "type": "string" }), json!({ "type": "integer" })]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`schemars` encodes `Option<T>` as a Draft-2020-12 `type` **array** (`["string", "null"]`). Gemini's `responseSchema` only accepts a single `type` string, so any consolidation schema with an optional field fails with:

> `400 INVALID_ARGUMENT … Unknown name "type" … Proto field is not repeating, cannot start list`

`prepare_schema_for_gemini` already inlines `$ref`s and strips `oneOf` / `additionalProperties` / … but left `type` arrays untouched. This adds a `normalize_nullable_types` pass that collapses them into Gemini's OpenAPI-3 shape:

- `["<t>", "null"]` → `type: "<t>"`, `nullable: true`
- `["null"]` (or empty) → drop `type`, keep `nullable: true`
- genuine multi-type union → `anyOf` of single-`type` schemas (+ `nullable` when `"null"` was present)

## Why

Consolidation / `auto-improve` are dead on Gemini as soon as a schema carries an `Option<_>` field — and it's request-layer validation, so switching models (flash / 2.0) doesn't help. It's neither auth nor quota: a plain `generateContent` with the same key returns 200.

## Testing

- `cargo test -p ai-memory-llm gemini` → 9 passed, incl. 3 new tests (nullable collapse, nested-in-array-items, multi-type union → `anyOf`).
- `cargo fmt -- --check` and `cargo clippy -p ai-memory-llm` clean.
- Verified against the live API: `{"type":"string","nullable":true}` → **200**; `{"type":["string","null"]}` → **400** (repro in #148).

Fixes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
