### PR TITLE
feat(mcp): name the resolved scope in memory_read_page not-found errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `memory_read_page` by-path not-found errors now name the resolved
+  workspace/project scope, making stale or mis-scoped page paths easier to
+  diagnose from MCP clients ([#166]).
+
 ## [1.11.2] - 2026-07-11
 
 ### Fixed

--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -968,6 +968,31 @@ impl AiMemoryServer {
             .map_err(Self::scope_error)
     }
 
+    /// Human-readable `workspace/project` label for a resolved scope. Makes
+    /// not-found errors diagnosable — especially under cross-project
+    /// scope-bleed, where a scoped-implicit read resolves to a different
+    /// scope than a concurrent write landed in. Degrades to a placeholder
+    /// when a name lookup fails so it never turns a not-found into a harder
+    /// error.
+    async fn scope_label(
+        &self,
+        ws: ai_memory_core::WorkspaceId,
+        proj: ai_memory_core::ProjectId,
+    ) -> String {
+        let ws_name = self.reader.workspace_name_by_id(ws).await.ok().flatten();
+        let proj_name = self
+            .reader
+            .project_name_by_id(ws, proj)
+            .await
+            .ok()
+            .flatten();
+        format!(
+            "{}/{}",
+            ws_name.as_deref().unwrap_or("<unknown-workspace>"),
+            proj_name.as_deref().unwrap_or("<unknown-project>")
+        )
+    }
+
     async fn embed_query(&self, query: &str) -> Option<Vec<f32>> {
         let Some(embedder) = &self.embedder else {
             return None;
@@ -1837,6 +1862,15 @@ impl AiMemoryServer {
                 &aps_actor,
             )
             .await?;
+        // Diagnose cross-project scope-bleed: a read with no explicit scope
+        // resolves to the active project, which may differ from the scope a
+        // concurrent write landed in — the write persists but the by-path
+        // read looks in the wrong bucket and 404s.
+        let auto_scoped = args
+            .workspace
+            .as_deref()
+            .is_none_or(|s| s.trim().is_empty())
+            && args.project.as_deref().is_none_or(|s| s.trim().is_empty());
 
         let page_path = if let Some(p) = args.path {
             PagePath::new(p)
@@ -1911,7 +1945,28 @@ impl AiMemoryServer {
                             "served_from": "db-fallback",
                         }))
                     }
-                    None => Err(McpError::internal_error(disk_err.to_string(), None)),
+                    None => {
+                        // Not on disk and not in the DB under the resolved
+                        // scope. Name the scope (and flag auto-resolution) so
+                        // scope-bleed is diagnosable from the error itself,
+                        // instead of leaking the raw disk error/path.
+                        let scope = self.scope_label(ws, proj).await;
+                        let hint = if auto_scoped {
+                            " — this scope was auto-resolved from the active \
+                             project; pass explicit workspace+project if this \
+                             is a parallel multi-project session where the \
+                             write may have landed in a different scope"
+                        } else {
+                            ""
+                        };
+                        Err(McpError::internal_error(
+                            format!(
+                                "page {} not found in resolved scope {scope}{hint}",
+                                page_path.as_str()
+                            ),
+                            None,
+                        ))
+                    }
                 }
             }
             Err(disk_err) => Err(McpError::internal_error(disk_err.to_string(), None)),
@@ -4280,6 +4335,55 @@ mod tests {
         assert!(
             text.contains("db-fallback"),
             "expected fallback diagnostic; got {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_read_page_missing_error_names_the_scope() {
+        let (tmp, store, server, _ws, _proj) = setup_server().await;
+        let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
+        let server = server.with_wiki(wiki);
+
+        // Explicit scope: the not-found error names workspace/project and the
+        // relative path (no raw disk error / absolute path leak).
+        let err = server
+            .memory_read_page(
+                Parameters(ReadPageArgs {
+                    query: None,
+                    path: Some("does-not-exist.md".into()),
+                    project: Some("scratch".into()),
+                    workspace: Some("default".into()),
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
+            .await
+            .expect_err("missing page must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("default/scratch"),
+            "must name the scope; got {msg}"
+        );
+        assert!(
+            msg.contains("does-not-exist.md"),
+            "must name the path; got {msg}"
+        );
+
+        // Auto-scoped read: the error adds the parallel-session hint.
+        let err = server
+            .memory_read_page(
+                Parameters(ReadPageArgs {
+                    query: None,
+                    path: Some("does-not-exist.md".into()),
+                    project: None,
+                    workspace: None,
+                }),
+                rmcp::handler::server::tool::Extension(test_parts_default()),
+            )
+            .await
+            .expect_err("missing page must error");
+        assert!(
+            err.to_string().contains("auto-resolved"),
+            "auto-scoped error must hint at scope-bleed; got {err}"
         );
     }
 


### PR DESCRIPTION
## Motivation
When `memory_read_page` is called by `path` with no explicit `workspace`/`project`, the scope is auto-resolved from the active project. In a parallel, multi-project setup the active-project pointer can resolve to a *different* scope than the one a concurrent write landed in — so the page exists (it shows up in `memory_recent`), but the by-path read looks in the wrong bucket, the DB fallback (`page_body_by_ids`) also misses, and the call errors. The surfaced message was the raw disk "file not found" error, which is undiagnosable (and could leak an absolute path).

This is not a write/visibility race — `write_page` installs the file atomically and synchronously before returning — it is transient cross-project scope-bleed.

## Change
On the not-found path (missing on disk **and** absent from the DB under the resolved scope), the error now:
- names the resolved `workspace/project` (via `workspace_name_by_id`/`project_name_by_id`, degrading to a placeholder if a name lookup fails), and
- when the scope was auto-resolved (no explicit workspace/project passed), adds a hint to pass explicit `workspace`+`project`.

Only the not-found arm changes; genuine disk parse/permission errors are untouched, and no data/scope-resolution logic changes.

## Test
`memory_read_page_missing_error_names_the_scope`: an explicit-scope miss names `default/scratch` + the relative path; an auto-scoped miss adds the "auto-resolved" hint. Existing read-page tests (db-fallback, unknown-explicit-project-no-fallback, instructive-empty-args) still pass. Clippy `-D warnings` clean.