### PR TITLE
fix(instructions): anchor marker matching to full lines so refresh is idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `ai-memory install-instructions` and `ai-memory uninstall --only instructions`
+  now match only line-anchored routing markers, handle CRLF marker lines, and
+  repair the exact orphan-tail shape left by older refreshes when the snippet
+  body mentioned an end marker inline.
 - Project creation now emits a warning when the same project name already
   exists in another workspace, helping catch accidental cross-workspace
   misroutes while preserving legal id-namespaced homonyms.

--- a/crates/ai-memory-cli/src/commands/install_instructions.rs
+++ b/crates/ai-memory-cli/src/commands/install_instructions.rs
@@ -29,6 +29,11 @@ use crate::config::Config;
 // block this subcommand writes. Single source of truth.
 use ai_memory_core::{MARKER_END, MARKER_START, find_marker_line, full_block};
 
+const LEGACY_ORPHAN_TAIL_LF: &str =
+    "` markers without\ndisturbing the rest of the file.\n<!-- ai-memory:end -->\n";
+const LEGACY_ORPHAN_TAIL_CRLF: &str =
+    "` markers without\r\ndisturbing the rest of the file.\r\n<!-- ai-memory:end -->\r\n";
+
 /// Run the `install-instructions` subcommand.
 ///
 /// # Errors
@@ -171,15 +176,18 @@ fn merge_instructions_block(existing: &str, block: &str) -> String {
         let end_idx = end_pos + MARKER_END.len();
         // Consume a trailing newline after the end marker if present
         // so we don't accumulate blank lines on every re-run.
-        let after_end = if existing.as_bytes().get(end_idx).copied() == Some(b'\n') {
+        let after_end = if existing.as_bytes().get(end_idx..end_idx + 2) == Some(b"\r\n") {
+            end_idx + 2
+        } else if existing.as_bytes().get(end_idx).copied() == Some(b'\n') {
             end_idx + 1
         } else {
             end_idx
         };
+        let tail = strip_legacy_orphan_tail(block, &existing[after_end..]);
         let mut out = String::with_capacity(existing.len() + block.len());
         out.push_str(&existing[..start_idx]);
         out.push_str(block);
-        out.push_str(&existing[after_end..]);
+        out.push_str(tail);
         return out;
     }
     // No prior block — append. If the file already ends with a
@@ -194,6 +202,44 @@ fn merge_instructions_block(existing: &str, block: &str) -> String {
     }
     out.push_str(block);
     out
+}
+
+fn strip_legacy_orphan_tail<'a>(block: &str, tail: &'a str) -> &'a str {
+    if let Some(rest) = tail.strip_prefix(LEGACY_ORPHAN_TAIL_LF) {
+        return rest;
+    }
+    if let Some(rest) = tail.strip_prefix(LEGACY_ORPHAN_TAIL_CRLF) {
+        return rest;
+    }
+    legacy_orphan_tail(block)
+        .and_then(|orphan| tail.strip_prefix(orphan))
+        .unwrap_or(tail)
+}
+
+fn legacy_orphan_tail(block: &str) -> Option<&str> {
+    let real_start = find_marker_line(block, MARKER_START, 0)?;
+    let real_end = find_marker_line(block, MARKER_END, real_start + MARKER_START.len())?;
+    let mut search_from = real_start + MARKER_START.len();
+    while let Some(rel) = block[search_from..real_end].find(MARKER_END) {
+        let inline = search_from + rel;
+        if find_marker_line(block, MARKER_END, inline) != Some(inline) {
+            let orphan_start = inline + MARKER_END.len();
+            let orphan_end = consume_line_ending(block, real_end + MARKER_END.len());
+            return Some(&block[orphan_start..orphan_end]);
+        }
+        search_from = inline + MARKER_END.len();
+    }
+    None
+}
+
+fn consume_line_ending(s: &str, idx: usize) -> usize {
+    if s.as_bytes().get(idx..idx + 2) == Some(b"\r\n") {
+        idx + 2
+    } else if s.as_bytes().get(idx).copied() == Some(b'\n') {
+        idx + 1
+    } else {
+        idx
+    }
 }
 
 #[cfg(test)]
@@ -260,6 +306,30 @@ mod tests {
         // One inline mention + one real delimiter — nothing accumulated.
         assert_eq!(second.matches(MARKER_START).count(), 1);
         assert_eq!(second.matches(MARKER_END).count(), 2);
+    }
+
+    #[test]
+    fn merge_repairs_exact_legacy_orphan_tail() {
+        let block = full_block();
+        let legacy_corrupt = format!("# Title\n\n{block}{LEGACY_ORPHAN_TAIL_LF}More notes.\n");
+        let out = merge_instructions_block(&legacy_corrupt, &block);
+        assert_eq!(out, format!("# Title\n\n{block}More notes.\n"));
+    }
+
+    #[test]
+    fn merge_repairs_exact_legacy_orphan_tail_crlf_variant() {
+        let block = full_block();
+        let legacy_corrupt = format!("# Title\r\n\r\n{block}{LEGACY_ORPHAN_TAIL_CRLF}More\r\n");
+        let out = merge_instructions_block(&legacy_corrupt, &block);
+        assert_eq!(out, format!("# Title\r\n\r\n{block}More\r\n"));
+    }
+
+    #[test]
+    fn merge_consumes_crlf_after_end_marker() {
+        let original = format!("# Title\r\n\r\n{MARKER_START}\r\nOLD\r\n{MARKER_END}\r\nMore\r\n");
+        let block = format!("{MARKER_START}\nNEW\n{MARKER_END}\n");
+        let out = merge_instructions_block(&original, &block);
+        assert_eq!(out, format!("# Title\r\n\r\n{block}More\r\n"));
     }
 
     /// The real shipped block round-trips cleanly through a refresh.

--- a/crates/ai-memory-cli/src/commands/install_instructions.rs
+++ b/crates/ai-memory-cli/src/commands/install_instructions.rs
@@ -27,7 +27,7 @@ use crate::config::Config;
 // Markers + the snippet body live in `ai_memory_core::routing_snippet`
 // so the `memory_install_self_routing` MCP tool can return the same
 // block this subcommand writes. Single source of truth.
-use ai_memory_core::{MARKER_END, MARKER_START, full_block};
+use ai_memory_core::{MARKER_END, MARKER_START, find_marker_line, full_block};
 
 /// Run the `install-instructions` subcommand.
 ///
@@ -161,10 +161,14 @@ fn infer_skills_agent_from_instruction_targets(targets: &[PathBuf]) -> InstallSk
 /// `block` to the end of the file with a single blank-line
 /// separator. The user's other content is never touched.
 fn merge_instructions_block(existing: &str, block: &str) -> String {
-    if let Some(start_idx) = existing.find(MARKER_START)
-        && let Some(end_idx_rel) = existing[start_idx..].find(MARKER_END)
+    // Anchor on markers that occupy their own line so an inline mention of
+    // the marker strings (e.g. this block's own prose describing them)
+    // cannot be mistaken for the real end delimiter — which would truncate
+    // the block and leave an orphan tail on every refresh.
+    if let Some(start_idx) = find_marker_line(existing, MARKER_START, 0)
+        && let Some(end_pos) = find_marker_line(existing, MARKER_END, start_idx)
     {
-        let end_idx = start_idx + end_idx_rel + MARKER_END.len();
+        let end_idx = end_pos + MARKER_END.len();
         // Consume a trailing newline after the end marker if present
         // so we don't accumulate blank lines on every re-run.
         let after_end = if existing.as_bytes().get(end_idx).copied() == Some(b'\n') {
@@ -238,6 +242,38 @@ mod tests {
         let first = merge_instructions_block("# Title\n", &block);
         let second = merge_instructions_block(&first, &block);
         assert_eq!(first, second, "second merge must be a no-op");
+    }
+
+    /// Regression: a block whose body *mentions* the end marker inline
+    /// (mid-line, as older snippets did between backticks) must not be
+    /// truncated at that mention. The naive `find` matched the inline
+    /// marker, cut early, and re-injected the tail on every refresh; the
+    /// line-anchored matcher must keep the double-run a true no-op.
+    #[test]
+    fn merge_ignores_inline_marker_mention_in_block() {
+        let block = format!(
+            "{MARKER_START}\nsee the `{MARKER_END}` marker inline\nreal body\n{MARKER_END}\n"
+        );
+        let first = merge_instructions_block("# Title\n", &block);
+        let second = merge_instructions_block(&first, &block);
+        assert_eq!(first, second, "double-run must be a no-op");
+        // One inline mention + one real delimiter — nothing accumulated.
+        assert_eq!(second.matches(MARKER_START).count(), 1);
+        assert_eq!(second.matches(MARKER_END).count(), 2);
+    }
+
+    /// The real shipped block round-trips cleanly through a refresh.
+    #[test]
+    fn merge_idempotent_with_real_block() {
+        let block = full_block();
+        let first = merge_instructions_block("# Title\n", &block);
+        let second = merge_instructions_block(&first, &block);
+        assert_eq!(first, second, "refresh of the real block must be a no-op");
+        assert_eq!(
+            second.matches(MARKER_END).count(),
+            block.matches(MARKER_END).count(),
+            "no orphaned end marker accumulated"
+        );
     }
 
     /// Defensive: existing file ends without trailing newline. We

--- a/crates/ai-memory-cli/src/commands/uninstall.rs
+++ b/crates/ai-memory-cli/src/commands/uninstall.rs
@@ -22,6 +22,11 @@ use anyhow::{Context, Result};
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
+const LEGACY_ORPHAN_TAIL_LF: &str =
+    "` markers without\ndisturbing the rest of the file.\n<!-- ai-memory:end -->\n";
+const LEGACY_ORPHAN_TAIL_CRLF: &str =
+    "` markers without\r\ndisturbing the rest of the file.\r\n<!-- ai-memory:end -->\r\n";
+
 /// One rewrite operation to apply to a config file.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RewriteOp {
@@ -490,19 +495,27 @@ fn strip_instructions_block(content: &str) -> (String, bool) {
     };
     let end = end_pos + MARKER_END.len();
     // Consume a trailing newline after the end marker if present.
-    let after = if content.as_bytes().get(end).copied() == Some(b'\n') {
+    let after = if content.as_bytes().get(end..end + 2) == Some(b"\r\n") {
+        end + 2
+    } else if content.as_bytes().get(end).copied() == Some(b'\n') {
         end + 1
     } else {
         end
     };
     let mut head = content[..start].to_string();
-    let tail = &content[after..];
+    let tail = strip_legacy_orphan_tail(&content[after..]);
     // When the block sat at EOF, install added a blank-line separator
     // before it; drop that artifact so install→uninstall round-trips.
     if tail.is_empty() && head.ends_with("\n\n") {
         head.pop();
     }
     (format!("{head}{tail}"), true)
+}
+
+fn strip_legacy_orphan_tail(tail: &str) -> &str {
+    tail.strip_prefix(LEGACY_ORPHAN_TAIL_LF)
+        .or_else(|| tail.strip_prefix(LEGACY_ORPHAN_TAIL_CRLF))
+        .unwrap_or(tail)
 }
 
 /// True when a hook command string was written by ai-memory. Legacy script
@@ -903,6 +916,23 @@ mod tests {
             stripped, original,
             "no orphan tail after the real end marker"
         );
+    }
+
+    #[test]
+    fn strip_consumes_crlf_after_end_marker() {
+        let content = format!("# Top\r\n\r\n{MARKER_START}\r\nBODY\r\n{MARKER_END}\r\nMore\r\n");
+        let (stripped, found) = strip_instructions_block(&content);
+        assert!(found);
+        assert_eq!(stripped, "# Top\r\n\r\nMore\r\n");
+    }
+
+    #[test]
+    fn strip_removes_exact_legacy_orphan_tail() {
+        let content =
+            format!("# Top\n\n{MARKER_START}\nBODY\n{MARKER_END}\n{LEGACY_ORPHAN_TAIL_LF}More\n");
+        let (stripped, found) = strip_instructions_block(&content);
+        assert!(found);
+        assert_eq!(stripped, "# Top\n\nMore\n");
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/uninstall.rs
+++ b/crates/ai-memory-cli/src/commands/uninstall.rs
@@ -17,7 +17,7 @@ use crate::config::Config;
 use ai_memory_core::routing_skills::{
     AGENTS_SKILL_DIR, CLAUDE_SKILL_DIR, MANAGED_MARKER, MANAGED_SKILLS, SKILLS_DIR,
 };
-use ai_memory_core::{MARKER_END, MARKER_START};
+use ai_memory_core::{MARKER_END, MARKER_START, find_marker_line};
 use anyhow::{Context, Result};
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
@@ -478,13 +478,17 @@ fn print_docker_hint(data_purged: bool) {
 /// `install_instructions::merge_instructions_block`: an install
 /// followed by an uninstall round-trips to the original file.
 fn strip_instructions_block(content: &str) -> (String, bool) {
-    let Some(start) = content.find(MARKER_START) else {
+    // Line-anchored so an inline mention of the marker strings inside the
+    // managed block can't be matched as the real end delimiter (which would
+    // leave an orphan tail behind, breaking the install->uninstall
+    // round-trip).
+    let Some(start) = find_marker_line(content, MARKER_START, 0) else {
         return (content.to_string(), false);
     };
-    let Some(end_rel) = content[start..].find(MARKER_END) else {
+    let Some(end_pos) = find_marker_line(content, MARKER_END, start) else {
         return (content.to_string(), false);
     };
-    let end = start + end_rel + MARKER_END.len();
+    let end = end_pos + MARKER_END.len();
     // Consume a trailing newline after the end marker if present.
     let after = if content.as_bytes().get(end).copied() == Some(b'\n') {
         end + 1
@@ -881,6 +885,23 @@ mod tests {
         assert_eq!(
             stripped, original,
             "uninstall must restore the original file"
+        );
+    }
+
+    /// Regression: a managed block whose body mentions the end marker
+    /// inline must be stripped up to the REAL delimiter, not the inline
+    /// mention — otherwise an orphan tail survives the uninstall.
+    #[test]
+    fn strip_ignores_inline_marker_mention() {
+        let original = "# Title\n";
+        let block =
+            format!("{MARKER_START}\nsee the `{MARKER_END}` marker inline\nbody\n{MARKER_END}\n");
+        let installed = format!("{original}\n{block}");
+        let (stripped, found) = strip_instructions_block(&installed);
+        assert!(found);
+        assert_eq!(
+            stripped, original,
+            "no orphan tail after the real end marker"
         );
     }
 

--- a/crates/ai-memory-consolidate/src/auto_improve.rs
+++ b/crates/ai-memory-consolidate/src/auto_improve.rs
@@ -1914,7 +1914,11 @@ mod tests {
         let mut perms = std::fs::metadata(&path).unwrap().permissions();
         perms.set_mode(0o755);
         std::fs::set_permissions(&path, perms).unwrap();
-        path.display().to_string()
+        // Execute through the shell instead of exec'ing the freshly-written
+        // temp file directly. Some Linux filesystems can briefly report
+        // ETXTBSY for direct exec under parallel tests even after write(2)
+        // returns and the file handle has been dropped.
+        format!("sh {}", path.display())
     }
 
     #[cfg(windows)]

--- a/crates/ai-memory-core/src/lib.rs
+++ b/crates/ai-memory-core/src/lib.rs
@@ -45,6 +45,6 @@ pub use ids::{
 };
 pub use observation::{NewObservation, NewSession, Observation, ObservationKind};
 pub use page::{LinkTarget, NewPage, Page, Tier};
-pub use routing_snippet::{MARKER_END, MARKER_START, SNIPPET_BODY, full_block};
+pub use routing_snippet::{MARKER_END, MARKER_START, SNIPPET_BODY, find_marker_line, full_block};
 pub use sanitize::{SanitizeConfig, Sanitized, Sanitizer};
 pub use user::{MAX_EMAIL_LEN, MAX_USERNAME_LEN, NewUser, User, validate_email, validate_username};

--- a/crates/ai-memory-core/src/routing_snippet.rs
+++ b/crates/ai-memory-core/src/routing_snippet.rs
@@ -115,6 +115,10 @@ pub fn full_block() -> String {
 /// `None` when no line-anchored occurrence exists.
 #[must_use]
 pub fn find_marker_line(haystack: &str, marker: &str, from: usize) -> Option<usize> {
+    if marker.is_empty() || from > haystack.len() || !haystack.is_char_boundary(from) {
+        return None;
+    }
+
     let mut idx = from;
     while let Some(rel) = haystack[idx..].find(marker) {
         let pos = idx + rel;
@@ -155,6 +159,13 @@ mod tests {
     #[test]
     fn find_marker_line_absent_returns_none() {
         assert!(find_marker_line("no markers here\n", MARKER_END, 0).is_none());
+    }
+
+    #[test]
+    fn find_marker_line_rejects_invalid_search_inputs() {
+        assert!(find_marker_line(MARKER_END, "", 0).is_none());
+        assert!(find_marker_line(MARKER_END, MARKER_END, MARKER_END.len() + 1).is_none());
+        assert!(find_marker_line("é\n", MARKER_END, 1).is_none());
     }
 
     /// Option-2 guard: the canonical block must not embed the markers

--- a/crates/ai-memory-core/src/routing_snippet.rs
+++ b/crates/ai-memory-core/src/routing_snippet.rs
@@ -90,9 +90,8 @@ latest binary's recommended copy:
   `CLAUDE.md`; pass `--target AGENTS.md` for non-Claude agents or projects
   that use `AGENTS.md` as the canonical instruction file).
 
-Both are idempotent: re-runs replace the block bracketed by
-`<!-- ai-memory:start -->` / `<!-- ai-memory:end -->` markers without
-disturbing the rest of the file.
+Both are idempotent: re-runs replace the block delimited by the ai-memory
+start/end HTML-comment markers, without disturbing the rest of the file.
 "#;
 
 /// Build the full markered block that should land in CLAUDE.md /
@@ -104,4 +103,68 @@ disturbing the rest of the file.
 #[must_use]
 pub fn full_block() -> String {
     format!("{MARKER_START}\n{}\n{MARKER_END}\n", SNIPPET_BODY.trim())
+}
+
+/// Byte offset, at or after `from`, of an occurrence of `marker` that sits
+/// alone on its own line (only whitespace before it on the line and after
+/// it up to the newline). [`full_block`] always writes the real delimiters
+/// on their own lines, so this matches the true markers while skipping any
+/// inline mention of the marker strings — a marker quoted inside prose or
+/// code — which a naive [`str::find`] would hit first, truncating the
+/// managed block and leaving an orphan tail on every refresh. Returns
+/// `None` when no line-anchored occurrence exists.
+#[must_use]
+pub fn find_marker_line(haystack: &str, marker: &str, from: usize) -> Option<usize> {
+    let mut idx = from;
+    while let Some(rel) = haystack[idx..].find(marker) {
+        let pos = idx + rel;
+        let line_start = haystack[..pos].rfind('\n').map_or(0, |n| n + 1);
+        let before = &haystack[line_start..pos];
+        let after = haystack[pos + marker.len()..]
+            .split('\n')
+            .next()
+            .unwrap_or("");
+        if before.trim().is_empty() && after.trim().is_empty() {
+            return Some(pos);
+        }
+        idx = pos + marker.len();
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_marker_line_skips_inline_mention() {
+        let text = format!("a\nsee `{MARKER_END}` inline\n{MARKER_END}\nb\n");
+        let pos = find_marker_line(&text, MARKER_END, 0).unwrap();
+        let line_start = text[..pos].rfind('\n').map_or(0, |n| n + 1);
+        assert_eq!(
+            &text[line_start..pos],
+            "",
+            "matched marker must start its own line"
+        );
+        assert!(
+            text[pos + MARKER_END.len()..].starts_with('\n'),
+            "nothing may follow the marker on its line"
+        );
+    }
+
+    #[test]
+    fn find_marker_line_absent_returns_none() {
+        assert!(find_marker_line("no markers here\n", MARKER_END, 0).is_none());
+    }
+
+    /// Option-2 guard: the canonical block must not embed the markers
+    /// anywhere but as the real delimiters, so the agent-driven install
+    /// path (which never runs the CLI matcher) stays safe too.
+    #[test]
+    fn full_block_has_exactly_one_of_each_marker() {
+        let block = full_block();
+        assert_eq!(block.matches(MARKER_START).count(), 1);
+        assert_eq!(block.matches(MARKER_END).count(), 1);
+        assert!(block.trim_end().ends_with(MARKER_END));
+    }
 }

--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -2852,8 +2852,9 @@ mod tests {
             "snippet must tell agents to refresh managed skill files"
         );
         assert!(
-            snippet.contains(ai_memory_core::MARKER_START)
-                && snippet.contains(ai_memory_core::MARKER_END),
+            snippet.contains("start/end HTML-comment markers")
+                && ai_memory_core::full_block().contains(ai_memory_core::MARKER_START)
+                && ai_memory_core::full_block().contains(ai_memory_core::MARKER_END),
             "snippet must preserve marker replacement guidance"
         );
     }


### PR DESCRIPTION
## Problem
`install-instructions` (and the uninstall strip) located the managed `<!-- ai-memory:start -->`…`<!-- ai-memory:end -->` block with a naive `str::find` of the marker strings. The canonical snippet body quotes the end marker inline in its own "Refreshing this snippet" prose, so `find(MARKER_END)` matched that **inline mention**, cut the block short, and re-appended the leftover tail on every refresh — the block grew an orphan on each run. `uninstall`'s `strip_instructions_block` had the same bug and so never round-tripped an install back to the original file.

## Fix (defense in depth)
1. **Line-anchored matcher.** New `routing_snippet::find_marker_line(haystack, marker, from)` returns only an occurrence that sits alone on its own line (whitespace-only before it and after it to the newline) — exactly how `full_block()` writes the real delimiters. Both `merge_instructions_block` and `strip_instructions_block` use it, so an inline mention of the marker strings is skipped. This also repairs blocks written by older binaries and any user prose that happens to mention the markers.
2. **Reworded snippet.** The canonical body no longer embeds the literal markers, so the agent-driven `memory_install_self_routing` path (which returns the block for the agent's own Write/Edit tool and never runs the CLI matcher) is safe as well.

## Tests
New regression tests for the inline-mention case: `find_marker_line_skips_inline_mention` + `full_block_has_exactly_one_of_each_marker` (core), `merge_ignores_inline_marker_mention_in_block` + `merge_idempotent_with_real_block` (install), `strip_ignores_inline_marker_mention` (uninstall). `cargo clippy -p ai-memory-core -p ai-memory-cli --all-targets -- -D warnings` is clean. (An unrelated, environment-dependent test `rootless_docker_uses_root_uid_only_for_host_config_commands` fails identically on a clean tree here and is not touched by this change.)