### PR TITLE
feat(recall): honor [recall] default_global in memory_recent too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   high-precision signal ([#182]).
 
 ### Added
+- The `[recall] default_global` marker now broadens `memory_recent` too,
+  completing the pair started with `memory_query` in v1.12.0: an unscoped
+  `memory_recent` from an opted-in repo returns the most-recently-updated
+  pages across every project as `global_hits` (workspace + project
+  annotated). Explicit `workspace`/`project` arguments still scope exactly
+  as before, and the plain project-scoped response shape is unchanged
+  ([#181]).
 - New read-only admin endpoint `GET /admin/projects`: the authoritative
   `(workspace, project)` inventory with page counts and last-updated
   timestamps. Gives dashboards, exports, and backup/mirror tooling a

--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -413,11 +413,6 @@ struct StatusArgs {
 }
 
 #[derive(Debug, Serialize)]
-struct QueryResponse<T: Serialize> {
-    hits: Vec<T>,
-}
-
-#[derive(Debug, Serialize)]
 struct MemoryQueryResponse {
     hits: Vec<ai_memory_store::PageHit>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -433,6 +428,18 @@ struct MemoryQueryResponse {
     /// `global=true`).
     #[serde(skip_serializing_if = "Vec::is_empty")]
     global_scope_hits: Vec<ai_memory_store::PageHit>,
+}
+
+/// Response for `memory_recent`. `hits` carries the current project's recent
+/// pages; `global_hits` is populated instead when the read broadened to global
+/// (repo opted into `[recall] default_global`), each hit annotated with its
+/// workspace + project. `global_hits` is omitted when empty, so a plain
+/// project-scoped response is unchanged.
+#[derive(Debug, Serialize)]
+struct MemoryRecentResponse {
+    hits: Vec<ai_memory_store::PageHit>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    global_hits: Vec<ai_memory_store::PageHitWithMeta>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1333,6 +1340,29 @@ impl AiMemoryServer {
     ) -> Result<CallToolResult, McpError> {
         let aps_actor = Self::actor_key_from_parts(Some(&parts));
         let limit = args.limit.unwrap_or(self.default_limit).clamp(1, 100);
+        // A repo that opted into `[recall] default_global` broadens an
+        // unscoped `memory_recent` to "most recent across every project", each
+        // hit annotated with its workspace + project. An explicit
+        // `workspace`/`project` always wins (same precedence as memory_query).
+        let explicit_scoping = args
+            .workspace
+            .as_deref()
+            .is_some_and(|s| !s.trim().is_empty())
+            || args
+                .project
+                .as_deref()
+                .is_some_and(|s| !s.trim().is_empty());
+        if !explicit_scoping && self.active_project.default_global_for(&aps_actor) {
+            let global_hits = self
+                .reader
+                .recent_pages_global(limit)
+                .await
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+            return ok_json(&MemoryRecentResponse {
+                hits: Vec::new(),
+                global_hits,
+            });
+        }
         let (ws, proj) = self
             .effective_ids_for_read_args_with_actor(
                 args.workspace.as_deref(),
@@ -1346,8 +1376,10 @@ impl AiMemoryServer {
             .await
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
         self.spawn_access_bump(hits.iter().map(|h| h.id).collect());
-        let response = QueryResponse { hits };
-        ok_json(&response)
+        ok_json(&MemoryRecentResponse {
+            hits,
+            global_hits: Vec::new(),
+        })
     }
 
     /// Run the M8 forget sweep over episodic pages.
@@ -4987,6 +5019,92 @@ mod tests {
             .map(|t| t.text.clone())
             .unwrap();
         assert!(text.contains("foo.md"), "expected hit; got {text}");
+    }
+
+    #[tokio::test]
+    async fn memory_recent_default_global_marker_broadens_to_all_projects() {
+        let (_tmp, store, server, ws, _pj) = setup_server().await;
+        let infra = store
+            .writer
+            .get_or_create_project(ws, "infra", None)
+            .await
+            .unwrap();
+        let ops_ws = store.writer.get_or_create_workspace("ops").await.unwrap();
+        let runbooks = store
+            .writer
+            .get_or_create_project(ops_ws, "runbooks", None)
+            .await
+            .unwrap();
+        for (w, p, path) in [(ws, infra, "cluster.md"), (ops_ws, runbooks, "deploy.md")] {
+            store
+                .writer
+                .upsert_page(NewPage {
+                    workspace_id: w,
+                    project_id: p,
+                    path: PagePath::new(path).unwrap(),
+                    title: path.into(),
+                    body: "recent body".into(),
+                    tier: Tier::Semantic,
+                    frontmatter_json: serde_json::json!({}),
+                    pinned: false,
+                    links: Vec::new(),
+                    author_id: None,
+                })
+                .await
+                .unwrap();
+        }
+        // Opt into default_global on the (empty) test actor's single slot.
+        server
+            .active_project
+            .set_for(&ai_memory_core::ActorKey::default(), ws, infra, true);
+
+        let result = server
+            .memory_recent(
+                Parameters(RecentArgs {
+                    limit: Some(10),
+                    project: None,
+                    workspace: None,
+                }),
+                OptionalParts(test_parts_default()),
+            )
+            .await
+            .unwrap();
+        let text = result
+            .content
+            .first()
+            .and_then(|c| c.as_text())
+            .map(|t| t.text.clone())
+            .unwrap();
+        assert!(
+            text.contains("global_hits"),
+            "default_global must broaden recent across projects: {text}"
+        );
+        assert!(text.contains("cluster.md"), "{text}");
+        assert!(text.contains("deploy.md"), "{text}");
+
+        // An explicit workspace+project still scopes (no cross-project broaden).
+        let scoped = server
+            .memory_recent(
+                Parameters(RecentArgs {
+                    limit: Some(10),
+                    project: Some("runbooks".into()),
+                    workspace: Some("ops".into()),
+                }),
+                OptionalParts(test_parts_default()),
+            )
+            .await
+            .unwrap();
+        let scoped_text = scoped
+            .content
+            .first()
+            .and_then(|c| c.as_text())
+            .map(|t| t.text.clone())
+            .unwrap();
+        assert!(scoped_text.contains("deploy.md"), "{scoped_text}");
+        assert!(
+            !scoped_text.contains("cluster.md"),
+            "explicit scope must not broaden: {scoped_text}"
+        );
     }
 
     #[tokio::test]

--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -1134,14 +1134,7 @@ impl AiMemoryServer {
         // `global` / `scopes` / `workspace` / `project` arg always wins, so
         // this only fires when the caller passed none of them.
         let explicit_scoping = !args.scopes.is_empty()
-            || args
-                .workspace
-                .as_deref()
-                .is_some_and(|s| !s.trim().is_empty())
-            || args
-                .project
-                .as_deref()
-                .is_some_and(|s| !s.trim().is_empty());
+            || named_scope_args_present(args.workspace.as_deref(), args.project.as_deref());
         let recall_global = !explicit_scoping
             && !args.global.unwrap_or(false)
             && self.active_project.default_global_for(&aps_actor);
@@ -1345,14 +1338,8 @@ impl AiMemoryServer {
         // unscoped `memory_recent` to "most recent across every project", each
         // hit annotated with its workspace + project. An explicit
         // `workspace`/`project` always wins (same precedence as memory_query).
-        let explicit_scoping = args
-            .workspace
-            .as_deref()
-            .is_some_and(|s| !s.trim().is_empty())
-            || args
-                .project
-                .as_deref()
-                .is_some_and(|s| !s.trim().is_empty());
+        let explicit_scoping =
+            named_scope_args_present(args.workspace.as_deref(), args.project.as_deref());
         if !explicit_scoping && self.active_project.default_global_for(&aps_actor) {
             let global_hits = self
                 .reader
@@ -2531,6 +2518,14 @@ impl AiMemoryServer {
             }
         });
     }
+}
+
+/// True when the caller explicitly scoped the read by name — a non-empty
+/// `workspace` or `project` argument. Explicit scoping always wins over the
+/// `[recall] default_global` marker broadening; `memory_query` also counts
+/// its `scopes` list on top of this.
+fn named_scope_args_present(workspace: Option<&str>, project: Option<&str>) -> bool {
+    workspace.is_some_and(|s| !s.trim().is_empty()) || project.is_some_and(|s| !s.trim().is_empty())
 }
 
 fn ok_json<T: Serialize>(value: &T) -> Result<CallToolResult, McpError> {

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -1001,6 +1001,53 @@ impl ReaderPool {
         .await
     }
 
+    /// The `limit` most-recently-updated `is_latest` pages across EVERY
+    /// project, each annotated with its workspace + project name. The
+    /// cross-project analog of [`Self::recent_pages_for_project`]; used when a
+    /// read's scope broadens to global.
+    ///
+    /// # Errors
+    /// Propagates any SQL or pool error.
+    pub async fn recent_pages_global(&self, limit: usize) -> StoreResult<Vec<PageHitWithMeta>> {
+        self.with_conn(move |conn| {
+            let mut stmt = conn.prepare_cached(
+                "SELECT workspaces.name, projects.name, pages.path, pages.title, \
+                        substr(pages.body, 1, 240) AS snip, \
+                        CAST(pages.updated_at AS REAL) AS rank \
+                 FROM pages \
+                 JOIN projects ON projects.id = pages.project_id \
+                 JOIN workspaces ON workspaces.id = pages.workspace_id \
+                 WHERE pages.is_latest = 1 \
+                 ORDER BY pages.updated_at DESC \
+                 LIMIT ?1",
+            )?;
+            #[allow(clippy::cast_possible_wrap)]
+            let rows = stmt.query_map(params![limit as i64], |row| {
+                let workspace_name: String = row.get(0)?;
+                let project_name: String = row.get(1)?;
+                let path: String = row.get(2)?;
+                let title: String = row.get(3)?;
+                let snippet: String = row.get(4)?;
+                let rank: f64 = row.get(5)?;
+                Ok((workspace_name, project_name, path, title, snippet, rank))
+            })?;
+            let mut hits = Vec::new();
+            for row in rows {
+                let (workspace_name, project_name, path, title, snippet, rank) = row?;
+                hits.push(PageHitWithMeta {
+                    workspace_name,
+                    project_name,
+                    path: PagePath::new(path)?,
+                    title,
+                    snippet,
+                    rank,
+                });
+            }
+            Ok(hits)
+        })
+        .await
+    }
+
     /// Return all observations for the given session, ordered by
     /// `created_at` ascending.
     ///

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -1001,6 +1001,11 @@ impl ReaderPool {
     /// cross-project analog of [`Self::recent_pages_for_project`]; used when a
     /// read's scope broadens to global.
     ///
+    /// Recency has no FTS relevance score, so the reused
+    /// [`PageHitWithMeta::rank`] field carries `updated_at` (µs, cast to
+    /// REAL) — larger still means "ranks first", callers must not read it
+    /// as an FTS rank.
+    ///
     /// # Errors
     /// Propagates any SQL or pool error.
     pub async fn recent_pages_global(&self, limit: usize) -> StoreResult<Vec<PageHitWithMeta>> {

--- a/docs/marker-file.md
+++ b/docs/marker-file.md
@@ -65,7 +65,8 @@ drop_subagent_captures = "true"
 
 # Optional. Broaden this repo's DEFAULT memory recall to every project:
 # an unscoped `memory_query` from sessions in this tree behaves as
-# `global=true` (each hit annotated with its workspace + project).
+# `global=true`, and an unscoped `memory_recent` returns the most recent
+# pages across every project (each hit annotated with workspace + project).
 # Meant for meta-repos that constantly need sibling-project context.
 # Explicit args always win — passing `workspace`/`project`/`scopes`/
 # `global` overrides this for that call. Off by default. Note: while


### PR DESCRIPTION
Completes the pair started by #177. That PR made `memory_query` broaden an **unscoped** read to global when a repo opts into `[recall] default_global` (the meta-repo case); `memory_recent` was left project-scoped. Now "most recent" also spans every project under the same opt-in.

## Changes
- **reader** `recent_pages_global(limit)` — the cross-project analog of `recent_pages_for_project`: the most-recently-updated `is_latest` pages across **every** project, each annotated with its `workspace` + `project` name (reuses the `PageHitWithMeta` shape already returned by the global search).
- **`memory_recent`** — when the caller passes no explicit `workspace`/`project` **and** the actor opted into `default_global`, return those cross-project hits in a `global_hits` field. **Strict precedence:** an explicit `workspace`/`project` always scopes (identical rule to `memory_query`).
- The response gains an optional `global_hits` (`skip_serializing_if empty`), so a plain project-scoped `{ "hits": [...] }` is byte-identical to before.

## Test
`memory_recent_default_global_marker_broadens_to_all_projects`: an unscoped `memory_recent` under `default_global` surfaces pages from two workspaces; an explicit `workspace`+`project` still scopes to one.

## Validation
`cargo test -p ai-memory-store -p ai-memory-mcp` green · `cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` clean.