### PR TITLE
chore(ci): unbreak main — clear RUSTSEC-2026-0204 and fix the macOS rootless test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -226,15 +226,31 @@ fn run_wrapper_with_fake_docker(args: &[&str], docker_info_stdout: &str) -> Stri
         ),
     )
     .unwrap();
+    // Pin `uname -s` to Linux via a fake on PATH so the rootless-UID logic
+    // under test runs regardless of the CI runner's real OS. On a macOS host
+    // the wrapper's Darwin arm deliberately clears USER_ARGS (Docker Desktop
+    // handles bind-mount perms), which is unrelated to the Linux rootless
+    // subordinate-UID behavior this asserts — so without pinning, the test
+    // exercised the wrong branch and failed on macOS runners. Mirrors the
+    // fake-uname approach in run_wrapper_on_fake_macos.
+    let uname = tmp.path().join("uname");
+    std::fs::write(&uname, "#!/usr/bin/env bash\nprintf 'Linux\\n'\n").unwrap();
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&docker, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::set_permissions(&uname, std::fs::Permissions::from_mode(0o755)).unwrap();
     }
 
+    let path = format!(
+        "{}:{}",
+        shell_path(tmp.path()),
+        std::env::var("PATH").unwrap_or_default()
+    );
     let mut command = shell_script_command(&repo_root().join("bin/ai-memory"));
     let output = command
         .args(args)
+        .env("PATH", path)
         .env("AI_MEMORY_DOCKER", shell_path(&docker))
         .env("AI_MEMORY_NO_VERSION_CHECK", "1")
         .env("AI_MEMORY_DATA_VOLUME", "test-ai-memory-data")


### PR DESCRIPTION
CI is currently red on `main` (and therefore on every open PR) on two independent, gating checks. This bundles both fixes so `main` goes green in one merge.

## 1. `cargo-audit` / `cargo-deny` — RUSTSEC-2026-0204
Invalid pointer dereference in the `fmt::Pointer` impl for crossbeam-epoch's `Atomic`/`Shared`. `crossbeam-epoch` is transitive (`sysinfo -> rayon -> rayon-core -> crossbeam-deque`). Bumping the lockfile entry `0.9.18 -> 0.9.20` (a compatible patched release) clears the advisory at the source — no `--ignore` entry needed.

Verified: `cargo audit` (with the existing CI ignore set) exits 0; `cargo deny check advisories` → `advisories ok`.

## 2. `test (macos-latest)` — rootless-Docker UID test
`rootless_docker_uses_root_uid_only_for_host_config_commands` asserts the Linux rootless subordinate-UID behavior (`-u 0:0` for host-config subcommands), but read the **real** host OS via `uname -s`. On a macOS runner the wrapper's `Darwin` arm deliberately clears `USER_ARGS` (Docker Desktop handles bind-mount perms), so the test hit the wrong branch and failed. Fixed by installing a fake `uname` reporting `Linux` on `PATH` inside the test helper — the same technique `run_wrapper_on_fake_macos` already uses — so the Linux path is exercised deterministically on any runner.

Verified on macOS (where it failed): `cargo test -p ai-memory-cli --test packaging` is fully green (9/9). Test-harness only; no wrapper/production code changed.