### PR TITLE
fix(hooks): simplify normalize_segments with ? operator

### DIFF
--- a/crates/ai-memory-hooks/src/capture_policy.rs
+++ b/crates/ai-memory-hooks/src/capture_policy.rs
@@ -777,10 +777,9 @@ fn normalize_segments(path: &str) -> Option<String> {
             format!("{}:/", path[..1].to_ascii_uppercase()),
             path[3..].split('/').collect(),
         )
-    } else if let Some(rest) = path.strip_prefix('/') {
-        ("/".into(), rest.split('/').collect())
     } else {
-        return None;
+        let rest = path.strip_prefix('/')?;
+        ("/".into(), rest.split('/').collect())
     };
     let mut parts = Vec::new();
     for part in tail {


### PR DESCRIPTION
## What changed

`normalize_segments` now uses `?` for the absolute-path branch instead of an explicit `else { return None; }`. Behaviour is unchanged; the code remains equivalent and becomes clean under newer Clippy versions that flag this pattern.

## Why

This is a preventive Clippy cleanup observed while validating with a newer secondary toolchain. The project still pins Rust 1.95, so this is not fixing a current pinned-toolchain failure.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `cargo deny check` passes
- [x] Manual test: validated the change against Rust 1.95.0 and a newer Rust/Clippy environment where the lint is emitted.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected
      any unintended identity before requesting merge. See
      [commit attribution guidance](https://github.com/akitaonrails/ai-memory/blob/main/CONTRIBUTING.md#commit-attribution).

## CHANGELOG (merge gate)

- [x] No `CHANGELOG.md` entry: this is an internal Clippy/style cleanup with no user-facing behaviour, flag, env var, endpoint, MCP tool, marker key, default, or observable bug fix.
- [x] No default changed.

## Notes for reviewers

Trivial mechanical cleanup only; the `strip_prefix('/')?` branch is equivalent to the previous explicit `return None`.
