### PR TITLE
fix: rootless Docker UID remap breaks install-mcp/install-hooks/install-instructions/install-skills/setup-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `bin/ai-memory` no longer fails `install-mcp`, `install-hooks`,
+  `setup-agent`, `install-instructions`, and `install-skills` under
+  rootless Docker. Rootless Docker maps container UID 0 back to the real
+  host user but routes any other UID (including the host UID the wrapper
+  always passed via `-u`) through an unrelated subordinate-UID range, so
+  every write to a bind-mounted host path (`~/.claude/settings.json`,
+  the hook staging dir, `$PWD/CLAUDE.md`, skill directories) failed with
+  `Permission denied` or a misleading "does not exist" error. The wrapper
+  now detects rootless Docker via `docker info --format
+  '{{.SecurityOptions}}'` and runs as `-u 0:0` for just the commands that
+  write host-side files; thin-client commands (`status`, `bootstrap`, …)
+  are unaffected since they only touch the `/data` named volume.
+
 ## [1.8.0] - 2026-07-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `bin/ai-memory` no longer fails `install-mcp`, `install-hooks`,
-  `setup-agent`, `install-instructions`, and `install-skills` under
-  rootless Docker. Rootless Docker maps container UID 0 back to the real
+  `setup-agent`, `install-instructions`, `install-skills`, `uninstall`,
+  and `backup` under rootless Docker. Rootless Docker maps container UID
+  0 back to the real
   host user but routes any other UID (including the host UID the wrapper
   always passed via `-u`) through an unrelated subordinate-UID range, so
   every write to a bind-mounted host path (`~/.claude/settings.json`,

--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -257,7 +257,8 @@ done
 NETWORK_ARGS=()
 # Default: map the container process to the host user so files written
 # through bind mounts (~/.claude/settings.json, $PWD/, …) stay editable
-# by the invoking user. macOS is the one exception (see Darwin arm).
+# by the invoking user. macOS is one exception (see Darwin arm); rootless
+# Docker is the other (see the WRITES_HOST_FILES check below).
 USER_ARGS=(-u "$(id -u):$(id -g)")
 
 # Does this invocation RENDER host-side agent config? install-mcp,
@@ -290,11 +291,34 @@ while [ "${idx}" -lt "${#WRAPPER_ARGS[@]}" ]; do
       ;;
   esac
 done
+WRITES_HOST_FILES=0
 case "${WRAPPER_SUBCOMMAND}" in
     install-mcp | install-hooks | setup-agent)
       RENDERS_HOST_CONFIG=1
+      WRITES_HOST_FILES=1
+      ;;
+    install-instructions | install-skills)
+      WRITES_HOST_FILES=1
       ;;
 esac
+
+# Rootless Docker runs the whole daemon inside its own user namespace, where
+# container UID 0 maps back to the invoking host user, but any *non-zero*
+# UID we pass (e.g. our own "$(id -u):$(id -g)" above) is instead routed
+# through a separate subordinate-UID range (/etc/subuid, typically 100000+)
+# that has no relation to real host file ownership. So under rootless
+# Docker, "-u <host-uid>:<host-gid>" writes end up owned by an unmapped
+# UID and every bind-mounted write (~/.claude/settings.json, the hook
+# staging dir, $PWD/CLAUDE.md, skill directories, …) fails with
+# EACCES/ENOENT. Running as UID 0 instead hits rootlesskit's primary
+# mapping and lands as the real host user. Only do this for commands that
+# write to a host bind mount: other commands only touch the /data named
+# volume, which isn't host-visible and doesn't have this problem, so leave
+# their UID mapping alone.
+if [ "${WRITES_HOST_FILES}" -eq 1 ] \
+   && "${DOCKER}" info --format '{{.SecurityOptions}}' 2>/dev/null | grep -q 'name=rootless'; then
+  USER_ARGS=(-u 0:0)
+fi
 
 case "$(uname -s 2>/dev/null || true)" in
   Linux)

--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -297,7 +297,11 @@ case "${WRAPPER_SUBCOMMAND}" in
       RENDERS_HOST_CONFIG=1
       WRITES_HOST_FILES=1
       ;;
-    install-instructions | install-skills)
+    # uninstall edits the same host agent-config files the install-*
+    # commands write; backup writes its tarball to a host path. Both go
+    # through the same $HOME/$PWD bind mounts, so they need the same
+    # rootless-Docker UID treatment.
+    install-instructions | install-skills | uninstall | backup)
       WRITES_HOST_FILES=1
       ;;
 esac

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -262,6 +262,10 @@ fn rootless_docker_uses_root_uid_only_for_host_config_commands() {
         "setup-agent",
         "install-instructions",
         "install-skills",
+        // uninstall edits the same host agent-config files; backup writes
+        // its tarball to a host path — same bind mounts, same UID rule.
+        "uninstall",
+        "backup",
     ] {
         let args = run_wrapper_with_fake_docker(&[subcommand], rootless_info);
         assert!(

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -204,6 +204,96 @@ fn macos_wrapper_routes_urls_by_real_subcommand() {
     );
 }
 
+// Unlike run_wrapper_on_fake_macos's docker fake (which only ever sees one
+// meaningful call — the final `docker run`), the rootless-Docker UID check
+// calls `docker info` *before* `docker run`, so this fake must dispatch on
+// $1: real stdout for `info` (read by the wrapper's `grep -q rootless`) vs.
+// logging argv to a file for `run` (read back by the test).
+#[cfg(unix)]
+fn run_wrapper_with_fake_docker(args: &[&str], docker_info_stdout: &str) -> String {
+    let tmp = tempfile::tempdir().unwrap();
+    let docker_args = tmp.path().join("docker-args.txt");
+    let docker = tmp.path().join("docker");
+    std::fs::write(
+        &docker,
+        format!(
+            "#!/usr/bin/env bash\n\
+             if [ \"$1\" = info ]; then\n  printf '%s\\n' '{}'\n  exit 0\nfi\n\
+             if [ \"$1\" = run ]; then\n  shift\n  printf '%s\\n' \"$@\" > {}\n  exit 0\nfi\n\
+             exit 0\n",
+            docker_info_stdout,
+            shell_path(&docker_args)
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&docker, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let mut command = shell_script_command(&repo_root().join("bin/ai-memory"));
+    let output = command
+        .args(args)
+        .env("AI_MEMORY_DOCKER", shell_path(&docker))
+        .env("AI_MEMORY_NO_VERSION_CHECK", "1")
+        .env("AI_MEMORY_DATA_VOLUME", "test-ai-memory-data")
+        .env("HOME", shell_path(tmp.path()))
+        .env_remove("AI_MEMORY_SERVER_URL")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "wrapper failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    std::fs::read_to_string(docker_args).unwrap()
+}
+
+#[cfg(unix)]
+#[test]
+fn rootless_docker_uses_root_uid_only_for_host_config_commands() {
+    let rootless_info = "[name=apparmor name=seccomp,profile=default name=rootless]";
+
+    for subcommand in [
+        "install-mcp",
+        "install-hooks",
+        "setup-agent",
+        "install-instructions",
+        "install-skills",
+    ] {
+        let args = run_wrapper_with_fake_docker(&[subcommand], rootless_info);
+        assert!(
+            args.contains("-u\n0:0"),
+            "{subcommand} writes host bind-mounted files and must run as root \
+             under rootless Docker so the write lands as the real host user \
+             (rootlesskit only maps container UID 0 back to it); got {args}"
+        );
+    }
+
+    let args = run_wrapper_with_fake_docker(&["status"], rootless_info);
+    assert!(
+        !args.contains("-u\n0:0"),
+        "thin-client commands only touch the /data named volume, which isn't \
+         host-visible, so they must keep the host-UID mapping; got {args}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn rootful_docker_keeps_host_uid_for_host_config_commands() {
+    let rootful_info = "[name=seccomp,profile=default]";
+
+    let args = run_wrapper_with_fake_docker(&["install-hooks"], rootful_info);
+    assert!(
+        !args.contains("-u\n0:0"),
+        "rootful Docker must not switch to root UID — that would write \
+         ~/.local/share/ai-memory/hooks owned by root instead of the invoking \
+         user; got {args}"
+    );
+}
+
 #[test]
 fn macos_docs_use_valid_install_commands_and_release_body_points_to_them() {
     let docs = read_repo("docs/macos.md");


### PR DESCRIPTION
Fixes #151

## Summary

Rootless Docker maps container UID **0** back to the real host UID via rootlesskit's primary user-namespace mapping, but any *non-zero* UID passed via `-u` — including the host UID the wrapper always passes — is instead routed through a separate subordinate-UID range (`/etc/subuid`, typically `100000+`) that owns nothing on the host filesystem. So every `bin/ai-memory` subcommand that writes to a host bind-mounted path (`~/.claude/settings.json`, `~/.claude.json`, the hook-staging dir, `$PWD/CLAUDE.md`, skill directories) failed under rootless Docker with `Permission denied` or a misleading "does not exist" error.

This fixes it: detect rootless Docker via `docker info --format '{{.SecurityOptions}}'` and run as `-u 0:0` only for the subcommands that write host-side files (`install-mcp`, `install-hooks`, `setup-agent`, `install-instructions`, `install-skills`). Thin-client commands (`status`, `bootstrap`, `search`, …) are untouched — they only touch the `/data` named volume, which isn't host-visible and has no such issue.

Verified manually against the published image:
```
$ docker run --rm --entrypoint sh -u 0:0 -v "$PWD:/t" akitaonrails/ai-memory:latest -c "touch /t/probe; id"
uid=0(root) gid=0(root) groups=0(root)
$ stat probe   # Uid: (1000/holocaster) — correct, root maps back to host user

$ docker run --rm --entrypoint sh -u 1000:1000 -v "$PWD:/t" akitaonrails/ai-memory:latest -c "touch /t/probe2; id"
uid=1000(ai-memory) gid=1000(1000) groups=1000(1000)
$ stat probe2  # Uid: (100999/UNKNOWN) — wrong, unrelated subordinate-range UID
```

## Versioning

Per `CONTRIBUTING.md`'s semver policy: this is a **patch**-level bug fix. No public API, CLI surface, or on-disk format changes — `bin/ai-memory`'s behavior is identical for rootful Docker (the common case) and only changes the UID for host-config-writing commands specifically under rootless Docker, where those commands were already broken.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (includes 2 new tests: `rootless_docker_uses_root_uid_only_for_host_config_commands`, `rootful_docker_keeps_host_uid_for_host_config_commands`, both using a fake `docker` binary that dispatches on `info` vs `run` to simulate the rootless/rootful distinction)
- [x] `cargo deny check`
- [x] Reproduced and fixed the failure against the real published image on rootless Docker (Linux Mint 22.3, Docker 29.1.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)