### PR TITLE
feat(admin): workspace-level operations — delete + rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- `/admin/delete-workspace` now runs `purge_workspace` admission before
+  destructive work, reports filesystem partial failures in `files_failed`, and
+  notifies non-blocking mirrors after durable deletion; `/admin/rename-workspace`
+  refreshes scope manifests after the SQLite rename.
 - OIDC CLI help and token-store test fixtures now use a neutral `ai-memory`
   realm placeholder instead of the old project-specific `serpro` example, and
   the unused LLM retry-exhaustion error variant was removed ([#171]).

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -515,6 +515,7 @@ pub fn admin_router(state: AdminState) -> Router {
         .route("/admin/purge-project", post(handle_purge_project))
         .route("/admin/rename-project", post(handle_rename_project))
         .route("/admin/move-project", post(handle_move_project))
+        .route("/admin/delete-workspace", post(handle_delete_workspace))
         .route("/admin/write-page", post(handle_write_page))
         .route("/admin/delete-page", post(handle_delete_page));
     let users = Router::new()
@@ -2952,6 +2953,86 @@ async fn handle_purge_project(
 // ---------------------------------------------------------------------
 // rename-project
 // ---------------------------------------------------------------------
+
+/// JSON request body for `POST /admin/delete-workspace`.
+#[derive(Deserialize)]
+struct DeleteWorkspaceRequest {
+    /// Workspace name to delete (must exist).
+    workspace: String,
+    /// Delete even when the workspace still holds projects. Without it, a
+    /// non-empty workspace is refused so a typo can't wipe live data.
+    #[serde(default)]
+    force: bool,
+}
+
+/// Wire-format summary returned by `POST /admin/delete-workspace`.
+#[derive(Debug, Serialize)]
+pub struct DeleteWorkspaceResult {
+    /// Workspace name that was deleted.
+    pub workspace: String,
+    /// Projects removed via the `workspace_id` cascade.
+    pub projects_deleted: u64,
+    /// `pages` rows removed via cascade (all versions).
+    pub pages_deleted: u64,
+    /// Post-delete mirror checkpoint, if one was taken.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint: Option<String>,
+}
+
+/// `POST /admin/delete-workspace` — remove a workspace and, via cascade, every
+/// project/page under it. Guarded: refuses a non-empty workspace unless
+/// `force` (a typo shouldn't wipe live data). Orphan-workspace cleanup.
+async fn handle_delete_workspace(
+    State(state): State<Arc<AdminState>>,
+    Json(req): Json<DeleteWorkspaceRequest>,
+) -> impl IntoResponse {
+    let ws_id = match state.reader.find_workspace(req.workspace.clone()).await {
+        Ok(Some(id)) => id,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({
+                    "error": format!("workspace '{}' not found", req.workspace)
+                })),
+            );
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            );
+        }
+    };
+
+    let summary = match state.writer.delete_workspace(ws_id, req.force).await {
+        Ok(s) => s,
+        Err(e) => {
+            let status = match &e {
+                StoreError::WorkspaceNotEmpty(_) => StatusCode::CONFLICT,
+                StoreError::NotFound(_) => StatusCode::NOT_FOUND,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            return (status, Json(serde_json::json!({ "error": e.to_string() })));
+        }
+    };
+
+    // DB rows are gone (cascade); drop the on-disk dir best-effort so a
+    // filesystem hiccup doesn't fail an already-durable delete.
+    if let Err(e) = state.wiki.remove_workspace_dir(ws_id).await {
+        warn!(error = %e, workspace = %req.workspace, "delete-workspace: on-disk dir removal failed");
+    }
+
+    let result = DeleteWorkspaceResult {
+        workspace: req.workspace.clone(),
+        projects_deleted: summary.projects_deleted,
+        pages_deleted: summary.pages_deleted,
+        checkpoint: checkpoint_or_warn(&state.wiki, format!("delete-workspace {}", req.workspace)),
+    };
+    (
+        StatusCode::OK,
+        Json(serde_json::to_value(&result).unwrap_or(serde_json::Value::Null)),
+    )
+}
 
 /// JSON request body for `POST /admin/rename-project`.
 #[derive(Deserialize)]

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -49,7 +49,7 @@ use ai_memory_store::{
     ApproveAutoImproveProposalResult, AutoImproveProposalOperation, AutoImproveProposalStatus,
     DecayParams, EmbeddingWrite, NewAutoImproveProposal, ReaderPool, RejectAutoImproveProposal,
     ScopeResolutionError, StageAutoImproveRun, StoreError, WriterHandle, create_explicit_scope,
-    f32_vec_to_bytes, lookup_existing_scope,
+    f32_vec_to_bytes, lookup_existing_scope, lookup_existing_workspace,
 };
 use ai_memory_wiki::{AdmissionContext, AdmissionOp, Markdown, Wiki, WikiError, WritePageRequest};
 use axum::Json;
@@ -1025,6 +1025,16 @@ async fn lookup_ws_proj_no_create(
     lookup_existing_scope(&state.reader, workspace, project)
         .await
         .map(ai_memory_store::ResolvedScope::as_tuple)
+        .map_err(scope_err)
+}
+
+/// Look up a workspace by name **without** auto-creating it.
+async fn lookup_ws_no_create(
+    state: &AdminState,
+    workspace: &str,
+) -> Result<WorkspaceId, (StatusCode, Json<serde_json::Value>)> {
+    lookup_existing_workspace(&state.reader, workspace)
+        .await
         .map_err(scope_err)
 }
 
@@ -2975,6 +2985,8 @@ pub struct RenameWorkspaceResult {
     /// Post-rename mirror checkpoint, if one was taken.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checkpoint: Option<String>,
+    /// Number of scope manifests refreshed after the SQLite rename.
+    pub manifests_refreshed: usize,
 }
 
 /// `POST /admin/rename-workspace` — rename a workspace (column-only; the
@@ -2983,22 +2995,9 @@ async fn handle_rename_workspace(
     State(state): State<Arc<AdminState>>,
     Json(req): Json<RenameWorkspaceRequest>,
 ) -> impl IntoResponse {
-    let ws_id = match state.reader.find_workspace(req.from.clone()).await {
-        Ok(Some(id)) => id,
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({
-                    "error": format!("workspace '{}' not found", req.from)
-                })),
-            );
-        }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": e.to_string() })),
-            );
-        }
+    let ws_id = match lookup_ws_no_create(&state, &req.from).await {
+        Ok(id) => id,
+        Err(e) => return e,
     };
     if let Err(e) = state.writer.rename_workspace(ws_id, req.to.clone()).await {
         let status = match &e {
@@ -3010,6 +3009,10 @@ async fn handle_rename_workspace(
         };
         return (status, Json(serde_json::json!({ "error": e.to_string() })));
     }
+    let manifests_refreshed = match state.wiki.backfill_scope_manifests().await {
+        Ok(n) => n,
+        Err(e) => return internal_err(e.to_string()),
+    };
     let checkpoint = checkpoint_or_warn(
         &state.wiki,
         format!("rename-workspace {} -> {}", req.from, req.to),
@@ -3018,6 +3021,7 @@ async fn handle_rename_workspace(
         from: req.from.clone(),
         to: req.to.clone(),
         checkpoint,
+        manifests_refreshed,
     };
     (
         StatusCode::OK,
@@ -3045,6 +3049,13 @@ pub struct DeleteWorkspaceResult {
     pub projects_deleted: u64,
     /// `pages` rows removed via cascade (all versions).
     pub pages_deleted: u64,
+    /// Paths removed from disk (the workspace's UUID-namespaced directory).
+    pub files_deleted: Vec<String>,
+    /// Paths that could not be removed from disk (non-fatal; DB rows are gone).
+    pub files_failed: Vec<String>,
+    /// Pre-delete checkpoint, if the tree had uncommitted changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pre_checkpoint: Option<String>,
     /// Post-delete mirror checkpoint, if one was taken.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checkpoint: Option<String>,
@@ -3055,24 +3066,58 @@ pub struct DeleteWorkspaceResult {
 /// `force` (a typo shouldn't wipe live data). Orphan-workspace cleanup.
 async fn handle_delete_workspace(
     State(state): State<Arc<AdminState>>,
+    actor_ext: Option<axum::Extension<ai_memory_core::ActorContext>>,
     Json(req): Json<DeleteWorkspaceRequest>,
 ) -> impl IntoResponse {
-    let ws_id = match state.reader.find_workspace(req.workspace.clone()).await {
-        Ok(Some(id)) => id,
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({
-                    "error": format!("workspace '{}' not found", req.workspace)
-                })),
-            );
+    let ws_id = match lookup_ws_no_create(&state, &req.workspace).await {
+        Ok(id) => id,
+        Err(e) => return e,
+    };
+
+    if !req.force {
+        match state
+            .reader
+            .list_projects_with_stats_for_workspace(req.workspace.clone())
+            .await
+        {
+            Ok(projects) if !projects.is_empty() => {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({
+                        "error": StoreError::WorkspaceNotEmpty(projects.len() as u64).to_string()
+                    })),
+                );
+            }
+            Ok(_) => {}
+            Err(e) => return internal_err(e.to_string()),
         }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": e.to_string() })),
-            );
-        }
+    }
+
+    let actor = actor_ext
+        .map(|axum::Extension(a)| a)
+        .unwrap_or_else(ai_memory_core::ActorContext::anonymous);
+    let purge_ctx = AdmissionContext {
+        workspace: req.workspace.clone(),
+        project: String::new(),
+        op: AdmissionOp::PurgeWorkspace,
+        actor,
+        ..Default::default()
+    };
+    let resolved_purge_ctx = match state
+        .wiki
+        .admit_purge_workspace(ws_id, Some(purge_ctx))
+        .await
+    {
+        Ok(ctx) => ctx,
+        Err(e) => return internal_err(e.to_string()),
+    };
+
+    let pre_checkpoint = match checkpoint_or_500(
+        &state.wiki,
+        format!("pre-delete-workspace {}", req.workspace),
+    ) {
+        Ok(oid) => oid,
+        Err(e) => return e,
     };
 
     let summary = match state.writer.delete_workspace(ws_id, req.force).await {
@@ -3087,16 +3132,37 @@ async fn handle_delete_workspace(
         }
     };
 
-    // DB rows are gone (cascade); drop the on-disk dir best-effort so a
-    // filesystem hiccup doesn't fail an already-durable delete.
-    if let Err(e) = state.wiki.remove_workspace_dir(ws_id).await {
-        warn!(error = %e, workspace = %req.workspace, "delete-workspace: on-disk dir removal failed");
+    let ws_root_str = state
+        .wiki
+        .root()
+        .join(ws_id.to_string())
+        .display()
+        .to_string();
+    let mut files_deleted = Vec::new();
+    let mut files_failed = Vec::new();
+    match state.wiki.remove_workspace_dir(ws_id).await {
+        Ok(()) => files_deleted.push(ws_root_str.clone()),
+        Err(e) => {
+            warn!(error = %e, workspace = %req.workspace, path = %ws_root_str, "delete-workspace: on-disk dir removal failed");
+            files_failed.push(ws_root_str);
+        }
     }
+
+    let mut dispatch_ctx = resolved_purge_ctx;
+    if !files_failed.is_empty()
+        && let Some(ref mut c) = dispatch_ctx
+    {
+        c.partial_failure = true;
+    }
+    state.wiki.dispatch_purge_workspace(dispatch_ctx.as_ref());
 
     let result = DeleteWorkspaceResult {
         workspace: req.workspace.clone(),
         projects_deleted: summary.projects_deleted,
         pages_deleted: summary.pages_deleted,
+        files_deleted,
+        files_failed,
+        pre_checkpoint,
         checkpoint: checkpoint_or_warn(&state.wiki, format!("delete-workspace {}", req.workspace)),
     };
     (
@@ -6424,6 +6490,16 @@ mod tests {
             ),
             (
                 "POST",
+                "/admin/delete-workspace",
+                serde_json::json!({"workspace": "default", "force": true}),
+            ),
+            (
+                "POST",
+                "/admin/rename-workspace",
+                serde_json::json!({"from": "default", "to": "renamed"}),
+            ),
+            (
+                "POST",
                 "/admin/write-page",
                 serde_json::json!({
                     "workspace": "default",
@@ -6523,6 +6599,45 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn multiuser_workspace_admin_routes_reach_handler_for_root() {
+        let (_tmp, router) = user_admin_test_router("root-token");
+        for (uri, payload) in [
+            (
+                "/admin/delete-workspace",
+                serde_json::json!({"workspace": "missing", "force": true}),
+            ),
+            (
+                "/admin/rename-workspace",
+                serde_json::json!({"from": "missing", "to": "renamed"}),
+            ),
+        ] {
+            let resp = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri(uri)
+                        .header("authorization", "Bearer root-token")
+                        .header("content-type", "application/json")
+                        .body(Body::from(serde_json::to_vec(&payload).unwrap()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_ne!(
+                resp.status(),
+                StatusCode::UNAUTHORIZED,
+                "{uri} rejected root auth"
+            );
+            assert_ne!(
+                resp.status(),
+                StatusCode::FORBIDDEN,
+                "{uri} rejected root auth"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -516,6 +516,7 @@ pub fn admin_router(state: AdminState) -> Router {
         .route("/admin/rename-project", post(handle_rename_project))
         .route("/admin/move-project", post(handle_move_project))
         .route("/admin/delete-workspace", post(handle_delete_workspace))
+        .route("/admin/rename-workspace", post(handle_rename_workspace))
         .route("/admin/write-page", post(handle_write_page))
         .route("/admin/delete-page", post(handle_delete_page));
     let users = Router::new()
@@ -2953,6 +2954,75 @@ async fn handle_purge_project(
 // ---------------------------------------------------------------------
 // rename-project
 // ---------------------------------------------------------------------
+
+/// JSON request body for `POST /admin/rename-workspace`.
+#[derive(Deserialize)]
+struct RenameWorkspaceRequest {
+    /// Current workspace name (must exist).
+    from: String,
+    /// New workspace name. Must be non-empty, no slashes, and not already used.
+    to: String,
+}
+
+/// Wire-format summary returned by `POST /admin/rename-workspace`.
+#[derive(Debug, Serialize)]
+pub struct RenameWorkspaceResult {
+    /// Previous workspace name.
+    pub from: String,
+    /// New workspace name.
+    pub to: String,
+    /// Post-rename mirror checkpoint, if one was taken.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint: Option<String>,
+}
+
+/// `POST /admin/rename-workspace` — rename a workspace (column-only; the
+/// on-disk dir is UUID-keyed, so nothing moves). 404 unknown, 422 taken/invalid.
+async fn handle_rename_workspace(
+    State(state): State<Arc<AdminState>>,
+    Json(req): Json<RenameWorkspaceRequest>,
+) -> impl IntoResponse {
+    let ws_id = match state.reader.find_workspace(req.from.clone()).await {
+        Ok(Some(id)) => id,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({
+                    "error": format!("workspace '{}' not found", req.from)
+                })),
+            );
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            );
+        }
+    };
+    if let Err(e) = state.writer.rename_workspace(ws_id, req.to.clone()).await {
+        let status = match &e {
+            StoreError::WorkspaceNameTaken(_) | StoreError::InvalidWorkspaceName(_) => {
+                StatusCode::UNPROCESSABLE_ENTITY
+            }
+            StoreError::NotFound(_) => StatusCode::NOT_FOUND,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        return (status, Json(serde_json::json!({ "error": e.to_string() })));
+    }
+    let checkpoint = checkpoint_or_warn(
+        &state.wiki,
+        format!("rename-workspace {} -> {}", req.from, req.to),
+    );
+    let result = RenameWorkspaceResult {
+        from: req.from.clone(),
+        to: req.to.clone(),
+        checkpoint,
+    };
+    (
+        StatusCode::OK,
+        Json(serde_json::to_value(&result).unwrap_or(serde_json::Value::Null)),
+    )
+}
 
 /// JSON request body for `POST /admin/delete-workspace`.
 #[derive(Deserialize)]

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -1633,3 +1633,66 @@ async fn delete_workspace_unknown_is_404() {
     .await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
+
+#[tokio::test]
+async fn rename_workspace_ok_collision_and_unknown() {
+    // OK: renames in place; old name no longer resolves, new one does.
+    {
+        let tmp = TempDir::new().unwrap();
+        let (state, store) = make_state(&tmp).await;
+        seed_page(&store, &state.wiki, "old", "proj", "notes/a.md", "b").await;
+        let resp = post(
+            state,
+            "/admin/rename-workspace",
+            json!({"from":"old","to":"new"}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(
+            store
+                .reader
+                .find_workspace("new".into())
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            store
+                .reader
+                .find_workspace("old".into())
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+    // 422: destination name already taken.
+    {
+        let tmp = TempDir::new().unwrap();
+        let (state, store) = make_state(&tmp).await;
+        seed_page(&store, &state.wiki, "old", "proj", "notes/a.md", "b").await;
+        store
+            .writer
+            .get_or_create_workspace("occupied")
+            .await
+            .unwrap();
+        let resp = post(
+            state,
+            "/admin/rename-workspace",
+            json!({"from":"old","to":"occupied"}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+    // 404: unknown source workspace.
+    {
+        let tmp = TempDir::new().unwrap();
+        let (state, _store) = make_state(&tmp).await;
+        let resp = post(
+            state,
+            "/admin/rename-workspace",
+            json!({"from":"ghost","to":"x"}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -34,7 +34,38 @@ use tower::ServiceExt;
 
 async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
     let store = Store::open(tmp.path()).unwrap();
-    let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
+    let wiki = Wiki::new(tmp.path(), store.writer.clone())
+        .unwrap()
+        .with_store_reader(store.reader.clone());
+    let db_path = store.db_path().to_path_buf();
+    let state = AdminState {
+        writer: store.writer.clone(),
+        reader: store.reader.clone(),
+        wiki,
+        llm: None,
+        auto_improve_require_approval: false,
+        auto_improve_review_config: Default::default(),
+        embedder: None,
+        provider_health: ai_memory_llm::ProviderHealth::default(),
+        decay_params: DecayParams::default(),
+        data_dir: tmp.path().to_path_buf(),
+        db_path,
+        bind: "127.0.0.1:0".to_string(),
+        home_dir: None,
+        bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
+        token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
+        on_project_moved: None,
+    };
+    (state, store)
+}
+
+async fn make_state_with_chain(tmp: &TempDir, chain: AdmissionChain) -> (AdminState, Store) {
+    let store = Store::open(tmp.path()).unwrap();
+    let wiki = Wiki::new(tmp.path(), store.writer.clone())
+        .unwrap()
+        .with_admission_chain(chain)
+        .with_store_reader(store.reader.clone());
     let db_path = store.db_path().to_path_buf();
     let state = AdminState {
         writer: store.writer.clone(),
@@ -1802,4 +1833,179 @@ async fn rename_workspace_ok_collision_and_unknown() {
         .await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
+}
+
+#[tokio::test]
+async fn rename_workspace_refreshes_scope_manifests() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    seed_page(&store, &state.wiki, "old", "proj", "notes/a.md", "b").await;
+    state.wiki.backfill_scope_manifests().await.unwrap();
+    let ws_id = store
+        .reader
+        .find_workspace("old".into())
+        .await
+        .unwrap()
+        .expect("workspace exists");
+
+    let resp = post(
+        state,
+        "/admin/rename-workspace",
+        json!({"from":"old","to":"new"}),
+    )
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert!(
+        body["manifests_refreshed"].as_u64().unwrap_or(0) >= 1,
+        "rename should rewrite the workspace manifest: {body}"
+    );
+    let manifest = std::fs::read_to_string(
+        tmp.path()
+            .join("wiki")
+            .join(ws_id.to_string())
+            .join("_meta.md"),
+    )
+    .unwrap();
+    assert!(manifest.contains("workspace: new"), "{manifest}");
+    assert!(!manifest.contains("workspace: old"), "{manifest}");
+}
+
+#[tokio::test]
+async fn delete_workspace_reject_policy_aborts_before_db_or_disk_destruction() {
+    let app = Router::new().route(
+        "/hook",
+        axum_post(
+            |headers: HeaderMap, Json(_payload): Json<serde_json::Value>| async move {
+                let op = headers
+                    .get("X-Memory-Op")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("");
+                assert_eq!(op, "purge_workspace");
+                (StatusCode::INTERNAL_SERVER_ERROR, "no workspace purge")
+            },
+        ),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}/hook", listener.local_addr().unwrap());
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let tmp = TempDir::new().unwrap();
+    let chain = AdmissionChain::new(vec![WebhookConfig {
+        name: "rejecting-mirror".into(),
+        url,
+        timeout_ms: 2_000,
+        failure_policy: FailurePolicy::Reject,
+        events: vec![AdmissionOp::PurgeWorkspace],
+        blocking: true,
+    }])
+    .unwrap();
+    let (state, store) = make_state_with_chain(&tmp, chain).await;
+    seed_page(&store, &state.wiki, "victim", "proj", "notes/a.md", "body").await;
+    let ws_id = store
+        .reader
+        .find_workspace("victim".into())
+        .await
+        .unwrap()
+        .expect("workspace exists");
+    let ws_root = tmp.path().join("wiki").join(ws_id.to_string());
+
+    let resp = post(
+        state,
+        "/admin/delete-workspace",
+        json!({ "workspace": "victim", "force": true }),
+    )
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(
+        store
+            .reader
+            .find_workspace("victim".into())
+            .await
+            .unwrap()
+            .is_some(),
+        "rejecting admission must leave DB rows intact"
+    );
+    assert!(
+        ws_root.exists(),
+        "rejecting admission must leave disk intact"
+    );
+}
+
+#[tokio::test]
+async fn delete_workspace_reports_partial_disk_failure_and_dispatches_notification() {
+    let (tx, rx) = tokio::sync::oneshot::channel::<serde_json::Value>();
+    let tx = Arc::new(Mutex::new(Some(tx)));
+    let tx_for_route = tx.clone();
+    let app = Router::new().route(
+        "/hook",
+        axum_post(move |Json(payload): Json<serde_json::Value>| {
+            let tx_for_route = tx_for_route.clone();
+            async move {
+                if let Some(tx) = tx_for_route.lock().unwrap().take() {
+                    let _ = tx.send(payload);
+                }
+                StatusCode::NO_CONTENT
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}/hook", listener.local_addr().unwrap());
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let tmp = TempDir::new().unwrap();
+    let chain = AdmissionChain::new(vec![WebhookConfig {
+        name: "async-mirror".into(),
+        url,
+        timeout_ms: 2_000,
+        failure_policy: FailurePolicy::Ignore,
+        events: vec![AdmissionOp::PurgeWorkspace],
+        blocking: false,
+    }])
+    .unwrap();
+    let (state, store) = make_state_with_chain(&tmp, chain).await;
+    seed_page(&store, &state.wiki, "victim", "proj", "notes/a.md", "body").await;
+    let ws_id = store
+        .reader
+        .find_workspace("victim".into())
+        .await
+        .unwrap()
+        .expect("workspace exists");
+    let ws_root = tmp.path().join("wiki").join(ws_id.to_string());
+    std::fs::remove_dir_all(&ws_root).unwrap();
+    std::fs::write(&ws_root, "not a directory").unwrap();
+
+    let resp = post(
+        state,
+        "/admin/delete-workspace",
+        json!({ "workspace": "victim", "force": true }),
+    )
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert!(
+        body["files_deleted"].as_array().unwrap().is_empty(),
+        "{body}"
+    );
+    assert_eq!(body["files_failed"].as_array().unwrap().len(), 1, "{body}");
+    assert!(
+        store
+            .reader
+            .find_workspace("victim".into())
+            .await
+            .unwrap()
+            .is_none(),
+        "DB delete should still commit and be reported as partial filesystem failure"
+    );
+
+    let payload = tokio::time::timeout(std::time::Duration::from_secs(2), rx)
+        .await
+        .expect("async purge_workspace dispatch should fire")
+        .unwrap();
+    assert_eq!(payload["ctx"]["op"], "purge_workspace");
+    assert_eq!(payload["ctx"]["workspace"], "victim");
+    assert_eq!(payload["ctx"]["partial_failure"], true);
 }

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -1565,3 +1565,71 @@ async fn copy_purge_rerun_is_idempotent() {
     paths.sort();
     assert_eq!(paths, vec!["notes/a.md", "notes/keep.md"]);
 }
+
+#[tokio::test]
+async fn delete_workspace_refuses_non_empty_without_force() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    seed_page(&store, &state.wiki, "victim", "proj", "notes/a.md", "body").await;
+
+    let resp = post(
+        state,
+        "/admin/delete-workspace",
+        json!({ "workspace": "victim" }),
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "non-empty delete must be refused without force"
+    );
+    assert!(
+        store
+            .reader
+            .find_workspace("victim".into())
+            .await
+            .unwrap()
+            .is_some(),
+        "a refused delete must not remove the workspace"
+    );
+}
+
+#[tokio::test]
+async fn delete_workspace_force_removes_everything() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    seed_page(&store, &state.wiki, "victim", "proj", "notes/a.md", "body").await;
+
+    let resp = post(
+        state,
+        "/admin/delete-workspace",
+        json!({ "workspace": "victim", "force": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["projects_deleted"].as_u64().unwrap_or(0), 1, "{body}");
+    assert!(body["pages_deleted"].as_u64().unwrap_or(0) >= 1, "{body}");
+    assert!(
+        store
+            .reader
+            .find_workspace("victim".into())
+            .await
+            .unwrap()
+            .is_none(),
+        "workspace must be gone after a force delete"
+    );
+}
+
+#[tokio::test]
+async fn delete_workspace_unknown_is_404() {
+    let tmp = TempDir::new().unwrap();
+    let (state, _store) = make_state(&tmp).await;
+    let resp = post(
+        state,
+        "/admin/delete-workspace",
+        json!({ "workspace": "ghost" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/ai-memory-store/src/error.rs
+++ b/crates/ai-memory-store/src/error.rs
@@ -54,6 +54,12 @@ pub enum StoreError {
     #[error("not found: {0}")]
     NotFound(String),
 
+    /// A workspace delete was refused because it still holds projects and the
+    /// caller did not pass `force`. Carries the project count so the admin
+    /// endpoint / CLI can report it before the operator retries with force.
+    #[error("workspace still has {0} project(s); pass force to delete anyway")]
+    WorkspaceNotEmpty(u64),
+
     /// A UNIQUE constraint was violated by an insert (e.g. duplicate
     /// `users.username` / `users.email`). The string carries a
     /// human-readable explanation the CLI / admin endpoint surfaces

--- a/crates/ai-memory-store/src/error.rs
+++ b/crates/ai-memory-store/src/error.rs
@@ -60,6 +60,15 @@ pub enum StoreError {
     #[error("workspace still has {0} project(s); pass force to delete anyway")]
     WorkspaceNotEmpty(u64),
 
+    /// A workspace rename was rejected because the destination name is already
+    /// in use by another workspace (`workspaces.name` is UNIQUE).
+    #[error("workspace name '{0}' is already taken")]
+    WorkspaceNameTaken(String),
+
+    /// The supplied workspace name failed validation (empty, slash, etc.).
+    #[error("invalid workspace name: {0}")]
+    InvalidWorkspaceName(String),
+
     /// A UNIQUE constraint was violated by an insert (e.g. duplicate
     /// `users.username` / `users.email`). The string carries a
     /// human-readable explanation the CLI / admin endpoint surfaces

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -46,8 +46,8 @@ pub use reader::{
 };
 pub use scope::{
     ResolvedScope, ScopeName, ScopeResolutionError, ScopeResolver, WORKSPACE_PROJECT_PAIR_REQUIRED,
-    create_explicit_scope, create_global_scope, lookup_existing_scope, lookup_global_scope,
-    resolve_many_existing_scopes,
+    create_explicit_scope, create_global_scope, lookup_existing_scope, lookup_existing_workspace,
+    lookup_global_scope, resolve_many_existing_scopes,
 };
 pub use users::{TOKEN_HASH_LEN, TOKEN_RAW_LEN, TokenPepper, generate_token, hash_token};
 pub use writer::WriterHandle;

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -34,7 +34,7 @@ pub use auto_improve::{
 };
 pub use decay::{DecayParams, retention_score};
 pub use error::{StoreError, StoreResult};
-pub use ops::{EmbeddingWrite, MoveSummary, PurgeSummary, ReorgSummary};
+pub use ops::{DeleteWorkspaceSummary, EmbeddingWrite, MoveSummary, PurgeSummary, ReorgSummary};
 pub use reader::{
     ActivityWindow, AutoImproveCandidateSession, BriefingPage, BriefingSnapshot,
     ContaminationFinding, ContaminationReport, ContaminationSummary, DecayCandidate,

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -1398,6 +1398,48 @@ pub fn delete_workspace(
     })
 }
 
+/// Rename a workspace: a `workspaces.name` UPDATE only — the on-disk dir is
+/// keyed by UUID, so nothing moves. Mirrors [`rename_project`].
+///
+/// # Errors
+/// [`StoreError::InvalidWorkspaceName`] on an empty / `/`-containing name;
+/// [`StoreError::WorkspaceNameTaken`] on a `UNIQUE(name)` collision;
+/// [`StoreError::NotFound`] when the workspace vanished (race with delete).
+pub fn rename_workspace(
+    conn: &mut Connection,
+    workspace_id: &WorkspaceId,
+    new_name: &str,
+) -> StoreResult<()> {
+    let trimmed = new_name.trim();
+    if trimmed.is_empty() {
+        return Err(StoreError::InvalidWorkspaceName(
+            "workspace name must not be empty or all whitespace".into(),
+        ));
+    }
+    if trimmed.contains('/') {
+        return Err(StoreError::InvalidWorkspaceName(
+            "workspace name must not contain '/'".into(),
+        ));
+    }
+    let rows = conn.execute(
+        "UPDATE workspaces SET name = ?1 WHERE id = ?2",
+        params![trimmed, workspace_id.as_bytes()],
+    );
+    match rows {
+        Ok(0) => Err(StoreError::NotFound(format!(
+            "workspace id {workspace_id} no longer exists (race with delete)"
+        ))),
+        Ok(_) => Ok(()),
+        Err(rusqlite::Error::SqliteFailure(err, _))
+            if err.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE
+                || err.code == rusqlite::ErrorCode::ConstraintViolation =>
+        {
+            Err(StoreError::WorkspaceNameTaken(trimmed.to_string()))
+        }
+        Err(e) => Err(StoreError::Sqlite(e)),
+    }
+}
+
 /// Summary returned by [`move_project_workspace`] and exposed via
 /// [`crate::writer::WriterHandle::move_project_workspace`].
 #[derive(Debug, Default, Clone)]
@@ -1820,6 +1862,31 @@ mod tests {
         let summary = delete_workspace(&mut conn, &empty, false).unwrap();
         assert_eq!(summary.projects_deleted, 0);
         assert_eq!(summary.pages_deleted, 0);
+    }
+
+    #[test]
+    fn rename_workspace_updates_name_and_rejects_collision() {
+        let (_tmp, mut conn, ws, _proj) = fresh_db();
+        get_or_create_workspace(&mut conn, "taken").unwrap();
+
+        rename_workspace(&mut conn, &ws, "renamed").unwrap();
+        let name: String = conn
+            .query_row(
+                "SELECT name FROM workspaces WHERE id = ?1",
+                rusqlite::params![ws.as_bytes()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(name, "renamed", "name column updated in place");
+
+        assert!(matches!(
+            rename_workspace(&mut conn, &ws, "taken").unwrap_err(),
+            StoreError::WorkspaceNameTaken(_)
+        ));
+        assert!(matches!(
+            rename_workspace(&mut conn, &ws, "   ").unwrap_err(),
+            StoreError::InvalidWorkspaceName(_)
+        ));
     }
 
     fn fresh_db() -> (

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -1345,6 +1345,59 @@ pub fn purge_project(
     })
 }
 
+/// Summary returned by [`delete_workspace`].
+#[derive(Debug, Default, Clone)]
+pub struct DeleteWorkspaceSummary {
+    /// Projects removed (0 when the workspace was already empty).
+    pub projects_deleted: u64,
+    /// `pages` rows removed via cascade (all versions).
+    pub pages_deleted: u64,
+}
+
+/// Delete a workspace row. Refuses a workspace that still holds projects
+/// unless `force` is set (the guard exists so a stray typo can't wipe a live
+/// workspace). The `workspace_id` FKs are `ON DELETE CASCADE`, so a single
+/// `DELETE FROM workspaces` also removes its projects / pages / sessions /
+/// observations / handoffs. The caller removes the on-disk workspace dir
+/// afterwards.
+///
+/// # Errors
+/// [`StoreError::WorkspaceNotEmpty`] when it still holds projects and `force`
+/// is false; [`StoreError::NotFound`] when the workspace does not exist.
+pub fn delete_workspace(
+    conn: &mut Connection,
+    workspace_id: &WorkspaceId,
+    force: bool,
+) -> StoreResult<DeleteWorkspaceSummary> {
+    let tx = conn.transaction()?;
+    let wid = workspace_id.as_bytes();
+    let count = |sql: &str| -> StoreResult<u64> {
+        let n: Option<i64> = tx
+            .query_row(sql, rusqlite::params![&wid[..]], |row| row.get(0))
+            .optional()?;
+        Ok(u64::try_from(n.unwrap_or(0)).unwrap_or(0))
+    };
+
+    let projects_deleted = count("SELECT COUNT(*) FROM projects WHERE workspace_id = ?1")?;
+    if projects_deleted > 0 && !force {
+        return Err(StoreError::WorkspaceNotEmpty(projects_deleted));
+    }
+    let pages_deleted = count("SELECT COUNT(*) FROM pages WHERE workspace_id = ?1")?;
+
+    let removed = tx.execute(
+        "DELETE FROM workspaces WHERE id = ?1",
+        rusqlite::params![&wid[..]],
+    )?;
+    if removed == 0 {
+        return Err(StoreError::NotFound("workspace".into()));
+    }
+    tx.commit()?;
+    Ok(DeleteWorkspaceSummary {
+        projects_deleted,
+        pages_deleted,
+    })
+}
+
 /// Summary returned by [`move_project_workspace`] and exposed via
 /// [`crate::writer::WriterHandle::move_project_workspace`].
 #[derive(Debug, Default, Clone)]
@@ -1716,6 +1769,57 @@ mod tests {
             !logs.contains("already exists in other workspace"),
             "failed validation must not emit a creation warning: {logs}"
         );
+    }
+
+    #[test]
+    fn delete_workspace_refuses_non_empty_then_cascades_with_force() {
+        let (_tmp, mut conn, ws, proj) = fresh_db();
+        upsert_page(&mut conn, &page(ws, proj, "notes/a.md", "body")).unwrap();
+
+        // Non-empty (holds the "scratch" project + a page) → refused w/o force.
+        let err = delete_workspace(&mut conn, &ws, false).unwrap_err();
+        assert!(
+            matches!(err, StoreError::WorkspaceNotEmpty(n) if n >= 1),
+            "expected WorkspaceNotEmpty, got {err:?}"
+        );
+        let ws_still: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM workspaces WHERE id = ?1",
+                rusqlite::params![ws.as_bytes()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(ws_still, 1, "refused delete must not touch the row");
+
+        // Force cascades: project + page gone, workspace row gone.
+        let summary = delete_workspace(&mut conn, &ws, true).unwrap();
+        assert!(
+            summary.projects_deleted >= 1 && summary.pages_deleted >= 1,
+            "{summary:?}"
+        );
+        let proj_left: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM projects WHERE workspace_id = ?1",
+                rusqlite::params![ws.as_bytes()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(proj_left, 0, "projects must cascade on workspace delete");
+
+        // Deleting again → NotFound.
+        assert!(matches!(
+            delete_workspace(&mut conn, &ws, true).unwrap_err(),
+            StoreError::NotFound(_)
+        ));
+    }
+
+    #[test]
+    fn delete_workspace_empty_succeeds_without_force() {
+        let (_tmp, mut conn, _ws, _proj) = fresh_db();
+        let empty = get_or_create_workspace(&mut conn, "orphan-ws").unwrap();
+        let summary = delete_workspace(&mut conn, &empty, false).unwrap();
+        assert_eq!(summary.projects_deleted, 0);
+        assert_eq!(summary.pages_deleted, 0);
     }
 
     fn fresh_db() -> (

--- a/crates/ai-memory-store/src/scope.rs
+++ b/crates/ai-memory-store/src/scope.rs
@@ -183,12 +183,7 @@ pub async fn lookup_existing_scope(
     workspace: &str,
     project: &str,
 ) -> Result<ResolvedScope, ScopeResolutionError> {
-    let workspace_id = reader
-        .find_workspace(workspace.to_owned())
-        .await?
-        .ok_or_else(|| ScopeResolutionError::WorkspaceNotFound {
-            workspace: workspace.to_owned(),
-        })?;
+    let workspace_id = lookup_existing_workspace(reader, workspace).await?;
     let project_id = reader
         .find_project(workspace_id, project.to_owned())
         .await?
@@ -200,6 +195,22 @@ pub async fn lookup_existing_scope(
         workspace_id,
         project_id,
     })
+}
+
+/// Look up an explicit workspace by name without creating anything.
+///
+/// This is for admin/destructive surfaces that operate at workspace granularity
+/// and must fail closed on typos instead of auto-creating a scope.
+pub async fn lookup_existing_workspace(
+    reader: &ReaderPool,
+    workspace: &str,
+) -> Result<WorkspaceId, ScopeResolutionError> {
+    reader
+        .find_workspace(workspace.to_owned())
+        .await?
+        .ok_or_else(|| ScopeResolutionError::WorkspaceNotFound {
+            workspace: workspace.to_owned(),
+        })
 }
 
 /// Create or fetch an explicit workspace/project pair.

--- a/crates/ai-memory-store/src/writer.rs
+++ b/crates/ai-memory-store/src/writer.rs
@@ -22,7 +22,9 @@ use crate::auto_improve::{
     RejectAutoImproveProposal, StageAutoImproveRun, StagedAutoImproveRun,
 };
 use crate::error::{StoreError, StoreResult};
-use crate::ops::{self, EmbeddingWrite, MoveSummary, PurgeSummary, ReorgSummary};
+use crate::ops::{
+    self, DeleteWorkspaceSummary, EmbeddingWrite, MoveSummary, PurgeSummary, ReorgSummary,
+};
 use crate::users::{self, TOKEN_HASH_LEN};
 
 /// Commands accepted by the writer thread.
@@ -153,6 +155,13 @@ pub(crate) enum WriteCmd {
         /// Human-readable `workspace/project` label forwarded into the summary.
         label: String,
         reply: oneshot::Sender<StoreResult<PurgeSummary>>,
+    },
+    /// Delete a workspace row (its `workspace_id` FKs cascade projects/pages/
+    /// sessions/…). Refused when non-empty unless `force`.
+    DeleteWorkspace {
+        workspace_id: WorkspaceId,
+        force: bool,
+        reply: oneshot::Sender<StoreResult<DeleteWorkspaceSummary>>,
     },
     /// Re-stamp a project's `workspace_id` across every domain table in one
     /// transaction, keeping the same `project_id` (a lossless cross-workspace
@@ -618,6 +627,28 @@ impl WriterHandle {
             workspace_id,
             project_id,
             label: label.into(),
+            reply: tx,
+        })
+        .await?;
+        rx.await.map_err(|_| StoreError::WriterClosed)?
+    }
+
+    /// Delete a workspace and, via the `workspace_id` cascade, every project /
+    /// page / session under it. Refuses a non-empty workspace unless `force`.
+    ///
+    /// # Errors
+    /// [`StoreError::WorkspaceNotEmpty`] when it still holds projects and
+    /// `force` is false; [`StoreError::NotFound`] when the workspace is absent;
+    /// [`StoreError::WriterClosed`] if the actor has shut down.
+    pub async fn delete_workspace(
+        &self,
+        workspace_id: WorkspaceId,
+        force: bool,
+    ) -> StoreResult<DeleteWorkspaceSummary> {
+        let (tx, rx) = oneshot::channel();
+        self.send(WriteCmd::DeleteWorkspace {
+            workspace_id,
+            force,
             reply: tx,
         })
         .await?;
@@ -1161,6 +1192,14 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
             } => {
                 let result = ops::purge_project(&mut conn, &workspace_id, &project_id, &label);
                 send_or_warn(reply, result, "purge_project");
+            }
+            WriteCmd::DeleteWorkspace {
+                workspace_id,
+                force,
+                reply,
+            } => {
+                let result = ops::delete_workspace(&mut conn, &workspace_id, force);
+                send_or_warn(reply, result, "delete_workspace");
             }
             WriteCmd::MoveProjectWorkspace {
                 project_id,

--- a/crates/ai-memory-store/src/writer.rs
+++ b/crates/ai-memory-store/src/writer.rs
@@ -163,6 +163,12 @@ pub(crate) enum WriteCmd {
         force: bool,
         reply: oneshot::Sender<StoreResult<DeleteWorkspaceSummary>>,
     },
+    /// Rename a workspace's `name` column (UUID-keyed dir doesn't move).
+    RenameWorkspace {
+        workspace_id: WorkspaceId,
+        new_name: String,
+        reply: oneshot::Sender<StoreResult<()>>,
+    },
     /// Re-stamp a project's `workspace_id` across every domain table in one
     /// transaction, keeping the same `project_id` (a lossless cross-workspace
     /// "true move"). The caller renames the on-disk dir and ensures the
@@ -649,6 +655,26 @@ impl WriterHandle {
         self.send(WriteCmd::DeleteWorkspace {
             workspace_id,
             force,
+            reply: tx,
+        })
+        .await?;
+        rx.await.map_err(|_| StoreError::WriterClosed)?
+    }
+
+    /// Rename a workspace (column-only; the on-disk dir is UUID-keyed).
+    ///
+    /// # Errors
+    /// [`StoreError::WorkspaceNameTaken`] / [`StoreError::InvalidWorkspaceName`]
+    /// / [`StoreError::NotFound`] / [`StoreError::WriterClosed`].
+    pub async fn rename_workspace(
+        &self,
+        workspace_id: WorkspaceId,
+        new_name: impl Into<String>,
+    ) -> StoreResult<()> {
+        let (tx, rx) = oneshot::channel();
+        self.send(WriteCmd::RenameWorkspace {
+            workspace_id,
+            new_name: new_name.into(),
             reply: tx,
         })
         .await?;
@@ -1200,6 +1226,14 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
             } => {
                 let result = ops::delete_workspace(&mut conn, &workspace_id, force);
                 send_or_warn(reply, result, "delete_workspace");
+            }
+            WriteCmd::RenameWorkspace {
+                workspace_id,
+                new_name,
+                reply,
+            } => {
+                let result = ops::rename_workspace(&mut conn, &workspace_id, &new_name);
+                send_or_warn(reply, result, "rename_workspace");
             }
             WriteCmd::MoveProjectWorkspace {
                 project_id,

--- a/crates/ai-memory-wiki/src/admission.rs
+++ b/crates/ai-memory-wiki/src/admission.rs
@@ -56,6 +56,9 @@ pub enum AdmissionOp {
     /// `remove_dir_all`). Carries the project (ctx), no page path. Lets a
     /// mirror remove the project's directory.
     PurgeProject,
+    /// A whole workspace is being purged. Carries the workspace (ctx), no page
+    /// path, and an empty project. Lets a mirror remove the workspace tree.
+    PurgeWorkspace,
     /// A whole project is being moved between workspaces without changing its
     /// project id. Carries source names in `workspace`/`project` and
     /// destination names in `destination_workspace`/`destination_project`.
@@ -71,6 +74,7 @@ impl AdmissionOp {
             AdmissionOp::Consolidate => "consolidate",
             AdmissionOp::Delete => "delete",
             AdmissionOp::PurgeProject => "purge_project",
+            AdmissionOp::PurgeWorkspace => "purge_workspace",
             AdmissionOp::MoveProject => "move_project",
         }
     }
@@ -568,6 +572,25 @@ mod tests {
         assert!(matches!(pol, FailurePolicy::Ignore));
         let op = AdmissionOp::default();
         assert!(matches!(op, AdmissionOp::WritePage));
+    }
+
+    #[test]
+    fn purge_workspace_header_value_is_stable() {
+        assert_eq!(
+            AdmissionOp::PurgeWorkspace.as_header_value(),
+            "purge_workspace"
+        );
+    }
+
+    #[test]
+    fn purge_workspace_event_deserializes_from_config_value() {
+        let cfg: WebhookConfig = serde_json::from_value(serde_json::json!({
+            "name": "mirror",
+            "url": "http://127.0.0.1:1/hook",
+            "events": ["purge_workspace"]
+        }))
+        .unwrap();
+        assert_eq!(cfg.events, vec![AdmissionOp::PurgeWorkspace]);
     }
 
     #[test]

--- a/crates/ai-memory-wiki/src/wiki.rs
+++ b/crates/ai-memory-wiki/src/wiki.rs
@@ -436,6 +436,17 @@ impl Wiki {
         }
     }
 
+    /// Best-effort fill of `ctx.workspace` from a workspace id via the store
+    /// reader. Workspace-wide ops have no project id to resolve.
+    async fn resolve_workspace_name(&self, workspace_id: WorkspaceId, ctx: &mut AdmissionContext) {
+        if let Some(reader) = &self.store_reader
+            && ctx.workspace.is_empty()
+            && let Ok(Some(name)) = reader.workspace_name_by_id(workspace_id).await
+        {
+            ctx.workspace = name;
+        }
+    }
+
     /// Delete a single page file. When an admission chain is attached, it is
     /// notified (`op=delete`) BEFORE the file is removed, so a mirror can
     /// `git rm` the same path. A `Reject`-policy webhook aborts the delete.
@@ -543,6 +554,29 @@ impl Wiki {
         }
     }
 
+    /// Run the blocking admission notification for a workspace purge without
+    /// removing files. Admin callers use this before the DB purge so a
+    /// `failure_policy = reject` webhook can still abort all destructive work.
+    ///
+    /// # Errors
+    /// Returns [`WikiError`] when a reject-policy webhook fails.
+    pub async fn admit_purge_workspace(
+        &self,
+        workspace_id: WorkspaceId,
+        admission_ctx: Option<AdmissionContext>,
+    ) -> WikiResult<Option<AdmissionContext>> {
+        if let Some(chain) = &self.admission_chain {
+            let mut ctx = admission_ctx.unwrap_or_default();
+            ctx.op = AdmissionOp::PurgeWorkspace;
+            self.resolve_workspace_name(workspace_id, &mut ctx).await;
+            ctx.project.clear();
+            chain.notify(None, &ctx).await?;
+            Ok(Some(ctx))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Remove the project's on-disk directory without running admission.
     ///
     /// # Errors
@@ -580,6 +614,14 @@ impl Wiki {
     /// Dispatch non-blocking purge webhooks after the caller's purge has
     /// completed its durable DB/filesystem work.
     pub fn dispatch_purge_project(&self, admission_ctx: Option<&AdmissionContext>) {
+        if let (Some(chain), Some(ctx)) = (&self.admission_chain, admission_ctx) {
+            chain.dispatch_async(None, &serde_json::Value::Null, "", ctx);
+        }
+    }
+
+    /// Dispatch non-blocking purge-workspace webhooks after the caller's purge
+    /// has completed its durable DB/filesystem work.
+    pub fn dispatch_purge_workspace(&self, admission_ctx: Option<&AdmissionContext>) {
         if let (Some(chain), Some(ctx)) = (&self.admission_chain, admission_ctx) {
             chain.dispatch_async(None, &serde_json::Value::Null, "", ctx);
         }

--- a/crates/ai-memory-wiki/src/wiki.rs
+++ b/crates/ai-memory-wiki/src/wiki.rs
@@ -561,6 +561,22 @@ impl Wiki {
         }
     }
 
+    /// Remove a workspace's on-disk directory (`<wiki_root>/<ws>`), including
+    /// every project under it, without running admission. Best-effort: a
+    /// missing dir is not an error.
+    ///
+    /// # Errors
+    /// Returns [`WikiError::Io`] on filesystem errors other than NotFound.
+    pub async fn remove_workspace_dir(&self, workspace_id: WorkspaceId) -> WikiResult<()> {
+        let _guard = self.mutation_lock.write().await;
+        let root = self.root.join(workspace_id.to_string());
+        match std::fs::remove_dir_all(&root) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(crate::WikiError::Io(e)),
+        }
+    }
+
     /// Dispatch non-blocking purge webhooks after the caller's purge has
     /// completed its durable DB/filesystem work.
     pub fn dispatch_purge_project(&self, admission_ctx: Option<&AdmissionContext>) {

--- a/docs/admission-webhooks.md
+++ b/docs/admission-webhooks.md
@@ -1,7 +1,7 @@
 # Admission webhooks: pre-persistence HTTP hooks
 
 > Operator-configured HTTP hooks invoked on the engine's write path
-> (`Wiki::write_page`, `delete_page`, `purge_project`, `move_project`)
+> (`Wiki::write_page`, `delete_page`, `purge_project`, `purge_workspace`, `move_project`)
 > just before the durable mutation commits. Write hooks can mutate the page
 > (return a new frontmatter / body); delete/purge/move hooks are notifications
 > that can observe, mirror, or reject. Sourced from
@@ -50,6 +50,11 @@ Webhooks fire on these `op` values today (extensible enum):
   `remove_dir_all`, routed from `/admin/purge-project`). Carries the
   project in `ctx`, **no** page path; fired before the directory is
   removed so a mirror can drop the project.
+- `purge_workspace` — a whole workspace is purged (routed from
+  `/admin/delete-workspace`). Carries the workspace in `ctx.workspace`, leaves
+  `ctx.project` empty, and has **no** page path; fired before SQL/file
+  destruction for reject-policy admission and dispatched again to non-blocking
+  observers after durable work.
 - `move_project` — a whole project is moved between workspaces without
   changing `project_id` (fresh-destination true move). Carries the source
   project in `ctx.workspace` / `ctx.project`, destination names in
@@ -57,12 +62,13 @@ Webhooks fire on these `op` values today (extensible enum):
   fired before the directory rename + DB re-stamp so a mirror can rename or
   reject the project move.
 
-`delete` / `purge_project` / `move_project` are notifications — there is no
+`delete` / `purge_project` / `purge_workspace` / `move_project` are notifications — there is no
 body to mutate; a `Reject`-policy webhook still aborts the operation
 (admission fires BEFORE the SQL destruction in both the `/admin/purge-project`
-and `/admin/move-project` copy-purge paths, so reject leaves the source
-intact). Each webhook opts into the ops it cares about via `events`; the
-chain checks the op against `WebhookConfig::events` before dispatching.
+and `/admin/delete-workspace` paths, and before source teardown in
+`/admin/move-project` copy-purge paths, so reject leaves the source intact).
+Each webhook opts into the ops it cares about via `events`; the chain checks the
+op against `WebhookConfig::events` before dispatching.
 
 A copy-purge `/admin/move-project` fires **two** webhook events from
 one request: one or more `write_page` notifications as the pages copy
@@ -70,6 +76,10 @@ into the destination, then one terminal `purge_project` notification
 when the source is torn down. The `purge_project` event carries
 `partial_failure: true` if the SQL purge committed but the on-disk
 dir removal failed afterwards.
+
+`/admin/delete-workspace` emits `purge_workspace`. Its final async observer
+notification carries `partial_failure: true` if the SQL workspace cascade
+committed but `<wiki_root>/<workspace_id>` could not be removed.
 
 During the copy leg, the engine skips only the webhook named exactly
 `contributors`. Move copies preserve page frontmatter verbatim, including any
@@ -91,6 +101,9 @@ terminal `purge_project` notification is unchanged.
   do. (Only `purge_project` removes files in bulk.)
 - **`rename-project`** — a `projects.name` column update; the on-disk path
   is the stable UUID, so no file moves and nothing to propagate.
+- **`rename-workspace`** — a `workspaces.name` column update plus refreshed
+  `_meta.md` manifests; workspace paths are stable UUIDs, so no file move
+  notification is needed.
 - **External / manual edits on disk** — reconciled by the watcher, not the
   admission chain (the chain is for the engine's own write path).
 
@@ -101,7 +114,7 @@ terminal `purge_project` notification is unchanged.
 ```http
 POST <webhook.url>
 Content-Type: application/json
-X-Memory-Op: write_page | consolidate | delete | purge_project | move_project
+X-Memory-Op: write_page | consolidate | delete | purge_project | purge_workspace | move_project
 ```
 
 ```jsonc
@@ -123,8 +136,8 @@ X-Memory-Op: write_page | consolidate | delete | purge_project | move_project
       "client": "72836f52-...",              // DCR client UUID
       "session_id": "019e6d-..."
     },
-    "op": "write_page",                      // write_page | consolidate | delete | purge_project | move_project
-    "partial_failure": true                  // purge_project only, and ONLY when set
+    "op": "write_page",                      // write_page | consolidate | delete | purge_project | purge_workspace | move_project
+    "partial_failure": true                  // purge_project/purge_workspace only, and ONLY when set
                                              //   (skipped on the wire when false).
                                              //   true → the DB rows were purged but
                                              //   `remove_project_dir` failed afterwards;

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -10,6 +10,8 @@ on a homelab box where mistakes are harder to undo.
 |---|---|---|---|---|
 | `purge-project --confirm` | ✅ yes | the one project's data | no | Atomic `rm -rf <project_root>` on the namespaced disk path; sibling projects untouched. |
 | `rename-project --from --to` | ✅ yes | no | yes (rename back) | Column-only update on `projects.name`. The on-disk dir is keyed by `project_id` (UUID), so the rename never moves a file. |
+| `/admin/rename-workspace` | ✅ yes | no | yes (rename back) | Column-only update on `workspaces.name`; refreshes `_meta.md` scope manifests and checkpoints the wiki tree. |
+| `/admin/delete-workspace` | ✅ yes | the workspace and every child project | no | Runs `purge_workspace` admission first, deletes SQLite rows in one cascade, removes the UUID-keyed workspace directory, reports filesystem partial failures, and dispatches mirror notification after durable work. |
 | `move-project --confirm` | ✅ yes | source only in the merge case (a `Reject`-policy `purge_project` webhook can still abort the source teardown leaving everything intact) | no | Fresh destination → lossless **true move** (re-stamp `workspace_id`, keep `project_id`, rename the dir): sessions/observations/handoffs + history all survive. Destination with a same-named project → **copy+purge merge**: only latest pages migrate. |
 | `backup --output-path` | ✅ yes | no | n/a | Streams a gzipped tarball from the server's online `sqlite3 .backup` plus the wiki tree. Safe alongside the live writer. |
 | `checkpoints` | ✅ yes | no | n/a | Lists recent wiki git checkpoints. Read-only. |
@@ -129,6 +131,46 @@ Failure modes:
 - **`to` name already exists in this workspace** → 422.
 - **`to` invalid (empty, slash, whitespace)** → 422.
 - **Source `from` not found** → 404.
+
+### `/admin/rename-workspace`
+
+Renames a workspace by updating `workspaces.name`; on-disk paths remain keyed by
+`workspace_id`, so no page files move. After the SQLite rename, the handler
+refreshes `_meta.md` scope manifests with `Wiki::backfill_scope_manifests()` and
+returns `manifests_refreshed` plus a post-rename checkpoint when the wiki tree
+changed.
+
+Failure modes:
+
+- **Source `from` not found** → 404.
+- **`to` name already exists or is invalid** → 422.
+
+### `/admin/delete-workspace`
+
+Deletes a workspace row and all child projects/pages/sessions through the
+`workspace_id` cascade. The route is guarded by `force: true` for non-empty
+workspaces and follows the destructive-operation ordering used by project
+purges:
+
+1. Look up the workspace without creating missing scopes.
+2. Run blocking `op=purge_workspace` admission. A reject-policy webhook aborts
+   before DB rows or files are removed.
+3. Take a pre-delete checkpoint if the wiki tree is dirty.
+4. Delete the workspace in one writer-actor transaction.
+5. Remove `<wiki_root>/<workspace_id>` from disk.
+6. Dispatch non-blocking `purge_workspace` mirror notifications after durable
+   work. If the DB delete committed but disk removal failed, the response
+   includes `files_failed` and webhook `ctx.partial_failure: true`.
+7. Take a post-delete checkpoint if the wiki tree changed.
+
+Failure modes:
+
+- **Workspace not found** → 404, no mutation.
+- **Non-empty workspace without `force: true`** → 409, no mutation.
+- **Reject-policy `purge_workspace` webhook fails** → 500, no DB/disk mutation.
+- **Filesystem removal fails after SQL commit** → 200 with `files_failed`
+  populated and `partial_failure: true` on async mirror notifications; manual
+  cleanup of the reported path is required.
 
 ### `move-project`
 


### PR DESCRIPTION
Fills the gap of **workspace-level admin operations** (there was none — a cross-workspace `move-project` could create empty workspace rows, e.g. `_perftmp`, that nothing could remove or rename). Two operations, guarded and mirroring the existing project-level ones.

## delete-workspace — `POST /admin/delete-workspace {workspace, force?}`
Store `delete_workspace(force)` refuses a workspace that still holds projects unless `force` (`StoreError::WorkspaceNotEmpty`), then a single `DELETE FROM workspaces` whose `workspace_id` FKs are `ON DELETE CASCADE` — projects/pages/sessions/observations/handoffs go with it. Writer command + best-effort `Wiki::remove_workspace_dir`. **409** non-empty-without-force (nothing destroyed), **404** unknown, **200** with the cascade counts.

## rename-workspace — `POST /admin/rename-workspace {from, to}`
Mirrors `rename-project`: a `workspaces.name` UPDATE only (the on-disk dir is UUID-keyed, so nothing moves). **404** unknown, **422** on a UNIQUE(name) collision (`WorkspaceNameTaken`) or empty/`/` name (`InvalidWorkspaceName`), **200** with the checkpoint.

`merge-workspace` is a deliberate follow-on: it needs to reuse the full `move-project` orchestration (dir rename + admission + copy-purge on name collision) per project, which is a larger refactor.

## Tests
Store: delete (guard/cascade/empty/not-found), rename (in-place update, collision → taken, empty → invalid). Admin integration: delete 409/200/404, rename 200/422/404. `cargo clippy -p ai-memory-store -p ai-memory-wiki -p ai-memory-mcp --all-targets -- -D warnings` clean.