### PR TITLE
docs: complete managed Kimi support lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Code's `--yolo`, and kimi joins the automatic bare-run harness pool.
 
 ### Fixed
+- Managed-workstream overview and command-reference documentation now
+  consistently includes Kimi Code in the supported and automatic-selection
+  harness lists.
 - Windows PowerShell fallback hooks now force text output and silence
   non-interactive progress records. This prevents nested PowerShell runners
   such as Antigravity CLI from reporting serialized `CLIXML` progress on every

--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ priors are at the [bottom](#influences-and-prior-art).
   codex --yolo`, transparently resumes one logical workstream with native
   per-harness sessions, a portable visible-event ledger, and full-ledger search.
   `ai-memory run` with no harness continues the newest usable Claude Code,
-  Codex, OpenCode, Pi, or Crush session for this checkout. On first explicit use,
-  an interactive launcher can adopt a previous session from the same checkout;
-  later switches cannot select unrelated native history. Native arguments pass
-  through unchanged except the wrapper-owned `--yolo`; direct commands are
-  unaffected.
+  Codex, OpenCode, Pi, Crush, or Kimi Code session for this checkout. On first
+  explicit use, an interactive launcher can adopt a previous session from the
+  same checkout; later switches cannot select unrelated native history. Native
+  arguments pass through unchanged except the wrapper-owned `--yolo`; direct
+  commands are unaffected.
 - **Per-repository capture exclusions.** A nearest-marker `[capture]`
   `ignore_paths` policy drops matching recognized file-tool events before they
   reach the local spool or server. See [the capture policy reference](docs/marker-file.md#capture-exclusions).
@@ -153,8 +153,8 @@ priors are at the [bottom](#influences-and-prior-art).
   newer cross-harness history. After a normal quit, the next launch waits
   briefly if the previous launcher is still finalizing; handled failures release
   the workstream immediately. Managed mode currently covers Claude Code, Codex,
-  OpenCode, Pi, Crush, and OMP; direct harness launches remain unchanged. See
-  [Managed cross-harness workstreams](docs/managed-workstreams.md).
+  OpenCode, Pi, Crush, Kimi Code, and OMP; direct harness launches remain
+  unchanged. See [Managed cross-harness workstreams](docs/managed-workstreams.md).
 - **"Quit at 4 PM, pick up at 9 AM in a different agent."** The
   classic. SessionStart hook in the next supported hook client prepends a
   typed handoff with open questions, next steps, and a session summary. Grok
@@ -704,7 +704,7 @@ diagram, crate breakdown, schema notes, and invariants.
 |---|---|
 | [`docs/install.md`](docs/install.md) | **Installation cookbook.** Every agent CLI, every alternative (curl, source build, no-docker, no-auth), and the server-on-a-different-machine (homelab/LAN) walkthrough. Read after the Quick start if your setup doesn't match the happy path. |
 | [`docs/usage.md`](docs/usage.md) | Handoffs, proactive memory queries, slim routing snippet + managed Agent Skills, migration from other memory tools, web UI, raw-wiki inspection, and rules-vs-facts workflow. |
-| [`docs/managed-workstreams.md`](docs/managed-workstreams.md) | Optional `ai-memory run` continuity across Claude Code, Codex, OpenCode, Pi, Crush, and OMP: automatic harness selection, native resume, argument forwarding, ledger search, privacy, and recovery. |
+| [`docs/managed-workstreams.md`](docs/managed-workstreams.md) | Optional `ai-memory run` continuity across Claude Code, Codex, OpenCode, Pi, Crush, Kimi Code, and OMP: automatic harness selection, native resume, argument forwarding, ledger search, privacy, and recovery. |
 | [`docs/managed-harness-contributions.md`](docs/managed-harness-contributions.md) | Protocol and acceptance bar for contributors adding managed resume, read-only transcript import, and startup context delivery to another harness. |
 | [`docs/marker-file.md`](docs/marker-file.md) | `.ai-memory.toml` workspace/project routing for multi-client trees, mono-repos, worktrees, and work/personal separation. |
 | [`docs/auto-scope.md`](docs/auto-scope.md) | `[auto_scope]` modes for shared servers: default single-slot routing, session-aware isolation, and multi-user `per_actor` behavior. |

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -283,10 +283,11 @@ Top-line rules carved into the codebase:
 ## 15. Managed workstreams use a portable ledger, not native format conversion
 
 Managed cross-harness continuity is explicitly opt-in through `ai-memory run`.
-Direct Claude Code, Codex, OpenCode, Pi, Crush, and OMP launches retain the
-existing hook and single-use handoff behavior. There is no process-global mode
-or manual harness switch: the wrapper selects the current repository/worktree
-workstream and each adapter applies that harness's native create/resume syntax.
+Direct Claude Code, Codex, OpenCode, Pi, Crush, Kimi Code, and OMP launches
+retain the existing hook and single-use handoff behavior. There is no
+process-global mode or manual harness switch: the wrapper selects the current
+repository/worktree workstream and each adapter applies that harness's native
+create/resume syntax.
 
 One logical workstream owns one native session per harness plus an append-only
 portable event ledger. We rejected converting a Claude transcript into a fake

--- a/docs/install.md
+++ b/docs/install.md
@@ -1171,7 +1171,7 @@ docker run --rm akitaonrails/ai-memory:latest --help     # full subcommand tree
 | Subcommand | Pattern | What it does |
 |---|---|---|
 | `serve` | `docker compose up -d` (already done) | Run the HTTP MCP server |
-| `run [harness] [args...]` | host wrapper or native binary | Opt into one managed cross-harness workstream; omit the harness to resume the newest usable local session, or name Claude Code, Codex, OpenCode, Pi, Crush, or OMP explicitly; exact `--yolo` is wrapper-owned and other native arguments pass through |
+| `run [harness] [args...]` | host wrapper or native binary | Opt into one managed cross-harness workstream; omit the harness to resume the newest usable local session, or name Claude Code, Codex, OpenCode, Pi, Crush, Kimi Code, or OMP explicitly; exact `--yolo` is wrapper-owned and other native arguments pass through |
 | `workstream-search [query]` | managed child or thin HTTP client | Search the complete visible managed-workstream ledger; the managed child receives its workstream id automatically |
 | `status` | `docker exec` | Counts, paths, derived-index diagnostics, and passive LLM/embedding provider health |
 | `search "<query>"` | `docker exec` | Wiki search with FTS5 + graph/vector RRF |


### PR DESCRIPTION
## Summary
- include Kimi Code in the README managed-workstream feature, use-case, and docs overview lists
- include Kimi Code in the install command reference and managed-workstream design decision
- record the documentation correction in the unreleased changelog

## Verification
- `git diff --check`
- searched current README/docs for pre-Kimi managed-harness lists

Post-audit follow-up after #223.