### PR TITLE
feat(store): warn when a new project's name already exists in another workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Project creation now emits a warning when the same project name already
+  exists in another workspace, helping catch accidental cross-workspace
+  misroutes while preserving legal id-namespaced homonyms.
 - `memory_query` now runs the raw-observation fallback for explicit `scopes`
   requests when compiled wiki pages miss, so scoped cross-project searches can
   still surface bounded raw session matches without falling back to the current

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/crates/ai-memory-store/Cargo.toml
+++ b/crates/ai-memory-store/Cargo.toml
@@ -33,6 +33,7 @@ parking_lot.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -105,6 +105,30 @@ pub fn get_or_create_workspace(
     Ok(id)
 }
 
+/// Names of other workspaces that already contain a project called `name`
+/// (excluding `workspace_id`), ordered by workspace name. Homonymous
+/// projects across workspaces are legal — rows are id-namespaced — but on
+/// *creation* a non-empty result is almost always an accidental misroute,
+/// so the caller can surface a warning. Runs inside the caller's `tx`.
+fn project_name_in_other_workspaces(
+    tx: &rusqlite::Transaction<'_>,
+    workspace_id: &ai_memory_core::WorkspaceId,
+    name: &str,
+) -> StoreResult<Vec<String>> {
+    let mut stmt = tx.prepare(
+        "SELECT w.name FROM projects p \
+         JOIN workspaces w ON w.id = p.workspace_id \
+         WHERE p.name = ?1 AND p.workspace_id != ?2 \
+         ORDER BY w.name",
+    )?;
+    let rows = stmt
+        .query_map(rusqlite::params![name, workspace_id.as_bytes()], |row| {
+            row.get::<_, String>(0)
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
 /// Resolve a project by `(workspace_id, name)`, creating it if missing.
 /// Atomic.
 pub fn get_or_create_project(
@@ -125,6 +149,16 @@ pub fn get_or_create_project(
     let id = if let Some(bytes) = existing {
         ai_memory_core::ProjectId::from_slice(&bytes)?
     } else {
+        let also_in = project_name_in_other_workspaces(&tx, workspace_id, name)?;
+        if !also_in.is_empty() {
+            tracing::warn!(
+                project = name,
+                also_in = ?also_in,
+                "creating a project whose name already exists in other \
+                 workspace(s) — legal (id-namespaced) but often an \
+                 accidental misroute"
+            );
+        }
         let id = ai_memory_core::ProjectId::new();
         tx.execute(
             "INSERT INTO projects (id, workspace_id, name, repo_path, created_at) \
@@ -1515,6 +1549,43 @@ mod tests {
                 )
             });
         }
+    }
+
+    #[test]
+    fn get_or_create_project_flags_homonym_across_workspaces() {
+        let (_tmp, mut conn, _ws, _proj) = fresh_db();
+        let ws_a = get_or_create_workspace(&mut conn, "alpha").unwrap();
+        let ws_b = get_or_create_workspace(&mut conn, "beta").unwrap();
+        let a_shared = get_or_create_project(&mut conn, &ws_a, "shared", None).unwrap();
+
+        // "shared" already lives in `alpha`, so from `beta`'s side it is a
+        // cross-workspace homonym; the owning workspace and unique names
+        // flag nothing.
+        {
+            let tx = conn.transaction().unwrap();
+            assert_eq!(
+                project_name_in_other_workspaces(&tx, &ws_b, "shared").unwrap(),
+                vec!["alpha".to_string()]
+            );
+            assert!(
+                project_name_in_other_workspaces(&tx, &ws_a, "shared")
+                    .unwrap()
+                    .is_empty(),
+                "the owning workspace must be excluded"
+            );
+            assert!(
+                project_name_in_other_workspaces(&tx, &ws_b, "unique-name")
+                    .unwrap()
+                    .is_empty()
+            );
+        }
+
+        // Creation is NOT blocked — the homonym is id-namespaced.
+        let b_shared = get_or_create_project(&mut conn, &ws_b, "shared", None).unwrap();
+        assert_ne!(
+            a_shared, b_shared,
+            "homonymous projects must get distinct ids"
+        );
     }
 
     fn fresh_db() -> (

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -129,6 +129,16 @@ fn project_name_in_other_workspaces(
     Ok(rows)
 }
 
+fn warn_project_name_in_other_workspaces(name: &str, also_in: &[String]) {
+    if !also_in.is_empty() {
+        tracing::warn!(
+            project = name,
+            also_in = ?also_in,
+            "creating a project whose name already exists in other workspace(s) — legal (id-namespaced) but often an accidental misroute"
+        );
+    }
+}
+
 /// Resolve a project by `(workspace_id, name)`, creating it if missing.
 /// Atomic.
 pub fn get_or_create_project(
@@ -139,6 +149,8 @@ pub fn get_or_create_project(
 ) -> StoreResult<ai_memory_core::ProjectId> {
     let repo_path = repo_path.map(normalize_repo_path_key);
     let tx = conn.transaction()?;
+    let mut also_in = Vec::new();
+    let mut created = false;
     let existing: Option<Vec<u8>> = tx
         .query_row(
             "SELECT id FROM projects WHERE workspace_id = ?1 AND name = ?2",
@@ -149,16 +161,7 @@ pub fn get_or_create_project(
     let id = if let Some(bytes) = existing {
         ai_memory_core::ProjectId::from_slice(&bytes)?
     } else {
-        let also_in = project_name_in_other_workspaces(&tx, workspace_id, name)?;
-        if !also_in.is_empty() {
-            tracing::warn!(
-                project = name,
-                also_in = ?also_in,
-                "creating a project whose name already exists in other \
-                 workspace(s) — legal (id-namespaced) but often an \
-                 accidental misroute"
-            );
-        }
+        also_in = project_name_in_other_workspaces(&tx, workspace_id, name)?;
         let id = ai_memory_core::ProjectId::new();
         tx.execute(
             "INSERT INTO projects (id, workspace_id, name, repo_path, created_at) \
@@ -171,11 +174,15 @@ pub fn get_or_create_project(
                 Timestamp::now().as_microsecond()
             ],
         )?;
+        created = true;
         id
     };
     tx.commit()?;
     if scheduler_state_table_exists(conn)? {
         crate::auto_improve::ensure_scheduler_state(conn, *workspace_id, id)?;
+    }
+    if created {
+        warn_project_name_in_other_workspaces(name, &also_in);
     }
     Ok(id)
 }
@@ -362,7 +369,8 @@ pub fn ensure_project_with_id(
     repo_path: Option<&str>,
 ) -> StoreResult<()> {
     let repo_path = repo_path.map(normalize_repo_path_key);
-    conn.execute(
+    let tx = conn.transaction()?;
+    let inserted = tx.execute(
         "INSERT INTO projects (id, workspace_id, name, repo_path, created_at) \
          VALUES (?1, ?2, ?3, ?4, ?5) ON CONFLICT(id) DO NOTHING",
         params![
@@ -373,8 +381,13 @@ pub fn ensure_project_with_id(
             Timestamp::now().as_microsecond()
         ],
     )?;
+    let also_in = if inserted > 0 {
+        project_name_in_other_workspaces(&tx, &workspace_id, name)?
+    } else {
+        Vec::new()
+    };
     type ProjectRow = (Vec<u8>, String, Option<String>);
-    let existing: Option<ProjectRow> = conn
+    let existing: Option<ProjectRow> = tx
         .query_row(
             "SELECT workspace_id, name, repo_path FROM projects WHERE id = ?1",
             params![id.as_bytes()],
@@ -399,6 +412,10 @@ pub fn ensure_project_with_id(
             "project id {id} was not inserted"
         ))),
     }?;
+    tx.commit()?;
+    if inserted > 0 {
+        warn_project_name_in_other_workspaces(name, &also_in);
+    }
     Ok(())
 }
 
@@ -1519,7 +1536,44 @@ mod tests {
         LinkTarget, NewHandoff, NewPage, NewSession, PagePath, ProjectId, Tier, WorkspaceId,
     };
     use rusqlite::Connection;
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
+
+    #[derive(Clone, Default)]
+    struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+    struct CapturedLogWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for CapturedLogWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedLogs {
+        type Writer = CapturedLogWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            CapturedLogWriter(Arc::clone(&self.0))
+        }
+    }
+
+    fn capture_warnings(run: impl FnOnce()) -> String {
+        let logs = CapturedLogs::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::WARN)
+            .with_writer(logs.clone())
+            .without_time()
+            .finish();
+        tracing::subscriber::with_default(subscriber, run);
+        String::from_utf8(logs.0.lock().unwrap().clone()).unwrap()
+    }
 
     /// Open a fresh DB with migrations applied + a default workspace
     /// and "scratch" project pre-created. Tuple-return keeps the
@@ -1585,6 +1639,82 @@ mod tests {
         assert_ne!(
             a_shared, b_shared,
             "homonymous projects must get distinct ids"
+        );
+    }
+
+    #[test]
+    fn get_or_create_project_warns_when_creating_homonym_across_workspaces() {
+        let (_tmp, mut conn, _ws, _proj) = fresh_db();
+        let ws_a = get_or_create_workspace(&mut conn, "alpha").unwrap();
+        let ws_b = get_or_create_workspace(&mut conn, "beta").unwrap();
+        get_or_create_project(&mut conn, &ws_a, "shared", None).unwrap();
+
+        let logs = capture_warnings(|| {
+            get_or_create_project(&mut conn, &ws_b, "shared", None).unwrap();
+        });
+        assert!(
+            logs.contains("already exists in other workspace")
+                && logs.contains("shared")
+                && logs.contains("alpha"),
+            "homonym creation warning should name the project and other workspace: {logs}"
+        );
+
+        let logs = capture_warnings(|| {
+            get_or_create_project(&mut conn, &ws_b, "shared", None).unwrap();
+        });
+        assert!(
+            !logs.contains("already exists in other workspace"),
+            "idempotent lookup must not warn: {logs}"
+        );
+    }
+
+    #[test]
+    fn ensure_project_with_id_warns_when_creating_homonym_across_workspaces() {
+        let (_tmp, mut conn, _ws, _proj) = fresh_db();
+        let ws_a = get_or_create_workspace(&mut conn, "alpha").unwrap();
+        let ws_b = get_or_create_workspace(&mut conn, "beta").unwrap();
+        get_or_create_project(&mut conn, &ws_a, "shared", None).unwrap();
+        let id = ProjectId::new();
+
+        let logs = capture_warnings(|| {
+            ensure_project_with_id(&mut conn, id, ws_b, "shared", None).unwrap();
+        });
+        assert!(
+            logs.contains("already exists in other workspace")
+                && logs.contains("shared")
+                && logs.contains("alpha"),
+            "manifest project creation warning should name the project and other workspace: {logs}"
+        );
+
+        let logs = capture_warnings(|| {
+            ensure_project_with_id(&mut conn, id, ws_b, "shared", None).unwrap();
+        });
+        assert!(
+            !logs.contains("already exists in other workspace"),
+            "idempotent manifest import must not warn: {logs}"
+        );
+    }
+
+    #[test]
+    fn ensure_project_with_id_does_not_warn_when_validation_fails() {
+        let (_tmp, mut conn, _ws, _proj) = fresh_db();
+        let ws_a = get_or_create_workspace(&mut conn, "alpha").unwrap();
+        let ws_b = get_or_create_workspace(&mut conn, "beta").unwrap();
+        get_or_create_project(&mut conn, &ws_a, "shared", None).unwrap();
+        let id = ProjectId::new();
+        ensure_project_with_id(&mut conn, id, ws_b, "other", None).unwrap();
+
+        let logs = capture_warnings(|| {
+            let err = ensure_project_with_id(&mut conn, id, ws_b, "shared", None)
+                .expect_err("same id with different name must fail validation");
+            assert!(
+                matches!(err, StoreError::Duplicate(_)),
+                "unexpected error: {err}"
+            );
+        });
+        assert!(
+            !logs.contains("already exists in other workspace"),
+            "failed validation must not emit a creation warning: {logs}"
         );
     }
 


### PR DESCRIPTION
## Motivation
Homonymous projects across workspaces are legal — rows are id-namespaced — but creating one *by accident* (a write that resolves to `(other_ws, name)` and then materializes `(ws, name)`) is almost always a mis-scoped write. The creation path had no safety net: it passed silently, with no warning and no signal in the return.

## Change
`get_or_create_project` now, **only on the creation branch and inside the same transaction**, checks whether the project name already exists in any *other* workspace and emits a `tracing::warn` naming those workspaces. Creation is **not** blocked — the homonym still gets its own id — so the legitimate multi-workspace case is unaffected; this is pure observability on the cold creation path (one extra `SELECT`, never on the idempotent hit).

## Test
`get_or_create_project_flags_homonym_across_workspaces`: the helper returns the other workspace's name, excludes the owning workspace, returns empty for a unique name, and creation of the homonym still yields a distinct id. `cargo clippy -p ai-memory-store --all-targets -- -D warnings` is clean.