### PR TITLE
feat(workstream): support kimi-cli alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for what it can contain and where it flows. Script-fallback installs cannot
   sanitize the field and drop the whole Stop event instead; move to a native
   install to capture it.
-- Managed workstreams now support Kimi Code through `ai-memory run kimi`.
+- Managed workstreams now support Kimi Code through `ai-memory run kimi`;
+  `kimi-code` and `kimi-cli` are accepted aliases for the installed `kimi`
+  executable.
   Returning runs resume the linked native session with `--session <id>`;
   fresh sessions are discovered post-exit by exact checkout match through
   `state.json`'s `workDir` (the session bucket name is a one-way hash and is
@@ -43,7 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   messages and compaction summaries from `agents/main/wire.jsonl`, excluding
   system prompts, hidden reasoning, hook-injected context (`hook_result` and
   related origins), and subagent transcripts. Wrapper `--yolo` maps to Kimi
-  Code's `--yolo`, and kimi joins the automatic bare-run harness pool.
+  Code's `--yolo`, and kimi joins the automatic bare-run harness pool. The
+  deterministic and opt-in real-harness acceptance paths cover Kimi creation,
+  transcript import, cross-harness delivery, and returning native resume; the
+  native contract was live-verified against Kimi Code v0.29.0.
 
 ### Fixed
 - Native hook spool retries now reuse a per-entry idempotency key, so a lost

--- a/README.md
+++ b/README.md
@@ -64,14 +64,16 @@ priors are at the [bottom](#influences-and-prior-art).
   sanitized prompt, tool-lifecycle, and session-boundary observations. Direct
   launches keep this lightweight path; it is not a complete native transcript.
 - **Opt-in managed workstreams.** `ai-memory run claude`, then `ai-memory run
-  codex --yolo`, transparently resumes one logical workstream with native
-  per-harness sessions, a portable visible-event ledger, and full-ledger search.
+  codex --yolo`, then `ai-memory run kimi`, transparently resumes one logical
+  workstream with native per-harness sessions, a portable visible-event ledger,
+  and full-ledger search.
   `ai-memory run` with no harness continues the newest usable Claude Code,
   Codex, OpenCode, Pi, Crush, or Kimi Code session for this checkout. On first
   explicit use, an interactive launcher can adopt a previous session from the
   same checkout; later switches cannot select unrelated native history. Native
   arguments pass through unchanged except the wrapper-owned `--yolo`; direct
-  commands are unaffected.
+  commands are unaffected. `kimi-code` and `kimi-cli` are accepted aliases for
+  the installed `kimi` command.
 - **Per-repository capture exclusions.** A nearest-marker `[capture]`
   `ignore_paths` policy drops matching recognized file-tool events before they
   reach the local spool or server. See [the capture policy reference](docs/marker-file.md#capture-exclusions).

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -217,7 +217,7 @@ pub enum RunHarnessChoice {
     #[value(alias = "oh-my-pi")]
     Omp,
     /// Moonshot AI Kimi Code.
-    #[value(name = "kimi", alias = "kimi-code")]
+    #[value(name = "kimi", alias = "kimi-code", alias = "kimi-cli")]
     Kimi,
 }
 

--- a/crates/ai-memory-cli/src/commands/run.rs
+++ b/crates/ai-memory-cli/src/commands/run.rs
@@ -1237,6 +1237,29 @@ mod tests {
     }
 
     #[test]
+    fn kimi_cli_alias_selects_the_kimi_adapter() {
+        let cli = Cli::try_parse_from([
+            OsStr::new("ai-memory"),
+            OsStr::new("run"),
+            OsStr::new("kimi-cli"),
+            OsStr::new("--model"),
+            OsStr::new("kimi-for-coding"),
+        ])
+        .unwrap();
+        let CliCommand::Run(args) = cli.command else {
+            panic!("expected run command");
+        };
+        assert!(matches!(
+            args.harness,
+            Some(crate::cli::RunHarnessChoice::Kimi)
+        ));
+        assert_eq!(
+            args.native_args,
+            ["--model", "kimi-for-coding"].map(OsString::from).to_vec()
+        );
+    }
+
+    #[test]
     fn bare_run_and_wrapper_yolo_parse_without_a_harness() {
         let cli = Cli::try_parse_from(["ai-memory", "run", "--yolo"]).unwrap();
         let CliCommand::Run(args) = cli.command else {

--- a/crates/ai-memory-workstream/src/harness.rs
+++ b/crates/ai-memory-workstream/src/harness.rs
@@ -37,7 +37,7 @@ impl ManagedHarness {
             "pi" => Some(Self::Pi),
             "crush" => Some(Self::Crush),
             "omp" | "oh-my-pi" => Some(Self::Omp),
-            "kimi" | "kimi-code" => Some(Self::Kimi),
+            "kimi" | "kimi-code" | "kimi-cli" => Some(Self::Kimi),
             _ => None,
         }
     }
@@ -904,6 +904,13 @@ mod tests {
         assert_eq!(strings(&plan.args), ["continue here"]);
         assert_eq!(plan.expected_session_id, None);
         assert_eq!(plan.mode, LaunchMode::Session);
+    }
+
+    #[test]
+    fn kimi_cli_name_is_an_alias_for_kimi_code() {
+        for name in ["kimi", "kimi-code", "kimi-cli"] {
+            assert_eq!(ManagedHarness::from_name(name), Some(ManagedHarness::Kimi));
+        }
     }
 
     #[test]

--- a/docs/managed-workstreams.md
+++ b/docs/managed-workstreams.md
@@ -15,6 +15,8 @@ ai-memory run claude
 ai-memory run codex --yolo
 # return to Claude Code later; ai-memory supplies Claude's native --resume
 ai-memory run claude --model opus
+# Kimi Code installs `kimi`; `kimi-cli` is accepted as a launcher alias
+ai-memory run kimi-cli
 # or omit the harness and continue the newest usable session automatically
 ai-memory run
 ```
@@ -197,7 +199,9 @@ workstream.
 Legacy sessions that keep `wire.jsonl` directly in the session directory
 (the pre-`agents/` layout the kimi session-store still reads through its
 stat fallback) are neither discovered nor imported in v1. The native
-contract was verified against Kimi Code v0.28.1.
+contract was verified against Kimi Code v0.29.0. The managed launcher accepts
+`kimi`, `kimi-code`, and `kimi-cli`; all three resolve the installed `kimi`
+executable.
 
 Crush needs no ai-memory hook installation for managed mode. The launcher reads
 its one-time context from the server, copies the existing global Crush JSON into
@@ -296,6 +300,8 @@ against obsolete sessions. Native session creation, read-only extraction,
 cross-harness injection, and returning resume paths are all exercised. Docker
 wrapper host execution and remote URL preservation are covered separately by
 the `ai-memory-cli` packaging tests. Set
-`AI_MEMORY_ACCEPTANCE_HARNESSES="claude codex"` to select
-a subset, `AI_MEMORY_ACCEPTANCE_DETERMINISTIC_ONLY=1` to skip model calls, or
+`AI_MEMORY_ACCEPTANCE_HARNESSES="kimi-cli codex"` to select a
+Kimi-to-Codex-to-Kimi round trip (Kimi aliases normalize to the installed
+`kimi` executable), `AI_MEMORY_ACCEPTANCE_DETERMINISTIC_ONLY=1` to skip model
+calls, or
 `AI_MEMORY_ACCEPTANCE_KEEP=1` to retain all temporary logs and data.

--- a/scripts/managed-workstream-acceptance.sh
+++ b/scripts/managed-workstream-acceptance.sh
@@ -396,7 +396,7 @@ jq -e --arg id "$kimi_session_id" \
   AI_MEMORY_ACCEPTANCE_ARGV_LOG="$TMP/kimi-second-argv.log" \
   AI_MEMORY_ACCEPTANCE_SENTINEL="AMWS-FAKE-KIMI-TWO" \
     "$BIN" --data-dir "$DATA" run --workstream edge-kimi --executable "$FAKE" \
-      kimi >"$LOGS/edge-kimi-second.log" 2>&1
+      kimi-cli >"$LOGS/edge-kimi-second.log" 2>&1
 )
 diff -u <(printf '%s\n' --session "$kimi_session_id") "$TMP/kimi-second-argv.log"
 kimi_second_hits=$("$BIN" --data-dir "$DATA" workstream-search \
@@ -481,11 +481,15 @@ fi
 
 read -r -a requested_harnesses <<<"$HARNESS_WORDS"
 harnesses=()
-for harness in "${requested_harnesses[@]}"; do
+for requested_harness in "${requested_harnesses[@]}"; do
+  case "$requested_harness" in
+    kimi-code | kimi-cli) harness=kimi ;;
+    *) harness=$requested_harness ;;
+  esac
   if command -v "$harness" >/dev/null 2>&1; then
     harnesses+=("$harness")
   else
-    printf 'skipping unavailable harness: %s\n' "$harness" >&2
+    printf 'skipping unavailable harness: %s\n' "$requested_harness" >&2
   fi
 done
 [ "${#harnesses[@]}" -ge 2 ] || {
@@ -628,7 +632,7 @@ run_harness() {
   if [ -z "$previous" ]; then
     prompt="Do not use tools. Reply with exactly: $current"
   else
-    prompt="Do not use tools. From the injected ai-memory managed-workstream context, identify the most recent assistant sentinel beginning with AMWS-. Reply on one line with that prior sentinel, then $current."
+    prompt="Do not use tools. In the newest assistant event from the injected ai-memory managed-workstream context, find the final whitespace-delimited token beginning with AMWS-. Reply with exactly that token, one space, then $current."
   fi
   if [ "$first_run" = 1 ]; then
     wrapper_args=(--new "$WORKSTREAM_NAME")


### PR DESCRIPTION
## Summary
- accept `kimi-cli` as an alias for the existing Kimi Code managed-workstream adapter
- exercise the alias in deterministic acceptance and normalize it for real-harness runs
- make the cross-harness model assertion unambiguous and document Kimi Code v0.29.0 live verification

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash -n scripts/managed-workstream-acceptance.sh`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- `AI_MEMORY_ACCEPTANCE_DETERMINISTIC_ONLY=1 AI_MEMORY_ACCEPTANCE_REBUILD=0 scripts/managed-workstream-acceptance.sh`
- `AI_MEMORY_ACCEPTANCE_HARNESSES="kimi-cli codex" AI_MEMORY_ACCEPTANCE_REBUILD=0 scripts/managed-workstream-acceptance.sh`

The live acceptance used the locally authenticated Kimi Code CLI v0.29.0 and returned to the exact native Kimi session after the Codex leg.