### PR TITLE
feat(consolidate): prioritize captured Stop conclusions in review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The session-review sampler now scores a non-empty `Stop` observation just
   below `PreCompact` (88 vs 90) instead of the low `55` prior, so the opt-in
   assistant/Stop excerpt (a late summary or correction) competes for a sampling
-  slot without evicting user prompts. An empty `Stop` keeps its low prior. The
-  reviewer still sees only the first 1500 characters of any observation body, so
-  a correction inside a long excerpt must fall in that window ([#196]).
+  slot while keeping the `UserPrompt` base priority higher. An empty `Stop`
+  keeps its low prior. The reviewer still sees only the first 1500 characters
+  of any observation body, so a correction inside a long excerpt must fall in
+  that window ([#196]).
 - Opt-in assistant/Stop capture for Claude Code (#196). When BOTH the server
   (`capture_assistant = true` / `AI_MEMORY_CAPTURE_ASSISTANT=true`) and the
   client (`install-hooks --agent claude-code --capture-assistant`) opt in, a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- The session-review sampler now scores a non-empty `Stop` observation just
+  below `PreCompact` (88 vs 90) instead of the low `55` prior, so the opt-in
+  assistant/Stop excerpt (a late summary or correction) competes for a sampling
+  slot without evicting user prompts. An empty `Stop` keeps its low prior. The
+  reviewer still sees only the first 1500 characters of any observation body, so
+  a correction inside a long excerpt must fall in that window ([#196]).
 - Opt-in assistant/Stop capture for Claude Code (#196). When BOTH the server
   (`capture_assistant = true` / `AI_MEMORY_CAPTURE_ASSISTANT=true`) and the
   client (`install-hooks --agent claude-code --capture-assistant`) opt in, a

--- a/crates/ai-memory-consolidate/src/auto_improve.rs
+++ b/crates/ai-memory-consolidate/src/auto_improve.rs
@@ -50,6 +50,11 @@ const DEFAULT_REVIEW_MAX_TOKENS: u32 = 16_000;
 const MAX_SESSION_PAGE_CHARS: usize = 32_000;
 const SAMPLE_LIMIT_WITH_SESSION_PAGE: usize = 48;
 const SAMPLE_LIMIT_WITHOUT_SESSION_PAGE: usize = 72;
+// Per-observation body cap in the reviewer projection. Note this is a SECOND,
+// tighter truncation than storage: the opt-in assistant/Stop excerpt (#196) is
+// persisted at up to 2 KB, but the reviewer only ever sees its first 1500 chars
+// here (head-biased). A late correction inside a long Stop body must fall within
+// this window to influence the reviewer.
 const MAX_OBSERVATION_BODY_CHARS: usize = 1_500;
 const PROMPT_SCAFFOLD_RESERVE_CHARS: usize = 4_000;
 const MAX_REJECTION_CONTEXT_CHARS: usize = 12_000;

--- a/crates/ai-memory-consolidate/src/projection.rs
+++ b/crates/ai-memory-consolidate/src/projection.rs
@@ -650,12 +650,11 @@ mod tests {
         assert!(projected.text.contains("observations omitted"));
     }
 
-    /// Lock the exact reviewer ordering for the opt-in Stop excerpt (#196, D4):
+    /// Lock the base reviewer ordering for the opt-in Stop excerpt (#196):
     /// a non-empty Stop scores below PreCompact (no tie — ties resolve by
-    /// position), above PostCompaction, well above an empty Stop, and never
-    /// outranks a UserPrompt (so a busy multi-turn session cannot let Stops
-    /// crowd prompts out). Same idx/total/importance so only the kind term (and
-    /// body-emptiness) differ — neutral text avoids the high-signal/anchor bonuses.
+    /// position), above PostCompaction, well above an empty Stop, and below a
+    /// UserPrompt. Same idx/total/importance means only the kind term (and body
+    /// emptiness) differs; neutral text avoids high-signal and anchor bonuses.
     #[test]
     fn non_empty_stop_score_sits_below_precompact_above_postcompaction() {
         let idx = 50;
@@ -680,7 +679,7 @@ mod tests {
         assert_eq!(stop_full, stop_empty + 33, "non-empty must beat empty Stop");
         assert!(
             user_prompt > stop_full,
-            "a Stop must never outrank a prompt"
+            "the UserPrompt base priority must remain higher"
         );
     }
 
@@ -714,10 +713,11 @@ mod tests {
         );
     }
 
-    /// The Stop=88 bump must not create a herd that evicts UserPrompts (100): in a
-    /// busy multi-turn session, every prompt AND every non-empty Stop is selected.
+    /// A sampled multi-turn session retains representative prompts and
+    /// non-empty Stops together. This is not a claim that every prompt fits in
+    /// every bounded projection.
     #[test]
-    fn non_empty_stops_do_not_evict_user_prompts() {
+    fn sampled_session_retains_prompts_and_non_empty_stops() {
         let mut observations: Vec<_> = (0..60)
             .map(|idx| obs(idx, ObservationKind::PostToolUse, "routine", "x", 1))
             .collect();
@@ -735,7 +735,7 @@ mod tests {
         for i in prompts {
             assert!(
                 projected.selected_indices.contains(&i),
-                "UserPrompt at {i} was evicted: {:?}",
+                "expected UserPrompt at {i} to be selected: {:?}",
                 projected.selected_indices
             );
         }

--- a/crates/ai-memory-consolidate/src/projection.rs
+++ b/crates/ai-memory-consolidate/src/projection.rs
@@ -353,6 +353,12 @@ fn observation_score(obs: &Observation, idx: usize, total: usize) -> i32 {
         ObservationKind::SessionEnd => 95,
         ObservationKind::PreCompact => 90,
         ObservationKind::PostCompaction => 85,
+        // A non-empty Stop carries the opt-in assistant excerpt (#196) — a
+        // high-signal end-of-turn summary or late correction. Score it just
+        // below PreCompact (90), above PostCompaction (85), so it competes for a
+        // sampling slot without TYING any kind (ties resolve by position). An
+        // empty Stop (capture off, or gated out) keeps its low prior.
+        ObservationKind::Stop if !obs.body.trim().is_empty() => 88,
         ObservationKind::Stop => 55,
         ObservationKind::PostToolUse => 30,
         ObservationKind::Notification => 25,
@@ -642,5 +648,103 @@ mod tests {
         let projected = project_observations(&observations, &cfg);
         assert!(projected.text.chars().count() <= cfg.max_total_chars);
         assert!(projected.text.contains("observations omitted"));
+    }
+
+    /// Lock the exact reviewer ordering for the opt-in Stop excerpt (#196, D4):
+    /// a non-empty Stop scores below PreCompact (no tie — ties resolve by
+    /// position), above PostCompaction, well above an empty Stop, and never
+    /// outranks a UserPrompt (so a busy multi-turn session cannot let Stops
+    /// crowd prompts out). Same idx/total/importance so only the kind term (and
+    /// body-emptiness) differ — neutral text avoids the high-signal/anchor bonuses.
+    #[test]
+    fn non_empty_stop_score_sits_below_precompact_above_postcompaction() {
+        let idx = 50;
+        let total = 100;
+        let imp = 5;
+        let mk = |kind, body| observation_score(&obs(idx, kind, "note", body, imp), idx, total);
+
+        let stop_full = mk(ObservationKind::Stop, "the assistant said hello");
+        let stop_empty = mk(ObservationKind::Stop, "");
+        let precompact = mk(ObservationKind::PreCompact, "the assistant said hello");
+        let postcompaction = mk(ObservationKind::PostCompaction, "the assistant said hello");
+        let user_prompt = mk(ObservationKind::UserPrompt, "the assistant said hello");
+
+        // Kind terms: Stop-nonempty 88, PreCompact 90, PostCompaction 85,
+        // Stop-empty 55, UserPrompt 100. Everything else cancels.
+        assert_eq!(stop_full, precompact - 2, "must sit just below PreCompact");
+        assert_eq!(
+            stop_full,
+            postcompaction + 3,
+            "must sit above PostCompaction"
+        );
+        assert_eq!(stop_full, stop_empty + 33, "non-empty must beat empty Stop");
+        assert!(
+            user_prompt > stop_full,
+            "a Stop must never outrank a prompt"
+        );
+    }
+
+    /// A late non-empty Stop (the opt-in assistant excerpt with a correction) is
+    /// selected out of a long routine session AND its text reaches the projection.
+    #[test]
+    fn non_empty_stop_late_correction_is_selected_and_rendered() {
+        let mut observations: Vec<_> = (0..60)
+            .map(|idx| obs(idx, ObservationKind::PostToolUse, "routine", "x", 1))
+            .collect();
+        // The assistant's final turn retracts an earlier claim — the exact signal
+        // PR3 wants the reviewer to see. Kept within the excerpt window.
+        observations[40] = obs(
+            40,
+            ObservationKind::Stop,
+            "stop",
+            "CORRECTION_SENTINEL: the earlier fix was wrong; use config.rs instead",
+            6,
+        );
+        let cfg = ObservationProjectionConfig::new(20_000, 12, 2_000);
+        let projected = project_observations(&observations, &cfg);
+
+        assert!(
+            projected.selected_indices.contains(&40),
+            "non-empty Stop must win a sampling slot: {:?}",
+            projected.selected_indices
+        );
+        assert!(
+            projected.text.contains("CORRECTION_SENTINEL"),
+            "the correction must reach the reviewer projection"
+        );
+    }
+
+    /// The Stop=88 bump must not create a herd that evicts UserPrompts (100): in a
+    /// busy multi-turn session, every prompt AND every non-empty Stop is selected.
+    #[test]
+    fn non_empty_stops_do_not_evict_user_prompts() {
+        let mut observations: Vec<_> = (0..60)
+            .map(|idx| obs(idx, ObservationKind::PostToolUse, "routine", "x", 1))
+            .collect();
+        let prompts = [10, 25, 45];
+        let stops = [15, 30, 50];
+        for &i in &prompts {
+            observations[i] = obs(i, ObservationKind::UserPrompt, "prompt", "a request", 5);
+        }
+        for &i in &stops {
+            observations[i] = obs(i, ObservationKind::Stop, "stop", "assistant summary", 5);
+        }
+        let cfg = ObservationProjectionConfig::new(20_000, 12, 2_000);
+        let projected = project_observations(&observations, &cfg);
+
+        for i in prompts {
+            assert!(
+                projected.selected_indices.contains(&i),
+                "UserPrompt at {i} was evicted: {:?}",
+                projected.selected_indices
+            );
+        }
+        for i in stops {
+            assert!(
+                projected.selected_indices.contains(&i),
+                "non-empty Stop at {i} was not selected: {:?}",
+                projected.selected_indices
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Completes the final reviewer-side part of #196 after the opt-in capture path merged in #222.

- score non-empty `Stop` observations at base priority 88, between `PreCompact` and `PostCompaction`, while empty Stops retain the existing 55 priority
- verify a late captured correction survives bounded observation sampling and reaches the reviewer projection
- document the reviewer's 1,500-character per-observation projection cap
- correct the original branch's over-broad prompt-eviction claim: `UserPrompt` has a higher base priority, but bounded sampling does not promise every prompt can fit

The feature commit is preserved with Samir Hanna Verza as its author. The audit correction is a separate follow-up commit; no history was rewritten.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`

Fixes #196