### PR TITLE
Add Atlas Cloud LLM provider

### DIFF
--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -1068,6 +1068,8 @@ pub enum LlmProviderChoice {
     Copilot,
     /// OpenCode Zen/Go cloud API.
     Opencode,
+    /// Atlas Cloud OpenAI-compatible API.
+    Atlascloud,
 }
 
 /// Arguments for `embed`.

--- a/crates/ai-memory-cli/src/commands/llm_test.rs
+++ b/crates/ai-memory-cli/src/commands/llm_test.rs
@@ -58,6 +58,7 @@ impl From<LlmProviderChoice> for ProviderChoice {
             LlmProviderChoice::OpenaiOauth => Self::OpenAiOAuth,
             LlmProviderChoice::Copilot => Self::Copilot,
             LlmProviderChoice::Opencode => Self::OpenCode,
+            LlmProviderChoice::Atlascloud => Self::AtlasCloud,
         }
     }
 }

--- a/crates/ai-memory-cli/src/config.rs
+++ b/crates/ai-memory-cli/src/config.rs
@@ -9,8 +9,8 @@
 use std::path::{Path, PathBuf};
 
 use ai_memory_llm::{
-    AuthRequirement, EmbedderChoice, EmbedderConfig, LlmError, LlmResult, OPENCODE_DEFAULT_MODEL,
-    ProviderAuth, ProviderChoice, ProviderConfig,
+    ATLASCLOUD_DEFAULT_MODEL, AuthRequirement, EmbedderChoice, EmbedderConfig, LlmError, LlmResult,
+    OPENCODE_DEFAULT_MODEL, ProviderAuth, ProviderChoice, ProviderConfig,
 };
 use anyhow::{Context, Result};
 use figment::{
@@ -202,6 +202,7 @@ pub struct RuntimeEnv {
     copilot_client_id: Option<String>,
     voyage_api_key: Option<SecretString>,
     opencode_api_key: Option<SecretString>,
+    atlascloud_api_key: Option<SecretString>,
 }
 
 impl RuntimeEnv {
@@ -231,6 +232,7 @@ impl RuntimeEnv {
             copilot_client_id: env_string("AI_MEMORY_COPILOT_CLIENT_ID"),
             voyage_api_key: env_secret("VOYAGE_API_KEY"),
             opencode_api_key: env_secret("OPENCODE_API_KEY"),
+            atlascloud_api_key: env_secret("ATLASCLOUD_API_KEY"),
         }
     }
 
@@ -658,10 +660,11 @@ impl Config {
             "copilot" | "github-copilot" | "github_copilot" => ProviderChoice::Copilot,
             "anthropic-oauth" | "anthropic_oauth" => ProviderChoice::AnthropicOAuth,
             "opencode" | "opencode-zen" | "opencode_zen" => ProviderChoice::OpenCode,
+            "atlascloud" | "atlas-cloud" | "atlas_cloud" | "atlas" => ProviderChoice::AtlasCloud,
             other => {
                 return Err(LlmError::NotConfigured(format!(
                     "AI_MEMORY_LLM_PROVIDER={other} is not one of \
-                     anthropic|openai|gemini|openai-compat|openai-oauth|copilot|anthropic-oauth|opencode"
+                     anthropic|openai|gemini|openai-compat|openai-oauth|copilot|anthropic-oauth|opencode|atlascloud"
                 )));
             }
         };
@@ -682,6 +685,7 @@ impl Config {
                     ));
                 }
                 ProviderChoice::OpenCode => OPENCODE_DEFAULT_MODEL.to_string(),
+                ProviderChoice::AtlasCloud => ATLASCLOUD_DEFAULT_MODEL.to_string(),
             },
         };
         Ok(Some(ProviderConfig {
@@ -779,6 +783,7 @@ impl Config {
             ProviderChoice::Copilot => None,
             ProviderChoice::AnthropicOAuth => None,
             ProviderChoice::OpenCode => self.runtime_env.opencode_api_key.clone(),
+            ProviderChoice::AtlasCloud => self.runtime_env.atlascloud_api_key.clone(),
         }
     }
 
@@ -1390,6 +1395,36 @@ mod tests {
             assert_eq!(
                 provider.auth.require_api_key().unwrap().expose_secret(),
                 "sk-opencode-test",
+                "{spelling}"
+            );
+        }
+    }
+
+    #[test]
+    fn atlascloud_provider_resolves_aliases_default_model_and_api_key() {
+        for spelling in ["atlascloud", "atlas-cloud", "atlas_cloud", "atlas"] {
+            let cfg = Config {
+                llm_provider: Some(spelling.into()),
+                runtime_env: RuntimeEnv {
+                    atlascloud_api_key: Some(SecretString::from("sk-atlascloud-test")),
+                    ..RuntimeEnv::default()
+                },
+                ..Config::default()
+            };
+
+            let provider = cfg.llm_provider_config().unwrap().unwrap();
+            assert_eq!(provider.provider, ProviderChoice::AtlasCloud, "{spelling}");
+            assert_eq!(provider.model, ATLASCLOUD_DEFAULT_MODEL, "{spelling}");
+            assert_eq!(
+                provider.auth.requirement(),
+                AuthRequirement::RequiredApiKey {
+                    env_var: "ATLASCLOUD_API_KEY"
+                },
+                "{spelling}"
+            );
+            assert_eq!(
+                provider.auth.require_api_key().unwrap().expose_secret(),
+                "sk-atlascloud-test",
                 "{spelling}"
             );
         }

--- a/crates/ai-memory-llm/src/atlascloud.rs
+++ b/crates/ai-memory-llm/src/atlascloud.rs
@@ -1,0 +1,61 @@
+//! Atlas Cloud provider.
+//!
+//! Thin wrapper around [`OpenAiCompatProvider`] that bakes in Atlas Cloud's
+//! OpenAI-compatible chat-completions endpoint and names the provider
+//! `"atlascloud"`. Accepts an API key from `ATLASCLOUD_API_KEY`.
+
+use async_trait::async_trait;
+use secrecy::SecretString;
+
+use crate::error::LlmResult;
+use crate::openai_compat::OpenAiCompatProvider;
+use crate::provider::LlmProvider;
+use crate::types::{ChatRequest, ChatResponse};
+
+/// Public Atlas Cloud OpenAI-compatible base URL.
+pub const ATLASCLOUD_BASE_URL: &str = "https://api.atlascloud.ai/v1";
+
+/// Default model when `AI_MEMORY_LLM_MODEL` is not set.
+pub const ATLASCLOUD_DEFAULT_MODEL: &str = "qwen/qwen3.5-flash";
+
+/// Atlas Cloud LLM provider.
+///
+/// Routes through `https://api.atlascloud.ai/v1` using the OpenAI chat
+/// completions wire format. Authenticate with `ATLASCLOUD_API_KEY`.
+pub struct AtlasCloudProvider {
+    inner: OpenAiCompatProvider,
+}
+
+impl AtlasCloudProvider {
+    /// Construct an Atlas Cloud provider.
+    ///
+    /// # Errors
+    /// Returns a `reqwest::Error` if the HTTP client cannot be built.
+    pub fn new(api_key: SecretString, model: impl Into<String>) -> LlmResult<Self> {
+        let inner = OpenAiCompatProvider::new(ATLASCLOUD_BASE_URL, Some(api_key), model.into())?;
+        Ok(Self { inner })
+    }
+}
+
+#[async_trait]
+impl LlmProvider for AtlasCloudProvider {
+    fn name(&self) -> &'static str {
+        "atlascloud"
+    }
+
+    fn model(&self) -> &str {
+        self.inner.model()
+    }
+
+    async fn complete(&self, request: ChatRequest) -> LlmResult<ChatResponse> {
+        self.inner.complete(request).await
+    }
+
+    async fn complete_structured_raw(
+        &self,
+        request: ChatRequest,
+        schema: serde_json::Value,
+    ) -> LlmResult<serde_json::Value> {
+        self.inner.complete_structured_raw(request, schema).await
+    }
+}

--- a/crates/ai-memory-llm/src/factory.rs
+++ b/crates/ai-memory-llm/src/factory.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use secrecy::SecretString;
 
 use crate::AnthropicProvider;
+use crate::AtlasCloudProvider;
 use crate::CopilotProvider;
 use crate::GeminiProvider;
 use crate::OpenAiCompatProvider;
@@ -39,6 +40,8 @@ pub enum ProviderChoice {
     AnthropicOAuth,
     /// OpenCode Zen/Go cloud API (OpenAI-compatible endpoint).
     OpenCode,
+    /// Atlas Cloud OpenAI-compatible API.
+    AtlasCloud,
 }
 
 impl ProviderChoice {
@@ -54,6 +57,7 @@ impl ProviderChoice {
             Self::Copilot => "copilot",
             Self::AnthropicOAuth => "anthropic-oauth",
             Self::OpenCode => "opencode",
+            Self::AtlasCloud => "atlascloud",
         }
     }
 
@@ -78,6 +82,9 @@ impl ProviderChoice {
             Self::AnthropicOAuth => AuthRequirement::AnthropicOAuthToken,
             Self::OpenCode => AuthRequirement::RequiredApiKey {
                 env_var: "OPENCODE_API_KEY",
+            },
+            Self::AtlasCloud => AuthRequirement::RequiredApiKey {
+                env_var: "ATLASCLOUD_API_KEY",
             },
         }
     }
@@ -237,6 +244,10 @@ pub fn build_provider(config: ProviderConfig) -> LlmResult<Arc<dyn LlmProvider>>
             let key = config.auth.require_api_key()?;
             Ok(Arc::new(OpenCodeProvider::new(key, config.model)?))
         }
+        ProviderChoice::AtlasCloud => {
+            let key = config.auth.require_api_key()?;
+            Ok(Arc::new(AtlasCloudProvider::new(key, config.model)?))
+        }
     }
 }
 
@@ -281,6 +292,12 @@ mod tests {
         assert_eq!(
             ProviderChoice::AnthropicOAuth.auth_requirement(),
             AuthRequirement::AnthropicOAuthToken
+        );
+        assert_eq!(
+            ProviderChoice::AtlasCloud.auth_requirement(),
+            AuthRequirement::RequiredApiKey {
+                env_var: "ATLASCLOUD_API_KEY"
+            }
         );
     }
 

--- a/crates/ai-memory-llm/src/lib.rs
+++ b/crates/ai-memory-llm/src/lib.rs
@@ -27,6 +27,7 @@
 //!   No tenacity-style 8-128s backoff (cognee #2840 lesson).
 
 pub mod anthropic;
+pub mod atlascloud;
 pub mod auth;
 pub mod copilot;
 pub mod embedding;
@@ -48,6 +49,7 @@ mod response;
 mod text;
 
 pub use anthropic::AnthropicProvider;
+pub use atlascloud::{ATLASCLOUD_BASE_URL, ATLASCLOUD_DEFAULT_MODEL, AtlasCloudProvider};
 pub use auth::{AuthRequirement, CopilotAuth, Credential, CredentialSource, ProviderAuth};
 pub use copilot::{
     COPILOT_INTEGRATION_ID, CopilotProvider, CopilotToken, DEFAULT_COPILOT_API_BASE_URL,


### PR DESCRIPTION
## Summary
- add an `atlascloud` LLM provider backed by Atlas Cloud's OpenAI-compatible chat-completions endpoint
- wire `ATLASCLOUD_API_KEY`, Atlas provider aliases, default model selection, and `llm-test` CLI mapping
- add focused config/factory coverage for Atlas Cloud auth and provider resolution

## Validation
- `RUSTUP_TOOLCHAIN=stable cargo test -p ai-memory-cli atlascloud_provider_resolves_aliases_default_model_and_api_key`
- `RUSTUP_TOOLCHAIN=stable cargo test -p ai-memory-llm provider_choices_declare_current_auth_requirements`
- `RUSTUP_TOOLCHAIN=stable cargo check -p ai-memory-llm -p ai-memory-cli`
- `RUSTUP_TOOLCHAIN=stable cargo fmt --all -- --check`
- `git diff --check`
- confirmed Atlas Cloud live model catalog includes `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

No README changes; this is a code-level provider integration only.