### PR TITLE
Respect CLAUDE_CONFIG_DIR in the claude-code installers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,16 +27,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `install-mcp --client claude-code` and `uninstall` now honour
   `CLAUDE_CONFIG_DIR`: MCP registrations go to
   `$CLAUDE_CONFIG_DIR/.claude.json` when the variable is set (non-empty),
-  falling back to `~/.claude.json` otherwise. The dry-run output prints the
-  resolved config path instead of a hardcoded `~/.claude.json`.
+  falling back to `~/.claude.json` otherwise. Uninstall checks both the active
+  relocated path and the home default so enabling the variable does not orphan
+  a prior default-path registration. The
+  dry-run output prints the resolved config path instead of a hardcoded path.
 - `install-hooks --agent claude-code` and `setup-agent` follow the same
   resolution for the hooks settings file: `$CLAUDE_CONFIG_DIR/settings.json`
-  when set, else `~/.claude/settings.json`. Rendered output and the
-  chmod-600 warning show the resolved path.
+  when set, else `~/.claude/settings.json`. Uninstall checks both locations;
+  rendered output and the chmod-600 warning show the resolved path.
 - `install-skills --scope global` (claude-code root) installs to
   `$CLAUDE_CONFIG_DIR/skills` when the variable is set, else
   `~/.claude/skills`. `uninstall` sweeps the relocated root alongside the
   home default so installs that predate the env var are still removed.
+- The Docker CLI wrapper forwards `CLAUDE_CONFIG_DIR` into its helper
+  container for relocated Claude Code configs beneath the existing home bind.
 
 ## [1.17.1] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `install-mcp --client claude-code` and `uninstall` now honour
+  `CLAUDE_CONFIG_DIR`: MCP registrations go to
+  `$CLAUDE_CONFIG_DIR/.claude.json` when the variable is set (non-empty),
+  falling back to `~/.claude.json` otherwise. The dry-run output prints the
+  resolved config path instead of a hardcoded `~/.claude.json`.
+
 ## [1.17.1] - 2026-07-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `$CLAUDE_CONFIG_DIR/.claude.json` when the variable is set (non-empty),
   falling back to `~/.claude.json` otherwise. The dry-run output prints the
   resolved config path instead of a hardcoded `~/.claude.json`.
+- `install-hooks --agent claude-code` and `setup-agent` follow the same
+  resolution for the hooks settings file: `$CLAUDE_CONFIG_DIR/settings.json`
+  when set, else `~/.claude/settings.json`. Rendered output and the
+  chmod-600 warning show the resolved path.
 
 ## [1.17.1] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolution for the hooks settings file: `$CLAUDE_CONFIG_DIR/settings.json`
   when set, else `~/.claude/settings.json`. Rendered output and the
   chmod-600 warning show the resolved path.
+- `install-skills --scope global` (claude-code root) installs to
+  `$CLAUDE_CONFIG_DIR/skills` when the variable is set, else
+  `~/.claude/skills`. `uninstall` sweeps the relocated root alongside the
+  home default so installs that predate the env var are still removed.
 
 ## [1.17.1] - 2026-07-20
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ docker run -d --name ai-memory \
     akitaonrails/ai-memory:latest
 
 # 3. Wire your agent CLI in two commands. The wrapper takes care of
-#    mounts + auto-detecting ~/.claude/settings.json. Re-run with
+#    mounts and each client's config-path detection. Re-run with
 #    `--agent codex`, `--agent devin`, `--agent opencode`, `--agent gemini-cli`,
 #    `--agent grok`, `--agent kimi-code`, `--agent omp`, `--agent oh-my-pi`, `--client cursor`,
 #    `--client gemini-cli`, `--client grok`, etc.
@@ -338,6 +338,14 @@ other server / hook you have configured, and write a timestamped
 scripts are staged into `~/.local/share/ai-memory/hooks/<agent>/`
 automatically; re-running overwrites them so future image updates ship
 updated hooks. Drop `--apply` to print the snippet instead of mutating.
+For Claude Code, `CLAUDE_CONFIG_DIR` relocates MCP registration to
+`$CLAUDE_CONFIG_DIR/.claude.json`, hooks to
+`$CLAUDE_CONFIG_DIR/settings.json`, and global managed skills to
+`$CLAUDE_CONFIG_DIR/skills`. The Docker wrapper forwards this variable when
+the directory is under its existing `$HOME` bind mount. Use the native binary
+when the Claude config root is outside `$HOME`. Uninstall checks both the
+active relocated paths and Claude's home defaults, so enabling the variable
+does not leave an older default-path ai-memory installation behind.
 If your agent often starts inside repository subdirectories or linked
 worktrees, add `--project-strategy repo-root` to `install-hooks` so captures
 collapse to the main git repo name; see [`docs/install.md`](docs/install.md)

--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -23,6 +23,8 @@
 #   AI_MEMORY_NO_TTY=1      force non-interactive even on a real tty
 #   AI_MEMORY_NO_VERSION_CHECK=1  skip the once-per-day update check
 #   AI_MEMORY_NATIVE_BIN    native ai-memory binary used for `run` (optional)
+#   CLAUDE_CONFIG_DIR       Claude Code config root (forwarded to the helper;
+#                           paths under $HOME are covered by the home bind mount)
 set -euo pipefail
 
 IMAGE="${AI_MEMORY_IMAGE:-akitaonrails/ai-memory:latest}"
@@ -330,6 +332,7 @@ for var in \
   AI_MEMORY_WORKSTREAM_ID \
   AI_MEMORY_HOOK_PLATFORM \
   AI_MEMORY_HOOKS_HOST_ROOT \
+  CLAUDE_CONFIG_DIR \
   ANTHROPIC_API_KEY \
   OPENAI_API_KEY \
   COPILOT_GITHUB_TOKEN \
@@ -470,8 +473,8 @@ else
 fi
 
 # Mount $HOME at the same path inside the container so:
-#   - dirs::home_dir() resolves identically (~/.claude/settings.json
-#     auto-detect works without --config-file)
+#   - dirs::home_dir() resolves identically (Claude's default paths and any
+#     CLAUDE_CONFIG_DIR beneath $HOME work without extra path flags)
 #   - install-hooks stages scripts into ~/.local/share/ai-memory/hooks/
 #
 # Mount $PWD at /work and set the container workdir there. This

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -1434,7 +1434,7 @@ pub struct InstallMcpArgs {
     #[arg(long)]
     pub apply: bool,
     /// Override the config-file path. Auto-detected per client when
-    /// absent (e.g. `~/.claude/settings.json` for Claude Code).
+    /// absent (e.g. `~/.claude.json` for Claude Code).
     #[arg(long)]
     pub config_file: Option<PathBuf>,
 }

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -34,8 +34,22 @@ use crate::commands::render_shared::{
 };
 use crate::config::{Config, DEFAULT_SERVER_URL};
 
-/// `~/.claude/settings.json` — Claude Code hooks live under `hooks`.
+/// Claude Code's settings file — hooks live under `hooks`.
+/// `$CLAUDE_CONFIG_DIR/settings.json` when the var is set, else
+/// `~/.claude/settings.json`.
 pub(crate) fn claude_settings_path() -> anyhow::Result<std::path::PathBuf> {
+    claude_settings_path_in(std::env::var_os("CLAUDE_CONFIG_DIR"))
+}
+
+/// The env value comes in as a parameter so tests can exercise both
+/// branches without mutating process env (mirrors
+/// `install_mcp::kimi_code_home`).
+fn claude_settings_path_in(
+    env_override: Option<std::ffi::OsString>,
+) -> anyhow::Result<std::path::PathBuf> {
+    if let Some(dir) = crate::commands::path_util::claude_config_dir(env_override) {
+        return Ok(dir.join("settings.json"));
+    }
     Ok(home_dir()
         .context("could not locate $HOME for ~/.claude/settings.json")?
         .join(".claude")
@@ -265,7 +279,18 @@ pub fn run(config: &Config, args: InstallHooksArgs) -> Result<()> {
         AgentChoice::Omp => render_omp_extension(&server_url, auth, strategy),
         AgentChoice::ClaudeCode => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
-            render_claude_code(&hooks_dir, &server_url, auth, &config.data_dir, strategy)
+            let settings_path = match &args.config_file {
+                Some(p) => p.clone(),
+                None => claude_settings_path()?,
+            };
+            render_claude_code(
+                &hooks_dir,
+                &server_url,
+                auth,
+                &config.data_dir,
+                strategy,
+                &settings_path,
+            )
         }
         AgentChoice::Codex => {
             let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
@@ -2886,6 +2911,7 @@ fn render_claude_code(
     auth_token: Option<&str>,
     data_dir: &Path,
     project_strategy: Option<&str>,
+    settings_path: &Path,
 ) -> Result<()> {
     // Soft check: warn (don't bail) if a script is missing. The user
     // may be running this command inside docker against a host path
@@ -2913,12 +2939,18 @@ fn render_claude_code(
     );
     let serialized =
         serde_json::to_string_pretty(&payload).context("serializing claude code hook config")?;
-    println!("# Claude Code hook config — merge into ~/.claude/settings.json");
+    println!(
+        "# Claude Code hook config — merge into {}",
+        settings_path.display()
+    );
     println!("# Hook scripts: {}", hooks_dir.display());
     println!("# AI-memory server URL: {server_url}");
     if auth_token.is_some() {
         println!("# Auth: AI_MEMORY_AUTH_TOKEN embedded in each hook command below.");
-        println!("#       Treat ~/.claude/settings.json as sensitive (chmod 600).");
+        println!(
+            "#       Treat {} as sensitive (chmod 600).",
+            settings_path.display()
+        );
     }
     println!();
     println!("{serialized}");
@@ -5196,6 +5228,27 @@ command = "AI_MEMORY_HOOK_URL=http://old:1 /old/ai-memory/hooks/kimi-code/sessio
         )
         .unwrap();
         assert_eq!(second, ApplyOutcome::NoOp, "second apply must be a no-op");
+    }
+
+    #[test]
+    fn claude_settings_path_honours_claude_config_dir() {
+        let custom = if cfg!(windows) {
+            r"C:\custom\claude"
+        } else {
+            "/custom/claude"
+        };
+        let path = claude_settings_path_in(Some(std::ffi::OsString::from(custom))).unwrap();
+        assert_eq!(path, Path::new(custom).join("settings.json"));
+
+        // Empty override and unset var both fall back to ~/.claude/settings.json.
+        for env in [None, Some(std::ffi::OsString::new())] {
+            let path = claude_settings_path_in(env).unwrap();
+            assert!(
+                path.ends_with(Path::new(".claude").join("settings.json")),
+                "default must be ~/.claude/settings.json, got {}",
+                path.display()
+            );
+        }
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/install_mcp.rs
+++ b/crates/ai-memory-cli/src/commands/install_mcp.rs
@@ -14,14 +14,14 @@
 //! OMP uses a native `~/.omp/agent/mcp.json` file with the same
 //! `mcpServers` root as several other clients.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use serde_json::json;
 
 use crate::cli::{InstallMcpArgs, McpClient};
 use crate::commands::apply_shared::{ApplyOutcome, apply_atomic, mutate_json, mutate_toml};
-use crate::commands::path_util::home_dir;
+use crate::commands::path_util::{claude_config_dir, home_dir};
 use crate::commands::render_shared::bearer_header_value;
 use crate::config::{Config, DEFAULT_MCP_URL};
 
@@ -56,7 +56,7 @@ pub fn run(config: &Config, args: InstallMcpArgs) -> Result<()> {
         return apply_to_config_file(&args);
     }
     let snippet = match args.client {
-        McpClient::ClaudeCode => render_claude_code(&args)?,
+        McpClient::ClaudeCode => render_claude_code(&args, &resolve_config_file(&args)?)?,
         McpClient::Codex => render_codex(&args),
         McpClient::Grok => render_grok(&args)?,
         McpClient::OpenCode => render_opencode(&args)?,
@@ -111,15 +111,7 @@ pub(crate) fn mcp_config_path(client: crate::cli::McpClient) -> Result<PathBuf> 
     use crate::cli::McpClient;
     let home = || home_dir().context("could not locate $HOME for config-file auto-detect");
     Ok(match client {
-        // Claude Code reads MCP-server registrations from `~/.claude.json`
-        // (the same file `claude mcp add`/`claude mcp list` operate on).
-        // `~/.claude/settings.json` is a separate file for hooks /
-        // permissions / etc. — putting `mcpServers` there does NOT make
-        // Claude Code load the server. (Confirmed against CC 1.x by
-        // observing that `mcpServers` in settings.json is silently
-        // ignored while the same entry under `~/.claude.json` shows up
-        // in `claude mcp list`.)
-        McpClient::ClaudeCode => home()?.join(".claude.json"),
+        McpClient::ClaudeCode => claude_code_config_path_in(std::env::var_os("CLAUDE_CONFIG_DIR"))?,
         McpClient::Codex => home()?.join(".codex").join("config.toml"),
         // Project scope is `.grok/config.toml` under cwd/repo; pass
         // --config-file for that case rather than inventing a second default.
@@ -184,6 +176,25 @@ pub(crate) fn mcp_config_path(client: crate::cli::McpClient) -> Result<PathBuf> 
             .join(".vscode")
             .join("mcp.json"),
     })
+}
+
+/// Claude Code reads MCP-server registrations from `.claude.json`
+/// (the same file `claude mcp add`/`claude mcp list` operate on) —
+/// `$CLAUDE_CONFIG_DIR/.claude.json` when the var is set, else
+/// `~/.claude.json`. `settings.json` is a separate file for hooks /
+/// permissions / etc. — putting `mcpServers` there does NOT make
+/// Claude Code load the server. (Confirmed against CC 1.x by
+/// observing that `mcpServers` in settings.json is silently ignored
+/// while the same entry under `~/.claude.json` shows up in
+/// `claude mcp list`.) The env value comes in as a parameter so tests
+/// can exercise both branches without mutating process env.
+fn claude_code_config_path_in(env_override: Option<std::ffi::OsString>) -> Result<PathBuf> {
+    if let Some(dir) = claude_config_dir(env_override) {
+        return Ok(dir.join(".claude.json"));
+    }
+    Ok(home_dir()
+        .context("could not locate $HOME for ~/.claude.json")?
+        .join(".claude.json"))
 }
 
 /// Kimi Code's data dir: `$KIMI_CODE_HOME` when set (non-empty), else
@@ -623,7 +634,7 @@ fn upsert_toml_mcp_server(doc: &mut toml_edit::DocumentMut, name: &str, server: 
     doc.insert("mcp_servers", Item::Table(parent));
 }
 
-fn render_claude_code(args: &InstallMcpArgs) -> Result<String> {
+fn render_claude_code(args: &InstallMcpArgs, config_path: &Path) -> Result<String> {
     let bearer = bearer_header_value(args.auth_token.as_deref());
     let cli_line = if let Some(b) = &bearer {
         format!(
@@ -646,8 +657,9 @@ fn render_claude_code(args: &InstallMcpArgs) -> Result<String> {
          # Recommended (one-shot CLI):\n\
          {cli_line}\n\
          #\n\
-         # Equivalent JSON if you'd rather edit ~/.claude.json directly:\n\
-         {snippet}\n"
+         # Equivalent JSON if you'd rather edit {config_path} directly:\n\
+         {snippet}\n",
+        config_path = config_path.display(),
     ))
 }
 
@@ -934,10 +946,48 @@ mod tests {
         }
     }
 
+    #[test]
+    fn claude_code_config_path_honours_claude_config_dir() {
+        let custom = if cfg!(windows) {
+            r"C:\custom\claude"
+        } else {
+            "/custom/claude"
+        };
+        let path = claude_code_config_path_in(Some(std::ffi::OsString::from(custom))).unwrap();
+        assert_eq!(path, std::path::Path::new(custom).join(".claude.json"));
+
+        // Empty override and unset var both fall back to ~/.claude.json.
+        for env in [None, Some(std::ffi::OsString::new())] {
+            let path = claude_code_config_path_in(env).unwrap();
+            assert!(
+                path.ends_with(".claude.json") && !path.starts_with(custom),
+                "default must be ~/.claude.json, got {}",
+                path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn claude_code_render_shows_resolved_config_path() {
+        let args = args_for(McpClient::ClaudeCode);
+        let config_path = std::path::Path::new("/stores/claude/.claude.json");
+        let out = render_claude_code(&args, config_path).unwrap();
+        assert!(
+            out.contains("/stores/claude/.claude.json"),
+            "render must mention the resolved config path:\n{out}"
+        );
+        assert!(
+            !out.contains("~/.claude.json"),
+            "render must not hardcode ~/.claude.json when the resolved path differs:\n{out}"
+        );
+    }
+
     fn render_with_token(client: McpClient) -> String {
         let args = args_with_token(client);
         match args.client {
-            McpClient::ClaudeCode => render_claude_code(&args).unwrap(),
+            McpClient::ClaudeCode => {
+                render_claude_code(&args, Path::new("/home/alice/.claude.json")).unwrap()
+            }
             McpClient::Codex => render_codex(&args),
             McpClient::Grok => render_grok(&args).unwrap(),
             McpClient::OpenCode => render_opencode(&args).unwrap(),
@@ -1022,7 +1072,9 @@ mod tests {
     fn render_for_test(client: McpClient) -> String {
         let args = args_for(client);
         match args.client {
-            McpClient::ClaudeCode => render_claude_code(&args).unwrap(),
+            McpClient::ClaudeCode => {
+                render_claude_code(&args, Path::new("/home/alice/.claude.json")).unwrap()
+            }
             McpClient::Codex => render_codex(&args),
             McpClient::Grok => render_grok(&args).unwrap(),
             McpClient::OpenCode => render_opencode(&args).unwrap(),

--- a/crates/ai-memory-cli/src/commands/install_skills.rs
+++ b/crates/ai-memory-cli/src/commands/install_skills.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result, bail};
 use crate::cli::{InstallSkillsAgent, InstallSkillsArgs, InstallSkillsScope};
 use crate::commands::apply_shared::{ApplyOutcome, apply_atomic};
 use crate::commands::install_mcp;
-use crate::commands::path_util::home_dir;
+use crate::commands::path_util::{claude_config_dir, home_dir};
 use crate::config::Config;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -88,12 +88,14 @@ fn resolve_target_roots_from_env(args: &InstallSkillsArgs) -> Result<Vec<TargetR
         && args.agent == InstallSkillsAgent::Grok)
         .then(install_mcp::grok_home)
         .transpose()?;
+    let claude_config_dir = claude_config_dir(std::env::var_os("CLAUDE_CONFIG_DIR"));
     resolve_target_roots_for_platform(
         args,
         &cwd,
         home.as_deref(),
         appdata.as_deref(),
         grok_home.as_deref(),
+        claude_config_dir.as_deref(),
         SkillHostPlatform::current(),
     )
 }
@@ -104,7 +106,7 @@ fn resolve_target_roots(
     cwd: &Path,
     home: Option<&Path>,
 ) -> Result<Vec<TargetRoot>> {
-    resolve_target_roots_for_platform(args, cwd, home, None, None, SkillHostPlatform::Other)
+    resolve_target_roots_for_platform(args, cwd, home, None, None, None, SkillHostPlatform::Other)
 }
 
 fn resolve_target_roots_for_platform(
@@ -113,6 +115,7 @@ fn resolve_target_roots_for_platform(
     home: Option<&Path>,
     appdata: Option<&Path>,
     grok_home: Option<&Path>,
+    claude_config_dir: Option<&Path>,
     platform: SkillHostPlatform,
 ) -> Result<Vec<TargetRoot>> {
     if let Some(target_dir) = &args.target_dir {
@@ -128,6 +131,7 @@ fn resolve_target_roots_for_platform(
                 home,
                 appdata,
                 grok_home,
+                claude_config_dir,
                 platform,
             )?]
         }
@@ -139,6 +143,7 @@ fn resolve_target_roots_for_platform(
                 home,
                 appdata,
                 grok_home,
+                claude_config_dir,
                 platform,
             )?]
         }
@@ -150,6 +155,7 @@ fn resolve_target_roots_for_platform(
                 home,
                 appdata,
                 grok_home,
+                claude_config_dir,
                 platform,
             )?]
         }
@@ -161,6 +167,7 @@ fn resolve_target_roots_for_platform(
                 home,
                 appdata,
                 grok_home,
+                claude_config_dir,
                 platform,
             )?]
         }
@@ -172,6 +179,7 @@ fn resolve_target_roots_for_platform(
                 home,
                 appdata,
                 grok_home,
+                claude_config_dir,
                 platform,
             )?,
             agent_root(
@@ -181,6 +189,7 @@ fn resolve_target_roots_for_platform(
                 home,
                 appdata,
                 grok_home,
+                claude_config_dir,
                 platform,
             )?,
         ],
@@ -213,6 +222,7 @@ enum SkillRootKind {
     Grok,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn agent_root(
     scope: InstallSkillsScope,
     kind: SkillRootKind,
@@ -220,6 +230,7 @@ fn agent_root(
     home: Option<&Path>,
     appdata: Option<&Path>,
     grok_home: Option<&Path>,
+    claude_config_dir: Option<&Path>,
     platform: SkillHostPlatform,
 ) -> Result<PathBuf> {
     if scope == InstallSkillsScope::Global
@@ -236,6 +247,16 @@ fn agent_root(
         && let Some(grok_home) = grok_home
     {
         return Ok(grok_home.join(SKILLS_DIR));
+    }
+
+    // Claude Code relocates its whole config dir under $CLAUDE_CONFIG_DIR;
+    // global skills live at `$CLAUDE_CONFIG_DIR/skills`, not
+    // `~/.claude/skills`. Project scope stays under the repo.
+    if scope == InstallSkillsScope::Global
+        && kind == SkillRootKind::Claude
+        && let Some(claude_config_dir) = claude_config_dir
+    {
+        return Ok(claude_config_dir.join(SKILLS_DIR));
     }
 
     let base = match scope {
@@ -445,6 +466,7 @@ mod tests {
             Some(home),
             Some(appdata),
             None,
+            None,
             SkillHostPlatform::Windows,
         )
         .unwrap();
@@ -466,6 +488,7 @@ mod tests {
             Some(home),
             None,
             None,
+            None,
             SkillHostPlatform::Windows,
         )
         .unwrap_err();
@@ -481,10 +504,41 @@ mod tests {
             Some(Path::new("/home/alice")),
             None,
             Some(Path::new("/custom/grok")),
+            None,
             SkillHostPlatform::Other,
         )
         .unwrap();
         assert_eq!(root_names(&roots), ["/custom/grok/skills"]);
+    }
+
+    #[test]
+    fn global_claude_skill_root_uses_injected_claude_config_dir() {
+        let roots = resolve_target_roots_for_platform(
+            &args(InstallSkillsScope::Global, InstallSkillsAgent::ClaudeCode),
+            Path::new("/repo"),
+            Some(Path::new("/home/alice")),
+            None,
+            None,
+            Some(Path::new("/stores/claude")),
+            SkillHostPlatform::Other,
+        )
+        .unwrap();
+        assert_eq!(root_names(&roots), ["/stores/claude/skills"]);
+    }
+
+    #[test]
+    fn project_claude_skill_root_ignores_claude_config_dir() {
+        let roots = resolve_target_roots_for_platform(
+            &args(InstallSkillsScope::Project, InstallSkillsAgent::ClaudeCode),
+            Path::new("/repo"),
+            Some(Path::new("/home/alice")),
+            None,
+            None,
+            Some(Path::new("/stores/claude")),
+            SkillHostPlatform::Other,
+        )
+        .unwrap();
+        assert_eq!(root_names(&roots), ["/repo/.claude/skills"]);
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/path_util.rs
+++ b/crates/ai-memory-cli/src/commands/path_util.rs
@@ -14,6 +14,18 @@ pub(crate) fn home_dir() -> Option<PathBuf> {
     dirs::home_dir()
 }
 
+/// Claude Code's relocated config root: `$CLAUDE_CONFIG_DIR` when set to a
+/// non-empty, non-whitespace value, else `None` (callers fall back to the
+/// `~/.claude*` defaults). The env value comes in as a parameter so tests
+/// can exercise both branches without mutating process env.
+pub(crate) fn claude_config_dir(env_override: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    let value = env_override?;
+    if value.to_str().is_some_and(|s| s.trim().is_empty()) {
+        return None;
+    }
+    Some(PathBuf::from(value))
+}
+
 /// Strip only Windows verbatim path prefixes that are safe to render as plain
 /// paths. Unknown verbatim forms are left unchanged.
 pub(crate) fn strip_windows_verbatim_prefix(path: &str) -> Cow<'_, str> {
@@ -45,6 +57,22 @@ pub(crate) fn strip_windows_verbatim_prefix(path: &str) -> Cow<'_, str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+
+    #[test]
+    fn claude_config_dir_honours_non_empty_value() {
+        assert_eq!(
+            claude_config_dir(Some(OsString::from("/stores/claude"))),
+            Some(PathBuf::from("/stores/claude"))
+        );
+    }
+
+    #[test]
+    fn claude_config_dir_treats_unset_empty_and_whitespace_as_unset() {
+        for env in [None, Some(OsString::new()), Some(OsString::from("   "))] {
+            assert_eq!(claude_config_dir(env.clone()), None, "env {env:?}");
+        }
+    }
 
     #[test]
     fn strip_windows_verbatim_prefix_handles_drive_paths() {

--- a/crates/ai-memory-cli/src/commands/path_util.rs
+++ b/crates/ai-memory-cli/src/commands/path_util.rs
@@ -1,7 +1,7 @@
 //! Path helpers shared by command renderers and hook capture.
 
 use std::borrow::Cow;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Resolve the user home used for agent configuration paths.
 ///
@@ -24,6 +24,27 @@ pub(crate) fn claude_config_dir(env_override: Option<std::ffi::OsString>) -> Opt
         return None;
     }
     Some(PathBuf::from(value))
+}
+
+/// Candidate Claude Code paths for uninstall. The active relocated path comes
+/// first, followed by the legacy home path, with exact duplicates removed.
+pub(crate) fn claude_config_paths(
+    home: Option<&Path>,
+    relocated: Option<&Path>,
+    legacy_relative: &Path,
+    relocated_relative: &Path,
+) -> Vec<PathBuf> {
+    let mut paths = Vec::with_capacity(2);
+    if let Some(root) = relocated {
+        paths.push(root.join(relocated_relative));
+    }
+    if let Some(root) = home {
+        let legacy = root.join(legacy_relative);
+        if !paths.contains(&legacy) {
+            paths.push(legacy);
+        }
+    }
+    paths
 }
 
 /// Strip only Windows verbatim path prefixes that are safe to render as plain
@@ -72,6 +93,31 @@ mod tests {
         for env in [None, Some(OsString::new()), Some(OsString::from("   "))] {
             assert_eq!(claude_config_dir(env.clone()), None, "env {env:?}");
         }
+    }
+
+    #[test]
+    fn claude_config_paths_put_relocated_first_and_deduplicate() {
+        assert_eq!(
+            claude_config_paths(
+                Some(Path::new("/home/alice")),
+                Some(Path::new("/stores/claude")),
+                Path::new(".claude/settings.json"),
+                Path::new("settings.json"),
+            ),
+            [
+                PathBuf::from("/stores/claude/settings.json"),
+                PathBuf::from("/home/alice/.claude/settings.json"),
+            ]
+        );
+        assert_eq!(
+            claude_config_paths(
+                Some(Path::new("/home/alice")),
+                Some(Path::new("/home/alice/.claude")),
+                Path::new(".claude/settings.json"),
+                Path::new("settings.json"),
+            ),
+            [PathBuf::from("/home/alice/.claude/settings.json")]
+        );
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/setup_agent.rs
+++ b/crates/ai-memory-cli/src/commands/setup_agent.rs
@@ -256,13 +256,17 @@ fn emit_claude_code(emit_root: &Path, args: &SetupAgentArgs) -> Result<()> {
         build_claude_code_payload(emit_root, &args.server_url, args.auth_token.as_deref());
     let serialized =
         serde_json::to_string_pretty(&payload).context("serializing Claude Code hook config")?;
-    println!("# Claude Code — merge into ~/.claude/settings.json");
+    let settings_path = crate::commands::install_hooks::claude_settings_path()?;
+    println!("# Claude Code — merge into {}", settings_path.display());
     println!("# Hook scripts (must be reachable from the host that runs Claude Code):");
     println!("#   {}", emit_root.display());
     println!("# AI-memory server: {}", args.server_url);
     if args.auth_token.is_some() {
         println!("# Auth: AI_MEMORY_AUTH_TOKEN embedded in each hook's env block.");
-        println!("#       Treat ~/.claude/settings.json as sensitive (chmod 600).");
+        println!(
+            "#       Treat {} as sensitive (chmod 600).",
+            settings_path.display()
+        );
     }
     println!("# Tip: also run `ai-memory install-mcp --client claude-code --auth-token <…>`");
     println!("#      to register the MCP endpoint (separate from hooks).");

--- a/crates/ai-memory-cli/src/commands/uninstall.rs
+++ b/crates/ai-memory-cli/src/commands/uninstall.rs
@@ -11,7 +11,7 @@ use crate::cli::UninstallArgs;
 use crate::commands::apply_shared::apply_atomic;
 use crate::commands::apply_shared::mutate_json;
 use crate::commands::apply_shared::mutate_toml;
-use crate::commands::path_util::home_dir;
+use crate::commands::path_util::{claude_config_dir, claude_config_paths, home_dir};
 use crate::commands::{data_purge, install_hooks, install_mcp, openclaw_plugin};
 use crate::config::Config;
 use ai_memory_core::routing_skills::{
@@ -136,14 +136,21 @@ fn build_plan(args: &UninstallArgs) -> anyhow::Result<Vec<PlannedChange>> {
     let want = |k: crate::cli::UninstallOnly| args.only.is_none() || args.only == Some(k);
     let name = args.mcp_name.as_deref();
     let url = args.mcp_url.as_str();
+    let home = home_dir();
+    let claude_config_dir = claude_config_dir(std::env::var_os("CLAUDE_CONFIG_DIR"));
 
     // ---- Hooks (JSON configs) ----
     if want(crate::cli::UninstallOnly::Hooks) {
-        let hook_files = [
-            (
-                install_hooks::claude_settings_path()?,
-                HookConfigShape::NestedHooksKey,
-            ),
+        let mut hook_files: Vec<_> = claude_config_paths(
+            home.as_deref(),
+            claude_config_dir.as_deref(),
+            Path::new(".claude/settings.json"),
+            Path::new("settings.json"),
+        )
+        .into_iter()
+        .map(|path| (path, HookConfigShape::NestedHooksKey))
+        .collect();
+        hook_files.extend([
             (
                 install_hooks::codex_hooks_path()?,
                 HookConfigShape::NestedHooksKey,
@@ -173,7 +180,7 @@ fn build_plan(args: &UninstallArgs) -> anyhow::Result<Vec<PlannedChange>> {
                 install_hooks::devin_config_path()?,
                 HookConfigShape::NestedHooksKey,
             ),
-        ];
+        ]);
         for (path, shape) in hook_files {
             if !path.exists() {
                 continue;
@@ -277,25 +284,37 @@ fn build_plan(args: &UninstallArgs) -> anyhow::Result<Vec<PlannedChange>> {
             Devin,
             KimiCode,
         ] {
-            let Ok(path) = install_mcp::mcp_config_path(client) else {
-                continue;
+            let paths = if matches!(client, ClaudeCode) {
+                claude_config_paths(
+                    home.as_deref(),
+                    claude_config_dir.as_deref(),
+                    Path::new(".claude.json"),
+                    Path::new(".claude.json"),
+                )
+            } else {
+                let Ok(path) = install_mcp::mcp_config_path(client) else {
+                    continue;
+                };
+                vec![path]
             };
-            if !path.exists() {
-                continue;
+            for path in paths {
+                if !path.exists() {
+                    continue;
+                }
+                let content = std::fs::read_to_string(&path)
+                    .with_context(|| format!("reading {}", path.display()))?;
+                let (_new, removed) = if matches!(client, Codex | Grok) {
+                    strip_mcp_toml(&content, name, url)?
+                } else {
+                    strip_mcp_json_client(&content, client, name, url)?
+                };
+                let op = if matches!(client, Codex | Grok) {
+                    RewriteOp::McpToml
+                } else {
+                    RewriteOp::McpJson(client)
+                };
+                push_rewrite(&mut plan, path, removed, op);
             }
-            let content = std::fs::read_to_string(&path)
-                .with_context(|| format!("reading {}", path.display()))?;
-            let (_new, removed) = if matches!(client, Codex | Grok) {
-                strip_mcp_toml(&content, name, url)?
-            } else {
-                strip_mcp_json_client(&content, client, name, url)?
-            };
-            let op = if matches!(client, Codex | Grok) {
-                RewriteOp::McpToml
-            } else {
-                RewriteOp::McpJson(client)
-            };
-            push_rewrite(&mut plan, path, removed, op);
         }
     }
 
@@ -324,11 +343,8 @@ fn build_plan(args: &UninstallArgs) -> anyhow::Result<Vec<PlannedChange>> {
     // ---- Managed Agent Skills (project + global roots) ----
     if want(crate::cli::UninstallOnly::Skills) {
         let cwd = std::env::current_dir().context("getting CWD for skill removal")?;
-        let home = home_dir();
         let appdata = std::env::var_os("APPDATA").map(PathBuf::from);
         let grok_home = install_mcp::grok_home().ok();
-        let claude_config_dir =
-            crate::commands::path_util::claude_config_dir(std::env::var_os("CLAUDE_CONFIG_DIR"));
         for root in skill_roots(
             &cwd,
             home.as_deref(),

--- a/crates/ai-memory-cli/src/commands/uninstall.rs
+++ b/crates/ai-memory-cli/src/commands/uninstall.rs
@@ -327,11 +327,14 @@ fn build_plan(args: &UninstallArgs) -> anyhow::Result<Vec<PlannedChange>> {
         let home = home_dir();
         let appdata = std::env::var_os("APPDATA").map(PathBuf::from);
         let grok_home = install_mcp::grok_home().ok();
+        let claude_config_dir =
+            crate::commands::path_util::claude_config_dir(std::env::var_os("CLAUDE_CONFIG_DIR"));
         for root in skill_roots(
             &cwd,
             home.as_deref(),
             appdata.as_deref(),
             grok_home.as_deref(),
+            claude_config_dir.as_deref(),
         ) {
             for skill in MANAGED_SKILLS {
                 push_generated_delete(
@@ -351,8 +354,9 @@ fn skill_roots(
     home: Option<&Path>,
     appdata: Option<&Path>,
     grok_home: Option<&Path>,
+    claude_config_dir: Option<&Path>,
 ) -> Vec<PathBuf> {
-    let mut roots = Vec::with_capacity(9);
+    let mut roots = Vec::with_capacity(10);
     push_unique_skill_root(&mut roots, cwd.join(CLAUDE_SKILL_DIR).join(SKILLS_DIR));
     push_unique_skill_root(&mut roots, cwd.join(AGENTS_SKILL_DIR).join(SKILLS_DIR));
     push_unique_skill_root(&mut roots, cwd.join(DEVIN_SKILL_DIR).join(SKILLS_DIR));
@@ -370,6 +374,12 @@ fn skill_roots(
     // $HOME/.devin/skills — sweep it too or uninstall orphans those skills.
     if let Some(appdata) = appdata {
         push_unique_skill_root(&mut roots, appdata.join("devin").join(SKILLS_DIR));
+    }
+    // With CLAUDE_CONFIG_DIR set, global Claude Code skills install to
+    // `$CLAUDE_CONFIG_DIR/skills`. Sweep it alongside ~/.claude/skills —
+    // installs may predate the env var.
+    if let Some(claude_config_dir) = claude_config_dir {
+        push_unique_skill_root(&mut roots, claude_config_dir.join(SKILLS_DIR));
     }
     roots
 }
@@ -1089,13 +1099,13 @@ mod tests {
         let home = Path::new("/home/alice");
         let appdata = Path::new("C:/Users/Alice/AppData/Roaming");
 
-        let roots = skill_roots(cwd, Some(home), Some(appdata), None);
+        let roots = skill_roots(cwd, Some(home), Some(appdata), None, None);
         assert!(
             roots.contains(&appdata.join("devin").join(SKILLS_DIR)),
             "{roots:?}"
         );
 
-        let without = skill_roots(cwd, Some(home), None, None);
+        let without = skill_roots(cwd, Some(home), None, None, None);
         assert_eq!(
             without.len(),
             8,
@@ -1111,6 +1121,28 @@ mod tests {
         );
     }
 
+    /// `$CLAUDE_CONFIG_DIR/skills` is swept *in addition to*
+    /// `~/.claude/skills` — installs may predate the env var, so uninstall
+    /// must plan removal from both candidate roots.
+    #[test]
+    fn skill_roots_sweep_claude_config_dir_root_alongside_home() {
+        let roots = skill_roots(
+            Path::new("/repo"),
+            Some(Path::new("/home/alice")),
+            None,
+            None,
+            Some(Path::new("/stores/claude")),
+        );
+        assert!(
+            roots.contains(&PathBuf::from("/stores/claude/skills")),
+            "{roots:?}"
+        );
+        assert!(
+            roots.contains(&PathBuf::from("/home/alice/.claude/skills")),
+            "{roots:?}"
+        );
+    }
+
     #[test]
     fn skill_roots_use_injected_grok_home_override() {
         let roots = skill_roots(
@@ -1118,6 +1150,7 @@ mod tests {
             Some(Path::new("/home/alice")),
             None,
             Some(Path::new("/custom/grok")),
+            None,
         );
         assert!(
             roots.contains(&PathBuf::from("/custom/grok/skills")),

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -72,6 +72,7 @@ fn run_wrapper_on_fake_macos(args: &[&str]) -> String {
         .env("AI_MEMORY_DATA_VOLUME", "test-ai-memory-data")
         .env("HOME", shell_path(tmp.path()))
         .env_remove("AI_MEMORY_SERVER_URL")
+        .env_remove("CLAUDE_CONFIG_DIR")
         .output()
         .unwrap();
     assert!(
@@ -281,6 +282,15 @@ fn run_wrapper_with_fake_docker(args: &[&str], docker_info_stdout: &str) -> Stri
     run_wrapper_with_fake_docker_and_uname(args, docker_info_stdout, None)
 }
 
+#[cfg(unix)]
+fn run_wrapper_with_fake_docker_and_claude_config(
+    args: &[&str],
+    docker_info_stdout: &str,
+    claude_config_dir: &str,
+) -> String {
+    run_wrapper_with_fake_docker_env(args, docker_info_stdout, None, Some(claude_config_dir))
+}
+
 // The wrapper also shells out to `id -u` / `id -g` when choosing its default
 // Docker uid mapping. Arch container tests often run as root, which would make
 // the default mapping `-u 0:0` and produce a false positive in the assertions
@@ -293,6 +303,16 @@ fn run_wrapper_with_fake_docker_and_uname(
     args: &[&str],
     docker_info_stdout: &str,
     uname_stdout: Option<&str>,
+) -> String {
+    run_wrapper_with_fake_docker_env(args, docker_info_stdout, uname_stdout, None)
+}
+
+#[cfg(unix)]
+fn run_wrapper_with_fake_docker_env(
+    args: &[&str],
+    docker_info_stdout: &str,
+    uname_stdout: Option<&str>,
+    claude_config_dir: Option<&str>,
 ) -> String {
     let tmp = tempfile::tempdir().unwrap();
     let docker_args = tmp.path().join("docker-args.txt");
@@ -354,7 +374,11 @@ fn run_wrapper_with_fake_docker_and_uname(
         .env("AI_MEMORY_NO_VERSION_CHECK", "1")
         .env("AI_MEMORY_DATA_VOLUME", "test-ai-memory-data")
         .env("HOME", shell_path(tmp.path()))
-        .env_remove("AI_MEMORY_SERVER_URL");
+        .env_remove("AI_MEMORY_SERVER_URL")
+        .env_remove("CLAUDE_CONFIG_DIR");
+    if let Some(claude_config_dir) = claude_config_dir {
+        command.env("CLAUDE_CONFIG_DIR", claude_config_dir);
+    }
     let output = command.output().unwrap();
     assert!(
         output.status.success(),
@@ -363,6 +387,20 @@ fn run_wrapper_with_fake_docker_and_uname(
         String::from_utf8_lossy(&output.stderr)
     );
     std::fs::read_to_string(docker_args).unwrap()
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_forwards_claude_config_dir_to_helper_container() {
+    let args = run_wrapper_with_fake_docker_and_claude_config(
+        &["install-hooks", "--agent", "claude-code", "--apply"],
+        "[name=seccomp,profile=default]",
+        "/home/alice/.config/claude",
+    );
+    assert!(
+        args.contains("-e\nCLAUDE_CONFIG_DIR"),
+        "wrapper must forward Claude's config root; got {args}"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/ai-memory-cli/tests/removal.rs
+++ b/crates/ai-memory-cli/tests/removal.rs
@@ -35,9 +35,14 @@ fn command_with_home(home: &Path) -> Command {
         .env("LOCALAPPDATA", local_app_data)
         .env("AI_MEMORY_HOME", home)
         .env("AI_MEMORY_DATA_DIR", home.join(".ai-memory-data"))
+        .env_remove("AI_MEMORY_SERVER_URL")
+        .env_remove("AI_MEMORY_AUTH_TOKEN")
         // A host-level KIMI_CODE_HOME would pull uninstall's kimi-code
         // config sweep out of the sandbox; tests opt back in explicitly.
-        .env_remove("KIMI_CODE_HOME");
+        .env_remove("KIMI_CODE_HOME")
+        // Keep Claude installer/removal tests inside their temp HOME unless a
+        // test explicitly opts into a relocated config root.
+        .env_remove("CLAUDE_CONFIG_DIR");
     command
 }
 
@@ -115,6 +120,103 @@ fn install_then_uninstall_round_trip_claude_hooks() {
             after["hooks"].get(ours).is_none(),
             "{ours} should be removed"
         );
+    }
+}
+
+#[test]
+fn relocated_claude_uninstall_sweeps_active_and_legacy_installs() {
+    let _guard = cli_test_lock();
+    let project = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let relocated = home.path().join("claude-work");
+
+    let run = |relocate: bool, args: &[&str]| {
+        let mut command = command_with_home(home.path());
+        if relocate {
+            command.env("CLAUDE_CONFIG_DIR", &relocated);
+        }
+        command
+            .args(args)
+            .current_dir(project.path())
+            .output()
+            .unwrap()
+    };
+
+    for relocate in [false, true] {
+        for args in [
+            &["install-hooks", "--agent", "claude-code", "--apply"][..],
+            &["install-mcp", "--client", "claude-code", "--apply"][..],
+            &[
+                "install-skills",
+                "--agent",
+                "claude-code",
+                "--scope",
+                "global",
+            ][..],
+        ] {
+            let output = run(relocate, args);
+            assert!(
+                output.status.success(),
+                "install failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+
+    let legacy_settings = home.path().join(".claude/settings.json");
+    let legacy_mcp = home.path().join(".claude.json");
+    let legacy_skills = home.path().join(".claude/skills");
+    let relocated_settings = relocated.join("settings.json");
+    let relocated_mcp = relocated.join(".claude.json");
+    let relocated_skills = relocated.join("skills");
+    for path in [
+        &legacy_settings,
+        &legacy_mcp,
+        &relocated_settings,
+        &relocated_mcp,
+    ] {
+        assert!(path.exists(), "installer did not create {}", path.display());
+    }
+    for root in [&legacy_skills, &relocated_skills] {
+        assert!(
+            root.join(MANAGED_SKILLS[0].relative_path).exists(),
+            "installer did not create managed skills under {}",
+            root.display()
+        );
+    }
+
+    let output = run(true, &["uninstall", "--apply", "--yes"]);
+    assert!(
+        output.status.success(),
+        "uninstall failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    for path in [&legacy_settings, &relocated_settings] {
+        let content = std::fs::read_to_string(path).unwrap();
+        assert!(
+            !content.contains("AI_MEMORY_HOOK_URL"),
+            "Claude hooks survived in {}",
+            path.display()
+        );
+    }
+    for path in [&legacy_mcp, &relocated_mcp] {
+        let content = std::fs::read_to_string(path).unwrap();
+        let config: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert!(
+            config["mcpServers"].get("ai-memory").is_none(),
+            "Claude MCP entry survived in {}: {content}",
+            path.display(),
+        );
+    }
+    for root in [&legacy_skills, &relocated_skills] {
+        for skill in MANAGED_SKILLS {
+            assert!(
+                !root.join(skill.relative_path).exists(),
+                "managed skill survived under {}",
+                root.display()
+            );
+        }
     }
 }
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -68,10 +68,11 @@ ai-memory install-mcp   --client claude-code --apply
 ai-memory install-hooks --agent  claude-code --apply
 ```
 
-If `CLAUDE_CONFIG_DIR` is set, `install-mcp --client claude-code` writes the
-MCP registration to `$CLAUDE_CONFIG_DIR/.claude.json` instead of
-`~/.claude.json`, matching Claude Code's own config resolution. `uninstall`
-sweeps the same path.
+If `CLAUDE_CONFIG_DIR` is set, the claude-code installers match Claude Code's
+own config resolution: `install-mcp` writes the MCP registration to
+`$CLAUDE_CONFIG_DIR/.claude.json` (instead of `~/.claude.json`) and
+`install-hooks` / `setup-agent` target `$CLAUDE_CONFIG_DIR/settings.json`
+(instead of `~/.claude/settings.json`). `uninstall` sweeps the same paths.
 
 The CLI commands (`bootstrap`, `status`, `search`, `lint`, `auto-improve`,
 `curator`, `pending-writes`, etc.) inherit the two env vars automatically. So do

--- a/docs/install.md
+++ b/docs/install.md
@@ -68,6 +68,11 @@ ai-memory install-mcp   --client claude-code --apply
 ai-memory install-hooks --agent  claude-code --apply
 ```
 
+If `CLAUDE_CONFIG_DIR` is set, `install-mcp --client claude-code` writes the
+MCP registration to `$CLAUDE_CONFIG_DIR/.claude.json` instead of
+`~/.claude.json`, matching Claude Code's own config resolution. `uninstall`
+sweeps the same path.
+
 The CLI commands (`bootstrap`, `status`, `search`, `lint`, `auto-improve`,
 `curator`, `pending-writes`, etc.) inherit the two env vars automatically. So do
 `install-mcp`, `install-hooks`, and

--- a/docs/install.md
+++ b/docs/install.md
@@ -70,9 +70,11 @@ ai-memory install-hooks --agent  claude-code --apply
 
 If `CLAUDE_CONFIG_DIR` is set, the claude-code installers match Claude Code's
 own config resolution: `install-mcp` writes the MCP registration to
-`$CLAUDE_CONFIG_DIR/.claude.json` (instead of `~/.claude.json`) and
+`$CLAUDE_CONFIG_DIR/.claude.json` (instead of `~/.claude.json`),
 `install-hooks` / `setup-agent` target `$CLAUDE_CONFIG_DIR/settings.json`
-(instead of `~/.claude/settings.json`). `uninstall` sweeps the same paths.
+(instead of `~/.claude/settings.json`), and `install-skills --scope global`
+uses `$CLAUDE_CONFIG_DIR/skills` (instead of `~/.claude/skills`). `uninstall`
+sweeps the relocated paths alongside the defaults.
 
 The CLI commands (`bootstrap`, `status`, `search`, `lint`, `auto-improve`,
 `curator`, `pending-writes`, etc.) inherit the two env vars automatically. So do

--- a/docs/install.md
+++ b/docs/install.md
@@ -74,7 +74,11 @@ own config resolution: `install-mcp` writes the MCP registration to
 `install-hooks` / `setup-agent` target `$CLAUDE_CONFIG_DIR/settings.json`
 (instead of `~/.claude/settings.json`), and `install-skills --scope global`
 uses `$CLAUDE_CONFIG_DIR/skills` (instead of `~/.claude/skills`). `uninstall`
-sweeps the relocated paths alongside the defaults.
+sweeps the active relocated paths alongside the home defaults. It cannot
+discover an older arbitrary `CLAUDE_CONFIG_DIR` that is no longer set. The
+Docker wrapper forwards the variable for config roots under its existing
+`$HOME` bind mount; use the native binary when the relocated root is outside
+`$HOME`.
 
 The CLI commands (`bootstrap`, `status`, `search`, `lint`, `auto-improve`,
 `curator`, `pending-writes`, etc.) inherit the two env vars automatically. So do


### PR DESCRIPTION
Claude Code relocates its whole config dir when `CLAUDE_CONFIG_DIR` is set ([documented here](https://code.claude.com/docs/en/env-vars#variables)), so the installers were writing files the client never reads.

> ![CLAUDE_CONFIG_DIR — Override the configuration directory (default: ~/.claude). All settings, session history, and plugins are stored under this path.](https://raw.githubusercontent.com/klebervirgilio/ai-memory/pr-assets/assets/claude-config-dir-docs.png)

With the var set (non-empty), the claude-code paths now resolve the same way Claude Code does:

- `install-mcp` / `uninstall`: `$CLAUDE_CONFIG_DIR/.claude.json` instead of `~/.claude.json`
- `install-hooks` / `setup-agent`: `$CLAUDE_CONFIG_DIR/settings.json` instead of `~/.claude/settings.json`
- `install-skills --scope global`: `$CLAUDE_CONFIG_DIR/skills` instead of `~/.claude/skills`

`--config-file` still wins over the env var; empty or whitespace-only values count as unset. Dry-run output prints the resolved path instead of the hardcoded defaults, and `uninstall` sweeps the relocated skills root alongside `~/.claude/skills` so installs that predate the env var are still removed.

Unit tests follow the existing `KIMI_CODE_HOME`/`GROK_HOME` injected-env pattern. One commit per touchpoint (mcp, hooks, skills).

## Why not just `--config-file` / `--target-dir`?

Relocated installs were already reachable through the per-command flags, but that route left gaps the env var closes:

- `uninstall` has no path override at all — it only sweeps the default `~/.claude*` paths, so anything installed into a relocated dir via the flags could never be removed by it. `CLAUDE_CONFIG_DIR` is the first way `uninstall` reaches those files.
- The flags make the caller reproduce Claude Code's internal layout by hand (`.claude.json` keeps its dotted name *inside* the dir, `settings.json` sits at the dir root, skills at `<dir>/skills`). Getting it wrong fails silently — the client just never reads the file.
- Dry-run output printed the hardcoded default paths even when a flag redirected the write.

The flags still work and still win over the env var; they remain the right tool for one-off redirects.

## Tested manually with `CLAUDE_CONFIG_DIR=$HOME/.claude-work`

### install-hooks

```console
$ CLAUDE_CONFIG_DIR=$HOME/.claude-work ./ai-memory install-hooks --agent claude-code --apply
[ai-memory] capture-policy capability v1 enforced by this selected integration; re-run --apply to refresh existing installs.
✓ staged 18 hook script(s) → /***/ai-memory/hooks/claude-code
✓ updated /***/.claude-work/settings.json (backup written next to it)
```

### install-mcp

```console
$ CLAUDE_CONFIG_DIR=$HOME/.claude-work ./ai-memory install-mcp --client claude-code --apply
✓ updated /***/.claude-work/.claude.json (backup written next to it)
```

### install-skills

```console
$ CLAUDE_CONFIG_DIR=$HOME/.claude-work ./ai-memory install-skills --agent claude-code --scope global
✓ created /***/.claude-work/skills/ai-memory-retrieval/SKILL.md (new file)
✓ created /***/.claude-work/skills/ai-memory-handoff/SKILL.md (new file)
✓ created /***/.claude-work/skills/ai-memory-durable-pages/SKILL.md (new file)
✓ created /***/.claude-work/skills/ai-memory-learning-maintenance/SKILL.md (new file)
✓ created /***/.claude-work/skills/ai-memory-routing-install/SKILL.md (new file)
```

### uninstall (dry-run)

```console
$ CLAUDE_CONFIG_DIR=$HOME/.claude-work ./ai-memory uninstall
would remove SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, PreCompact, Stop, SessionEnd, SubagentStart, SubagentStop from /***/.claude-work/settings.json
would remove ai-memory from /***/.claude-work/.claude.json
would delete /***/.claude-work/skills/ai-memory-retrieval/SKILL.md (managed Agent Skill)
would delete /***/.claude-work/skills/ai-memory-handoff/SKILL.md (managed Agent Skill)
would delete /***/.claude-work/skills/ai-memory-durable-pages/SKILL.md (managed Agent Skill)
would delete /***/.claude-work/skills/ai-memory-learning-maintenance/SKILL.md (managed Agent Skill)
would delete /***/.claude-work/skills/ai-memory-routing-install/SKILL.md (managed Agent Skill)
```
