### PR TITLE
release: v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-07-23
+
 ### Added
 - The store writer only accepts `Sanitized<NewObservation>`: the privacy
   strip is enforced by the type system at the persistence boundary, so an
@@ -2270,7 +2272,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidator used server startup default project instead of the
   session's actual project.
 
-[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.17.3...HEAD
+[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.18.0...HEAD
+[1.18.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.18.0
 [1.17.3]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.3
 [1.17.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.2
 [1.17.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-cli"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-consolidate"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-core"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "jiff",
  "regex",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-eval"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-hooks"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-llm"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-mcp"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-store"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-web"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-store",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-wiki"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-workstream"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.17.3"
+version = "1.18.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"
@@ -26,15 +26,15 @@ authors = ["Fabio Akita <boss@akitaonrails.com>"]
 
 [workspace.dependencies]
 # Inter-crate dependencies.
-ai-memory-core = { path = "crates/ai-memory-core", version = "1.17.3" }
-ai-memory-store = { path = "crates/ai-memory-store", version = "1.17.3" }
-ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.17.3" }
-ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.17.3" }
-ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.17.3" }
-ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.17.3" }
-ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.17.3" }
-ai-memory-web = { path = "crates/ai-memory-web", version = "1.17.3" }
-ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.17.3" }
+ai-memory-core = { path = "crates/ai-memory-core", version = "1.18.0" }
+ai-memory-store = { path = "crates/ai-memory-store", version = "1.18.0" }
+ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.18.0" }
+ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.18.0" }
+ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.18.0" }
+ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.18.0" }
+ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.18.0" }
+ai-memory-web = { path = "crates/ai-memory-web", version = "1.18.0" }
+ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.18.0" }
 
 # (Workspace shared deps follow below)
 


### PR DESCRIPTION
## Summary
- set the workspace and internal crate dependency versions to 1.18.0
- refresh workspace package versions in Cargo.lock
- close the Unreleased changelog section as v1.18.0 dated 2026-07-23

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- `cargo run --quiet -p ai-memory-cli -- --version` -> `ai-memory 1.18.0`