### PR TITLE
fix(hooks): keep Windows hook transport textual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Code's `--yolo`, and kimi joins the automatic bare-run harness pool.
 
 ### Fixed
+- Windows PowerShell fallback hooks now force text input/output and silence
+  non-interactive progress records. This prevents nested PowerShell runners
+  such as Antigravity CLI from reporting serialized `CLIXML` progress on every
+  hook while preserving the hook's JSON stdout. Existing script-fallback
+  installs should rerun `install-hooks --agent <agent> --apply` after upgrading
+  ([#224]).
 - Kimi Code handoffs are now delivered through the `UserPromptSubmit` hook
   instead of `SessionStart`. Kimi Code fires `SessionStart` but discards the
   hook's stdout/result (verified against kimi-code v0.28.1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Code's `--yolo`, and kimi joins the automatic bare-run harness pool.
 
 ### Fixed
-- Windows PowerShell fallback hooks now force text input/output and silence
+- Windows PowerShell fallback hooks now force text output and silence
   non-interactive progress records. This prevents nested PowerShell runners
   such as Antigravity CLI from reporting serialized `CLIXML` progress on every
   hook while preserving the hook's JSON stdout. Existing script-fallback

--- a/crates/ai-memory-cli/src/commands/render_shared.rs
+++ b/crates/ai-memory-cli/src/commands/render_shared.rs
@@ -1024,7 +1024,13 @@ fn hook_command(
             format!("{prefix}{}", shell_quote(&script.to_string_lossy()))
         }
         HookCommandPlatform::Windows => {
-            let mut setup = format!("$env:AI_MEMORY_HOOK_URL={}", powershell_quote(server_url));
+            // Hook runners launch this child with redirected streams. Force
+            // text transport and suppress non-interactive progress so Windows
+            // PowerShell does not serialize progress records as CLIXML.
+            let mut setup = format!(
+                "$ProgressPreference='SilentlyContinue'; $env:AI_MEMORY_HOOK_URL={}",
+                powershell_quote(server_url)
+            );
             if let Some(t) = auth_token {
                 setup.push_str(&format!(
                     "; $env:AI_MEMORY_AUTH_TOKEN={}",
@@ -1040,7 +1046,7 @@ fn hook_command(
             let program = format!("{setup}; & {}", powershell_quote(&script.to_string_lossy()));
             let encoded = powershell_encoded_command(&program);
             format!(
-                "powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand {encoded}"
+                "powershell.exe -NoLogo -NoProfile -NonInteractive -InputFormat Text -OutputFormat Text -ExecutionPolicy Bypass -EncodedCommand {encoded}"
             )
         }
         HookCommandPlatform::WindowsBash => {
@@ -2144,7 +2150,7 @@ check(activeKeep.disposition === "keep" && activeKeep.protocol?.version === 1 &&
             .and_then(|s| s.as_str())
             .unwrap();
         assert!(cmd.starts_with(
-            "powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand "
+            "powershell.exe -NoLogo -NoProfile -NonInteractive -InputFormat Text -OutputFormat Text -ExecutionPolicy Bypass -EncodedCommand "
         ));
         assert!(
             !cmd.contains("$env:"),
@@ -2155,6 +2161,7 @@ check(activeKeep.disposition === "keep" && activeKeep.protocol?.version === 1 &&
             "outer command must not expose values to its caller: {cmd}"
         );
         let program = decode_powershell_encoded_command(cmd);
+        assert!(program.starts_with("$ProgressPreference='SilentlyContinue';"));
         assert!(program.contains("$env:AI_MEMORY_HOOK_URL='http://localhost:49374'"));
         assert!(program.contains("$env:AI_MEMORY_AUTH_TOKEN='tok''en'"));
         assert!(
@@ -2190,6 +2197,10 @@ check(activeKeep.disposition === "keep" && activeKeep.protocol?.version === 1 &&
                 "{pointer}: {command}"
             );
             assert!(
+                command.contains(" -InputFormat Text -OutputFormat Text "),
+                "{pointer}: nested PowerShell transport must stay textual: {command}"
+            );
+            assert!(
                 !command.contains("$env:")
                     && !command.contains("localhost:49374")
                     && !command.contains(".ps1"),
@@ -2197,6 +2208,10 @@ check(activeKeep.disposition === "keep" && activeKeep.protocol?.version === 1 &&
             );
 
             let program = decode_powershell_encoded_command(command);
+            assert!(
+                program.starts_with("$ProgressPreference='SilentlyContinue';"),
+                "{pointer}: {program}"
+            );
             assert!(
                 program.contains("$env:AI_MEMORY_HOOK_URL='http://localhost:49374'"),
                 "{pointer}: {program}"
@@ -2222,6 +2237,7 @@ check(activeKeep.disposition === "keep" && activeKeep.protocol?.version === 1 &&
             &script,
             r#"if ($env:AI_MEMORY_HOOK_URL -ne "http://localhost:49374") { exit 9 }
 if ($env:AI_MEMORY_AUTH_TOKEN -ne "tok'en") { exit 10 }
+Write-Progress -Activity "hook progress" -Status "must stay silent"
 $payload = [Console]::In.ReadToEnd()
 [Console]::Out.Write($payload)
 "#,
@@ -2257,6 +2273,11 @@ $payload = [Console]::In.ReadToEnd()
         assert!(
             output.status.success(),
             "nested PowerShell failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            output.stderr.is_empty(),
+            "non-interactive hook wrote stderr: {}",
             String::from_utf8_lossy(&output.stderr)
         );
         assert_eq!(output.stdout, br#"{"hook":"ok"}"#);

--- a/crates/ai-memory-cli/src/commands/render_shared.rs
+++ b/crates/ai-memory-cli/src/commands/render_shared.rs
@@ -1025,8 +1025,9 @@ fn hook_command(
         }
         HookCommandPlatform::Windows => {
             // Hook runners launch this child with redirected streams. Force
-            // text transport and suppress non-interactive progress so Windows
-            // PowerShell does not serialize progress records as CLIXML.
+            // text output and suppress non-interactive progress so Windows
+            // PowerShell does not serialize progress records as CLIXML. Leave
+            // input formatting at its default: the hook reads raw Console.In.
             let mut setup = format!(
                 "$ProgressPreference='SilentlyContinue'; $env:AI_MEMORY_HOOK_URL={}",
                 powershell_quote(server_url)
@@ -1046,7 +1047,7 @@ fn hook_command(
             let program = format!("{setup}; & {}", powershell_quote(&script.to_string_lossy()));
             let encoded = powershell_encoded_command(&program);
             format!(
-                "powershell.exe -NoLogo -NoProfile -NonInteractive -InputFormat Text -OutputFormat Text -ExecutionPolicy Bypass -EncodedCommand {encoded}"
+                "powershell.exe -NoLogo -NoProfile -NonInteractive -OutputFormat Text -ExecutionPolicy Bypass -EncodedCommand {encoded}"
             )
         }
         HookCommandPlatform::WindowsBash => {
@@ -2150,7 +2151,7 @@ check(activeKeep.disposition === "keep" && activeKeep.protocol?.version === 1 &&
             .and_then(|s| s.as_str())
             .unwrap();
         assert!(cmd.starts_with(
-            "powershell.exe -NoLogo -NoProfile -NonInteractive -InputFormat Text -OutputFormat Text -ExecutionPolicy Bypass -EncodedCommand "
+            "powershell.exe -NoLogo -NoProfile -NonInteractive -OutputFormat Text -ExecutionPolicy Bypass -EncodedCommand "
         ));
         assert!(
             !cmd.contains("$env:"),
@@ -2197,8 +2198,8 @@ check(activeKeep.disposition === "keep" && activeKeep.protocol?.version === 1 &&
                 "{pointer}: {command}"
             );
             assert!(
-                command.contains(" -InputFormat Text -OutputFormat Text "),
-                "{pointer}: nested PowerShell transport must stay textual: {command}"
+                command.contains(" -OutputFormat Text "),
+                "{pointer}: nested PowerShell output must stay textual: {command}"
             );
             assert!(
                 !command.contains("$env:")

--- a/docs/mcp-install.md
+++ b/docs/mcp-install.md
@@ -415,8 +415,8 @@ The rendered hooks config looks like:
 - Native Windows Docker-wrapper installs render hook entries as
   `powershell.exe ... -EncodedCommand <payload>` so Antigravity's outer command
   runner cannot expand the inner `$env:` setup. The child also forces text
-  input/output and disables progress so PowerShell does not serialize progress
-  records as `CLIXML` hook stderr. Rerun
+  output and disables progress so PowerShell does not serialize progress records
+  as `CLIXML` hook stderr. Rerun
   `install-hooks --agent antigravity-cli --apply` after upgrading to refresh
   existing entries.
 - The `PreInvocation` event fires before each model call (not just at

--- a/docs/mcp-install.md
+++ b/docs/mcp-install.md
@@ -414,7 +414,9 @@ The rendered hooks config looks like:
 - Hook scripts are staged under `~/.local/share/ai-memory/hooks/antigravity-cli/`.
 - Native Windows Docker-wrapper installs render hook entries as
   `powershell.exe ... -EncodedCommand <payload>` so Antigravity's outer command
-  runner cannot expand the inner `$env:` setup. Rerun
+  runner cannot expand the inner `$env:` setup. The child also forces text
+  input/output and disables progress so PowerShell does not serialize progress
+  records as `CLIXML` hook stderr. Rerun
   `install-hooks --agent antigravity-cli --apply` after upgrading to refresh
   existing entries.
 - The `PreInvocation` event fires before each model call (not just at
@@ -424,6 +426,9 @@ The rendered hooks config looks like:
 - Antigravity CLI does not expose a true session-end hook. `Stop` records
   a stop observation only; call `memory_handoff_begin` before quitting when
   you need the next agent to receive a handoff.
+- The built-in `/web` route displays compiled wiki pages, not raw session or
+  observation rows. To verify hook capture, compare the `sessions` and
+  `observations` counts from `ai-memory status` before and after a prompt.
 - Source: <https://antigravity.google/docs/hooks>
 
 ---

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -111,10 +111,10 @@ the CLI to render hook commands for the native Windows agent:
   use native single command strings matching their hook schema. The wrapper
   renders those `.ps1` fallback commands with PowerShell `-EncodedCommand` so a
   hook runner cannot expand their `$env:` setup before the inner PowerShell
-  process receives it. Those commands force text input/output and suppress
-  progress records so nested PowerShell runners do not emit `CLIXML` hook
-  stderr. PowerShell/Git Bash script bundles are compatibility fallbacks and do
-  not enforce capture-policy v1.
+  process receives it. Those commands force text output and suppress progress
+  records so nested PowerShell runners do not emit `CLIXML` hook stderr.
+  PowerShell/Git Bash script bundles are compatibility fallbacks and do not
+  enforce capture-policy v1.
 
 After upgrading the wrapper/image, rerun `install-hooks --agent <agent> --apply`
 for each native Windows agent so existing hook entries receive the current

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -111,8 +111,10 @@ the CLI to render hook commands for the native Windows agent:
   use native single command strings matching their hook schema. The wrapper
   renders those `.ps1` fallback commands with PowerShell `-EncodedCommand` so a
   hook runner cannot expand their `$env:` setup before the inner PowerShell
-  process receives it. PowerShell/Git Bash script bundles are compatibility
-  fallbacks and do not enforce capture-policy v1.
+  process receives it. Those commands force text input/output and suppress
+  progress records so nested PowerShell runners do not emit `CLIXML` hook
+  stderr. PowerShell/Git Bash script bundles are compatibility fallbacks and do
+  not enforce capture-policy v1.
 
 After upgrading the wrapper/image, rerun `install-hooks --agent <agent> --apply`
 for each native Windows agent so existing hook entries receive the current
@@ -345,7 +347,8 @@ For WSL2:
 2. Confirm generated hook commands reference `.sh` files under WSL paths.
 3. Launch the agent from WSL2.
 4. Call `memory_status` from the agent.
-5. Send a prompt, then run `ai-memory status` or `ai-memory recent`.
+5. Record `ai-memory status`, send a prompt, then confirm its `sessions` or
+   `observations` count increased.
 
 For native Windows:
 
@@ -358,7 +361,10 @@ For native Windows:
    generated `.ps1` hooks under your Windows home directory.
 3. Launch the native Windows agent.
 4. Call `memory_status` from the agent.
-5. Send a prompt, then run `ai-memory status` or `ai-memory recent`.
+5. Record `ai-memory status`, send a prompt, then confirm its `sessions` or
+   `observations` count increased.
 
 Report which mode you tested, which agent and version you used, and
 whether the hook command executed or failed with a path/shell error.
+The built-in `/web` browser lists compiled wiki pages; zero pages there does
+not mean the raw hook observations were missed.


### PR DESCRIPTION
Fixes #224.

## Summary
- force text input/output for Windows PowerShell fallback hook children
- silence noninteractive progress so Antigravity does not receive CLIXML stderr
- preserve JSON stdout and keep real PowerShell errors visible
- document the required hook refresh and the correct capture verification path

## Validation
- cargo fmt --check
- git diff --check
- TAILWIND_SKIP=1 cargo test --workspace
- TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p ai-memory-cli antigravity