### PR TITLE
chore: neutralize the serpro realm in OIDC examples + drop a dead error variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- OIDC CLI help and token-store test fixtures now use a neutral `ai-memory`
+  realm placeholder instead of the old project-specific `serpro` example, and
+  the unused LLM retry-exhaustion error variant was removed ([#171]).
+
 ### Fixed
 - Copy-purge `/admin/move-project` now skips only the webhook named exactly
   `contributors` while copying pages, avoiding redundant per-page contributor

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -298,7 +298,7 @@ pub struct AuthLoginArgs {
     #[arg(long)]
     pub client_id: Option<String>,
     /// OIDC issuer URL for `oidc-device` login, e.g. a Keycloak realm
-    /// (`https://keycloak.example.com/realms/serpro`). Endpoints are
+    /// (`https://keycloak.example.com/realms/ai-memory`). Endpoints are
     /// discovered from `<issuer>/.well-known/openid-configuration`.
     #[arg(long)]
     pub issuer: Option<String>,

--- a/crates/ai-memory-llm/src/error.rs
+++ b/crates/ai-memory-llm/src/error.rs
@@ -42,10 +42,6 @@ pub enum LlmError {
     /// JSON schema for structured output could not be derived.
     #[error("schema: {0}")]
     Schema(String),
-
-    /// Operation exhausted its retry budget.
-    #[error("retries exhausted: {0}")]
-    RetriesExhausted(String),
 }
 
 impl From<serde_json::Error> for LlmError {

--- a/crates/ai-memory-llm/src/oidc.rs
+++ b/crates/ai-memory-llm/src/oidc.rs
@@ -356,9 +356,9 @@ mod tests {
             access: SecretString::from("access-x".to_string()),
             refresh: SecretString::from("refresh-y".to_string()),
             expires_at_ms: now_ms() + 3_600_000,
-            issuer: "https://kc.example.com/realms/serpro".to_string(),
+            issuer: "https://kc.example.com/realms/ai-memory".to_string(),
             client_id: "ai-memory-dev".to_string(),
-            token_endpoint: "https://kc.example.com/realms/serpro/protocol/openid-connect/token"
+            token_endpoint: "https://kc.example.com/realms/ai-memory/protocol/openid-connect/token"
                 .to_string(),
         }
     }
@@ -375,7 +375,7 @@ mod tests {
         assert_eq!(loaded.client_id, "ai-memory-dev");
         assert_eq!(
             loaded.token_endpoint,
-            "https://kc.example.com/realms/serpro/protocol/openid-connect/token"
+            "https://kc.example.com/realms/ai-memory/protocol/openid-connect/token"
         );
     }
 


### PR DESCRIPTION
Small housekeeping.

- The OIDC example / doc issuer URLs used `…/realms/serpro`, tying the shipped examples to a specific org. Replaced with `…/realms/ai-memory` in `ai-memory-llm/src/oidc.rs` (incl. the round-trip test's `token_endpoint` assertion) and the `--issuer` doc in `ai-memory-cli/src/cli.rs`. No non-example occurrences remain (`rg serpro crates/` is empty).
- Removed `LlmError::RetriesExhausted` — it is never constructed and never matched by name.

`cargo test -p ai-memory-llm oidc` green; `cargo clippy -p ai-memory-llm -p ai-memory-cli --all-targets -- -D warnings` clean.