### PR TITLE
fix(audit): drop the observation-vs-session drift check (false positives)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `audit-contamination` no longer flags an observation whose project differs
+  from its session's home project (the old `observation_session_drift` CHECK
+  B, including the `observations_drifted` summary count and the finding's
+  `session_id` field). With per-event cwd resolution, an agent that
+  legitimately `cd`s across repos in one session produces exactly that shape
+  — it is correct attribution, not contamination — so the check drowned
+  multi-repo instances in false positives. CHECK A (`session_wrong_bucket`,
+  anchored on the session's own cwd evidence) is unchanged and remains the
+  high-precision signal ([#182]).
+
 ### Added
 - New read-only admin endpoint `GET /admin/projects`: the authoritative
   `(workspace, project)` inventory with page counts and last-updated

--- a/crates/ai-memory-cli/src/commands/audit_contamination.rs
+++ b/crates/ai-memory-cli/src/commands/audit_contamination.rs
@@ -24,8 +24,6 @@ struct Report {
 struct Summary {
     #[serde(default)]
     sessions_misbucketed: usize,
-    #[serde(default)]
-    observations_drifted: usize,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -40,8 +38,6 @@ struct Finding {
     expected_project: Option<String>,
     #[serde(default)]
     cwd: Option<String>,
-    #[serde(default)]
-    session_id: Option<String>,
 }
 
 /// Run the `audit-contamination` subcommand.
@@ -60,12 +56,12 @@ pub async fn run(config: &Config, args: AuditContaminationArgs) -> Result<()> {
     }
 
     if report.findings.is_empty() {
-        println!("No structural contamination found (sessions + observations consistent).");
+        println!("No structural contamination found (no session mis-bucketed by cwd).");
         return Ok(());
     }
     println!(
-        "Contamination audit: {} session(s) mis-bucketed, {} observation(s) drifted.",
-        report.summary.sessions_misbucketed, report.summary.observations_drifted
+        "Contamination audit: {} session(s) mis-bucketed.",
+        report.summary.sessions_misbucketed
     );
     for f in &report.findings {
         let expected = f.expected_project.as_deref().unwrap_or("?");
@@ -77,15 +73,6 @@ pub async fn run(config: &Config, args: AuditContaminationArgs) -> Result<()> {
                 f.landed_workspace,
                 f.landed_project,
                 f.cwd.as_deref().unwrap_or("?"),
-                expected,
-            ),
-            "observation_session_drift" => println!(
-                "  [{}] observation {} in {}/{} but its session ({}) is in project {}",
-                f.confidence,
-                f.entity_id,
-                f.landed_workspace,
-                f.landed_project,
-                f.session_id.as_deref().unwrap_or("?"),
                 expected,
             ),
             other => println!(

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -159,11 +159,11 @@ pub struct StatusCounts {
 /// with no cwd/session anomaly) is not detectable structurally.
 #[derive(Debug, Clone, Serialize)]
 pub struct ContaminationFinding {
-    /// Heuristic that fired: `session_wrong_bucket` | `observation_session_drift`.
+    /// Heuristic that fired: `session_wrong_bucket` (CHECK A).
     pub check: &'static str,
-    /// Confidence — `high` for both structural checks.
+    /// Confidence — `high` for the structural check.
     pub confidence: &'static str,
-    /// Entity kind: `session` | `observation`.
+    /// Entity kind: `session`.
     pub entity_kind: &'static str,
     /// Entity id (lowercase hex of the 16-byte UUID).
     pub entity_id: String,
@@ -171,16 +171,13 @@ pub struct ContaminationFinding {
     pub landed_workspace: String,
     /// Project name the entity actually landed in.
     pub landed_project: String,
-    /// Project the evidence says it belongs to (resolved cwd project for CHECK A,
-    /// the owning session's project for CHECK B).
+    /// Project the evidence says it belongs to (the session's cwd
+    /// prefix-resolution result for CHECK A).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expected_project: Option<String>,
     /// Originating session cwd — the prefix-resolution evidence (CHECK A).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
-    /// Owning session id (lowercase hex) — the drift evidence (CHECK B).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub session_id: Option<String>,
 }
 
 /// Per-check counts for an [`ReaderPool::audit_contamination`] run.
@@ -188,8 +185,6 @@ pub struct ContaminationFinding {
 pub struct ContaminationSummary {
     /// Sessions whose cwd prefix-resolves to a different project (CHECK A).
     pub sessions_misbucketed: usize,
-    /// Observations whose project disagrees with their session (CHECK B).
-    pub observations_drifted: usize,
 }
 
 /// Result of [`ReaderPool::audit_contamination`] — advisory, never mutates.
@@ -3826,15 +3821,21 @@ impl ReaderPool {
 
     /// Structural cross-project contamination audit (cheap, SQL-only, no LLM).
     ///
-    /// Two HIGH-precision heuristics:
+    /// One HIGH-precision heuristic:
     /// - **CHECK A** (`session_wrong_bucket`): a session whose `cwd`
     ///   longest-prefix-resolves to a *different* project than the one it landed
     ///   in — the direct signature of the auto-scope bleed bug. Resolved with the
     ///   same prefix and cwd-safety rules as [`Self::find_project_by_cwd_prefix`],
     ///   so the audit never claims a session a live resolve would not.
-    /// - **CHECK B** (`observation_session_drift`): an observation whose
-    ///   `project_id` disagrees with its owning session's. On a healthy DB this
-    ///   is always empty, so a non-empty result is a regression alarm.
+    ///
+    /// Note: an earlier "observation drifted from its session's project" check
+    /// was removed. With per-event cwd resolution, an observation's `project_id`
+    /// is set from the cwd *of that event* — so an agent that legitimately
+    /// `cd`s across repos in one session produces observations whose project
+    /// differs from the session's home project. That is correct attribution,
+    /// not contamination, so the check flagged normal cross-repo work as a false
+    /// positive (and observations carry no cwd of their own to disambiguate).
+    /// CHECK A — anchored on the session's own cwd — remains the precise signal.
     ///
     /// Detects only contamination with a STRUCTURAL trace; purely semantic
     /// mislandings (topic-level, no cwd/session anomaly) are not detectable.
@@ -3857,60 +3858,22 @@ impl ReaderPool {
             None => Vec::new(),
         };
 
-        // One connection: CHECK B findings + the candidate session list + the
-        // valid repo_path prefixes used to resolve CHECK A. Loading prefixes
-        // once avoids a reader query per historical session while preserving the
-        // same path boundary and safety rules as the runtime resolver.
+        // One connection: the candidate session list + the valid repo_path
+        // prefixes used to resolve CHECK A. Loading prefixes once avoids a
+        // reader query per historical session while preserving the same path
+        // boundary and safety rules as the runtime resolver.
         type Candidate = (String, WorkspaceId, ProjectId, String, String, String);
         type Prefix = (WorkspaceId, ProjectId, String, String);
-        let sp_b = scope_params.clone();
         let (mut findings, candidates, prefixes): (
             Vec<ContaminationFinding>,
             Vec<Candidate>,
             Vec<Prefix>,
         ) = self
             .with_conn(move |conn| {
-                let mut findings: Vec<ContaminationFinding> = Vec::new();
-
-                // CHECK B — observation drifted from its owning session.
-                let mut b_sql = String::from(
-                    "SELECT lower(hex(o.id)), lower(hex(o.session_id)), wl.name, pl.name, pe.name \
-                     FROM observations o \
-                     JOIN sessions s ON s.id = o.session_id \
-                     JOIN workspaces wl ON wl.id = o.workspace_id \
-                     JOIN projects pl ON pl.id = o.project_id \
-                     JOIN projects pe ON pe.id = s.project_id \
-                     WHERE o.project_id != s.project_id",
-                );
-                if scoped {
-                    b_sql.push_str(" AND o.workspace_id = ? AND o.project_id = ?");
-                }
-                {
-                    let mut stmt = conn.prepare(&b_sql)?;
-                    let rows = stmt.query_map(params_from_iter(sp_b.iter()), |row| {
-                        Ok((
-                            row.get::<_, String>(0)?,
-                            row.get::<_, String>(1)?,
-                            row.get::<_, String>(2)?,
-                            row.get::<_, String>(3)?,
-                            row.get::<_, String>(4)?,
-                        ))
-                    })?;
-                    for r in rows {
-                        let (id, sess, lws, lproj, eproj) = r?;
-                        findings.push(ContaminationFinding {
-                            check: "observation_session_drift",
-                            confidence: "high",
-                            entity_kind: "observation",
-                            entity_id: id,
-                            landed_workspace: lws,
-                            landed_project: lproj,
-                            expected_project: Some(eproj),
-                            cwd: None,
-                            session_id: Some(sess),
-                        });
-                    }
-                }
+                // CHECK A findings are built after this closure (they need the
+                // repo_path prefixes resolved outside the DB connection); this
+                // closure only gathers the raw inputs.
+                let findings: Vec<ContaminationFinding> = Vec::new();
 
                 // Candidate sessions (cwd present) — resolved outside the conn.
                 let mut s_sql = String::from(
@@ -4048,7 +4011,6 @@ impl ReaderPool {
                     landed_project: landed_proj_name,
                     expected_project: Some(resolved_name.clone()),
                     cwd: Some(cwd),
-                    session_id: None,
                 });
             }
         }
@@ -4057,10 +4019,6 @@ impl ReaderPool {
             sessions_misbucketed: findings
                 .iter()
                 .filter(|f| f.check == "session_wrong_bucket")
-                .count(),
-            observations_drifted: findings
-                .iter()
-                .filter(|f| f.check == "observation_session_drift")
                 .count(),
         };
         Ok(ContaminationReport { summary, findings })

--- a/crates/ai-memory-store/tests/audit_contamination.rs
+++ b/crates/ai-memory-store/tests/audit_contamination.rs
@@ -70,7 +70,7 @@ fn seed(db_path: &std::path::Path) {
 }
 
 #[tokio::test]
-async fn audit_flags_wrong_bucket_session_and_drifted_observation() {
+async fn audit_flags_wrong_bucket_session_but_not_cross_project_observation() {
     let tmp = tempfile::tempdir().unwrap();
     let store = Store::open(tmp.path()).unwrap();
     seed(store.db_path());
@@ -80,10 +80,6 @@ async fn audit_flags_wrong_bucket_session_and_drifted_observation() {
     assert_eq!(
         report.summary.sessions_misbucketed, 1,
         "exactly the wrong-bucket session is flagged (clean one is not)"
-    );
-    assert_eq!(
-        report.summary.observations_drifted, 1,
-        "exactly the drifted observation is flagged (clean one is not)"
     );
 
     let a = report
@@ -97,14 +93,17 @@ async fn audit_flags_wrong_bucket_session_and_drifted_observation() {
     assert_eq!(a.expected_project.as_deref(), Some("proj-b"));
     assert_eq!(a.cwd.as_deref(), Some("/w/b/sub"));
 
-    let b = report
-        .findings
-        .iter()
-        .find(|f| f.check == "observation_session_drift")
-        .expect("CHECK B finding present");
-    assert_eq!(b.entity_kind, "observation");
-    assert_eq!(b.landed_project, "proj-b");
-    assert_eq!(b.expected_project.as_deref(), Some("proj-a"));
+    // The observation whose project differs from its session's project (seeded
+    // above) is NOT flagged: with per-cwd attribution that is legitimate
+    // cross-repo work, not contamination. Only the session-cwd signal fires.
+    assert!(
+        report
+            .findings
+            .iter()
+            .all(|f| f.entity_kind != "observation"),
+        "cross-project observations must not be flagged (per-cwd is legitimate)"
+    );
+    assert_eq!(report.findings.len(), 1, "only CHECK A fires");
 }
 
 #[tokio::test]
@@ -136,7 +135,6 @@ async fn audit_clean_db_returns_no_findings() {
 
     let report = store.reader.audit_contamination(None, None).await.unwrap();
     assert_eq!(report.summary.sessions_misbucketed, 0);
-    assert_eq!(report.summary.observations_drifted, 0);
     assert!(report.findings.is_empty());
 }
 
@@ -272,16 +270,15 @@ async fn audit_scope_restricts_to_landed_bucket() {
     seed(store.db_path());
     let (ws, a) = (id(1), id(2));
 
-    // Scoped to proj-a: the wrong-bucket session (landed in A) is in scope; the
-    // drifted observation (landed in B) is out of scope.
+    // Scoped to proj-a: only the wrong-bucket session (landed in A) is in scope.
     let scope = Some((
         WorkspaceId::from_slice(&ws).unwrap(),
         ProjectId::from_slice(&a).unwrap(),
     ));
     let report = store.reader.audit_contamination(scope, None).await.unwrap();
     assert_eq!(report.summary.sessions_misbucketed, 1);
-    assert_eq!(
-        report.summary.observations_drifted, 0,
-        "the drifted obs landed in proj-b, outside the proj-a scope"
+    assert!(
+        report.findings.iter().all(|f| f.landed_project == "proj-a"),
+        "a scoped audit returns only findings landed in the scoped project"
     );
 }


### PR DESCRIPTION
The `audit-contamination` **CHECK B** (`observation_session_drift`) flagged every observation whose `project_id` differs from its owning session's `project_id` as high-confidence contamination, documented as "on a healthy DB this is always empty."

## The premise is wrong for per-event cwd resolution
The engine resolves each hook event's project from the cwd **of that event**. So an agent that legitimately `cd`s across repos within one session produces observations whose project differs from the session's *home* project — that is **correct attribution, not contamination**. And observations store no cwd of their own, so the check had no way to distinguish legitimate cross-repo work from an actual mis-filing. On a busy multi-repo instance the check drowns the report in false positives (every cross-repo session trips it).

## Change
Remove CHECK B entirely: the query, its findings, the `observations_drifted` summary count, and the now-unused `session_id` finding field (+ its CLI rendering). **CHECK A** (`session_wrong_bucket`) — a session whose own `cwd` longest-prefix-resolves to a different project than it landed in — is anchored on real cwd evidence and remains the precise, high-precision signature of the auto-scope-bleed bug this audit was built to catch.

## Test
`audit_flags_wrong_bucket_session_but_not_cross_project_observation`: the seeded cross-project observation is asserted **NOT** flagged; only CHECK A fires.

## Validation
`cargo test -p ai-memory-store` (158) / `-p ai-memory-cli` / `-p ai-memory-mcp` green · `cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` clean.