### PR TITLE
Fix stale generated and reference documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,8 @@ or prompt routing for learning review.
 ## Technology stack
 
 - **Rust edition 2024, toolchain 1.95** (pinned in `rust-toolchain.toml`),
-  workspace resolver 3. Current workspace version: 1.17.3.
+  workspace resolver 3. The authoritative workspace version is
+  `workspace.package.version` in `Cargo.toml`.
 - **Async runtime:** `tokio` (full features).
 - **MCP/HTTP:** `rmcp` 1.7 (server SDK) + `axum` 0.8 for MCP HTTP, hooks,
   admin, `/api/v1`, and the built-in `/web` UI; `tower` / `tower-http`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Claude Desktop's rendered Windows MCP instructions now distinguish the
+  unpackaged `%APPDATA%` config from the detected MSIX `LocalCache` config, and
+  contributor, managed-workstream, and CLI reference docs no longer omit
+  recently shipped harnesses or commands. (#256)
 - The opt-in managed-workstream real-harness acceptance runner now verifies
   context delivery from the managed-run cursor/acknowledgement state and a new
   persisted assistant event instead of requiring the model to quote a prior

--- a/README.md
+++ b/README.md
@@ -166,9 +166,10 @@ priors are at the [bottom](#influences-and-prior-art).
   briefly if the previous launcher is still finalizing; handled failures release
   the workstream immediately. If a linked native transcript was deleted,
   ai-memory detects the orphan before launch and starts fresh; `--fresh` forces
-  that recovery for one harness. Managed mode currently covers Claude Code, Codex,
-  OpenCode, Pi, Crush, Kimi Code, and OMP; direct harness launches remain
-  unchanged. See [Managed cross-harness workstreams](docs/managed-workstreams.md).
+  that recovery for one harness. Managed mode currently covers Claude Code,
+  Codex, OpenCode, Pi, Crush, Kimi Code, OMP, and Grok Build CLI; direct harness
+  launches remain unchanged. See
+  [Managed cross-harness workstreams](docs/managed-workstreams.md).
 - **"Quit at 4 PM, pick up at 9 AM in a different agent."** The
   classic. SessionStart hook in the next supported hook client prepends a
   typed handoff with open questions, next steps, and a session summary. Grok

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -1606,7 +1606,36 @@ pub struct WritePageArgs {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn architecture_lists_every_visible_cli_subcommand() {
+        let architecture = include_str!("../../../docs/ARCHITECTURE.md");
+        let cli_section = architecture
+            .split_once("## CLI subcommand surface")
+            .expect("architecture must have a CLI subcommand section")
+            .1;
+        let command_block = cli_section
+            .split_once("```")
+            .expect("CLI subcommand section must have a fenced block")
+            .1
+            .split_once("```")
+            .expect("CLI subcommand fence must be closed")
+            .0;
+        let documented = command_block.split_whitespace().collect::<BTreeSet<_>>();
+        let command = Cli::command();
+        let visible = command
+            .get_subcommands()
+            .filter(|subcommand| !subcommand.is_hide_set())
+            .map(|subcommand| subcommand.get_name())
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(
+            documented, visible,
+            "docs/ARCHITECTURE.md CLI subcommands must match `ai-memory --help`"
+        );
+    }
 
     #[test]
     fn claude_session_aware_mcp_flag_parses() {

--- a/crates/ai-memory-cli/src/commands/install_mcp.rs
+++ b/crates/ai-memory-cli/src/commands/install_mcp.rs
@@ -876,7 +876,10 @@ fn render_claude_desktop(args: &InstallMcpArgs) -> Result<String> {
     Ok(format!(
         "# Claude Desktop — write to claude_desktop_config.json:\n\
          #   - macOS:    ~/Library/Application Support/Claude/claude_desktop_config.json\n\
-         #   - Windows:  %APPDATA%\\Claude\\claude_desktop_config.json\n\
+         #   - Windows (unpackaged): %APPDATA%\\Claude\\claude_desktop_config.json\n\
+         #   - Windows (MSIX):       %LOCALAPPDATA%\\Packages\\Claude_<id>\\LocalCache\\Roaming\\Claude\\claude_desktop_config.json\n\
+         #     --apply detects the installed form; if multiple MSIX packages\n\
+         #     are present, select the active one with --config-file.\n\
          #   - Linux:    Claude Desktop is not officially distributed for Linux;\n\
          #               use Claude Code or another HTTP client instead.\n\
          #\n\
@@ -1058,6 +1061,17 @@ mod tests {
             config_file: None,
             session_aware: false,
         }
+    }
+
+    #[test]
+    fn claude_desktop_render_lists_packaged_and_unpacked_windows_paths() {
+        let rendered = render_claude_desktop(&args_for(McpClient::ClaudeDesktop)).unwrap();
+        assert!(rendered.contains(r"%APPDATA%\Claude\claude_desktop_config.json"));
+        assert!(rendered.contains(
+            r"%LOCALAPPDATA%\Packages\Claude_<id>\LocalCache\Roaming\Claude\claude_desktop_config.json"
+        ));
+        assert!(rendered.contains("--apply detects the installed form"));
+        assert!(rendered.contains("--config-file"));
     }
 
     #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -340,18 +340,20 @@ the explicit `install-mcp --client claude-code --session-aware` option.
 ## CLI subcommand surface
 
 ```
-init                 status               search
+init                 status               run
+workstream-search    audit-contamination  search
 read-page            write-page           delete-page
 serve                reset                backup
 restore              reindex              install-hooks
 hook                 install-mcp          commit
 checkpoints          restore-page         llm-test
-forget-sweep         lint                 auto-improve
-auto-improve-report  curator              pending-writes       embed
-generate-auth-token  setup-agent          bootstrap
-install-instructions install-skills        reorg
-rename-project       move-project         audit-contamination
-uninstall            auth                 user
+forget-sweep         lint                 curator
+auto-improve-report  auto-improve         finalize-session
+pending-writes       embed                generate-auth-token
+setup-agent          bootstrap            install-instructions
+install-skills       reorg                purge-project
+rename-project       move-project         uninstall
+auth                 user                 completions
 ```
 
 Run `ai-memory --help` for the full tree.

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -89,15 +89,15 @@ Why not LanceDB/Qdrant/Kuzu/CozoDB/SurrealDB?
 ## 5. Embedding & LLM
 
 **Embeddings:**
-- Default: **local model via `ort` (ONNX Runtime) crate or `fastembed-rs`** running `bge-small-en-v1.5` (384 dim) or `bge-small-en-v1.5-q` quantized. Same model basic-memory uses.
+- The original prototype proposed a default local `ort` / `fastembed-rs` model. The shipped v1 posture is instead **off by default**, with opt-in OpenAI, Voyage, or Google Gemini embeddings. Local ONNX embeddings remain future work; the current provider and model reference lives in [`ARCHITECTURE.md`](ARCHITECTURE.md).
 - Persist `{provider, model, dim}` next to every vector. On mismatch, warn and ignore stale vectors until `ai-memory embed --force` or scheduled backfill re-embeds them (agentmemory #469 lesson, without blocking startup).
-- Cache path: `<data_dir>/models/`, never `/tmp` (basic-memory #741).
-- Trait-based: `trait Embedder { ... }` with implementations `LocalOrtEmbedder`, `OpenAIEmbedder`, `VoyageEmbedder`. User configures one.
+- Any future local model cache belongs under `<data_dir>/models/`, never `/tmp` (basic-memory #741).
+- The shipped provider implementations share the `Embedder` trait and are selected through typed configuration.
 
 **LLM for consolidation passes:**
 - **Off by default**, behaves like agentmemory after #138's fix. Without a provider, the system still works: synthetic compression (rule-based), no LLM-generated summaries, no `memory_consolidate` page-rewrite.
 - With a provider, LLM consolidation runs on PreCompact, on demand via `memory_consolidate`, and at session end only when `AI_MEMORY_CONSOLIDATE_ON_SESSION_END=true` (off by default — session end always writes a rule-based summary page + handoff regardless). Optional 6h maintenance timer.
-- Provider trait `LlmProvider { complete(...); complete_structured(...) }`. Implementations: `AnthropicProvider`, `OpenAIProvider`, `GeminiProvider`, `OpenAICompatProvider` (the latter covers Ollama / vLLM / LM Studio and supersedes the earlier `OllamaProvider`).
+- Providers implement `LlmProvider { complete(...); complete_structured(...) }`. The current provider and authentication matrix lives in [`ARCHITECTURE.md`](ARCHITECTURE.md); this design boundary also covers OpenAI-compatible endpoints such as Ollama, vLLM, and LM Studio.
 - **Native HTTP per provider** - no LiteLLM-equivalent. The cognee tracker (#2412/#2430/#2537/#2608/#2749/#2782/#2840/#2842) showed silent-kwarg-drop in a generic gateway is the #1 source of provider bugs. Each provider's typed JSON, errors on unknown fields. Hand-coded but correct.
 - **Structured output via JSON schema, not XML, not Instructor-style wrapping.** Use each provider's native JSON-mode where available; for Anthropic, request a tool-use response with a typed schema. Validate with `serde_json` + `schemars`-derived schemas.
 
@@ -105,16 +105,16 @@ Why not LanceDB/Qdrant/Kuzu/CozoDB/SurrealDB?
 
 Three capture surfaces, in priority order:
 
-1. **Lifecycle hooks/extensions** (Claude Code, Codex, Cursor, Gemini CLI, Antigravity CLI, OpenClaw, OpenCode, OMP). These are fast, reliable, structured. We ship hook scripts or generated TypeScript integrations the user installs once. Lessons from agentmemory:
+1. **Lifecycle hooks/extensions.** The current clients are listed in the README support matrix. These are fast, reliable, structured. We ship hook scripts or generated TypeScript integrations the user installs once. Lessons from agentmemory:
   - Hooks must be **fire-and-forget** (#221). No `await fetch()` blocking session start.
   - Sub-second hard timeouts on the writer side (`tokio::time::timeout`).
   - All hooks → single HTTP/Unix-socket POST → server queues → returns 202
     immediately, or 429 when saturated.
   - Privacy strip at the hook boundary, not later (agentmemory `stripPrivateData`).
 
-2. **Transcript tail** (universal fallback). Watch `~/.claude/projects/`, `~/.codex/`, `~/.config/opencode/sessions/`. Lossier but works for any agent. Required for the basic-memory #669/#687/#730 demand the tracker has been asking for.
+2. **Managed-workstream transcript import** (opt-in through `ai-memory run`). Each supported adapter reads its linked native session after a managed launch and appends portable visible events to the shared ledger. ai-memory does not ship a universal background watcher over private harness stores.
 
-3. **Manual MCP tool** (`memory_remember`) - only for ad-hoc explicit captures from the user ("remember this"). Not the primary path; not what the agent reaches for by default.
+3. **Manual MCP tool** (`memory_write_page`) - only for explicit durable project knowledge from the user ("remember this"). Routine session capture remains automatic.
 
 ### Capture-policy boundary (#194)
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -17,7 +17,7 @@ path (docker + Claude Code). This page covers everything else:
 - [Managed cross-harness workstreams](managed-workstreams.md)
   (`ai-memory run`, transparent native resume, and argument forwarding)
 - [LLM provider tiers + self-hosted Ollama](#llm-provider-tiers)
-- [Subcommand reference](#subcommand-reference)
+- [Common subcommands](#common-subcommands)
 - [Managed routing snippets and Agent Skills](#managed-routing-snippets-and-agent-skills)
 - [Operating without auth](#operating-without-auth) (local-only)
 - [Keeping ai-memory up to date](#keeping-ai-memory-up-to-date)
@@ -1180,7 +1180,10 @@ falls back to the tolerant parser only when that raw strict call fails.
 
 ---
 
-## Subcommand reference
+## Common subcommands
+
+This is the operational shortlist. Run `ai-memory --help` for the authoritative
+full command tree.
 
 Two ways to invoke a subcommand against the docker deploy:
 

--- a/docs/managed-workstreams.md
+++ b/docs/managed-workstreams.md
@@ -172,9 +172,9 @@ chooser.
 the harness's native dangerous mode. The translation is Claude Code
 `--dangerously-skip-permissions`, Codex
 `--dangerously-bypass-approvals-and-sandbox`, OpenCode `--auto`, Pi `--approve`,
-Crush `--yolo`, and Kimi Code `--yolo`. OMP currently needs no added flag.
-ai-memory does not add a duplicate when the translated native flag is already
-present.
+Crush `--yolo`, Kimi Code `--yolo`, and Grok Build CLI `--yolo` (equivalent to
+its `--always-approve` option). OMP currently needs no added flag. ai-memory
+does not add a duplicate when the translated native flag is already present.
 
 Managed support is intentionally narrower than the general integration matrix.
 Gemini CLI, Devin CLI, Cursor, and other agents may
@@ -283,11 +283,11 @@ process launch is fatal; ai-memory does not silently start an unmanaged agent.
 ## Privacy and storage boundaries
 
 ai-memory's managed adapters do not write to Claude, Codex, OpenCode, Pi, Crush,
-Kimi Code, or OMP private stores. The launched harness retains normal ownership of its own
-session writes. Adapters read only documented or observed local session formats.
-Provider credentials, encrypted content, system/developer prompt records, and
-hidden reasoning are not copied. The server sanitizer runs before both the
-SQLite FTS ledger and immutable files under
+Kimi Code, OMP, or Grok private stores. The launched harness retains normal
+ownership of its own session writes. Adapters read only documented or observed
+local session formats. Provider credentials, encrypted content,
+system/developer prompt records, and hidden reasoning are not copied. The
+server sanitizer runs before both the SQLite FTS ledger and immutable files under
 `<data_dir>/raw/workstreams/<workstream-id>/segments/` are written.
 
 The ledger is an operational continuity substrate, not a replacement for the
@@ -316,8 +316,8 @@ checkout to match exactly.
 ## Manual acceptance
 
 The opt-in acceptance runner exercises launcher edge cases and then orchestrates
-the locally installed Claude, Codex, OpenCode, Pi, Crush, OMP, and Kimi CLIs
-through one real workstream:
+the locally installed Claude, Codex, OpenCode, Pi, Crush, OMP, Kimi, and Grok
+CLIs through one real workstream:
 
 ```bash
 scripts/managed-workstream-acceptance.sh


### PR DESCRIPTION
## Summary
- distinguish unpackaged and MSIX Claude Desktop config paths in rendered Windows instructions
- refresh managed-workstream harness lists, historical design notes, contributor version guidance, and the CLI command inventory
- add regression tests for rendered Windows paths and exact visible CLI/documentation parity

## Validation
- cargo fmt --all -- --check
- git diff --check
- TAILWIND_SKIP=1 cargo test --workspace
- TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings
- cargo deny check
- companion importer fmt/test/clippy
- env -u AI_MEMORY_RUN_ID tests/hooks/test_lib.sh
- scripts/check-native-packaging.sh

Closes #256