### PR TITLE
test(store): serialize warning capture

### DIFF
--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -1772,6 +1772,8 @@ mod tests {
 
     struct CapturedLogWriter(Arc<Mutex<Vec<u8>>>);
 
+    static WARNING_CAPTURE_LOCK: Mutex<()> = Mutex::new(());
+
     impl Write for CapturedLogWriter {
         fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
             self.0.lock().unwrap().extend_from_slice(buf);
@@ -1792,6 +1794,7 @@ mod tests {
     }
 
     fn capture_warnings(run: impl FnOnce()) -> String {
+        let _guard = WARNING_CAPTURE_LOCK.lock().unwrap();
         let logs = CapturedLogs::default();
         let subscriber = tracing_subscriber::fmt()
             .with_max_level(tracing::Level::WARN)


### PR DESCRIPTION
## Summary
- serialize test-only tracing subscriber creation and teardown for store warning assertions
- leave production logging and store behavior unchanged
- prevent rare empty log captures when warning tests run concurrently

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- 100 consecutive concurrent warning-test runs
- 20 consecutive full `ai-memory-store` library runs before the fix passed, confirming the defect is isolated to rare tracing-capture lifecycle timing

Found by the `v1.18.0` release gate after the prior post-audit PRs were merged.