### PR TITLE
test(packaging): pin uname to Linux in the rootless-Docker UID test

### DIFF
--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -226,15 +226,31 @@ fn run_wrapper_with_fake_docker(args: &[&str], docker_info_stdout: &str) -> Stri
         ),
     )
     .unwrap();
+    // Pin `uname -s` to Linux via a fake on PATH so the rootless-UID logic
+    // under test runs regardless of the CI runner's real OS. On a macOS host
+    // the wrapper's Darwin arm deliberately clears USER_ARGS (Docker Desktop
+    // handles bind-mount perms), which is unrelated to the Linux rootless
+    // subordinate-UID behavior this asserts — so without pinning, the test
+    // exercised the wrong branch and failed on macOS runners. Mirrors the
+    // fake-uname approach in run_wrapper_on_fake_macos.
+    let uname = tmp.path().join("uname");
+    std::fs::write(&uname, "#!/usr/bin/env bash\nprintf 'Linux\\n'\n").unwrap();
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&docker, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::set_permissions(&uname, std::fs::Permissions::from_mode(0o755)).unwrap();
     }
 
+    let path = format!(
+        "{}:{}",
+        shell_path(tmp.path()),
+        std::env::var("PATH").unwrap_or_default()
+    );
     let mut command = shell_script_command(&repo_root().join("bin/ai-memory"));
     let output = command
         .args(args)
+        .env("PATH", path)
         .env("AI_MEMORY_DOCKER", shell_path(&docker))
         .env("AI_MEMORY_NO_VERSION_CHECK", "1")
         .env("AI_MEMORY_DATA_VOLUME", "test-ai-memory-data")


### PR DESCRIPTION
## Problem
`rootless_docker_uses_root_uid_only_for_host_config_commands` fails the gating `test (macos-latest)` job (and is red on `main`). It asserts that under rootless Docker the wrapper passes `-u 0:0` for host-config subcommands. The test simulates rootless via a fake `docker info`, but the wrapper reads the **real** host OS through `uname -s`. On a macOS runner that takes the wrapper's `Darwin` arm, which deliberately clears `USER_ARGS` (Docker Desktop handles bind-mount permissions on macOS) — an entirely different, correct code path — so `-u 0:0` is never emitted and the assertion fails. The behavior under test (rootless subordinate-UID remap) is Linux-specific.

## Fix
Install a fake `uname` that reports `Linux` on `PATH` inside `run_wrapper_with_fake_docker`, exactly as the sibling `run_wrapper_on_fake_macos` helper already does to pin the OS. The rootless-UID logic is then exercised deterministically on any host runner.

## Verification
Reproduced on macOS (where it failed): after the change `cargo test -p ai-memory-cli --test packaging` is fully green (9/9), including the previously-failing test and the fake-macOS tests. No production/wrapper code changed — test harness only.