### PR TITLE
release: v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-07-23
+
 ### Added
 - The session-review sampler now scores a non-empty `Stop` observation just
   below `PreCompact` (88 vs 90) instead of the low `55` prior, so the opt-in
@@ -2255,7 +2257,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidator used server startup default project instead of the
   session's actual project.
 
-[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.17.3...HEAD
+[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.18.0...HEAD
+[1.18.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.18.0
 [1.17.3]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.3
 [1.17.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.2
 [1.17.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-cli"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-consolidate"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-core"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "jiff",
  "regex",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-eval"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-hooks"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-llm"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-mcp"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-store"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-web"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-store",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-wiki"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-workstream"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.17.3"
+version = "1.18.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"
@@ -26,15 +26,15 @@ authors = ["Fabio Akita <boss@akitaonrails.com>"]
 
 [workspace.dependencies]
 # Inter-crate dependencies.
-ai-memory-core = { path = "crates/ai-memory-core", version = "1.17.3" }
-ai-memory-store = { path = "crates/ai-memory-store", version = "1.17.3" }
-ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.17.3" }
-ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.17.3" }
-ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.17.3" }
-ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.17.3" }
-ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.17.3" }
-ai-memory-web = { path = "crates/ai-memory-web", version = "1.17.3" }
-ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.17.3" }
+ai-memory-core = { path = "crates/ai-memory-core", version = "1.18.0" }
+ai-memory-store = { path = "crates/ai-memory-store", version = "1.18.0" }
+ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.18.0" }
+ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.18.0" }
+ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.18.0" }
+ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.18.0" }
+ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.18.0" }
+ai-memory-web = { path = "crates/ai-memory-web", version = "1.18.0" }
+ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.18.0" }
 
 # (Workspace shared deps follow below)
 


### PR DESCRIPTION
## Summary
- bump all workspace crates from 1.17.3 to 1.18.0
- move the complete Unreleased changelog into the 2026-07-23 v1.18.0 section
- synchronize workspace package entries in Cargo.lock

This minor release includes opt-in Claude Code assistant/Stop capture, Kimi Code managed-workstream support, the Windows PowerShell CLIXML fix, and the audited regression-test hardening merged since v1.17.3.

## Verification
- `TAILWIND_SKIP=1 bin/release 1.18.0`
- full workspace fmt, clippy, tests, cargo-deny, and cargo-audit passed
- release diff limited to Cargo.toml, Cargo.lock, and CHANGELOG.md

The local v1.18.0 tag will not be pushed until the merged release commit is deployed and live-tested.