### PR TITLE
perf(admin): skip the contributors enrich webhook on move-project copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Copy-purge `/admin/move-project` now skips only the webhook named exactly
+  `contributors` while copying pages, avoiding redundant per-page contributor
+  enrichment on already-enriched frontmatter while preserving other
+  `write_page` webhooks and the terminal purge notification ([#167]).
 - `memory_read_page` by-path not-found errors now name the resolved
   workspace/project scope, making stale or mis-scoped page paths easier to
   diagnose from MCP clients ([#166]).

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -67,6 +67,7 @@ use tokio_util::io::ReaderStream;
 use tracing::{info, warn};
 
 const EMBEDDING_WRITE_BATCH: usize = 100;
+const CONTRIBUTORS_WEBHOOK_NAME: &str = "contributors";
 
 /// Shared state for the admin router.
 #[derive(Clone)]
@@ -3761,14 +3762,14 @@ async fn copy_purge_merge(
                 // Preserve the stored title verbatim (PageSummary.title is
                 // the DB-derived title), rather than re-deriving it.
                 title: Some(p.title.clone()),
-                // Skip the `contributors` enrich webhook on move copies: the
-                // frontmatter (including the contributors list) is copied
+                // Skip the named contributors enrich webhook on move copies:
+                // the frontmatter (including the contributors list) is copied
                 // verbatim, so re-enriching each copy adds nothing but blocking
                 // per-page latency to a bulk move. write_page still resolves
                 // the destination NAMES and runs the other hooks (git-mirror),
                 // so the copy lands under the destination path.
                 admission_ctx: Some(AdmissionContext {
-                    skip_webhooks: vec!["contributors".to_string()],
+                    skip_webhooks: vec![CONTRIBUTORS_WEBHOOK_NAME.to_string()],
                     ..AdmissionContext::default()
                 }),
                 author_id: None,

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -3761,10 +3761,16 @@ async fn copy_purge_merge(
                 // Preserve the stored title verbatim (PageSummary.title is
                 // the DB-derived title), rather than re-deriving it.
                 title: Some(p.title.clone()),
-                // None → the write_page admission chain resolves the
-                // workspace/project NAMES from the destination IDs, so the
-                // git-mirror lands the copy under the destination path.
-                admission_ctx: None,
+                // Skip the `contributors` enrich webhook on move copies: the
+                // frontmatter (including the contributors list) is copied
+                // verbatim, so re-enriching each copy adds nothing but blocking
+                // per-page latency to a bulk move. write_page still resolves
+                // the destination NAMES and runs the other hooks (git-mirror),
+                // so the copy lands under the destination path.
+                admission_ctx: Some(AdmissionContext {
+                    skip_webhooks: vec!["contributors".to_string()],
+                    ..AdmissionContext::default()
+                }),
                 author_id: None,
                 actor: actor.clone(),
             })

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -1523,6 +1523,113 @@ async fn copy_purge_purge_admission_runs_before_db_destruction() {
     );
 }
 
+/// A move copies frontmatter (including the contributors list) verbatim, so
+/// the copy leg skips the `contributors` enrich webhook — re-enriching would
+/// only add blocking per-page latency to a bulk move — while other hooks
+/// (e.g. the git-mirror) still fire for the copied page.
+#[tokio::test]
+async fn move_copy_skips_contributors_webhook_but_runs_others() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let contrib_hits = std::sync::Arc::new(AtomicUsize::new(0));
+    let mirror_hits = std::sync::Arc::new(AtomicUsize::new(0));
+    let c = contrib_hits.clone();
+    let m = mirror_hits.clone();
+    let app = Router::new()
+        .route(
+            "/contributors",
+            axum_post(move |Json(_p): Json<serde_json::Value>| {
+                let c = c.clone();
+                async move {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    (StatusCode::NO_CONTENT, String::new())
+                }
+            }),
+        )
+        .route(
+            "/mirror",
+            axum_post(move |Json(_p): Json<serde_json::Value>| {
+                let m = m.clone();
+                async move {
+                    m.fetch_add(1, Ordering::SeqCst);
+                    (StatusCode::NO_CONTENT, String::new())
+                }
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let chain = AdmissionChain::new(vec![
+        WebhookConfig {
+            name: "contributors".into(),
+            url: format!("{base}/contributors"),
+            timeout_ms: 2_000,
+            failure_policy: FailurePolicy::Reject,
+            events: vec![AdmissionOp::WritePage],
+            blocking: true,
+        },
+        WebhookConfig {
+            name: "mirror".into(),
+            url: format!("{base}/mirror"),
+            timeout_ms: 2_000,
+            failure_policy: FailurePolicy::Reject,
+            events: vec![AdmissionOp::WritePage],
+            blocking: true,
+        },
+    ])
+    .unwrap();
+    let wiki = Wiki::new(tmp.path(), store.writer.clone())
+        .unwrap()
+        .with_admission_chain(chain)
+        .with_store_reader(store.reader.clone());
+    let state = AdminState {
+        writer: store.writer.clone(),
+        reader: store.reader.clone(),
+        wiki,
+        llm: None,
+        auto_improve_require_approval: false,
+        auto_improve_review_config: Default::default(),
+        embedder: None,
+        provider_health: ai_memory_llm::ProviderHealth::default(),
+        decay_params: DecayParams::default(),
+        data_dir: tmp.path().to_path_buf(),
+        db_path: store.db_path().to_path_buf(),
+        bind: "127.0.0.1:0".to_string(),
+        home_dir: None,
+        bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
+        token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
+    };
+    // Pre-seed BOTH sides so the move takes the copy-purge (merge) path.
+    seed_page(&store, &state.wiki, "src", "proj", "notes/a.md", "body a").await;
+    seed_page(&store, &state.wiki, "dst", "proj", "notes/keep.md", "keep").await;
+
+    let contrib_before = contrib_hits.load(Ordering::SeqCst);
+    let mirror_before = mirror_hits.load(Ordering::SeqCst);
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({ "from_workspace": "src", "project": "proj", "to_workspace": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK, "merge move should succeed");
+
+    assert_eq!(
+        contrib_hits.load(Ordering::SeqCst),
+        contrib_before,
+        "the contributors enrich webhook must be skipped on the move copy"
+    );
+    assert!(
+        mirror_hits.load(Ordering::SeqCst) > mirror_before,
+        "non-skipped webhooks must still fire for the copied page"
+    );
+}
+
 /// W6: re-running a copy-purge merge is idempotent — re-copying an
 /// already-present page is a no-op supersession, leaving no duplicates.
 #[tokio::test]

--- a/docs/admission-webhooks.md
+++ b/docs/admission-webhooks.md
@@ -71,6 +71,13 @@ when the source is torn down. The `purge_project` event carries
 `partial_failure: true` if the SQL purge committed but the on-disk
 dir removal failed afterwards.
 
+During the copy leg, the engine skips only the webhook named exactly
+`contributors`. Move copies preserve page frontmatter verbatim, including any
+existing `contributors` list, so re-running that enrichment hook for every page
+adds bulk-move latency without changing the copied page. Other `write_page`
+webhooks, such as a `git-mirror`, still run normally for each copied page; the
+terminal `purge_project` notification is unchanged.
+
 ### What does NOT fire the chain (by design)
 
 - **`log.md` / `log-YYYY-MM.md` appends** — written on every hook event


### PR DESCRIPTION
## Motivation
A project move copies each page's frontmatter — including the `contributors` list — verbatim. Re-running the `contributors` enrich webhook on every copied page therefore adds nothing but **blocking** per-page latency to a bulk move. (The other historical bulk-move costs are already addressed: the source embedding vector is carried over instead of recomputed, and the git-mirror webhook is non-blocking in the chart.)

## Change
The copy leg of `copy_purge_merge` passes an `AdmissionContext { skip_webhooks: ["contributors"], .. }` instead of `admission_ctx: None`. `Wiki::write_page` still fills the actor from the request and resolves the destination workspace/project names, and runs every hook **not** in `skip_webhooks` — so the copy lands under the destination path and the git-mirror (and any other hook) fires exactly as before. Only the redundant enrich is skipped, and only on move copies; normal writes are unchanged.

## Test
`move_copy_skips_contributors_webhook_but_runs_others`: a merge move with two blocking `WritePage` webhooks (`contributors` + `mirror`) asserts the `contributors` count is unchanged by the copy while `mirror` fires for it. Existing move-admission tests (actor propagation, destination-name resolution, purge-before-destruction) still pass; clippy `-D warnings` clean.