### PR TITLE
release: v1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.0] - 2026-07-25
+
 ### Fixed
 - Claude Desktop's rendered Windows MCP instructions now distinguish the
   unpackaged `%APPDATA%` config from the detected MSIX `LocalCache` config, and
@@ -2381,7 +2383,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidator used server startup default project instead of the
   session's actual project.
 
-[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.18.0...HEAD
+[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.19.0...HEAD
+[1.19.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.19.0
 [1.18.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.18.0
 [1.17.3]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.3
 [1.17.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ai-memory finalize-session` now uses this endpoint instead of opening
   the local SQLite index directly, so every CLI command is a thin HTTP
   client of the running server; the command now requires a reachable
-  server and no longer works against an offline data directory.
+  server and no longer works against an offline data directory. (#236)
 - Managed workstream support for Grok Build CLI: `ai-memory run grok` (alias
   `grok-build`) creates fresh sessions with a wrapper-generated `--session-id`,
   resumes linked sessions with `--resume`, maps wrapper `--yolo` onto Grok's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-cli"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-consolidate"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-core"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "jiff",
  "regex",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-eval"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-hooks"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-llm"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-mcp"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-store"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-web"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-store",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-wiki"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-workstream"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.18.0"
+version = "1.19.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"
@@ -26,15 +26,15 @@ authors = ["Fabio Akita <boss@akitaonrails.com>"]
 
 [workspace.dependencies]
 # Inter-crate dependencies.
-ai-memory-core = { path = "crates/ai-memory-core", version = "1.18.0" }
-ai-memory-store = { path = "crates/ai-memory-store", version = "1.18.0" }
-ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.18.0" }
-ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.18.0" }
-ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.18.0" }
-ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.18.0" }
-ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.18.0" }
-ai-memory-web = { path = "crates/ai-memory-web", version = "1.18.0" }
-ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.18.0" }
+ai-memory-core = { path = "crates/ai-memory-core", version = "1.19.0" }
+ai-memory-store = { path = "crates/ai-memory-store", version = "1.19.0" }
+ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.19.0" }
+ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.19.0" }
+ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.19.0" }
+ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.19.0" }
+ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.19.0" }
+ai-memory-web = { path = "crates/ai-memory-web", version = "1.19.0" }
+ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.19.0" }
 
 # (Workspace shared deps follow below)
 


### PR DESCRIPTION
## Summary

- bump the workspace and intra-crate versions to 1.19.0
- publish the accumulated managed-workstream, Grok, session-aware MCP, scope, and documentation changes in the changelog
- attribute every user-visible release note to its originating PR

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo deny check`
- `cargo audit`
- pre-release homeserver deploy and authenticated MCP/status smoke tests

The local release tag is intentionally not pushed; after this PR merges, `v1.19.0` will be placed on the merge commit, matching the established release process.