### PR TITLE
fix(mcp): detect MSIX-packaged Claude Desktop config path on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `install-mcp --client claude-desktop` now detects an MSIX-packaged
-  Claude Desktop on Windows (the default distribution since February
-  2026) and writes to its virtualized
+  Claude Desktop on Windows and writes to its virtualized
   `AppData\Local\Packages\Claude_<id>\LocalCache\Roaming\Claude\claude_desktop_config.json`
-  instead of the plain `%APPDATA%\Claude\` path, which a packaged,
-  AppContainer-sandboxed Claude Desktop never reads. Previously this
+  instead of the plain `%APPDATA%\Claude\` path. Previously this
   silently wrote a config file the running app ignored, so the MCP
-  server never appeared after restart. Unpackaged/legacy installs are
-  unaffected and keep resolving to the plain path.
+  server never appeared after restart. The detector uses Windows'
+  resolved local and roaming app-data roots, prefers an existing config
+  when multiple package directories exist, and fails with an explicit
+  `--config-file` recovery instruction when the active package is
+  ambiguous. Unpackaged installs keep resolving to the plain path.
+  (#250)
 
 ## [1.18.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client of the running server; the command now requires a reachable
   server and no longer works against an offline data directory.
 
+### Fixed
+- `install-mcp --client claude-desktop` now detects an MSIX-packaged
+  Claude Desktop on Windows (the default distribution since February
+  2026) and writes to its virtualized
+  `AppData\Local\Packages\Claude_<id>\LocalCache\Roaming\Claude\claude_desktop_config.json`
+  instead of the plain `%APPDATA%\Claude\` path, which a packaged,
+  AppContainer-sandboxed Claude Desktop never reads. Previously this
+  silently wrote a config file the running app ignored, so the MCP
+  server never appeared after restart. Unpackaged/legacy installs are
+  unaffected and keep resolving to the plain path.
+
 ## [1.18.0] - 2026-07-23
 
 ### Added

--- a/crates/ai-memory-cli/src/commands/install_mcp.rs
+++ b/crates/ai-memory-cli/src/commands/install_mcp.rs
@@ -132,27 +132,11 @@ pub(crate) fn mcp_config_path(client: crate::cli::McpClient) -> Result<PathBuf> 
             }
             #[cfg(target_os = "windows")]
             {
-                // Since Anthropic's Feb 2026 move to MSIX packaging, a
-                // packaged Claude Desktop is an AppContainer: it never
-                // sees the real, shared %APPDATA% this unpackaged binary
-                // writes to. Windows silently virtualizes well-known
-                // paths for packaged processes into an isolated
-                // `AppData\Local\Packages\<PackageFamilyName>\LocalCache\...`
-                // tree instead — writing to the plain path produces a
-                // file the running app will never read (issue found
-                // 2026-07-16). Prefer the packaged location when a
-                // `Claude_*` package is present; only unpackaged/legacy
-                // Squirrel installs fall back to the plain path.
-                let home = home()?;
-                let local_packages_dir = home.join("AppData").join("Local").join("Packages");
-                match packaged_claude_desktop_config_path(&local_packages_dir) {
-                    Some(packaged) => packaged,
-                    None => home
-                        .join("AppData")
-                        .join("Roaming")
-                        .join("Claude")
-                        .join("claude_desktop_config.json"),
-                }
+                let local_data_dir = dirs::data_local_dir()
+                    .context("could not locate %LOCALAPPDATA% for Claude Desktop config")?;
+                let roaming_config_dir = dirs::config_dir()
+                    .context("could not locate %APPDATA% for Claude Desktop config")?;
+                claude_desktop_config_path_in(&local_data_dir, &roaming_config_dir)?
             }
             #[cfg(not(any(target_os = "macos", target_os = "windows")))]
             {
@@ -193,21 +177,40 @@ pub(crate) fn mcp_config_path(client: crate::cli::McpClient) -> Result<PathBuf> 
     })
 }
 
-/// Windows-only detection for an MSIX/AppX-packaged Claude Desktop.
-/// `local_packages_dir` is normally `%LOCALAPPDATA%\Packages`; a packaged
-/// Claude Desktop registers a `Claude_<PackageFamilyName>`-style directory
-/// there regardless of whether the app has ever been launched (Windows
-/// creates the package directory at install time, but the `LocalCache`
-/// subtree lazily on first run — so this checks for the package directory
-/// itself, not the config file, and lets the caller's atomic-write path
-/// create the remaining subdirectories). Returns `None` when no such
-/// directory exists (unpackaged/legacy Squirrel install, or a non-Windows
-/// test double), so callers fall back to the plain path. Sorted so the
-/// result is deterministic on the (unexpected) chance more than one
-/// `Claude_*` directory exists.
-fn packaged_claude_desktop_config_path(local_packages_dir: &Path) -> Option<PathBuf> {
-    let mut candidates: Vec<PathBuf> = std::fs::read_dir(local_packages_dir)
-        .ok()?
+#[cfg(any(target_os = "windows", test))]
+fn claude_desktop_config_path_in(
+    local_data_dir: &Path,
+    roaming_config_dir: &Path,
+) -> Result<PathBuf> {
+    let local_packages_dir = local_data_dir.join("Packages");
+    Ok(
+        packaged_claude_desktop_config_path(&local_packages_dir)?.unwrap_or_else(|| {
+            roaming_config_dir
+                .join("Claude")
+                .join("claude_desktop_config.json")
+        }),
+    )
+}
+
+/// Detect an MSIX/AppX-packaged Claude Desktop under
+/// `%LOCALAPPDATA%\Packages`. Prefer the package that already contains a
+/// config file; otherwise a single package directory is enough because the
+/// atomic apply path creates its lazy `LocalCache` descendants.
+#[cfg(any(target_os = "windows", test))]
+fn packaged_claude_desktop_config_path(local_packages_dir: &Path) -> Result<Option<PathBuf>> {
+    let entries = match std::fs::read_dir(local_packages_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "could not inspect Claude Desktop packages under {}",
+                    local_packages_dir.display()
+                )
+            });
+        }
+    };
+    let mut candidates: Vec<PathBuf> = entries
         .filter_map(|entry| entry.ok())
         .map(|entry| entry.path())
         .filter(|path| {
@@ -215,17 +218,44 @@ fn packaged_claude_desktop_config_path(local_packages_dir: &Path) -> Option<Path
                 && path
                     .file_name()
                     .and_then(|name| name.to_str())
-                    .is_some_and(|name| name.starts_with("Claude_"))
+                    .and_then(|name| name.get(.."Claude_".len()))
+                    .is_some_and(|prefix| prefix.eq_ignore_ascii_case("Claude_"))
         })
         .collect();
     candidates.sort();
-    candidates.into_iter().next().map(|package_dir| {
+
+    let config_path = |package_dir: &Path| {
         package_dir
             .join("LocalCache")
             .join("Roaming")
             .join("Claude")
             .join("claude_desktop_config.json")
-    })
+    };
+    let existing: Vec<PathBuf> = candidates
+        .iter()
+        .map(|package_dir| config_path(package_dir))
+        .filter(|path| path.is_file())
+        .collect();
+
+    match (existing.as_slice(), candidates.as_slice()) {
+        ([path], _) => Ok(Some(path.clone())),
+        ([], []) => Ok(None),
+        ([], [package_dir]) => Ok(Some(config_path(package_dir))),
+        _ => {
+            let package_names = candidates
+                .iter()
+                .filter_map(|path| path.file_name())
+                .map(|name| name.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!(
+                "multiple Claude Desktop packages were found under {} ({package_names}); \
+                 pass --config-file with the active package's \
+                 LocalCache\\Roaming\\Claude\\claude_desktop_config.json path",
+                local_packages_dir.display()
+            )
+        }
+    }
 }
 
 /// Claude Code reads MCP-server registrations from `.claude.json`
@@ -1022,7 +1052,9 @@ mod tests {
         let packages = tempfile::TempDir::new().unwrap();
         fs::create_dir_all(packages.path().join("Claude_pzs8sxrjxfjjc")).unwrap();
 
-        let found = packaged_claude_desktop_config_path(packages.path()).unwrap();
+        let found = packaged_claude_desktop_config_path(packages.path())
+            .unwrap()
+            .unwrap();
         assert_eq!(
             found,
             packages
@@ -1041,18 +1073,72 @@ mod tests {
         fs::create_dir_all(packages.path().join("Microsoft.WindowsTerminal_abc123")).unwrap();
         fs::write(packages.path().join("Claude_notadir"), b"").unwrap();
 
-        assert!(packaged_claude_desktop_config_path(packages.path()).is_none());
+        assert!(
+            packaged_claude_desktop_config_path(packages.path())
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
     fn packaged_claude_desktop_path_none_when_packages_dir_absent_or_empty() {
         let missing = tempfile::TempDir::new().unwrap();
         assert!(
-            packaged_claude_desktop_config_path(&missing.path().join("does-not-exist")).is_none()
+            packaged_claude_desktop_config_path(&missing.path().join("does-not-exist"))
+                .unwrap()
+                .is_none()
         );
 
         let empty = tempfile::TempDir::new().unwrap();
-        assert!(packaged_claude_desktop_config_path(empty.path()).is_none());
+        assert!(
+            packaged_claude_desktop_config_path(empty.path())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn claude_desktop_path_uses_resolved_app_data_roots() {
+        let root = tempfile::TempDir::new().unwrap();
+        let local = root.path().join("redirected-local");
+        let roaming = root.path().join("redirected-roaming");
+
+        assert_eq!(
+            claude_desktop_config_path_in(&local, &roaming).unwrap(),
+            roaming.join("Claude").join("claude_desktop_config.json")
+        );
+    }
+
+    #[test]
+    fn packaged_claude_desktop_path_prefers_existing_config_among_packages() {
+        let packages = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(packages.path().join("Claude_old")).unwrap();
+        let active_config = packages
+            .path()
+            .join("Claude_current")
+            .join("LocalCache")
+            .join("Roaming")
+            .join("Claude")
+            .join("claude_desktop_config.json");
+        fs::create_dir_all(active_config.parent().unwrap()).unwrap();
+        fs::write(&active_config, b"{}").unwrap();
+
+        assert_eq!(
+            packaged_claude_desktop_config_path(packages.path())
+                .unwrap()
+                .unwrap(),
+            active_config
+        );
+    }
+
+    #[test]
+    fn packaged_claude_desktop_path_rejects_ambiguous_packages() {
+        let packages = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(packages.path().join("Claude_first")).unwrap();
+        fs::create_dir_all(packages.path().join("Claude_second")).unwrap();
+
+        let error = packaged_claude_desktop_config_path(packages.path()).unwrap_err();
+        assert!(error.to_string().contains("--config-file"));
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/install_mcp.rs
+++ b/crates/ai-memory-cli/src/commands/install_mcp.rs
@@ -132,12 +132,27 @@ pub(crate) fn mcp_config_path(client: crate::cli::McpClient) -> Result<PathBuf> 
             }
             #[cfg(target_os = "windows")]
             {
-                // %APPDATA% is roughly ~/AppData/Roaming.
-                home()?
-                    .join("AppData")
-                    .join("Roaming")
-                    .join("Claude")
-                    .join("claude_desktop_config.json")
+                // Since Anthropic's Feb 2026 move to MSIX packaging, a
+                // packaged Claude Desktop is an AppContainer: it never
+                // sees the real, shared %APPDATA% this unpackaged binary
+                // writes to. Windows silently virtualizes well-known
+                // paths for packaged processes into an isolated
+                // `AppData\Local\Packages\<PackageFamilyName>\LocalCache\...`
+                // tree instead — writing to the plain path produces a
+                // file the running app will never read (issue found
+                // 2026-07-16). Prefer the packaged location when a
+                // `Claude_*` package is present; only unpackaged/legacy
+                // Squirrel installs fall back to the plain path.
+                let home = home()?;
+                let local_packages_dir = home.join("AppData").join("Local").join("Packages");
+                match packaged_claude_desktop_config_path(&local_packages_dir) {
+                    Some(packaged) => packaged,
+                    None => home
+                        .join("AppData")
+                        .join("Roaming")
+                        .join("Claude")
+                        .join("claude_desktop_config.json"),
+                }
             }
             #[cfg(not(any(target_os = "macos", target_os = "windows")))]
             {
@@ -175,6 +190,41 @@ pub(crate) fn mcp_config_path(client: crate::cli::McpClient) -> Result<PathBuf> 
             .context("could not resolve current dir for .vscode/mcp.json default")?
             .join(".vscode")
             .join("mcp.json"),
+    })
+}
+
+/// Windows-only detection for an MSIX/AppX-packaged Claude Desktop.
+/// `local_packages_dir` is normally `%LOCALAPPDATA%\Packages`; a packaged
+/// Claude Desktop registers a `Claude_<PackageFamilyName>`-style directory
+/// there regardless of whether the app has ever been launched (Windows
+/// creates the package directory at install time, but the `LocalCache`
+/// subtree lazily on first run — so this checks for the package directory
+/// itself, not the config file, and lets the caller's atomic-write path
+/// create the remaining subdirectories). Returns `None` when no such
+/// directory exists (unpackaged/legacy Squirrel install, or a non-Windows
+/// test double), so callers fall back to the plain path. Sorted so the
+/// result is deterministic on the (unexpected) chance more than one
+/// `Claude_*` directory exists.
+fn packaged_claude_desktop_config_path(local_packages_dir: &Path) -> Option<PathBuf> {
+    let mut candidates: Vec<PathBuf> = std::fs::read_dir(local_packages_dir)
+        .ok()?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_dir()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("Claude_"))
+        })
+        .collect();
+    candidates.sort();
+    candidates.into_iter().next().map(|package_dir| {
+        package_dir
+            .join("LocalCache")
+            .join("Roaming")
+            .join("Claude")
+            .join("claude_desktop_config.json")
     })
 }
 
@@ -965,6 +1015,44 @@ mod tests {
                 path.display()
             );
         }
+    }
+
+    #[test]
+    fn packaged_claude_desktop_path_prefers_localcache_when_package_dir_exists() {
+        let packages = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(packages.path().join("Claude_pzs8sxrjxfjjc")).unwrap();
+
+        let found = packaged_claude_desktop_config_path(packages.path()).unwrap();
+        assert_eq!(
+            found,
+            packages
+                .path()
+                .join("Claude_pzs8sxrjxfjjc")
+                .join("LocalCache")
+                .join("Roaming")
+                .join("Claude")
+                .join("claude_desktop_config.json")
+        );
+    }
+
+    #[test]
+    fn packaged_claude_desktop_path_ignores_unrelated_and_non_dir_entries() {
+        let packages = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(packages.path().join("Microsoft.WindowsTerminal_abc123")).unwrap();
+        fs::write(packages.path().join("Claude_notadir"), b"").unwrap();
+
+        assert!(packaged_claude_desktop_config_path(packages.path()).is_none());
+    }
+
+    #[test]
+    fn packaged_claude_desktop_path_none_when_packages_dir_absent_or_empty() {
+        let missing = tempfile::TempDir::new().unwrap();
+        assert!(
+            packaged_claude_desktop_config_path(&missing.path().join("does-not-exist")).is_none()
+        );
+
+        let empty = tempfile::TempDir::new().unwrap();
+        assert!(packaged_claude_desktop_config_path(empty.path()).is_none());
     }
 
     #[test]

--- a/docs/mcp-install.md
+++ b/docs/mcp-install.md
@@ -239,11 +239,12 @@ Aliases: `copilot`, `github-copilot`.
 **Config file:**
 - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - Windows: `%APPDATA%\Claude\claude_desktop_config.json` for an
-  unpackaged/legacy install, or `%LOCALAPPDATA%\Packages\Claude_<id>\LocalCache\Roaming\Claude\claude_desktop_config.json`
-  for the MSIX-packaged install Anthropic has shipped by default since
-  February 2026 — `install-mcp` detects which one applies automatically
-  by checking for a `Claude_*` directory under
-  `%LOCALAPPDATA%\Packages`.
+  unpackaged install, or
+  `%LOCALAPPDATA%\Packages\Claude_<id>\LocalCache\Roaming\Claude\claude_desktop_config.json`
+  for a detected MSIX-packaged install. `install-mcp` checks for
+  `Claude_*` package directories automatically and prefers one that
+  already contains a config. If multiple candidates remain ambiguous,
+  it stops and asks for an explicit `--config-file` instead of guessing.
 - Linux: not officially distributed by Anthropic. Use Claude Code
   (terminal) instead.
 
@@ -274,19 +275,20 @@ stdio shim. Requires Node.js installed on the same machine.
   prompt/tool capture and session-boundary handoffs are not possible
   unless Anthropic adds a desktop hook/plugin surface.
 - If the MCP indicator doesn't appear after restart, check the logs:
-  `~/Library/Logs/Claude/mcp*.log` (macOS) or `%APPDATA%\Claude\logs\`
-  (Windows).
+  `~/Library/Logs/Claude/mcp*.log` (macOS). On Windows, check
+  `%APPDATA%\Claude\logs\` for an unpackaged install or the corresponding
+  `LocalCache\Roaming\Claude\logs\` directory under the detected
+  `%LOCALAPPDATA%\Packages\Claude_<id>\` package.
 - **Windows MSIX packaging:** a packaged Claude Desktop is an
-  AppContainer — Windows virtualizes `%APPDATA%` for it into an isolated
+  AppContainer. Windows redirects its `%APPDATA%` writes into an isolated
   `AppData\Local\Packages\Claude_<id>\LocalCache\Roaming\` tree that an
-  unpackaged process (like this CLI) never sees at the plain path.
+  unpackaged process such as this CLI must address directly.
   `install-mcp --client claude-desktop --apply` detects this and writes
-  to the packaged location automatically; if you're on an older build of
-  this CLI without that detection, pass `--config-file` pointed at the
-  `LocalCache` path directly (find the exact `Claude_<id>` folder name
-  under `%LOCALAPPDATA%\Packages`).
+  to the packaged location automatically. On an older ai-memory build,
+  pass `--config-file` pointed at the `LocalCache` path directly.
 - Sources: <https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop>,
-  <https://support.claude.com/en/articles/11175166-how-to-connect-remote-mcp-integrations-to-claude>
+  <https://support.claude.com/en/articles/11175166-how-to-connect-remote-mcp-integrations-to-claude>,
+  <https://learn.microsoft.com/en-us/windows/msix/msix-containerization-overview>
 
 ---
 

--- a/docs/mcp-install.md
+++ b/docs/mcp-install.md
@@ -238,7 +238,12 @@ Aliases: `copilot`, `github-copilot`.
 
 **Config file:**
 - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json` for an
+  unpackaged/legacy install, or `%LOCALAPPDATA%\Packages\Claude_<id>\LocalCache\Roaming\Claude\claude_desktop_config.json`
+  for the MSIX-packaged install Anthropic has shipped by default since
+  February 2026 — `install-mcp` detects which one applies automatically
+  by checking for a `Claude_*` directory under
+  `%LOCALAPPDATA%\Packages`.
 - Linux: not officially distributed by Anthropic. Use Claude Code
   (terminal) instead.
 
@@ -271,6 +276,15 @@ stdio shim. Requires Node.js installed on the same machine.
 - If the MCP indicator doesn't appear after restart, check the logs:
   `~/Library/Logs/Claude/mcp*.log` (macOS) or `%APPDATA%\Claude\logs\`
   (Windows).
+- **Windows MSIX packaging:** a packaged Claude Desktop is an
+  AppContainer — Windows virtualizes `%APPDATA%` for it into an isolated
+  `AppData\Local\Packages\Claude_<id>\LocalCache\Roaming\` tree that an
+  unpackaged process (like this CLI) never sees at the plain path.
+  `install-mcp --client claude-desktop --apply` detects this and writes
+  to the packaged location automatically; if you're on an older build of
+  this CLI without that detection, pass `--config-file` pointed at the
+  `LocalCache` path directly (find the exact `Claude_<id>` folder name
+  under `%LOCALAPPDATA%\Packages`).
 - Sources: <https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop>,
   <https://support.claude.com/en/articles/11175166-how-to-connect-remote-mcp-integrations-to-claude>
 


### PR DESCRIPTION
## What changed

`install-mcp --client claude-desktop` on Windows now detects an MSIX-packaged Claude Desktop (the default distribution since February 2026) and writes to its virtualized `AppData\Local\Packages\Claude_<id>\LocalCache\Roaming\Claude\claude_desktop_config.json` instead of the plain `%APPDATA%\Claude\` path. Before this change, a packaged install silently received a config file the running app (an AppContainer) never reads, so the MCP server never showed up after restart. Detection checks for a `Claude_*` directory under `%LOCALAPPDATA%\Packages`; unpackaged/legacy Squirrel installs are unaffected and keep resolving to the plain path.

## Why

Confirmed on a real machine running the packaged build (`Claude_pzs8sxrjxfjjc`, version 1.24012.1.0, signed by "Anthropic, PBC" per `Get-AppxPackage`) that `install-mcp --client claude-desktop --apply` wrote to `%APPDATA%\Claude\claude_desktop_config.json`, while the running app only ever reads `AppData\Local\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\claude_desktop_config.json` — Windows silently virtualizes the plain path for packaged/AppContainer processes. Anthropic moved the Windows Claude Desktop installer from Squirrel to MSIX in February 2026 (both the Microsoft Store and the claude.com direct installer), so this affects essentially every current Windows install, not an edge case.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `cargo deny check` passes
- [x] Manual test: ran the 3 new focused tests (`packaged_claude_desktop_path_prefers_localcache_when_package_dir_exists`, `_ignores_unrelated_and_non_dir_entries`, `_none_when_packages_dir_absent_or_empty`) against synthetic tempdir fixtures, and separately confirmed against the real installed package on a Windows 11 machine that the function resolves to the exact path the running app actually reads.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected
      any unintended identity before requesting merge. See
      [commit attribution guidance](https://github.com/akitaonrails/ai-memory/blob/main/CONTRIBUTING.md#commit-attribution).

## CHANGELOG (merge gate)

- [x] I added a `CHANGELOG.md` `[Unreleased]` entry — **required** for any
      user-facing change: new flag / env var / endpoint / MCP tool / marker
      key, changed behaviour, or an observable bug fix. (Exempt only for
      internal refactors, dead-code removal, and test-only churn.)
- [x] Any changed **default** (flag behaviour, config default, env var,
      response shape) is called out explicitly in "What changed" above.

## Notes for reviewers

Detection only checks for the existence of a `Claude_*` directory under `Packages` (not the config file itself), since Windows creates the package directory at install time but the `LocalCache` subtree only lazily on first app launch — checking for the file itself would miss a packaged-but-never-launched install. The existing atomic-write path already creates missing parent directories, so no special-casing was needed there.

Validated end-to-end on one real Windows 11 machine so far; a second, independent Windows 11 machine is planned as a follow-up sanity check before considering this fully proven across environments.