### PR TITLE
release: v1.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   native commands and close the residual local-wire vector ([#196]).
 
 ### Fixed
+- Removed the unused `syntect` dependency and its `plist`, `quick-xml`,
+  `bincode`, and `yaml-rust` transitive dependencies. This eliminates two
+  high-severity `quick-xml` denial-of-service advisories and makes the prior
+  temporary cargo-audit exceptions unnecessary; ai-memory's rendered Markdown
+  behavior is unchanged because the syntax-highlighting crate was never used.
 - The Docker wrapper now buffers generated shell completions before streaming
   them to stdout. Piping `ai-memory completions <shell>` into a short-lived
   consumer such as `head` no longer exposes Docker's own broken-pipe error or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.2] - 2026-07-22
+
 ### Added
 - `ai-memory completions <shell>` prints a shell-completion script for bash,
   zsh, fish, PowerShell, or elvish. The script is generated from the binary's
@@ -2162,7 +2164,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidator used server startup default project instead of the
   session's actual project.
 
-[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.17.1...HEAD
+[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.17.2...HEAD
+[1.17.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.2
 [1.17.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.1
 [1.17.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.0
 [1.16.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.16.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-cli"
-version = "1.17.1"
+version = "1.17.2"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-consolidate"
-version = "1.17.1"
+version = "1.17.2"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-core"
-version = "1.17.1"
+version = "1.17.2"
 dependencies = [
  "jiff",
  "regex",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-eval"
-version = "1.17.1"
+version = "1.17.2"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-hooks"
-version = "1.17.1"
+version = "1.17.2"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-llm"
-version = "1.17.1"
+version = "1.17.2"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-mcp"
-version = "1.17.1"
+version = "1.17.2"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-store"
-version = "1.17.1"
+version = "1.17.2"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-web"
-version = "1.17.1"
+version = "1.17.2"
 dependencies = [
  "ai-memory-core",
  "ai-memory-store",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-wiki"
-version = "1.17.1"
+version = "1.17.2"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-workstream"
-version = "1.17.1"
+version = "1.17.2"
 dependencies = [
  "ai-memory-core",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syntect",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -513,30 +512,6 @@ checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -892,17 +867,6 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
-name = "fancy-regex"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
-dependencies = [
- "bit-set",
- "regex-automata",
- "regex-syntax",
-]
 
 [[package]]
 name = "fastrand"
@@ -1682,12 +1646,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,19 +1925,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
-name = "plist"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
-dependencies = [
- "base64",
- "indexmap",
- "quick-xml",
- "serde",
- "time",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,15 +2012,6 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
-
-[[package]]
-name = "quick-xml"
-version = "0.39.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "quinn"
@@ -2810,27 +2746,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "syntect"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
-dependencies = [
- "bincode",
- "fancy-regex",
- "flate2",
- "fnv",
- "once_cell",
- "plist",
- "regex-syntax",
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror 2.0.18",
- "walkdir",
- "yaml-rust",
 ]
 
 [[package]]
@@ -3955,15 +3870,6 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.17.1"
+version = "1.17.2"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"
@@ -26,15 +26,15 @@ authors = ["Fabio Akita <boss@akitaonrails.com>"]
 
 [workspace.dependencies]
 # Inter-crate dependencies.
-ai-memory-core = { path = "crates/ai-memory-core", version = "1.17.1" }
-ai-memory-store = { path = "crates/ai-memory-store", version = "1.17.1" }
-ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.17.1" }
-ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.17.1" }
-ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.17.1" }
-ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.17.1" }
-ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.17.1" }
-ai-memory-web = { path = "crates/ai-memory-web", version = "1.17.1" }
-ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.17.1" }
+ai-memory-core = { path = "crates/ai-memory-core", version = "1.17.2" }
+ai-memory-store = { path = "crates/ai-memory-store", version = "1.17.2" }
+ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.17.2" }
+ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.17.2" }
+ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.17.2" }
+ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.17.2" }
+ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.17.2" }
+ai-memory-web = { path = "crates/ai-memory-web", version = "1.17.2" }
+ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.17.2" }
 
 # (Workspace shared deps follow below)
 

--- a/crates/ai-memory-web/Cargo.toml
+++ b/crates/ai-memory-web/Cargo.toml
@@ -25,9 +25,6 @@ sha2.workspace = true
 # Templating + markdown.
 askama = "0.12"
 pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
-# Syntax highlighting for fenced code blocks. Default features pull
-# in onig (regex via C); the pure-Rust regex feature avoids that.
-syntect = { version = "5", default-features = false, features = ["default-fancy"] }
 
 [build-dependencies]
 anyhow.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -11,18 +11,7 @@ feature-depth = 1
 
 [advisories]
 version = 2
-ignore = [
-    # syntect transitively pulls these unmaintained crates. They are not
-    # network-facing in ai-memory's usage and there is no safe upstream upgrade
-    # path yet; keep cargo-deny useful for actionable advisories.
-    "RUSTSEC-2025-0141", # bincode 1.3.3 unmaintained
-    "RUSTSEC-2024-0320", # yaml-rust 0.4.5 unmaintained
-    # quick-xml is also pulled only through syntect -> plist for syntax/theme
-    # assets. plist v1.9 still constrains quick-xml to 0.39.x, so there is no
-    # compatible cargo update path to the fixed 0.41.x branch yet.
-    "RUSTSEC-2026-0194", # quick-xml duplicate-attribute check DoS
-    "RUSTSEC-2026-0195", # quick-xml NsReader namespace allocation DoS
-]
+ignore = []
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Summary
- prepare the audited fixes and documentation accumulated since v1.17.1 for v1.17.2
- remove the unused `syntect` dependency and its vulnerable/unmaintained transitive stack discovered by the release gate
- remove the now-obsolete RustSec exceptions

## Verification
- `cargo fmt --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- `cargo audit`
- `cargo deny check`
- merged-main deployment and authenticated admin/API/web/MCP live tests completed before the release bump
