### PR TITLE
feat(admin): GET /admin/projects — authoritative project inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- New read-only admin endpoint `GET /admin/projects`: the authoritative
+  `(workspace, project)` inventory with page counts and last-updated
+  timestamps. Gives dashboards, exports, and backup/mirror tooling a
+  first-class list to reconcile against — a mirror directory whose project
+  no longer appears here is an orphan and can be pruned. Root-only in
+  multi-user mode, like every `/admin/*` route ([#180]).
 - `memory_delete_page` / admin `delete-page` now write one attributed
   `audit_log` row pointing at the deleted page id, in the same transaction
   as the delete — completing the "who deleted the gotcha page about X?"

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -8,6 +8,7 @@
 //! - `POST /admin/auto-improve/report` — read-only auto-improve telemetry report.
 //! - `POST /admin/curator`        — dry-run or stage a rule-based curator report.
 //! - `GET  /admin/status`         — lifetime counts + server data-dir info.
+//! - `GET  /admin/projects`       — authoritative `(workspace, project)` list.
 //! - `GET  /admin/search?q=`      — FTS5 hits against the wiki index.
 //! - `POST /admin/reorg`          — retro-fit sessions to per-cwd projects.
 //! - `POST /admin/lint`           — run the M8 lint pass.
@@ -523,6 +524,7 @@ pub fn admin_router(state: AdminState) -> Router {
             post(handle_pending_write_reject),
         )
         .route("/admin/status", get(handle_status))
+        .route("/admin/projects", get(handle_list_projects))
         .route(
             "/admin/audit-contamination",
             get(handle_audit_contamination),
@@ -750,6 +752,24 @@ pub struct StatusReport {
     pub derived: ai_memory_store::DerivedIndexStatus,
     /// Passive process-scoped provider health.
     pub providers: ProviderHealthSnapshot,
+}
+
+/// `GET /admin/projects` — the authoritative list of `(workspace, project)`
+/// pairs (with page counts + last-updated), read-only. Useful to any external
+/// consumer that needs the live project inventory: a dashboard, an export, or
+/// a backup/mirror that lays the wiki out as `wiki/<workspace>/<project>/` and
+/// wants to reconcile against it — any directory whose project no longer
+/// appears here is an orphan (e.g. from a delete that bypassed the admission
+/// chain, such as an offline `--data-dir` purge or a direct DB edit) and can
+/// be pruned so the copy reflects the live server.
+async fn handle_list_projects(State(state): State<Arc<AdminState>>) -> impl IntoResponse {
+    match state.reader.list_projects_with_stats().await {
+        Ok(projects) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "projects": projects })),
+        ),
+        Err(e) => internal_err(e.to_string()),
+    }
 }
 
 async fn handle_status(State(state): State<Arc<AdminState>>) -> impl IntoResponse {

--- a/crates/ai-memory-mcp/tests/admin_status_search.rs
+++ b/crates/ai-memory-mcp/tests/admin_status_search.rs
@@ -122,6 +122,74 @@ async fn status_returns_counts_and_paths() {
 }
 
 #[tokio::test]
+async fn list_projects_returns_workspace_project_pairs() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_admin_state(&tmp).await;
+    // Seed pages in two distinct (workspace, project) scopes.
+    seed_page(&store, "A", "notes/a.md", "body a").await; // default/scratch
+    let ws = store
+        .writer
+        .get_or_create_workspace("acme".to_string())
+        .await
+        .unwrap();
+    let proj = store
+        .writer
+        .get_or_create_project(ws, "infra".to_string(), None)
+        .await
+        .unwrap();
+    store
+        .writer
+        .upsert_page(NewPage {
+            workspace_id: ws,
+            project_id: proj,
+            path: PagePath::new("notes/b.md").unwrap(),
+            title: "B".into(),
+            body: "body b".into(),
+            tier: Tier::Semantic,
+            frontmatter_json: serde_json::json!({}),
+            pinned: false,
+            links: Vec::new(),
+            author_id: None,
+        })
+        .await
+        .unwrap();
+    let app = admin_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/admin/projects")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes(resp).await).unwrap();
+    let pairs: Vec<(String, String)> = body["projects"]
+        .as_array()
+        .expect("projects array")
+        .iter()
+        .map(|p| {
+            (
+                p["workspace_name"].as_str().unwrap().to_string(),
+                p["project_name"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    assert!(
+        pairs.contains(&("default".to_string(), "scratch".to_string())),
+        "{pairs:?}"
+    );
+    assert!(
+        pairs.contains(&("acme".to_string(), "infra".to_string())),
+        "{pairs:?}"
+    );
+}
+
+#[tokio::test]
 async fn search_returns_matching_hits() {
     let tmp = TempDir::new().unwrap();
     let (state, store) = make_admin_state(&tmp).await;


### PR DESCRIPTION
Exposes the full `(workspace, project)` list (with page counts + last-updated, reusing the existing `list_projects_with_stats` reader) as a read-only admin endpoint.

## Why
Anything that needs the **live project inventory** — a dashboard, an export, or a **backup/mirror** that lays the wiki out as `wiki/<workspace>/<project>/…` — currently has no first-class way to enumerate it. In particular, a mirror that prunes on delete events can drift: a delete that **bypasses the admission chain** (an offline `--data-dir` purge run against a data dir, a direct DB edit, a dropped event) removes the project from the DB but leaves the mirror's directory behind, with no way to notice. `GET /admin/projects` is the authoritative list to reconcile against — any project directory not present in the response is an orphan and can be pruned.

## Change
- `GET /admin/projects` → `{ "projects": [ { workspace_name, project_name, page_count, last_updated }, … ] }`, read-only (no writes, no LLM).

## Test
`list_projects_returns_workspace_project_pairs` seeds two distinct `(workspace, project)` scopes and asserts both surface in the array.

## Validation
`cargo test -p ai-memory-mcp` (new test green) · `cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` clean.