### PR TITLE
docs: preserve canonical commit attribution

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,12 @@
 - [ ] `cargo test --workspace` passes
 - [ ] Manual test: <!-- describe what you ran and what you observed -->
 
+## Commit attribution
+
+- [ ] I verified the name and email on every commit in this PR and corrected
+      any unintended identity before requesting merge. See
+      [commit attribution guidance](https://github.com/akitaonrails/ai-memory/blob/main/CONTRIBUTING.md#commit-attribution).
+
 ## CHANGELOG (merge gate)
 
 - [ ] I added a `CHANGELOG.md` `[Unreleased]` entry — **required** for any

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+# Keep contributor identities canonical without rewriting published history.
+Lucas Oliveira <lucasouliveira@gmail.com> <lucasoliveira@apoioprodesp.sp.gov.br>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,31 @@ self-contained: SQLite is bundled via `rusqlite`'s `bundled` feature, and
 `libgit2` is vendored via `git2`'s `vendored-libgit2` feature. No system
 libraries need installing beyond a standard C toolchain.
 
+## Commit attribution
+
+GitHub associates commits with accounts through the author email stored in
+each commit. Before pushing a branch, inspect every commit that the pull request
+will add:
+
+```bash
+git log --format='%h %an <%ae>' "$(git merge-base HEAD origin/main)"..HEAD
+```
+
+Use an email verified by your GitHub account, or its GitHub-provided `noreply`
+address. Set it for this checkout when your global Git identity belongs to a
+different project or employer:
+
+```bash
+git config --local user.name "Your Name"
+git config --local user.email "your-verified-address@example.com"
+```
+
+Correct attribution mistakes on the pull-request branch before it is merged.
+The project does not rewrite shared `main` history or published release tags
+solely to change attribution because doing so invalidates commit hashes and
+breaks existing clones and forks. Maintainers use [`.mailmap`](.mailmap) to
+canonicalize accidental aliases without changing published commits.
+
 ## Required gates before every PR
 
 All four must pass — the CI workflow enforces them and so does the `bin/release`


### PR DESCRIPTION
## What changed

- map Lucas Oliveira's accidental work-email commits to his canonical personal identity through `.mailmap`
- document repository-local Git identity setup and pre-push verification
- add an explicit commit-attribution check to the pull request template

No published commit, tag, or release history is rewritten.

## Why

PR #195 included nine commits authored and committed with an unintended work address. Rewriting shared `main` would invalidate public hashes, verified merge signatures, the v1.15.0 release lineage, and existing contributor clones. The mailmap provides canonical attribution without that disruption, while the documentation and checklist prevent recurrence.

Closes #202.

## Test plan

- [x] `git diff --check`
- [x] `git check-mailmap` maps the reported work identity to `lucasouliveira@gmail.com`
- [x] all nine affected commits render the canonical author and committer email via mailmap-aware Git formats
- [x] Rust tests not run: documentation and Git metadata only

## CHANGELOG

Not required: this does not change ai-memory runtime or user-facing behavior.