### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20 to clear RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Problem
`cargo-audit` and `cargo-deny` currently fail on `main` (and therefore on every open PR) with **RUSTSEC-2026-0204** — an invalid pointer dereference in the `fmt::Pointer` impl for crossbeam-epoch's `Atomic`/`Shared` when the underlying pointer is invalid. `crossbeam-epoch` is a transitive dependency: `sysinfo -> rayon -> rayon-core -> crossbeam-deque -> crossbeam-epoch`.

## Fix
Bump the lockfile entry `crossbeam-epoch 0.9.18 -> 0.9.20` (0.9.20 is a compatible patched release). This clears the advisory at the source, so no `--ignore` entry is needed in the CI audit step or `deny.toml`. Lockfile-only change; no source or API impact.

## Verification
```
cargo audit --ignore RUSTSEC-2025-0141 --ignore RUSTSEC-2024-0320 \
            --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195
# -> exit 0, no vulnerabilities

cargo deny check advisories
# -> advisories ok
```