### PR TITLE
Fix Docker wrapper completion pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   native commands and close the residual local-wire vector ([#196]).
 
 ### Fixed
+- The Docker wrapper now buffers generated shell completions before streaming
+  them to stdout. Piping `ai-memory completions <shell>` into a short-lived
+  consumer such as `head` no longer exposes Docker's own broken-pipe error or
+  non-zero exit after the native command completed successfully; real helper
+  container failures still propagate without printing a partial script.
 - The Linux Docker wrapper now detects an SELinux-enforcing host plus a
   SELinux-enabled daemon and adds `--security-opt label=disable` only to
   short-lived helper commands that write bind-mounted host files. This avoids

--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -508,9 +508,11 @@ fi
 # `commands::resolve_project_name` helper checks this env var first
 # and falls back to the cwd basename only if it's unset.
 HELPER_ARGS=(run --rm)
-HELPER_ARGS+=("${TTY_ARGS[@]}")
-HELPER_ARGS+=("${NETWORK_ARGS[@]}")
-HELPER_ARGS+=("${SELINUX_ARGS[@]}")
+# Bash 3.2 (still shipped by macOS) rejects an empty-array expansion under
+# `set -u`. The `array[@]+...` form appends only arrays with at least one item.
+HELPER_ARGS+=(${TTY_ARGS[@]+"${TTY_ARGS[@]}"})
+HELPER_ARGS+=(${NETWORK_ARGS[@]+"${NETWORK_ARGS[@]}"})
+HELPER_ARGS+=(${SELINUX_ARGS[@]+"${SELINUX_ARGS[@]}"})
 HELPER_ARGS+=(
   -v "${HOME}:${HOME}"
   -v "${PWD}:/work"
@@ -518,9 +520,9 @@ HELPER_ARGS+=(
   -e HOME="${HOME}"
   -e AI_MEMORY_HOST_CWD="${PWD}"
 )
-HELPER_ARGS+=("${USER_ARGS[@]}")
+HELPER_ARGS+=(${USER_ARGS[@]+"${USER_ARGS[@]}"})
 HELPER_ARGS+=("${DATA_ARGS[@]}")
-HELPER_ARGS+=("${ENV_ARGS[@]}")
+HELPER_ARGS+=(${ENV_ARGS[@]+"${ENV_ARGS[@]}"})
 HELPER_ARGS+=("${IMAGE}" "$@")
 
 # The native binary renders completions into a buffer so a short consumer such

--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -507,15 +507,49 @@ fi
 # binary can derive the *real* host-side project name from it. The
 # `commands::resolve_project_name` helper checks this env var first
 # and falls back to the cwd basename only if it's unset.
-exec "${DOCKER}" run --rm ${TTY_ARGS[@]+"${TTY_ARGS[@]}"} \
-  ${NETWORK_ARGS[@]+"${NETWORK_ARGS[@]}"} \
-  ${SELINUX_ARGS[@]+"${SELINUX_ARGS[@]}"} \
-  -v "${HOME}:${HOME}" \
-  -v "${PWD}:/work" \
-  -w /work \
-  -e HOME="${HOME}" \
-  -e AI_MEMORY_HOST_CWD="${PWD}" \
-  ${USER_ARGS[@]+"${USER_ARGS[@]}"} \
-  "${DATA_ARGS[@]}" \
-  ${ENV_ARGS[@]+"${ENV_ARGS[@]}"} \
-  "${IMAGE}" "$@"
+HELPER_ARGS=(run --rm)
+HELPER_ARGS+=("${TTY_ARGS[@]}")
+HELPER_ARGS+=("${NETWORK_ARGS[@]}")
+HELPER_ARGS+=("${SELINUX_ARGS[@]}")
+HELPER_ARGS+=(
+  -v "${HOME}:${HOME}"
+  -v "${PWD}:/work"
+  -w /work
+  -e HOME="${HOME}"
+  -e AI_MEMORY_HOST_CWD="${PWD}"
+)
+HELPER_ARGS+=("${USER_ARGS[@]}")
+HELPER_ARGS+=("${DATA_ARGS[@]}")
+HELPER_ARGS+=("${ENV_ARGS[@]}")
+HELPER_ARGS+=("${IMAGE}" "$@")
+
+# The native binary renders completions into a buffer so a short consumer such
+# as `head` can close stdout without surfacing an error. Docker's streaming
+# client does not share that behavior: it reports its own broken pipe before the
+# container can return success. Buffer this bounded, read-only command outside
+# Docker, then preserve the same quiet SIGPIPE behavior while streaming the
+# completed script to the caller. Docker failures still return before any
+# partial completion script is printed.
+if [ "${WRAPPER_SUBCOMMAND}" = "completions" ]; then
+  COMPLETIONS_TMP=$(mktemp "${TMPDIR:-/tmp}/ai-memory-completions.XXXXXX")
+  trap 'rm -f "${COMPLETIONS_TMP}"' EXIT
+  if "${DOCKER}" "${HELPER_ARGS[@]}" >"${COMPLETIONS_TMP}"; then
+    DOCKER_STATUS=0
+  else
+    DOCKER_STATUS=$?
+  fi
+  if [ "${DOCKER_STATUS}" -ne 0 ]; then
+    exit "${DOCKER_STATUS}"
+  fi
+  if cat "${COMPLETIONS_TMP}"; then
+    OUTPUT_STATUS=0
+  else
+    OUTPUT_STATUS=$?
+  fi
+  rm -f "${COMPLETIONS_TMP}"
+  trap - EXIT
+  [ "${OUTPUT_STATUS}" -eq 141 ] && exit 0
+  exit "${OUTPUT_STATUS}"
+fi
+
+exec "${DOCKER}" "${HELPER_ARGS[@]}"

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -1,8 +1,12 @@
 //! Packaging asset regression tests.
 
+#[cfg(unix)]
+use std::io::BufRead as _;
 use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::process::Command;
+#[cfg(unix)]
+use std::process::Stdio;
 
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -270,6 +274,107 @@ fn managed_run_wrapper_uses_host_binary_path_and_remote_server_without_docker() 
         )
     );
     assert!(!docker_record.exists(), "managed run entered Docker");
+}
+
+#[cfg(unix)]
+#[test]
+fn docker_wrapper_completions_tolerate_an_early_reader_close() {
+    let tmp = tempfile::tempdir().unwrap();
+    let docker = tmp.path().join("docker");
+    std::fs::write(
+        &docker,
+        "#!/usr/bin/env bash\n\
+         if [ \"$1\" = info ]; then\n\
+           printf '[name=seccomp,profile=default]\\n'\n\
+           exit 0\n\
+         fi\n\
+         if [ \"$1\" = run ]; then\n\
+           i=0\n\
+           while [ \"$i\" -lt 20000 ]; do\n\
+             printf 'complete -c ai-memory -n condition-%s\\n' \"$i\"\n\
+             i=$((i + 1))\n\
+           done\n\
+           exit 0\n\
+         fi\n\
+         exit 1\n",
+    )
+    .unwrap();
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&docker, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let mut child = shell_script_command(&repo_root().join("bin/ai-memory"))
+        .args(["completions", "fish"])
+        .env("AI_MEMORY_DOCKER", &docker)
+        .env("AI_MEMORY_NO_TTY", "1")
+        .env("AI_MEMORY_NO_VERSION_CHECK", "1")
+        .env("AI_MEMORY_DATA_VOLUME", "test-ai-memory-data")
+        .env("HOME", tmp.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdout = std::io::BufReader::new(child.stdout.take().unwrap());
+    let mut first_line = String::new();
+    stdout.read_line(&mut first_line).unwrap();
+    drop(stdout);
+
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(first_line, "complete -c ai-memory -n condition-0\n");
+    assert!(
+        output.status.success(),
+        "early close should stay quiet and successful: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("broken pipe"),
+        "wrapper leaked Docker's broken-pipe diagnostic: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn docker_wrapper_completions_preserve_helper_failure_without_partial_output() {
+    let tmp = tempfile::tempdir().unwrap();
+    let docker = tmp.path().join("docker");
+    std::fs::write(
+        &docker,
+        "#!/usr/bin/env bash\n\
+         if [ \"$1\" = info ]; then\n\
+           printf '[name=seccomp,profile=default]\\n'\n\
+           exit 0\n\
+         fi\n\
+         if [ \"$1\" = run ]; then\n\
+           printf 'partial completion output\\n'\n\
+           printf 'helper failed\\n' >&2\n\
+           exit 42\n\
+         fi\n\
+         exit 1\n",
+    )
+    .unwrap();
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&docker, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let output = shell_script_command(&repo_root().join("bin/ai-memory"))
+        .args(["completions", "fish"])
+        .env("AI_MEMORY_DOCKER", &docker)
+        .env("AI_MEMORY_NO_TTY", "1")
+        .env("AI_MEMORY_NO_VERSION_CHECK", "1")
+        .env("AI_MEMORY_DATA_VOLUME", "test-ai-memory-data")
+        .env("HOME", tmp.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(42));
+    assert!(
+        output.stdout.is_empty(),
+        "failed helper leaked partial completions: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "helper failed\n");
 }
 
 // Unlike run_wrapper_on_fake_macos's docker fake (which only ever sees one

--- a/docs/shell-completions.md
+++ b/docs/shell-completions.md
@@ -13,6 +13,11 @@ completions.
 The command reads no config and does not need a data directory, so it can be
 run before `ai-memory init` or inside a packaging step.
 
+The Docker wrapper buffers this bounded command before writing it to stdout, so
+short consumers such as `head` can close the pipe without Docker adding a
+broken-pipe diagnostic. A helper-container failure still returns non-zero and
+prints no partial completion script.
+
 ## Install
 
 ### fish


### PR DESCRIPTION
## Summary

- buffer Docker-helper completion output before streaming it to callers
- keep short-reader pipe closure quiet while preserving real helper failures
- add packaging regressions for early closure and failed partial output
- document the wrapper behavior in the changelog and completion guide

## Verification

- `bash -n bin/ai-memory`
- real Docker wrapper: `set -o pipefail; bin/ai-memory completions fish | rg -m 1 'complete .*ai-memory'`
- `cargo fmt --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo test -p ai-memory-cli --test packaging`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`

Found during the pre-release live acceptance pass after PR #218.