### PR TITLE
Fix Docker wrapper writes on SELinux hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   native commands and close the residual local-wire vector ([#196]).
 
 ### Fixed
+- The Linux Docker wrapper now detects an SELinux-enforcing host plus a
+  SELinux-enabled daemon and adds `--security-opt label=disable` only to
+  short-lived helper commands that write bind-mounted host files. This avoids
+  `Permission denied` during `install-*`, `setup-agent`, `uninstall`, and
+  `backup` without relabeling the user's home directory or changing the
+  long-lived server container ([#212]).
 - Windows `.ps1` fallback hook commands now use PowerShell `-EncodedCommand`
   instead of embedding `$env:` setup inside a nested quoted command. This
   prevents outer Windows hook runners such as Antigravity CLI from expanding

--- a/README.md
+++ b/README.md
@@ -377,6 +377,11 @@ one matching entry.
 
 ### Install Notes
 
+- **SELinux:** on enforcing Linux hosts, the Docker wrapper automatically adds
+  `--security-opt label=disable` only to short-lived helper commands that write
+  bind-mounted host files. It does not alter the long-lived server container
+  or relabel `$HOME`; do not add `:z`/`:Z` to the whole home bind. See
+  [`docs/install.md`](docs/install.md#selinux-enforcing-hosts).
 - **Windows:** use the Linux path inside WSL2, or the native Windows wrapper
   from PowerShell/cmd. Local supported profiles default to host-native commands:
   Claude Code may use its supported `ai-memory.exe` exec form, while other

--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -417,18 +417,33 @@ esac
 # write to a host bind mount: other commands only touch the /data named
 # volume, which isn't host-visible and doesn't have this problem, so leave
 # their UID mapping alone.
+DOCKER_SECURITY_OPTIONS=$("${DOCKER}" info --format '{{.SecurityOptions}}' 2>/dev/null || true)
 ROOTLESS_DOCKER=0
-if "${DOCKER}" info --format '{{.SecurityOptions}}' 2>/dev/null | grep -q 'name=rootless'; then
+if printf '%s\n' "${DOCKER_SECURITY_OPTIONS}" | grep -q 'name=rootless'; then
   ROOTLESS_DOCKER=1
 fi
 if [ "${WRITES_HOST_FILES}" -eq 1 ] && [ "${ROOTLESS_DOCKER}" -eq 1 ]; then
   USER_ARGS=(-u 0:0)
 fi
 
+SELINUX_ARGS=()
 case "$(uname -s 2>/dev/null || true)" in
   Linux)
     if [ -z "${AI_MEMORY_SERVER_URL:-}" ]; then
       NETWORK_ARGS=(--network host)
+    fi
+    # SELinux blocks the helper's container label from writing normal home
+    # labels even when its uid/gid match the host user. Relabeling the entire
+    # $HOME bind with :z/:Z is unsafe, so relax label confinement only for the
+    # short-lived, trusted helper commands that actually write host files.
+    SELINUX_MODE=$(getenforce 2>/dev/null || true)
+    if [ -z "${SELINUX_MODE}" ] && [ -r /sys/fs/selinux/enforce ]; then
+      SELINUX_MODE=$(cat /sys/fs/selinux/enforce 2>/dev/null || true)
+    fi
+    if [ "${WRITES_HOST_FILES}" -eq 1 ] \
+      && { [ "${SELINUX_MODE}" = "Enforcing" ] || [ "${SELINUX_MODE}" = "enforcing" ] || [ "${SELINUX_MODE}" = "1" ]; } \
+      && printf '%s\n' "${DOCKER_SECURITY_OPTIONS}" | grep -q 'name=selinux'; then
+      SELINUX_ARGS=(--security-opt label=disable)
     fi
     ;;
   Darwin)
@@ -494,6 +509,7 @@ fi
 # and falls back to the cwd basename only if it's unset.
 exec "${DOCKER}" run --rm ${TTY_ARGS[@]+"${TTY_ARGS[@]}"} \
   ${NETWORK_ARGS[@]+"${NETWORK_ARGS[@]}"} \
+  ${SELINUX_ARGS[@]+"${SELINUX_ARGS[@]}"} \
   -v "${HOME}:${HOME}" \
   -v "${PWD}:/work" \
   -w /work \

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -288,7 +288,13 @@ fn run_wrapper_with_fake_docker_and_claude_config(
     docker_info_stdout: &str,
     claude_config_dir: &str,
 ) -> String {
-    run_wrapper_with_fake_docker_env(args, docker_info_stdout, None, Some(claude_config_dir))
+    run_wrapper_with_fake_docker_env(
+        args,
+        docker_info_stdout,
+        None,
+        Some(claude_config_dir),
+        None,
+    )
 }
 
 // The wrapper also shells out to `id -u` / `id -g` when choosing its default
@@ -304,7 +310,22 @@ fn run_wrapper_with_fake_docker_and_uname(
     docker_info_stdout: &str,
     uname_stdout: Option<&str>,
 ) -> String {
-    run_wrapper_with_fake_docker_env(args, docker_info_stdout, uname_stdout, None)
+    run_wrapper_with_fake_docker_env(args, docker_info_stdout, uname_stdout, None, None)
+}
+
+#[cfg(unix)]
+fn run_wrapper_with_fake_selinux(
+    args: &[&str],
+    docker_info_stdout: &str,
+    selinux_mode: &str,
+) -> String {
+    run_wrapper_with_fake_docker_env(
+        args,
+        docker_info_stdout,
+        Some("Linux"),
+        None,
+        Some(selinux_mode),
+    )
 }
 
 #[cfg(unix)]
@@ -313,12 +334,14 @@ fn run_wrapper_with_fake_docker_env(
     docker_info_stdout: &str,
     uname_stdout: Option<&str>,
     claude_config_dir: Option<&str>,
+    selinux_mode: Option<&str>,
 ) -> String {
     let tmp = tempfile::tempdir().unwrap();
     let docker_args = tmp.path().join("docker-args.txt");
     let docker = tmp.path().join("docker");
     let uname = tmp.path().join("uname");
     let id = tmp.path().join("id");
+    let getenforce = tmp.path().join("getenforce");
     std::fs::write(
         &docker,
         format!(
@@ -348,6 +371,14 @@ fn run_wrapper_with_fake_docker_env(
          esac\n",
     )
     .unwrap();
+    std::fs::write(
+        &getenforce,
+        format!(
+            "#!/usr/bin/env bash\nprintf '{}\\n'\n",
+            selinux_mode.unwrap_or("Disabled")
+        ),
+    )
+    .unwrap();
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -356,6 +387,7 @@ fn run_wrapper_with_fake_docker_env(
             std::fs::set_permissions(&uname, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
         std::fs::set_permissions(&id, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::set_permissions(&getenforce, std::fs::Permissions::from_mode(0o755)).unwrap();
     }
 
     // Always prepend the fake-binary dir to PATH: `id` is shadowed
@@ -486,6 +518,56 @@ fn rootful_docker_keeps_host_uid_for_host_config_commands() {
         "rootful Docker must not switch to root UID — that would write \
          ~/.local/share/ai-memory/hooks owned by root instead of the invoking \
          user; got {args}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn selinux_enforcing_disables_labels_only_for_host_file_commands() {
+    let selinux_info = "[name=seccomp,profile=default name=selinux name=cgroupns]";
+
+    for subcommand in [
+        "install-mcp",
+        "install-hooks",
+        "setup-agent",
+        "install-instructions",
+        "install-skills",
+        "uninstall",
+        "backup",
+    ] {
+        let args = run_wrapper_with_fake_selinux(&[subcommand], selinux_info, "Enforcing");
+        assert!(
+            args.contains("--security-opt\nlabel=disable"),
+            "{subcommand} writes bind-mounted host files and needs the scoped \
+             SELinux exception; got {args}"
+        );
+    }
+
+    let args = run_wrapper_with_fake_selinux(&["status"], selinux_info, "Enforcing");
+    assert!(
+        !args.contains("label=disable"),
+        "thin-client commands must retain SELinux label confinement; got {args}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn selinux_label_exception_requires_enforcement_and_daemon_support() {
+    let selinux_info = "[name=seccomp,profile=default name=selinux name=cgroupns]";
+    let args = run_wrapper_with_fake_selinux(&["install-mcp"], selinux_info, "Permissive");
+    assert!(
+        !args.contains("label=disable"),
+        "permissive hosts do not need a label exception; got {args}"
+    );
+
+    let args = run_wrapper_with_fake_selinux(
+        &["install-mcp"],
+        "[name=seccomp,profile=default name=cgroupns]",
+        "Enforcing",
+    );
+    assert!(
+        !args.contains("label=disable"),
+        "a daemon without SELinux support must not receive SELinux options; got {args}"
     );
 }
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1379,6 +1379,24 @@ that helper back to the host's `127.0.0.1:49374`, so `ai-memory status`,
 `ai-memory search`, and `ai-memory bootstrap` work with the same default
 URL as the generated agent config.
 
+#### SELinux-enforcing hosts
+
+On SELinux-enforcing Linux systems such as Fedora, RHEL, and openSUSE, normal
+home-directory labels can prevent the helper container from writing agent
+config even when its UID and GID match the host user. The wrapper checks both
+the host enforcement mode and Docker's advertised security options. For the
+short-lived helper commands that write host files (`install-*`, `setup-agent`,
+`uninstall`, and `backup`), it adds `--security-opt label=disable`; thin-client
+commands remain confined. This relaxes SELinux label confinement only for that
+trusted helper invocation. It does not modify the long-lived ai-memory server,
+which uses a Docker-managed named volume.
+
+Do not add `:z` or `:Z` to the wrapper's whole `$HOME` bind. Docker's
+[bind-mount documentation](https://docs.docker.com/engine/storage/bind-mounts/#configure-the-selinux-label)
+warns that relabeling system directories such as `/home` can make the host
+inoperable. Docker documents `label=disable` in the
+[`docker run` security options](https://docs.docker.com/reference/cli/docker/container/run/#security-opt).
+
 `ai-memory run` is the exception: the current wrapper intercepts it and starts a
 cached checksum-verified native client on the host, where harness executables
 and session stores exist. It preserves an explicit remote


### PR DESCRIPTION
## Summary
- detect enforcing SELinux plus Docker daemon SELinux support in the Linux wrapper
- disable label confinement only for short-lived helper commands that write bind-mounted host files
- preserve confinement for thin-client commands and avoid relabeling `$HOME` or changing the server container
- document the behavior and Docker security tradeoff

Closes #212

## Validation
- `bash -n bin/ai-memory`
- `cargo fmt --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo test -p ai-memory-cli --test packaging`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- local Docker accepted `--security-opt label=disable` with the published image