### PR TITLE
fix(cli): honor .ai-memory.toml scope in every client command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolved into `default` — the same repository split across two scopes, with
   `ai-memory run`'s managed workstream stranded on the wrong side. Each field
   still prefers an explicit flag; when the marker decides one, the command
-  announces the resolved scope on stderr. `AI_MEMORY_IGNORE_MARKER=1` restores
-  the previous resolution for one invocation. `ai-memory serve` is unchanged:
+  announces the resolved scope on stderr, naming which half the marker
+  decided. `AI_MEMORY_IGNORE_MARKER=1` restores the previous resolution for
+  one invocation (client commands only — the hooks keep reading the marker).
+  `embed --force` without `--project` still fans out across the workspace and
+  no longer needs a derivable project name. `ai-memory serve` is unchanged:
   it has no caller cwd, and its `--workspace` / `--project` remain the baked
   fallback for hook events without a usable one.
 
@@ -32,7 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `workstreams` and `managed_runs` the cascade removes plus the
   `raw/workstreams/<id>/` directories left orphaned on disk — counters that
   previously showed `0 pages, 0 sessions, …` and made such a scope look safe
-  to delete.
+  to delete. Liveness is the lease, not the row state: a crashed wrapper
+  leaves `state = 'active'` behind until the next `ai-memory run` sweeps it,
+  so only a lease that has not yet expired blocks the purge. `move-project`'s
+  copy-purge merge surfaces the same conflict as a `409` naming how many
+  pages were already copied, instead of a `500`.
 
 ## [1.19.0] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Client CLI commands now resolve their `(workspace, project)` from the
+  nearest `.ai-memory.toml` marker, not just the lifecycle hooks. Previously
+  only the hook path read the marker, so a checkout declaring
+  `workspace = "acme"` had its captures land in `acme` while `run`,
+  `bootstrap`, `search`, `write-page` and every other scope-taking command
+  resolved into `default` — the same repository split across two scopes, with
+  `ai-memory run`'s managed workstream stranded on the wrong side. Each field
+  still prefers an explicit flag; when the marker decides one, the command
+  announces the resolved scope on stderr. `AI_MEMORY_IGNORE_MARKER=1` restores
+  the previous resolution for one invocation. `ai-memory serve` is unchanged:
+  it has no caller cwd, and its `--workspace` / `--project` remain the baked
+  fallback for hook events without a usable one.
+
+### Fixed
+- `purge-project` no longer deletes a project out from under a running agent.
+  `workstreams` cascades from `projects` and `managed_runs` cascades from
+  `workstreams`, so purging a scope that still held a live managed run tore
+  out its lease row: the wrapper then failed every heartbeat with
+  `409 managed run lease is not active` and the session's transcript never
+  reached the ledger. The purge now refuses with a `409` naming the offending
+  workstreams unless `--force` is passed, and its report counts the
+  `workstreams` and `managed_runs` the cascade removes plus the
+  `raw/workstreams/<id>/` directories left orphaned on disk — counters that
+  previously showed `0 pages, 0 sessions, …` and made such a scope look safe
+  to delete.
+
 ## [1.19.0] - 2026-07-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `embed --force` without `--project` still fans out across the workspace and
   no longer needs a derivable project name. `ai-memory serve` is unchanged:
   it has no caller cwd, and its `--workspace` / `--project` remain the baked
-  fallback for hook events without a usable one.
+  fallback for hook events without a usable one. (#259)
 
 ### Fixed
 - `purge-project` no longer deletes a project out from under a running agent.
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   leaves `state = 'active'` behind until the next `ai-memory run` sweeps it,
   so only a lease that has not yet expired blocks the purge. `move-project`'s
   copy-purge merge surfaces the same conflict as a `409` naming how many
-  pages were already copied, instead of a `500`.
+  pages were already copied, instead of a `500`. (#259)
 
 ## [1.19.0] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no longer needs a derivable project name. `ai-memory serve` is unchanged:
   it has no caller cwd, and its `--workspace` / `--project` remain the baked
   fallback for hook events without a usable one. (#259)
+- Marker discovery now stays inside its trust boundary when the caller's cwd
+  is outside `$HOME`: it walks no higher than the nearest checkout root, or
+  checks only cwd for a non-git directory. Workspace-only markers also keep
+  the hooks' documented `project = basename(cwd)` behavior for CLI commands,
+  including subdirectories and linked worktrees. (#259)
 
 ### Fixed
 - `purge-project` no longer deletes a project out from under a running agent.
@@ -32,14 +37,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `409 managed run lease is not active` and the session's transcript never
   reached the ledger. The purge now refuses with a `409` naming the offending
   workstreams unless `--force` is passed, and its report counts the
-  `workstreams` and `managed_runs` the cascade removes plus the
-  `raw/workstreams/<id>/` directories left orphaned on disk — counters that
-  previously showed `0 pages, 0 sessions, …` and made such a scope look safe
-  to delete. Liveness is the lease, not the row state: a crashed wrapper
-  leaves `state = 'active'` behind until the next `ai-memory run` sweeps it,
-  so only a lease that has not yet expired blocks the purge. `move-project`'s
+  `workstreams` and `managed_runs` the cascade removes; their
+  `raw/workstreams/<id>/` directories are now removed server-side and included
+  in the same filesystem success/failure report instead of being orphaned.
+  Those counters previously showed `0 pages, 0 sessions, …` and made such a
+  scope look safe to delete. Liveness is the lease, not the row state: a
+  crashed wrapper leaves `state = 'active'` behind until the next
+  `ai-memory run` sweeps it, so only a lease that has not yet expired blocks
+  the purge. `move-project`'s
   copy-purge merge surfaces the same conflict as a `409` naming how many
-  pages were already copied, instead of a `500`. (#259)
+  pages were already copied, instead of a `500`; its `--force` flag only
+  overrides the active-project guard and never destroys a live managed-run
+  lease. (#259)
 
 ## [1.19.0] - 2026-07-25
 

--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -489,6 +489,32 @@ else
   DATA_ARGS+=(-v "${DATA_VOLUME}:/data")
 fi
 
+# `AI_MEMORY_HOST_CWD` keeps project identity stable inside the helper, while
+# `AI_MEMORY_SCOPE_CWD` names the same directory inside a bounded read-only
+# mount used for marker discovery. $HOME is already mounted below. For
+# checkouts outside it, expose no more than the nearest git root (or the exact
+# cwd outside git), matching the marker walk's trust bound.
+SCOPE_ARGS=()
+case "${PWD}" in
+  "${HOME}"|"${HOME}"/*) ;;
+  *)
+    SCOPE_ROOT="${PWD}"
+    if command -v git >/dev/null 2>&1; then
+      DETECTED_SCOPE_ROOT=$(git -C "${PWD}" rev-parse --show-toplevel 2>/dev/null || true)
+      [ -n "${DETECTED_SCOPE_ROOT}" ] && SCOPE_ROOT="${DETECTED_SCOPE_ROOT}"
+    fi
+    case "${PWD}" in
+      "${SCOPE_ROOT}") SCOPE_REL="" ;;
+      "${SCOPE_ROOT}"/*) SCOPE_REL="${PWD#"${SCOPE_ROOT}"}" ;;
+      *) SCOPE_ROOT="${PWD}"; SCOPE_REL="" ;;
+    esac
+    SCOPE_ARGS+=(
+      -v "${SCOPE_ROOT}:/scope:ro"
+      -e "AI_MEMORY_SCOPE_CWD=/scope${SCOPE_REL}"
+    )
+    ;;
+esac
+
 # Mount $HOME at the same path inside the container so:
 #   - dirs::home_dir() resolves identically (Claude's default paths and any
 #     CLAUDE_CONFIG_DIR beneath $HOME work without extra path flags)
@@ -522,6 +548,7 @@ HELPER_ARGS+=(
   -e HOME="${HOME}"
   -e AI_MEMORY_HOST_CWD="${PWD}"
 )
+HELPER_ARGS+=(${SCOPE_ARGS[@]+"${SCOPE_ARGS[@]}"})
 HELPER_ARGS+=(${USER_ARGS[@]+"${USER_ARGS[@]}"})
 HELPER_ARGS+=("${DATA_ARGS[@]}")
 HELPER_ARGS+=(${ENV_ARGS[@]+"${ENV_ARGS[@]}"})

--- a/bin/ai-memory.ps1
+++ b/bin/ai-memory.ps1
@@ -44,6 +44,40 @@ $HomePath = (Resolve-Path -LiteralPath $HOME).Path
 $WorkPath = (Get-Location).Path
 $HookHostRoot = ($HomePath -replace '\\', '/') + "/.local/share/ai-memory/hooks"
 
+$HomeRoot = $HomePath.TrimEnd([char[]]@('/', '\\'))
+$HomePrefix = $HomeRoot + [IO.Path]::DirectorySeparatorChar
+$InsideHome = $WorkPath.Equals($HomeRoot, [StringComparison]::OrdinalIgnoreCase) -or
+    $WorkPath.StartsWith($HomePrefix, [StringComparison]::OrdinalIgnoreCase)
+$ScopeMountArgs = @()
+if ($InsideHome) {
+    $ScopeSuffix = if ($WorkPath.Length -eq $HomeRoot.Length) {
+        ""
+    } else {
+        $WorkPath.Substring($HomeRoot.Length) -replace '\\', '/'
+    }
+    $ScopeCwd = "/host-home$ScopeSuffix"
+} else {
+    $ScopeRoot = $WorkPath
+    if (Get-Command git -ErrorAction SilentlyContinue) {
+        $DetectedScopeRoot = (& git -C $WorkPath rev-parse --show-toplevel 2>$null)
+        if (-not [string]::IsNullOrWhiteSpace($DetectedScopeRoot)) {
+            $ScopeRoot = [IO.Path]::GetFullPath($DetectedScopeRoot.Trim())
+        }
+    }
+    $ScopeRoot = $ScopeRoot.TrimEnd([char[]]@('/', '\\'))
+    $ScopePrefix = $ScopeRoot + [IO.Path]::DirectorySeparatorChar
+    if ($WorkPath.Equals($ScopeRoot, [StringComparison]::OrdinalIgnoreCase)) {
+        $ScopeSuffix = ""
+    } elseif ($WorkPath.StartsWith($ScopePrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        $ScopeSuffix = $WorkPath.Substring($ScopeRoot.Length) -replace '\\', '/'
+    } else {
+        $ScopeRoot = $WorkPath
+        $ScopeSuffix = ""
+    }
+    $ScopeMountArgs = @("-v", "${ScopeRoot}:/scope:ro")
+    $ScopeCwd = "/scope$ScopeSuffix"
+}
+
 $DockerArgs = @("run", "--rm", "-i")
 # Keep stdin attached in every mode. `AI_MEMORY_NO_TTY` suppresses only the
 # pseudo-terminal allocation.
@@ -57,10 +91,12 @@ $DockerArgs += @(
     "-w", "/work",
     "-e", "HOME=/host-home",
     "-e", "AI_MEMORY_HOST_CWD=$WorkPath",
+    "-e", "AI_MEMORY_SCOPE_CWD=$ScopeCwd",
     "-e", "AI_MEMORY_DATA_DIR=/data",
     "-e", "AI_MEMORY_HOOK_PLATFORM=windows",
     "-e", "AI_MEMORY_HOOKS_HOST_ROOT=$HookHostRoot"
 )
+$DockerArgs += $ScopeMountArgs
 
 if ($env:AI_MEMORY_DATA_DIR -and (Test-Path -LiteralPath $env:AI_MEMORY_DATA_DIR -PathType Container)) {
     $DataPath = (Resolve-Path -LiteralPath $env:AI_MEMORY_DATA_DIR).Path

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -636,8 +636,9 @@ pub struct BootstrapArgs {
     /// any subdir of the project works).
     #[arg(long)]
     pub repo_path: Option<PathBuf>,
-    /// Workspace name. Defaults to `default` (the single workspace
-    /// all hook-captured sessions land in today).
+    /// Workspace name. Defaults to the nearest `.ai-memory.toml` marker's
+    /// `workspace`, else `default` — the same resolution the lifecycle hooks
+    /// use, so bootstrap pages land where the session captures do.
     #[arg(long)]
     pub workspace: Option<String>,
     /// Project name. When omitted, auto-derived from the basename of
@@ -820,9 +821,10 @@ pub struct DeletePageArgs {
     /// Exact wiki path to delete (e.g. `notes/foo.md`).
     #[arg(long)]
     pub path: String,
-    /// Workspace name. Defaults to `default`. Required (no auto-detect) so
-    /// a cross-workspace project-name collision can never silently route
-    /// the delete to the wrong slot.
+    /// Workspace name. Defaults to the nearest `.ai-memory.toml` marker's
+    /// `workspace`, else `default`. Resolution is announced on stderr so a
+    /// cross-workspace project-name collision can never silently route the
+    /// delete to the wrong slot.
     #[arg(long)]
     pub workspace: Option<String>,
     /// Project name. When omitted, auto-derived from the current project

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -174,9 +174,10 @@ pub enum Command {
 #[derive(Debug, Args)]
 #[command(trailing_var_arg = true)]
 pub struct RunArgs {
-    /// Workspace containing the managed workstream.
-    #[arg(long, default_value = "default")]
-    pub workspace: String,
+    /// Workspace containing the managed workstream. Defaults to the nearest
+    /// `.ai-memory.toml` marker's `workspace`, else `default`.
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Project override. Defaults to the current repository project.
     #[arg(long)]
     pub project: Option<String>,
@@ -469,9 +470,15 @@ pub struct ReorgArgs {
 /// Arguments for `purge-project`.
 #[derive(Debug, Args)]
 pub struct PurgeProjectArgs {
-    /// Workspace name. Defaults to `default`.
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    /// Purge even when a managed workstream under this project still holds a
+    /// live run lease. Workstreams cascade out of the project row, so without
+    /// this the purge refuses rather than deleting a running session's lease.
+    #[arg(long)]
+    pub force: bool,
+    /// Workspace name. Defaults to the nearest `.ai-memory.toml` marker's
+    /// `workspace`, else `default`.
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Project name. When omitted, auto-derived from the basename of
     /// the current git repo root (or CWD if no git repo).
     #[arg(long)]
@@ -485,9 +492,10 @@ pub struct PurgeProjectArgs {
 /// Arguments for `rename-project`.
 #[derive(Debug, Args)]
 pub struct RenameProjectArgs {
-    /// Workspace name. Defaults to `default`.
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    /// Workspace name. Defaults to the nearest `.ai-memory.toml` marker's
+    /// `workspace`, else `default`.
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Current project name. When omitted, auto-derives from the
     /// basename of the current git repo root (or CWD) — handy when
     /// running `ai-memory rename-project --to new-name` from a dir
@@ -503,9 +511,11 @@ pub struct RenameProjectArgs {
 /// Arguments for `move-project`.
 #[derive(Debug, Args)]
 pub struct MoveProjectArgs {
-    /// Source workspace. Defaults to `default`.
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub from_workspace: String,
+    /// Source workspace. Defaults to the nearest `.ai-memory.toml` marker's
+    /// `workspace`, else `default`. Only the source is marker-resolved;
+    /// `--to-workspace` names the destination and stays literal.
+    #[arg(long)]
+    pub from_workspace: Option<String>,
     /// Project name to move. When omitted, auto-derived from the basename
     /// of the current git repo root (or CWD if no git repo).
     #[arg(long)]
@@ -628,8 +638,8 @@ pub struct BootstrapArgs {
     pub repo_path: Option<PathBuf>,
     /// Workspace name. Defaults to `default` (the single workspace
     /// all hook-captured sessions land in today).
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Project name. When omitted, auto-derived from the basename of
     /// the resolved repo path — same heuristic the hook router uses
     /// to bucket per-cwd observations, so the bootstrap pages land
@@ -768,9 +778,10 @@ pub struct AuditContaminationArgs {
 pub struct SearchArgs {
     /// FTS5 query string (e.g. `"karpathy wiki"` or `quick OR slow`).
     pub query: String,
-    /// Workspace name. Defaults to `default`.
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    /// Workspace name. Defaults to the nearest `.ai-memory.toml` marker's
+    /// `workspace`, else `default`.
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Project name. When omitted, auto-derived from the current project.
     #[arg(long)]
     pub project: Option<String>,
@@ -791,9 +802,10 @@ pub struct ReadPageArgs {
     /// Exact wiki path (e.g. `notes/foo.md`). Takes precedence over `query`.
     #[arg(long)]
     pub path: Option<String>,
-    /// Workspace name. Defaults to `default`.
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    /// Workspace name. Defaults to the nearest `.ai-memory.toml` marker's
+    /// `workspace`, else `default`.
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Project name. When omitted, auto-derived from the current project.
     #[arg(long)]
     pub project: Option<String>,
@@ -811,8 +823,8 @@ pub struct DeletePageArgs {
     /// Workspace name. Defaults to `default`. Required (no auto-detect) so
     /// a cross-workspace project-name collision can never silently route
     /// the delete to the wrong slot.
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Project name. When omitted, auto-derived from the current project
     /// (same heuristic write-page/read-page use).
     #[arg(long)]
@@ -866,9 +878,10 @@ pub struct RestorePageArgs {
     /// Git checkpoint/revision to restore from.
     #[arg(long)]
     pub from: String,
-    /// Workspace name. Defaults to `default`.
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    /// Workspace name. Defaults to the nearest `.ai-memory.toml` marker's
+    /// `workspace`, else `default`.
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Project name. When omitted, auto-derived from the current project.
     #[arg(long)]
     pub project: Option<String>,
@@ -991,9 +1004,10 @@ pub struct FinalizeSessionArgs {
     /// true SessionEnd hook.
     #[arg(long, value_enum, default_value_t = AgentChoice::Codex)]
     pub agent: AgentChoice,
-    /// Workspace name. Defaults to `default`.
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    /// Workspace name. Defaults to the nearest `.ai-memory.toml` marker's
+    /// `workspace`, else `default`.
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Project name. When omitted, auto-derived from the current project.
     #[arg(long)]
     pub project: Option<String>,
@@ -1108,8 +1122,8 @@ pub struct EmbedArgs {
     #[arg(long)]
     pub force: bool,
     /// Workspace name (auto-created if absent).
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Project name. When omitted, auto-derived from the basename of
     /// the current git repo root (or CWD if no git repo). Matches the
     /// hook router's per-cwd convention so this command targets the
@@ -1125,8 +1139,8 @@ pub struct ForgetSweepArgs {
     #[arg(long)]
     pub dry_run: bool,
     /// Workspace name (auto-created if absent).
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Project name. When omitted, auto-derived from the basename of
     /// the current git repo root (or CWD if no git repo).
     #[arg(long)]
@@ -1145,8 +1159,8 @@ pub struct LintArgs {
     #[arg(long)]
     pub no_llm: bool,
     /// Workspace name (auto-created if absent).
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Project name. When omitted, auto-derived from the basename of
     /// the current git repo root (or CWD if no git repo).
     #[arg(long)]
@@ -1162,9 +1176,10 @@ pub struct CuratorArgs {
     /// Stage one pending curator report page for approval.
     #[arg(long)]
     pub stage: bool,
-    /// Workspace name. Defaults to `default`.
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    /// Workspace name. Defaults to the nearest `.ai-memory.toml` marker's
+    /// `workspace`, else `default`.
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Project name. When omitted, auto-derived from the basename of
     /// the current git repo root (or CWD if no git repo).
     #[arg(long)]
@@ -1177,9 +1192,10 @@ pub struct CuratorArgs {
 /// Arguments for `auto-improve-report`.
 #[derive(Debug, Args)]
 pub struct AutoImproveReportArgs {
-    /// Workspace name. Defaults to `default`.
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    /// Workspace name. Defaults to the nearest `.ai-memory.toml` marker's
+    /// `workspace`, else `default`.
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Project name. When omitted, auto-derived from the basename of
     /// the current git repo root (or CWD if no git repo).
     #[arg(long)]
@@ -1204,9 +1220,10 @@ pub struct AutoImproveArgs {
     /// Completed session UUID to review.
     #[arg(long)]
     pub session_id: String,
-    /// Workspace name. Defaults to `default`.
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    /// Workspace name. Defaults to the nearest `.ai-memory.toml` marker's
+    /// `workspace`, else `default`.
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Project name. When omitted, auto-derived from the basename of
     /// the current git repo root (or CWD if no git repo).
     #[arg(long)]
@@ -1251,8 +1268,8 @@ pub enum PendingWritesCommand {
 
 #[derive(Debug, Args)]
 pub struct PendingWritesListArgs {
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    #[arg(long)]
+    pub workspace: Option<String>,
     #[arg(long)]
     pub project: Option<String>,
     #[arg(long)]
@@ -1266,8 +1283,8 @@ pub struct PendingWritesListArgs {
 #[derive(Debug, Args)]
 pub struct PendingWriteIdArgs {
     pub id: String,
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    #[arg(long)]
+    pub workspace: Option<String>,
     #[arg(long)]
     pub project: Option<String>,
     #[arg(long)]
@@ -1277,8 +1294,8 @@ pub struct PendingWriteIdArgs {
 #[derive(Debug, Args)]
 pub struct PendingWriteRejectArgs {
     pub id: String,
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    #[arg(long)]
+    pub workspace: Option<String>,
     #[arg(long)]
     pub project: Option<String>,
     #[arg(long, default_value = "rejected by reviewer")]
@@ -1515,6 +1532,10 @@ pub struct ServeArgs {
     #[arg(long)]
     pub no_watcher: bool,
     /// Workspace name (auto-created).
+    ///
+    /// Not marker-aware, unlike the client commands: the server has no
+    /// caller cwd to walk up from, and this is the baked fallback for hook
+    /// events that arrive without a usable one.
     #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
     pub workspace: String,
     /// Project name within the workspace (auto-created).
@@ -1595,8 +1616,8 @@ pub struct WritePageArgs {
     #[arg(long)]
     pub pinned: bool,
     /// Workspace name (auto-created if absent).
-    #[arg(long, default_value_t = crate::config::DEFAULT_WORKSPACE.to_string())]
-    pub workspace: String,
+    #[arg(long)]
+    pub workspace: Option<String>,
     /// Project name within the workspace. When omitted, auto-detect from the
     /// current project using the same resolver as read-page/search.
     #[arg(long)]

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -527,10 +527,9 @@ pub struct MoveProjectArgs {
     /// source, both irreversible. Without this flag the CLI errors out.
     #[arg(long)]
     pub confirm: bool,
-    /// Override the live-session guard. By default the server refuses (409) to
-    /// move the project a hook session is actively writing to; `--force`
-    /// proceeds anyway (still safe — the move keeps the active pointer correct
-    /// and the schema rejects any stale write).
+    /// Override the active-project guard. In a copy-purge merge this never
+    /// overrides a live managed-workstream lease, because deleting that lease
+    /// would strand the running agent's transcript.
     #[arg(long)]
     pub force: bool,
     /// Merge conflict policy (copy-purge path only): what to do when a source

--- a/crates/ai-memory-cli/src/commands/auto_improve.rs
+++ b/crates/ai-memory-cli/src/commands/auto_improve.rs
@@ -61,10 +61,11 @@ struct ProposalOutcome {
 /// Returns an error if the server is unreachable or rejects the review request.
 pub async fn run(config: &Config, args: AutoImproveArgs) -> Result<()> {
     let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
     let settings = &config.auto_improve;
     let request = AutoImproveRequest {
-        workspace: args.workspace,
+        workspace,
         project: project.clone(),
         session_id: args.session_id,
         min_observations: args.min_observations.unwrap_or(settings.min_observations),

--- a/crates/ai-memory-cli/src/commands/auto_improve_report.rs
+++ b/crates/ai-memory-cli/src/commands/auto_improve_report.rs
@@ -31,9 +31,10 @@ struct AutoImproveReportStageResponse {
 /// Returns an error if the server is unreachable or rejects the read-only report request.
 pub async fn run(config: &Config, args: AutoImproveReportArgs) -> Result<()> {
     let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
     let request = AutoImproveReportRequest {
-        workspace: args.workspace,
+        workspace,
         project: project.clone(),
         since_days: args.days,
         limit: args.limit,

--- a/crates/ai-memory-cli/src/commands/bootstrap.rs
+++ b/crates/ai-memory-cli/src/commands/bootstrap.rs
@@ -73,8 +73,9 @@ pub async fn run(config: &Config, args: BootstrapArgs) -> Result<()> {
     }
 
     // ---- project — auto-derive from repo basename if absent -------
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
-    info!(workspace = %args.workspace, project = %project, repo_path = %repo_path.display(), git = has_git, "bootstrap target");
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
+    info!(workspace = %workspace, project = %project, repo_path = %repo_path.display(), git = has_git, "bootstrap target");
 
     // ---- collect sources locally ----------------------------------
     let sources = collect_sources(
@@ -122,7 +123,7 @@ pub async fn run(config: &Config, args: BootstrapArgs) -> Result<()> {
             args.max_input_tokens,
             args.chunk_input_tokens,
         );
-        print_human_report(&outcome, &args.workspace, &project);
+        print_human_report(&outcome, &workspace, &project);
         let report = serde_json::to_string_pretty(&outcome)?;
         println!("\n--- machine-readable ---\n{report}");
         return Ok(());
@@ -130,7 +131,7 @@ pub async fn run(config: &Config, args: BootstrapArgs) -> Result<()> {
 
     // ---- POST to server -------------------------------------------
     let body = serde_json::json!({
-        "workspace": args.workspace,
+        "workspace": workspace,
         "project": project,
         "sources": sources,
         "sources_collected": collected,
@@ -141,7 +142,7 @@ pub async fn run(config: &Config, args: BootstrapArgs) -> Result<()> {
     });
     let outcome: BootstrapOutcome = post_json(&ep, "/admin/bootstrap", &body).await?;
 
-    print_human_report(&outcome, &args.workspace, &project);
+    print_human_report(&outcome, &workspace, &project);
     let report = serde_json::to_string_pretty(&outcome)?;
     println!("\n--- machine-readable ---\n{report}");
     Ok(())

--- a/crates/ai-memory-cli/src/commands/curator.rs
+++ b/crates/ai-memory-cli/src/commands/curator.rs
@@ -35,9 +35,10 @@ pub async fn run(config: &Config, args: CuratorArgs) -> Result<()> {
     }
     let dry_run = args.dry_run || !args.stage;
     let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
     let request = CuratorRequest {
-        workspace: args.workspace,
+        workspace,
         project: project.clone(),
         dry_run,
         stage: args.stage,

--- a/crates/ai-memory-cli/src/commands/delete_page.rs
+++ b/crates/ai-memory-cli/src/commands/delete_page.rs
@@ -37,14 +37,15 @@ pub async fn run(config: &Config, args: DeletePageArgs) -> Result<()> {
     // Resolve the project the same way write-page/read-page do: explicit
     // flag wins, otherwise derive the current project from host cwd / repo
     // root. Keeps delete + read-back pairs targeting the same project.
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
 
     let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
     let resp: DeletePageResponseBody = post_json(
         &endpoint,
         "/admin/delete-page",
         &DeletePageBody {
-            workspace: args.workspace.clone(),
+            workspace: workspace.clone(),
             project: project.clone(),
             path: args.path.clone(),
         },
@@ -53,9 +54,6 @@ pub async fn run(config: &Config, args: DeletePageArgs) -> Result<()> {
     .context("deleting page via server")?;
 
     let status = if resp.deleted { "✓ deleted" } else { "no-op" };
-    println!(
-        "{} {} under {}/{}",
-        status, resp.path, args.workspace, project
-    );
+    println!("{} {} under {}/{}", status, resp.path, workspace, project);
     Ok(())
 }

--- a/crates/ai-memory-cli/src/commands/embed.rs
+++ b/crates/ai-memory-cli/src/commands/embed.rs
@@ -32,14 +32,18 @@ pub async fn run(config: &Config, args: EmbedArgs) -> Result<()> {
     // Without an explicit `--project`, `--force` / `--reembed` fans out
     // across the whole workspace instead of the CWD-derived project only.
     let all_projects = args.force && args.project.is_none();
-    // Resolve the scope even in the fan-out case: `--force` without
-    // `--project` still targets one workspace, and the marker decides which.
-    let (workspace, resolved_project) =
-        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
-    let project = if all_projects {
-        String::new()
+    // The fan-out still targets one workspace, and the marker decides which —
+    // but only the workspace half is resolved there. Resolving the pair would
+    // make `--force` fail on a cwd whose project name cannot be derived (the
+    // stale-docker-wrapper bail, or a non-repo dir) for a name it then throws
+    // away, and would announce a project the request never carries.
+    let (workspace, project) = if all_projects {
+        (
+            super::resolve_workspace(config, args.workspace.as_deref()),
+            String::new(),
+        )
     } else {
-        resolved_project
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?
     };
     let report: serde_json::Value = post_json(
         &endpoint,

--- a/crates/ai-memory-cli/src/commands/embed.rs
+++ b/crates/ai-memory-cli/src/commands/embed.rs
@@ -32,16 +32,20 @@ pub async fn run(config: &Config, args: EmbedArgs) -> Result<()> {
     // Without an explicit `--project`, `--force` / `--reembed` fans out
     // across the whole workspace instead of the CWD-derived project only.
     let all_projects = args.force && args.project.is_none();
+    // Resolve the scope even in the fan-out case: `--force` without
+    // `--project` still targets one workspace, and the marker decides which.
+    let (workspace, resolved_project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
     let project = if all_projects {
         String::new()
     } else {
-        super::resolve_project_name(config, args.project.as_deref())?
+        resolved_project
     };
     let report: serde_json::Value = post_json(
         &endpoint,
         "/admin/embed",
         &EmbedRequest {
-            workspace: args.workspace,
+            workspace,
             project,
             // The CLI flag was historically named `force`; the server
             // field is `reembed` — map them here.

--- a/crates/ai-memory-cli/src/commands/finalize_session.rs
+++ b/crates/ai-memory-cli/src/commands/finalize_session.rs
@@ -53,12 +53,12 @@ struct FinalizeSessionReport {
 /// sessions or rejects a synthetic `session-end` hook.
 pub async fn run(config: &Config, args: FinalizeSessionArgs) -> Result<()> {
     let agent = args.agent.kind();
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
     let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
-    let sessions =
-        fetch_open_sessions(&endpoint, &args.workspace, &project, agent, args.all).await?;
+    let sessions = fetch_open_sessions(&endpoint, &workspace, &project, agent, args.all).await?;
     if sessions.is_empty() {
-        return print_report(args, project, agent, Vec::new());
+        return print_report(args, workspace, project, agent, Vec::new());
     }
 
     let client = reqwest::Client::new();
@@ -70,7 +70,7 @@ pub async fn run(config: &Config, args: FinalizeSessionArgs) -> Result<()> {
             &endpoint,
             session,
             fallback_cwd.as_str(),
-            &args.workspace,
+            &workspace,
             &project,
             agent,
         )
@@ -78,7 +78,7 @@ pub async fn run(config: &Config, args: FinalizeSessionArgs) -> Result<()> {
         finalized.push(session.session_id.clone());
     }
 
-    print_report(args, project, agent, finalized)
+    print_report(args, workspace, project, agent, finalized)
 }
 
 /// List open sessions for the scope + agent via the server. An unknown
@@ -119,12 +119,13 @@ async fn fetch_open_sessions(
 
 fn print_report(
     args: FinalizeSessionArgs,
+    workspace: String,
     project: String,
     agent: AgentKind,
     finalized: Vec<String>,
 ) -> Result<()> {
     let report = FinalizeSessionReport {
-        workspace: args.workspace,
+        workspace,
         project,
         agent: agent.as_str().to_string(),
         finalized,

--- a/crates/ai-memory-cli/src/commands/forget_sweep.rs
+++ b/crates/ai-memory-cli/src/commands/forget_sweep.rs
@@ -25,12 +25,13 @@ struct ForgetSweepRequest {
 /// response.
 pub async fn run(config: &Config, args: ForgetSweepArgs) -> Result<()> {
     let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
     let report: serde_json::Value = post_json(
         &endpoint,
         "/admin/forget-sweep",
         &ForgetSweepRequest {
-            workspace: args.workspace,
+            workspace,
             project,
             dry_run: args.dry_run,
         },

--- a/crates/ai-memory-cli/src/commands/hook_capture.rs
+++ b/crates/ai-memory-cli/src/commands/hook_capture.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::commands::path_util::home_dir;
+use crate::marker::{find_marker, is_truthy, parse_toml_flag, parse_toml_key, repo_root_project};
 use ai_memory_hooks::capture_policy::MAX_MARKER_BYTES;
 use ai_memory_hooks::{CaptureConfig, CapturePolicy, CaptureSource};
 
@@ -299,94 +300,6 @@ fn marker_query_suffix_impl(
         }
     }
     qs
-}
-
-/// Parse a root-level `key = <value>` line, accepting a quoted string
-/// (`key = "true"`) OR a bare token (`key = true` / `key = 1`), so a
-/// `[recall] default_global = true` marker works whether or not the operator
-/// quotes the value. Line-based like [`parse_toml_key`], so section headers
-/// are ignored; strips an optional trailing `# comment`.
-fn parse_toml_flag(file: &Path, key: &str) -> Option<String> {
-    let text = std::fs::read_to_string(file).ok()?;
-    for line in text.lines() {
-        let trimmed = line.trim_start();
-        let Some(after_key) = trimmed.strip_prefix(key) else {
-            continue;
-        };
-        let Some(rest) = after_key.trim_start().strip_prefix('=') else {
-            continue;
-        };
-        let val = rest
-            .split('#')
-            .next()
-            .unwrap_or("")
-            .trim()
-            .trim_matches('"');
-        if !val.is_empty() {
-            return Some(val.to_string());
-        }
-    }
-    None
-}
-
-fn is_truthy(value: &str) -> bool {
-    matches!(
-        value.trim().to_ascii_lowercase().as_str(),
-        "1" | "true" | "yes" | "on"
-    )
-}
-
-fn repo_root_project(cwd: &str) -> Option<String> {
-    let root = ai_memory_consolidate::discover_main_repo_root(Path::new(cwd)).ok()?;
-    root.file_name()
-        .and_then(|s| s.to_str())
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned)
-}
-
-/// Walk up from `cwd` toward `$HOME` (or the filesystem root) looking
-/// for `.ai-memory.toml`. Stops at `$HOME` to avoid leaking a parent
-/// user's declaration on shared machines (parity with
-/// `ai_memory_find_marker`).
-fn find_marker(cwd: &str) -> Option<PathBuf> {
-    let home = home_dir();
-    let mut dir = Path::new(cwd);
-    loop {
-        let candidate = dir.join(".ai-memory.toml");
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        if home.as_deref() == Some(dir) {
-            return None;
-        }
-        match dir.parent() {
-            Some(parent) if parent != dir => dir = parent,
-            _ => return None,
-        }
-    }
-}
-
-/// Parse a root-level `key = "value"` line (no nesting, arrays, or
-/// tables), mirroring `ai_memory_parse_toml_key`. Returns the first
-/// match. Avoids pulling in a TOML parser dependency.
-fn parse_toml_key(file: &Path, key: &str) -> Option<String> {
-    let text = std::fs::read_to_string(file).ok()?;
-    for line in text.lines() {
-        let trimmed = line.trim_start();
-        let Some(after_key) = trimmed.strip_prefix(key) else {
-            continue;
-        };
-        let Some(rest) = after_key.trim_start().strip_prefix('=') else {
-            continue;
-        };
-        let Some(rest) = rest.trim_start().strip_prefix('"') else {
-            continue;
-        };
-        if let Some(end) = rest.find('"') {
-            return Some(rest[..end].to_string());
-        }
-    }
-    None
 }
 
 /// Build a reqwest client for the hook's one-shot requests. `no_proxy`
@@ -716,69 +629,9 @@ mod tests {
         assert!(got.is_none(), "non-2xx body must not become context");
     }
 
-    /// Happy-path TOML parser: extracts each declared root-level
-    /// `key = "value"` pair. Mirrors the shell `ai_memory_parse_toml_key`.
-    #[test]
-    fn parse_toml_key_extracts_root_level_strings() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let marker = tmp.path().join(".ai-memory.toml");
-        std::fs::write(
-            &marker,
-            r#"
-workspace = "acme"
-project = "infra"
-project_strategy = "repo-root"
-"#,
-        )
-        .unwrap();
-        assert_eq!(
-            parse_toml_key(&marker, "workspace").as_deref(),
-            Some("acme")
-        );
-        assert_eq!(parse_toml_key(&marker, "project").as_deref(), Some("infra"));
-        assert_eq!(
-            parse_toml_key(&marker, "project_strategy").as_deref(),
-            Some("repo-root")
-        );
-        assert_eq!(parse_toml_key(&marker, "absent"), None);
-    }
-
-    /// Shapes the naive parser deliberately doesn't handle (parity with
-    /// the shell `_lib.sh` helper) — pin the contract so a future
-    /// "robustify" refactor doesn't silently start matching them.
-    #[test]
-    fn parse_toml_key_skips_unsupported_shapes() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let marker = tmp.path().join(".ai-memory.toml");
-        std::fs::write(
-            &marker,
-            r#"
-# Single-quoted values are not honoured.
-workspace = 'acme'
-# Comments after the value are not stripped.
-project = "infra" # this is fine
-"#,
-        )
-        .unwrap();
-        assert_eq!(parse_toml_key(&marker, "workspace"), None);
-        // The trailing comment is appended to the value because the parser
-        // looks for the first `"` — pin it so the contract is explicit.
-        assert_eq!(parse_toml_key(&marker, "project").as_deref(), Some("infra"));
-    }
-
-    /// `find_marker` walks up from `cwd` until it finds `.ai-memory.toml`
-    /// or reaches `$HOME`. Verify the walking — drop the marker two dirs
-    /// above the simulated cwd and confirm it's found.
-    #[test]
-    fn find_marker_walks_up_from_cwd() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let marker = tmp.path().join(".ai-memory.toml");
-        std::fs::write(&marker, "workspace = \"w\"\n").unwrap();
-        let deep = tmp.path().join("a/b/c");
-        std::fs::create_dir_all(&deep).unwrap();
-        let found = find_marker(deep.to_str().unwrap());
-        assert_eq!(found.as_deref(), Some(marker.as_path()));
-    }
+    // The marker parser's own tests (`parse_toml_key`, `find_marker`) moved to
+    // `crate::marker` along with the code. What stays here is hook-specific:
+    // the strict `[capture]` section and the query-string suffix.
 
     #[test]
     fn capture_section_is_strict_and_marker_read_is_bounded() {

--- a/crates/ai-memory-cli/src/commands/hook_capture.rs
+++ b/crates/ai-memory-cli/src/commands/hook_capture.rs
@@ -822,13 +822,13 @@ drop_subagent_captures = "true"
     #[test]
     fn marker_query_suffix_repo_root_non_git_keeps_project_implicit() {
         let tmp = tempfile::TempDir::new().unwrap();
+        let child = tmp.path().join("plain-dir");
+        std::fs::create_dir_all(&child).unwrap();
         std::fs::write(
-            tmp.path().join(".ai-memory.toml"),
+            child.join(".ai-memory.toml"),
             "workspace = \"oss\"\nproject_strategy = \"repo-root\"\n",
         )
         .unwrap();
-        let child = tmp.path().join("plain-dir");
-        std::fs::create_dir_all(&child).unwrap();
         let qs = marker_query_suffix(child.to_str().unwrap(), None);
         assert!(qs.contains("&workspace=oss"), "{qs}");
         assert!(!qs.contains("&project="), "{qs}");
@@ -877,11 +877,6 @@ drop_subagent_captures = "true"
 
         let worktrees = tmp.path().join("worktrees");
         std::fs::create_dir_all(&worktrees).unwrap();
-        std::fs::write(
-            worktrees.join(".ai-memory.toml"),
-            "workspace = \"oss\"\nproject_strategy = \"repo-root\"\n",
-        )
-        .unwrap();
         let wt = worktrees.join("acme-api/wt-feature");
         std::fs::create_dir_all(wt.parent().unwrap()).unwrap();
         if !std::process::Command::new("git")
@@ -895,6 +890,11 @@ drop_subagent_captures = "true"
         {
             return;
         }
+        std::fs::write(
+            wt.join(".ai-memory.toml"),
+            "workspace = \"oss\"\nproject_strategy = \"repo-root\"\n",
+        )
+        .unwrap();
 
         let qs = marker_query_suffix(wt.to_str().unwrap(), None);
         assert!(qs.contains("&workspace=oss"), "{qs}");

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -1776,7 +1776,7 @@ fn build_opencode_plugin(
 import type {{ Plugin }} from "@opencode-ai/plugin";
 import {{ execFileSync }} from "node:child_process";
 import {{ closeSync, existsSync, openSync, readFileSync as readMarkerText, readSync }} from "node:fs";
-import {{ basename, dirname, join, resolve }} from "node:path";
+import {{ basename, dirname, join, resolve, sep }} from "node:path";
 import {{ homedir }} from "node:os";
 
 const SERVER = {server_literal}.replace(/\/+$/, "");
@@ -1884,10 +1884,24 @@ function findMarker(cwd: string | undefined): string | undefined {{
   if (!cwd) return undefined;
   let dir = resolve(cwd);
   const home = homedir();
+  let boundary: string | undefined;
+  if (home && (dir === home || dir.startsWith(home.endsWith(sep) ? home : home + sep))) {{
+    boundary = home;
+  }} else if (home) {{
+    let probe = dir;
+    while (probe && probe !== dirname(probe)) {{
+      if (existsSync(join(probe, ".git"))) {{
+        boundary = probe;
+        break;
+      }}
+      probe = dirname(probe);
+    }}
+    boundary ??= dir;
+  }}
   while (dir && dir !== dirname(dir)) {{
     const marker = join(dir, ".ai-memory.toml");
     if (existsSync(marker)) return marker;
-    if (home && dir === home) return undefined;
+    if (boundary && dir === boundary) return undefined;
     dir = dirname(dir);
   }}
   return undefined;
@@ -2361,7 +2375,7 @@ fn build_omp_extension(
 
 import {{ execFileSync }} from "node:child_process";
 import {{ closeSync, existsSync, openSync, readFileSync as readMarkerText, readSync }} from "node:fs";
-import {{ basename, dirname, join, resolve }} from "node:path";
+import {{ basename, dirname, join, resolve, sep }} from "node:path";
 import {{ homedir }} from "node:os";
 
 const SERVER = {server_literal}.replace(/\/+$/, "");
@@ -2447,10 +2461,24 @@ function findMarker(cwd: string | undefined): string | undefined {{
   if (!cwd) return undefined;
   let dir = resolve(cwd);
   const home = homedir();
+  let boundary: string | undefined;
+  if (home && (dir === home || dir.startsWith(home.endsWith(sep) ? home : home + sep))) {{
+    boundary = home;
+  }} else if (home) {{
+    let probe = dir;
+    while (probe && probe !== dirname(probe)) {{
+      if (existsSync(join(probe, ".git"))) {{
+        boundary = probe;
+        break;
+      }}
+      probe = dirname(probe);
+    }}
+    boundary ??= dir;
+  }}
   while (dir && dir !== dirname(dir)) {{
     const marker = join(dir, ".ai-memory.toml");
     if (existsSync(marker)) return marker;
-    if (home && dir === home) return undefined;
+    if (boundary && dir === boundary) return undefined;
     dir = dirname(dir);
   }}
   return undefined;
@@ -4499,7 +4527,11 @@ model = "gpt-5"
             "OpenCode bus events must be handled through the `event` hook"
         );
         assert!(plugin.contains("import { execFileSync } from \"node:child_process\";"));
-        assert!(plugin.contains("import { basename, dirname, join, resolve } from \"node:path\";"));
+        assert!(
+            plugin.contains("import { basename, dirname, join, resolve, sep } from \"node:path\";")
+        );
+        assert!(plugin.contains("if (existsSync(join(probe, \".git\")))"));
+        assert!(plugin.contains("boundary ??= dir;"));
         assert!(plugin.contains("function repoRootProject"));
         assert!(plugin.contains("--git-common-dir"));
         assert!(
@@ -4597,8 +4629,11 @@ model = "gpt-5"
         assert!(extension.contains("Bearer ${TOKEN}"));
         assert!(extension.contains("tok"));
         assert!(
-            extension.contains("import { basename, dirname, join, resolve } from \"node:path\";")
+            extension
+                .contains("import { basename, dirname, join, resolve, sep } from \"node:path\";")
         );
+        assert!(extension.contains("if (existsSync(join(probe, \".git\")))"));
+        assert!(extension.contains("boundary ??= dir;"));
         assert!(extension.contains("import { execFileSync } from \"node:child_process\";"));
         assert!(extension.contains("function repoRootProject"));
         assert!(extension.contains("--git-common-dir"));

--- a/crates/ai-memory-cli/src/commands/lint.rs
+++ b/crates/ai-memory-cli/src/commands/lint.rs
@@ -23,12 +23,13 @@ struct LintRequest {
 /// response.
 pub async fn run(config: &Config, args: LintArgs) -> Result<()> {
     let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
     let report: serde_json::Value = post_json(
         &endpoint,
         "/admin/lint",
         &LintRequest {
-            workspace: args.workspace,
+            workspace,
             project,
             dry_run: args.dry_run,
             no_llm: args.no_llm,

--- a/crates/ai-memory-cli/src/commands/mod.rs
+++ b/crates/ai-memory-cli/src/commands/mod.rs
@@ -62,8 +62,8 @@ pub mod write_page;
 ///
 /// 1. The explicit flag (`--workspace` / `--project`) when non-empty.
 /// 2. The nearest `.ai-memory.toml` marker: `workspace`, and `project` —
-///    or, when the marker only pins `project_strategy = "repo-root"`, the
-///    main repository root's basename.
+///    or the hook-compatible derived project when the marker leaves it
+///    unpinned (`basename(cwd)` by default, main repo root for `repo-root`).
 /// 3. Today's fallbacks: [`crate::config::DEFAULT_WORKSPACE`] and
 ///    [`resolve_project_name`]'s cwd chain.
 ///
@@ -95,7 +95,7 @@ pub(crate) fn resolve_scope(
         Some(explicit) => explicit.to_string(),
         None => match marker
             .as_ref()
-            .and_then(|(scope, _)| scope.workspace.clone())
+            .and_then(|(scope, _, _)| scope.workspace.clone())
         {
             Some(declared) => {
                 decided.push("workspace");
@@ -108,20 +108,24 @@ pub(crate) fn resolve_scope(
     let project = match explicit_proj {
         Some(explicit) => explicit.to_string(),
         None => {
-            // A marker's explicit `project` pins the name for its whole tree;
-            // `project_strategy = "repo-root"` instead asks for the main repo
-            // root, collapsing linked worktrees and subdirectories onto one
-            // project. Rung 3 already resolves by main repo root, so the
-            // strategy only matters when it disagrees with an inherited
-            // `AI_MEMORY_HOST_CWD` basename.
-            let declared = marker.as_ref().and_then(|(scope, cwd)| {
-                scope.project.clone().or_else(|| {
-                    scope
-                        .is_repo_root()
-                        .then(|| crate::marker::repo_root_project(cwd))
-                        .flatten()
-                })
-            });
+            // A marker's explicit `project` pins the name for its whole tree.
+            // Otherwise derive exactly as the hook does: basename(cwd) by
+            // default, or the main repository root for `repo-root`.
+            let declared = marker
+                .as_ref()
+                .and_then(|(scope, identity_cwd, lookup_cwd)| {
+                    scope.project.clone().or_else(|| {
+                        if scope.is_repo_root() {
+                            crate::marker::repo_root_project(lookup_cwd)
+                        } else {
+                            ai_memory_consolidate::derive_project_name(
+                                std::path::Path::new(identity_cwd),
+                                ai_memory_consolidate::ProjectNameStrategy::Basename,
+                            )
+                            .map(|(name, _)| name)
+                        }
+                    })
+                });
             match declared {
                 Some(name) => {
                     decided.push("project");
@@ -132,7 +136,7 @@ pub(crate) fn resolve_scope(
         }
     };
 
-    if let Some((scope, _)) = marker.as_ref().filter(|_| !decided.is_empty()) {
+    if let Some((scope, _, _)) = marker.as_ref().filter(|_| !decided.is_empty()) {
         // Name only the halves the marker actually decided: an explicit flag
         // that was honoured must not read as if the file overrode it.
         eprintln!(
@@ -153,7 +157,7 @@ pub(crate) fn resolve_workspace(config: &Config, explicit_ws: Option<&str>) -> S
         return explicit.to_string();
     }
     match marker_scope(config) {
-        Some((scope, _)) => match scope.workspace {
+        Some((scope, _, _)) => match scope.workspace {
             Some(declared) => {
                 eprintln!(
                     "ai-memory: workspace {declared} (workspace from {})",
@@ -168,10 +172,23 @@ pub(crate) fn resolve_workspace(config: &Config, explicit_ws: Option<&str>) -> S
 }
 
 /// The nearest scope-declaring marker plus the cwd the walk started from.
-fn marker_scope(config: &Config) -> Option<(crate::marker::MarkerScope, String)> {
-    let cwd = scope_cwd(config)?;
-    let scope = crate::marker::read_scope(&cwd, &config.runtime_env)?;
-    Some((scope, cwd))
+fn marker_scope(config: &Config) -> Option<(crate::marker::MarkerScope, String, String)> {
+    let identity_cwd = scope_cwd(config)?;
+    // The Docker wrapper preserves the host cwd for identity but binds the
+    // checkout at /work. Check the host path when its bounded root is mounted;
+    // otherwise use the physical cwd so a marker in the /work bind is still
+    // visible. Project derivation keeps using the host identity either way.
+    let lookup_cwd = if let Some(scope_cwd) = config.runtime_env.scope_cwd() {
+        scope_cwd.to_string()
+    } else if std::path::Path::new(&identity_cwd).exists() {
+        identity_cwd.clone()
+    } else {
+        std::env::current_dir()
+            .ok()
+            .map(|cwd| cwd.to_string_lossy().into_owned())?
+    };
+    let scope = crate::marker::read_scope(&lookup_cwd, &config.runtime_env)?;
+    Some((scope, identity_cwd, lookup_cwd))
 }
 
 /// The directory marker discovery walks up from.
@@ -325,6 +342,51 @@ mod tests {
             project,
             tmp.path().file_name().unwrap().to_str().unwrap(),
             "an unpinned project still comes from the cwd chain"
+        );
+    }
+
+    #[test]
+    fn workspace_only_marker_uses_hook_basename_from_a_subdirectory() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".ai-memory.toml"), "workspace = \"acme\"\n").unwrap();
+        let subdir = tmp.path().join("crates").join("cli");
+        std::fs::create_dir_all(&subdir).unwrap();
+        let config = Config {
+            runtime_env: RuntimeEnv::with_host_cwd_for_tests(subdir.to_str().unwrap()),
+            ..Config::default()
+        };
+
+        assert_eq!(
+            resolve_scope(&config, None, None).unwrap(),
+            ("acme".to_string(), "cli".to_string())
+        );
+        assert_eq!(
+            resolve_scope(&config, Some("flagged"), None).unwrap(),
+            ("flagged".to_string(), "cli".to_string()),
+            "an explicit workspace must not restore the main-repo fallback"
+        );
+    }
+
+    #[test]
+    fn workspace_only_marker_uses_linked_worktree_directory_name() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let worktree = tmp.path().join("feature-worktree");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            "gitdir: /repo/.git/worktrees/feature\n",
+        )
+        .unwrap();
+        std::fs::write(worktree.join(".ai-memory.toml"), "workspace = \"acme\"\n").unwrap();
+        let config = Config {
+            runtime_env: RuntimeEnv::with_host_cwd_for_tests(worktree.to_str().unwrap()),
+            ..Config::default()
+        };
+
+        assert_eq!(
+            resolve_scope(&config, None, None).unwrap(),
+            ("acme".to_string(), "feature-worktree".to_string()),
+            "workspace-only markers preserve the hook's basename worktree identity"
         );
     }
 

--- a/crates/ai-memory-cli/src/commands/mod.rs
+++ b/crates/ai-memory-cli/src/commands/mod.rs
@@ -56,7 +56,104 @@ pub mod user;
 pub mod workstream_search;
 pub mod write_page;
 
+/// Resolve the effective `(workspace, project)` pair for a client command.
+///
+/// Each field is resolved independently, in this order:
+///
+/// 1. The explicit flag (`--workspace` / `--project`) when non-empty.
+/// 2. The nearest `.ai-memory.toml` marker: `workspace`, and `project` —
+///    or, when the marker only pins `project_strategy = "repo-root"`, the
+///    main repository root's basename.
+/// 3. Today's fallbacks: [`crate::config::DEFAULT_WORKSPACE`] and
+///    [`resolve_project_name`]'s cwd chain.
+///
+/// Rung 2 is why this function exists. Before it, only the lifecycle hooks
+/// read the marker, so a checkout declaring `workspace = "acme"` still had
+/// every CLI command resolve into `default` — the same repository ended up
+/// split across two scopes, with `run`'s managed workstream on one side and
+/// the hook-captured sessions on the other.
+///
+/// Resolution is announced on stderr whenever the marker decides a field, so
+/// a scope that differs from the flags the user typed is never silent.
+/// `AI_MEMORY_IGNORE_MARKER=1` skips rung 2 entirely.
+pub(crate) fn resolve_scope(
+    config: &Config,
+    explicit_ws: Option<&str>,
+    explicit_proj: Option<&str>,
+) -> Result<(String, String)> {
+    let marker =
+        scope_cwd(config).and_then(|cwd| crate::marker::read_scope(&cwd).map(|scope| (scope, cwd)));
+
+    let mut from_marker = false;
+    let workspace = match explicit_ws.filter(|s| !s.is_empty()) {
+        Some(explicit) => explicit.to_string(),
+        None => match marker
+            .as_ref()
+            .and_then(|(scope, _)| scope.workspace.clone())
+        {
+            Some(declared) => {
+                from_marker = true;
+                declared
+            }
+            None => crate::config::DEFAULT_WORKSPACE.to_string(),
+        },
+    };
+
+    let project = match explicit_proj.filter(|s| !s.is_empty()) {
+        Some(explicit) => explicit.to_string(),
+        None => {
+            // A marker's explicit `project` pins the name for its whole tree;
+            // `project_strategy = "repo-root"` instead asks for the main repo
+            // root, collapsing linked worktrees and subdirectories onto one
+            // project. Rung 3 already resolves by main repo root, so the
+            // strategy only matters when it disagrees with an inherited
+            // `AI_MEMORY_HOST_CWD` basename.
+            let declared = marker.as_ref().and_then(|(scope, cwd)| {
+                scope.project.clone().or_else(|| {
+                    scope
+                        .is_repo_root()
+                        .then(|| crate::marker::repo_root_project(cwd))
+                        .flatten()
+                })
+            });
+            match declared {
+                Some(name) => {
+                    from_marker = true;
+                    name
+                }
+                None => resolve_project_name(config, None)?,
+            }
+        }
+    };
+
+    if from_marker && let Some((scope, _)) = marker.as_ref() {
+        eprintln!(
+            "ai-memory: scope {workspace}/{project} declared by {}",
+            scope.path.display()
+        );
+    }
+    Ok((workspace, project))
+}
+
+/// The directory marker discovery walks up from.
+///
+/// Prefers `AI_MEMORY_HOST_CWD` for the same reason [`resolve_project_name`]
+/// does: inside the docker wrapper the container's own `current_dir()` is the
+/// `/work` bind mount, which would find the wrong marker (or none).
+fn scope_cwd(config: &Config) -> Option<String> {
+    if let Some(host_cwd) = config.runtime_env.host_cwd() {
+        return Some(host_cwd.to_string());
+    }
+    std::env::current_dir()
+        .ok()
+        .map(|cwd| cwd.to_string_lossy().into_owned())
+}
+
 /// Resolve the effective project name for a client command.
+///
+/// Prefer [`resolve_scope`] for new call sites: this resolves only half the
+/// scope and never consults the marker, so a command that uses it alone still
+/// pairs its project with whatever workspace the caller passed.
 ///
 /// Precedence:
 /// 1. `explicit` (the user's `--project` flag) when non-empty.
@@ -159,5 +256,105 @@ mod tests {
         };
 
         assert_eq!(resolve_project_name(&config, None).unwrap(), "my-project");
+    }
+
+    /// Build a config whose scope resolution walks up from `cwd`, and drop a
+    /// marker there when `marker` is given.
+    fn config_at(dir: &std::path::Path, marker: Option<&str>) -> Config {
+        if let Some(body) = marker {
+            std::fs::write(dir.join(".ai-memory.toml"), body).unwrap();
+        }
+        Config {
+            runtime_env: RuntimeEnv::with_host_cwd_for_tests(dir.to_str().unwrap()),
+            ..Config::default()
+        }
+    }
+
+    /// The bug this whole path exists for: a checkout whose marker declares a
+    /// workspace used to resolve into `default` for every CLI command, while
+    /// the lifecycle hooks — the only marker reader at the time — sent that
+    /// same checkout's captures to the declared workspace.
+    #[test]
+    fn resolve_scope_takes_the_workspace_from_the_marker() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = config_at(tmp.path(), Some("workspace = \"acme\"\n"));
+
+        let (workspace, project) = resolve_scope(&config, None, None).unwrap();
+
+        assert_eq!(workspace, "acme");
+        assert_eq!(
+            project,
+            tmp.path().file_name().unwrap().to_str().unwrap(),
+            "an unpinned project still comes from the cwd chain"
+        );
+    }
+
+    /// A marker that pins `project` overrides the cwd-derived name for its
+    /// whole tree.
+    #[test]
+    fn resolve_scope_takes_a_pinned_project_from_the_marker() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = config_at(
+            tmp.path(),
+            Some("workspace = \"acme\"\nproject = \"pinned\"\n"),
+        );
+
+        assert_eq!(
+            resolve_scope(&config, None, None).unwrap(),
+            ("acme".to_string(), "pinned".to_string())
+        );
+    }
+
+    /// Explicit flags are rung 1: they beat the marker on both halves, and
+    /// each half is resolved independently.
+    #[test]
+    fn resolve_scope_prefers_explicit_flags_over_the_marker() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = config_at(
+            tmp.path(),
+            Some("workspace = \"acme\"\nproject = \"pinned\"\n"),
+        );
+
+        assert_eq!(
+            resolve_scope(&config, Some("flagged"), Some("flagged-proj")).unwrap(),
+            ("flagged".to_string(), "flagged-proj".to_string())
+        );
+        assert_eq!(
+            resolve_scope(&config, Some("flagged"), None).unwrap(),
+            ("flagged".to_string(), "pinned".to_string()),
+            "an explicit workspace must not drag the project along with it"
+        );
+        assert_eq!(
+            resolve_scope(&config, None, Some("flagged-proj")).unwrap(),
+            ("acme".to_string(), "flagged-proj".to_string()),
+            "and vice versa"
+        );
+    }
+
+    /// No marker means the previous behaviour, byte for byte.
+    #[test]
+    fn resolve_scope_without_a_marker_keeps_the_old_fallbacks() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = config_at(tmp.path(), None);
+
+        let (workspace, project) = resolve_scope(&config, None, None).unwrap();
+
+        assert_eq!(workspace, crate::config::DEFAULT_WORKSPACE);
+        assert_eq!(project, tmp.path().file_name().unwrap().to_str().unwrap());
+    }
+
+    /// A marker carrying only `[capture]` rules declares no scope, so it must
+    /// not pull the command out of the default workspace.
+    #[test]
+    fn resolve_scope_ignores_a_marker_without_scope_keys() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = config_at(
+            tmp.path(),
+            Some("[capture]\nignore_paths = [\"secret/**\"]\n"),
+        );
+
+        let (workspace, _) = resolve_scope(&config, None, None).unwrap();
+
+        assert_eq!(workspace, crate::config::DEFAULT_WORKSPACE);
     }
 }

--- a/crates/ai-memory-cli/src/commands/mod.rs
+++ b/crates/ai-memory-cli/src/commands/mod.rs
@@ -81,25 +81,31 @@ pub(crate) fn resolve_scope(
     explicit_ws: Option<&str>,
     explicit_proj: Option<&str>,
 ) -> Result<(String, String)> {
-    let marker =
-        scope_cwd(config).and_then(|cwd| crate::marker::read_scope(&cwd).map(|scope| (scope, cwd)));
+    let explicit_ws = explicit_ws.filter(|s| !s.is_empty());
+    let explicit_proj = explicit_proj.filter(|s| !s.is_empty());
+    // Both halves pinned on the command line: the marker cannot change the
+    // answer, so skip the walk and the file reads entirely.
+    if let (Some(workspace), Some(project)) = (explicit_ws, explicit_proj) {
+        return Ok((workspace.to_string(), project.to_string()));
+    }
+    let marker = marker_scope(config);
 
-    let mut from_marker = false;
-    let workspace = match explicit_ws.filter(|s| !s.is_empty()) {
+    let mut decided: Vec<&str> = Vec::with_capacity(2);
+    let workspace = match explicit_ws {
         Some(explicit) => explicit.to_string(),
         None => match marker
             .as_ref()
             .and_then(|(scope, _)| scope.workspace.clone())
         {
             Some(declared) => {
-                from_marker = true;
+                decided.push("workspace");
                 declared
             }
             None => crate::config::DEFAULT_WORKSPACE.to_string(),
         },
     };
 
-    let project = match explicit_proj.filter(|s| !s.is_empty()) {
+    let project = match explicit_proj {
         Some(explicit) => explicit.to_string(),
         None => {
             // A marker's explicit `project` pins the name for its whole tree;
@@ -118,7 +124,7 @@ pub(crate) fn resolve_scope(
             });
             match declared {
                 Some(name) => {
-                    from_marker = true;
+                    decided.push("project");
                     name
                 }
                 None => resolve_project_name(config, None)?,
@@ -126,13 +132,46 @@ pub(crate) fn resolve_scope(
         }
     };
 
-    if from_marker && let Some((scope, _)) = marker.as_ref() {
+    if let Some((scope, _)) = marker.as_ref().filter(|_| !decided.is_empty()) {
+        // Name only the halves the marker actually decided: an explicit flag
+        // that was honoured must not read as if the file overrode it.
         eprintln!(
-            "ai-memory: scope {workspace}/{project} declared by {}",
+            "ai-memory: scope {workspace}/{project} ({} from {})",
+            decided.join(" + "),
             scope.path.display()
         );
     }
     Ok((workspace, project))
+}
+
+/// Resolve only the workspace half, for the one command whose project half is
+/// deliberately absent (`embed --force` fans out across every project in the
+/// workspace). Resolving the pair there would make the command fail on the
+/// cwd-derived project name it is about to throw away.
+pub(crate) fn resolve_workspace(config: &Config, explicit_ws: Option<&str>) -> String {
+    if let Some(explicit) = explicit_ws.filter(|s| !s.is_empty()) {
+        return explicit.to_string();
+    }
+    match marker_scope(config) {
+        Some((scope, _)) => match scope.workspace {
+            Some(declared) => {
+                eprintln!(
+                    "ai-memory: workspace {declared} (workspace from {})",
+                    scope.path.display()
+                );
+                declared
+            }
+            None => crate::config::DEFAULT_WORKSPACE.to_string(),
+        },
+        None => crate::config::DEFAULT_WORKSPACE.to_string(),
+    }
+}
+
+/// The nearest scope-declaring marker plus the cwd the walk started from.
+fn marker_scope(config: &Config) -> Option<(crate::marker::MarkerScope, String)> {
+    let cwd = scope_cwd(config)?;
+    let scope = crate::marker::read_scope(&cwd, &config.runtime_env)?;
+    Some((scope, cwd))
 }
 
 /// The directory marker discovery walks up from.

--- a/crates/ai-memory-cli/src/commands/move_project.rs
+++ b/crates/ai-memory-cli/src/commands/move_project.rs
@@ -29,7 +29,11 @@ struct MoveProjectRequest {
 /// Returns an error when `--confirm` is absent, the server is unreachable,
 /// or the server returns a non-2xx response.
 pub async fn run(config: &Config, args: MoveProjectArgs) -> Result<()> {
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (from_workspace, project) = super::resolve_scope(
+        config,
+        args.from_workspace.as_deref(),
+        args.project.as_deref(),
+    )?;
 
     if !args.confirm {
         bail!(
@@ -41,10 +45,10 @@ pub async fn run(config: &Config, args: MoveProjectArgs) -> Result<()> {
              Re-run with --confirm to proceed:\n\n  \
              ai-memory move-project --from-workspace {} --project {} \
              --to-workspace {} --confirm",
-            args.from_workspace,
+            from_workspace,
             project,
             args.to_workspace,
-            args.from_workspace,
+            from_workspace,
             project,
             args.to_workspace,
         );
@@ -55,7 +59,7 @@ pub async fn run(config: &Config, args: MoveProjectArgs) -> Result<()> {
         &endpoint,
         "/admin/move-project",
         &MoveProjectRequest {
-            from_workspace: args.from_workspace.clone(),
+            from_workspace: from_workspace.clone(),
             project: project.clone(),
             to_workspace: args.to_workspace.clone(),
             confirm: true,
@@ -75,7 +79,7 @@ pub async fn run(config: &Config, args: MoveProjectArgs) -> Result<()> {
         println!(
             "Moved {}/{} → {}/{}: {pages} pages re-stamped (true move — \
              sessions, observations and history preserved).",
-            args.from_workspace, project, args.to_workspace, project,
+            from_workspace, project, args.to_workspace, project,
         );
     } else {
         // copy-purge (merge into an existing same-named project).
@@ -89,7 +93,7 @@ pub async fn run(config: &Config, args: MoveProjectArgs) -> Result<()> {
         println!(
             "Moved {}/{} → {}/{}: {pages} pages copied (merged into existing \
              project){tail}.",
-            args.from_workspace, project, args.to_workspace, project,
+            from_workspace, project, args.to_workspace, project,
         );
         if skipped_count > 0 {
             println!(

--- a/crates/ai-memory-cli/src/commands/openclaw_plugin.rs
+++ b/crates/ai-memory-cli/src/commands/openclaw_plugin.rs
@@ -297,7 +297,7 @@ fn build_plugin(
 import {{ definePluginEntry }} from "openclaw/plugin-sdk/plugin-entry";
 import {{ execFileSync }} from "node:child_process";
 import {{ closeSync, existsSync, openSync, readFileSync as readMarkerText, readSync }} from "node:fs";
-import {{ basename, dirname, join, resolve }} from "node:path";
+import {{ basename, dirname, join, resolve, sep }} from "node:path";
 import {{ homedir }} from "node:os";
 
 const SERVER = {server_literal}.replace(/\/+$/, "");
@@ -319,10 +319,24 @@ function findMarker(cwd: string | undefined): string | undefined {{
   if (!cwd) return undefined;
   let dir = resolve(cwd);
   const home = homedir();
+  let boundary: string | undefined;
+  if (home && (dir === home || dir.startsWith(home.endsWith(sep) ? home : home + sep))) {{
+    boundary = home;
+  }} else if (home) {{
+    let probe = dir;
+    while (probe && probe !== dirname(probe)) {{
+      if (existsSync(join(probe, ".git"))) {{
+        boundary = probe;
+        break;
+      }}
+      probe = dirname(probe);
+    }}
+    boundary ??= dir;
+  }}
   while (dir && dir !== dirname(dir)) {{
     const marker = join(dir, ".ai-memory.toml");
     if (existsSync(marker)) return marker;
-    if (home && dir === home) return undefined;
+    if (boundary && dir === boundary) return undefined;
     dir = dirname(dir);
   }}
   return undefined;
@@ -555,7 +569,11 @@ mod tests {
         assert!(plugin.contains("tomlFlag(body, \"inject_on_session_start\")"));
         assert!(plugin.contains("url.searchParams.set(\"briefing_budget\", briefingBudget)"));
         assert!(plugin.contains("import { execFileSync } from \"node:child_process\";"));
-        assert!(plugin.contains("import { basename, dirname, join, resolve } from \"node:path\";"));
+        assert!(
+            plugin.contains("import { basename, dirname, join, resolve, sep } from \"node:path\";")
+        );
+        assert!(plugin.contains("if (existsSync(join(probe, \".git\")))"));
+        assert!(plugin.contains("boundary ??= dir;"));
         assert!(plugin.contains("function repoRootProject"));
         assert!(plugin.contains("--git-common-dir"));
         assert!(

--- a/crates/ai-memory-cli/src/commands/pending_writes.rs
+++ b/crates/ai-memory-cli/src/commands/pending_writes.rs
@@ -46,10 +46,11 @@ pub async fn run(config: &Config, args: PendingWritesArgs) -> Result<()> {
 }
 
 async fn list(config: &Config, ep: &ServerEndpoint, args: PendingWritesListArgs) -> Result<()> {
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
     let limit = args.limit.to_string();
     let mut query = vec![
-        ("workspace", args.workspace.as_str()),
+        ("workspace", workspace.as_str()),
         ("project", project.as_str()),
         ("limit", limit.as_str()),
     ];
@@ -70,12 +71,13 @@ async fn list(config: &Config, ep: &ServerEndpoint, args: PendingWritesListArgs)
 }
 
 async fn show(config: &Config, ep: &ServerEndpoint, args: PendingWriteIdArgs) -> Result<()> {
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
     let detail: ProposalDetail = get_json(
         ep,
         &format!("/admin/pending-writes/{}", args.id),
         &[
-            ("workspace", args.workspace.as_str()),
+            ("workspace", workspace.as_str()),
             ("project", project.as_str()),
         ],
     )
@@ -96,12 +98,13 @@ async fn show(config: &Config, ep: &ServerEndpoint, args: PendingWriteIdArgs) ->
 }
 
 async fn diff(config: &Config, ep: &ServerEndpoint, args: PendingWriteIdArgs) -> Result<()> {
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
     let resp: DiffResponse = get_json(
         ep,
         &format!("/admin/pending-writes/{}/diff", args.id),
         &[
-            ("workspace", args.workspace.as_str()),
+            ("workspace", workspace.as_str()),
             ("project", project.as_str()),
         ],
     )
@@ -115,12 +118,13 @@ async fn diff(config: &Config, ep: &ServerEndpoint, args: PendingWriteIdArgs) ->
 }
 
 async fn approve(config: &Config, ep: &ServerEndpoint, args: PendingWriteIdArgs) -> Result<()> {
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
     let resp: serde_json::Value = post_json_with_query(
         ep,
         &format!("/admin/pending-writes/{}/approve", args.id),
         &[
-            ("workspace", args.workspace.as_str()),
+            ("workspace", workspace.as_str()),
             ("project", project.as_str()),
         ],
         &serde_json::json!({}),
@@ -135,12 +139,13 @@ async fn approve(config: &Config, ep: &ServerEndpoint, args: PendingWriteIdArgs)
 }
 
 async fn reject(config: &Config, ep: &ServerEndpoint, args: PendingWriteRejectArgs) -> Result<()> {
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
     let resp: serde_json::Value = post_json_with_query(
         ep,
         &format!("/admin/pending-writes/{}/reject", args.id),
         &[
-            ("workspace", args.workspace.as_str()),
+            ("workspace", workspace.as_str()),
             ("project", project.as_str()),
         ],
         &serde_json::json!({ "reason": args.reason }),

--- a/crates/ai-memory-cli/src/commands/purge_project.rs
+++ b/crates/ai-memory-cli/src/commands/purge_project.rs
@@ -13,6 +13,8 @@ struct PurgeProjectRequest {
     workspace: String,
     project: String,
     confirm: bool,
+    /// Purge even when a managed workstream still holds a live run lease.
+    force: bool,
 }
 
 /// Run the `purge-project` subcommand.
@@ -25,14 +27,15 @@ struct PurgeProjectRequest {
 /// Returns an error when `--confirm` is absent, the server is unreachable,
 /// or the server returns a non-2xx response.
 pub async fn run(config: &Config, args: PurgeProjectArgs) -> Result<()> {
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
 
     if !args.confirm {
         bail!(
             "purge-project is destructive and irreversible.\n\
              Re-run with --confirm to proceed:\n\n  \
              ai-memory purge-project --workspace {} --project {} --confirm",
-            args.workspace,
+            workspace,
             project,
         );
     }
@@ -42,25 +45,43 @@ pub async fn run(config: &Config, args: PurgeProjectArgs) -> Result<()> {
         &endpoint,
         "/admin/purge-project",
         &PurgeProjectRequest {
-            workspace: args.workspace.clone(),
+            workspace: workspace.clone(),
             project: project.clone(),
             confirm: true,
+            force: args.force,
         },
     )
     .await?;
 
     // Human-friendly one-liner followed by the raw JSON for scripting.
-    let fallback_label = format!("{}/{}", args.workspace, project);
+    let fallback_label = format!("{}/{}", workspace, project);
     let label = report["label"].as_str().unwrap_or(&fallback_label);
     let pages = report["pages_deleted"].as_u64().unwrap_or(0);
     let sessions = report["sessions_deleted"].as_u64().unwrap_or(0);
     let observations = report["observations_deleted"].as_u64().unwrap_or(0);
     let handoffs = report["handoffs_deleted"].as_u64().unwrap_or(0);
     let embeddings = report["embeddings_deleted"].as_u64().unwrap_or(0);
+    // Workstreams cascade out of the project row, so a scope that looks empty
+    // by every other counter can still be carrying a managed workstream and
+    // its portable event ledger. Always name them.
+    let workstreams = report["workstreams_deleted"].as_u64().unwrap_or(0);
+    let managed_runs = report["managed_runs_deleted"].as_u64().unwrap_or(0);
     println!(
         "Purged {label}: {pages} pages, {sessions} sessions, \
-         {observations} observations, {handoffs} handoffs, {embeddings} embeddings."
+         {observations} observations, {handoffs} handoffs, {embeddings} embeddings, \
+         {workstreams} workstreams, {managed_runs} managed runs."
     );
+    if let Some(ids) = report["workstream_ids"].as_array()
+        && !ids.is_empty()
+    {
+        println!(
+            "The following workstream segment directories are now orphaned under \
+             <data_dir>/raw/workstreams/ and can be removed:"
+        );
+        for id in ids.iter().filter_map(serde_json::Value::as_str) {
+            println!("  - {id}");
+        }
+    }
     if let Some(failed) = report["files_failed"].as_array()
         && !failed.is_empty()
     {

--- a/crates/ai-memory-cli/src/commands/read_page.rs
+++ b/crates/ai-memory-cli/src/commands/read_page.rs
@@ -37,14 +37,15 @@ struct PageContent {
 /// or neither `--path` nor a query is supplied.
 pub async fn run(config: &Config, args: ReadPageArgs) -> Result<()> {
     let ep = ServerEndpoint::from_config_resolving_auth(config).await;
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
 
     let page: PageContent = if let Some(ref raw_path) = args.path {
         get_json(
             &ep,
             "/admin/read-page",
             &[
-                ("workspace", args.workspace.as_str()),
+                ("workspace", workspace.as_str()),
                 ("project", project.as_str()),
                 ("path", raw_path.as_str()),
             ],
@@ -55,7 +56,7 @@ pub async fn run(config: &Config, args: ReadPageArgs) -> Result<()> {
             &ep,
             "/admin/read-page",
             &[
-                ("workspace", args.workspace.as_str()),
+                ("workspace", workspace.as_str()),
                 ("project", project.as_str()),
                 ("q", query.as_str()),
             ],

--- a/crates/ai-memory-cli/src/commands/rename_project.rs
+++ b/crates/ai-memory-cli/src/commands/rename_project.rs
@@ -17,9 +17,13 @@ use crate::http_client::{ServerEndpoint, post_json};
 /// response (e.g. 404 workspace/project not found, 422 name taken or invalid).
 pub async fn run(config: &Config, args: RenameProjectArgs) -> Result<()> {
     let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
-    let from = super::resolve_project_name(config, args.from.as_deref())?;
+    // Rename happens inside one workspace, so the marker resolves it the same
+    // way it does for every other command. `--to` stays literal: it names the
+    // new project, it does not select a scope.
+    let (workspace, from) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.from.as_deref())?;
     let body = serde_json::json!({
-        "workspace": args.workspace,
+        "workspace": workspace,
         "from": from,
         "to": args.to,
     });
@@ -27,7 +31,7 @@ pub async fn run(config: &Config, args: RenameProjectArgs) -> Result<()> {
     let pages = summary["pages"].as_u64().unwrap_or(0);
     println!(
         "Renamed {}/{} → {}/{} ({} pages now under the new name).",
-        args.workspace, from, args.workspace, args.to, pages
+        workspace, from, workspace, args.to, pages
     );
     Ok(())
 }

--- a/crates/ai-memory-cli/src/commands/restore_page.rs
+++ b/crates/ai-memory-cli/src/commands/restore_page.rs
@@ -32,13 +32,14 @@ struct RestorePageResponse {
 /// Returns an error if the server is unreachable, the checkpoint/path cannot be
 /// restored, or the restored page cannot be reindexed.
 pub async fn run(config: &Config, args: RestorePageArgs) -> Result<()> {
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
     let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
     let resp: RestorePageResponse = post_json(
         &endpoint,
         "/admin/restore-page",
         &RestorePageRequest {
-            workspace: args.workspace.clone(),
+            workspace: workspace.clone(),
             project: project.clone(),
             path: args.path.clone(),
             rev: args.from.clone(),
@@ -55,7 +56,7 @@ pub async fn run(config: &Config, args: RestorePageArgs) -> Result<()> {
     println!(
         "restored {} under {}/{} from {} (page_id={})",
         resp.path,
-        args.workspace,
+        workspace,
         project,
         resp.restored_from,
         &resp.page_id[..resp.page_id.len().min(8)]

--- a/crates/ai-memory-cli/src/commands/run.rs
+++ b/crates/ai-memory-cli/src/commands/run.rs
@@ -23,7 +23,7 @@ use anyhow::{Context as _, Result, anyhow};
 use tokio::process::Command;
 
 use crate::cli::{RunArgs, RunHarnessChoice};
-use crate::commands::{path_util, resolve_project_name};
+use crate::commands::{path_util, resolve_scope};
 use crate::config::Config;
 use crate::http_client::{
     ServerEndpoint, ServerResponseError, get_json, post_empty, post_json, post_json_no_content,
@@ -87,11 +87,16 @@ pub async fn run(config: &Config, args: RunArgs) -> Result<i32> {
     };
     let executable = args.executable.map(PathBuf::into_os_string);
     ensure_executable_available(provisional_harness, executable.as_deref())?;
-    let project = resolve_project_name(config, args.project.as_deref())?;
+    // Resolve BOTH halves here. `--workspace` used to default to a literal
+    // `default`, so a checkout whose marker declared another workspace put its
+    // managed workstream in one scope while its hook-captured sessions went to
+    // another — the same repository split in two.
+    let (workspace, project) =
+        resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
     let may_adopt_native_session = args.new_workstream.is_none() && !force_fresh;
     let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
     let prepare = PrepareManagedRunRequest {
-        workspace: args.workspace,
+        workspace,
         project,
         cwd: repository.cwd.to_string_lossy().into_owned(),
         repo_fingerprint: repository.repo_fingerprint,

--- a/crates/ai-memory-cli/src/commands/search.rs
+++ b/crates/ai-memory-cli/src/commands/search.rs
@@ -25,14 +25,15 @@ struct Hit {
 /// Returns an error if the server is unreachable or returns non-2xx.
 pub async fn run(config: &Config, args: SearchArgs) -> Result<()> {
     let ep = ServerEndpoint::from_config_resolving_auth(config).await;
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
     let limit_str = args.limit.to_string();
     let hits: Vec<Hit> = get_json(
         &ep,
         "/admin/search",
         &[
             ("q", args.query.as_str()),
-            ("workspace", args.workspace.as_str()),
+            ("workspace", workspace.as_str()),
             ("project", project.as_str()),
             ("limit", limit_str.as_str()),
         ],

--- a/crates/ai-memory-cli/src/commands/write_page.rs
+++ b/crates/ai-memory-cli/src/commands/write_page.rs
@@ -53,14 +53,15 @@ pub async fn run(config: &Config, args: WritePageArgs) -> Result<()> {
     // Resolve the project the same way read-page/search do: explicit flag wins,
     // otherwise derive the current project from host cwd / repo root. This keeps
     // write + read-back pairs from silently targeting different projects.
-    let project = super::resolve_project_name(config, args.project.as_deref())?;
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
 
     let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
     let resp: WritePageResponseBody = post_json(
         &endpoint,
         "/admin/write-page",
         &WritePageBody {
-            workspace: args.workspace.clone(),
+            workspace: workspace.clone(),
             project: project.clone(),
             path: args.path.clone(),
             body: body_text,
@@ -77,7 +78,7 @@ pub async fn run(config: &Config, args: WritePageArgs) -> Result<()> {
     let short_id = &resp.page_id[..resp.page_id.len().min(8)];
     println!(
         "✓ wrote {} (page_id={}) under {}/{}",
-        resp.path, short_id, args.workspace, project
+        resp.path, short_id, workspace, project
     );
     Ok(())
 }

--- a/crates/ai-memory-cli/src/config.rs
+++ b/crates/ai-memory-cli/src/config.rs
@@ -198,6 +198,8 @@ pub struct RuntimeEnv {
     server_url: Option<String>,
     auth_token: Option<String>,
     host_cwd: Option<String>,
+    ignore_marker: bool,
+    project_strategy: Option<String>,
     claude_code_session_id: Option<String>,
     anthropic_api_key: Option<SecretString>,
     anthropic_oauth_token: Option<SecretString>,
@@ -221,6 +223,14 @@ impl RuntimeEnv {
             server_url: env_string("AI_MEMORY_SERVER_URL"),
             auth_token: env_string("AI_MEMORY_AUTH_TOKEN"),
             host_cwd: env_string("AI_MEMORY_HOST_CWD"),
+            // One-invocation escape hatch: run a command against the fallback
+            // scope without editing (or leaving) the marker's tree.
+            ignore_marker: env_string("AI_MEMORY_IGNORE_MARKER")
+                .is_some_and(|value| crate::marker::is_truthy(&value)),
+            // Install-wide project strategy, matching what `install-hooks
+            // --project-strategy` bakes into the generated hook commands.
+            // Consulted only when a marker does not pin one.
+            project_strategy: env_string("AI_MEMORY_PROJECT_STRATEGY"),
             claude_code_session_id: env_string("CLAUDE_CODE_SESSION_ID"),
             anthropic_api_key: env_secret("ANTHROPIC_API_KEY"),
             // CLAUDE_CODE_OAUTH_TOKEN is what `claude setup-token` writes;
@@ -248,6 +258,19 @@ impl RuntimeEnv {
     #[must_use]
     pub fn host_cwd(&self) -> Option<&str> {
         self.host_cwd.as_deref()
+    }
+
+    /// Whether `AI_MEMORY_IGNORE_MARKER` asked this invocation to resolve its
+    /// scope as if no `.ai-memory.toml` existed.
+    #[must_use]
+    pub fn ignore_marker(&self) -> bool {
+        self.ignore_marker
+    }
+
+    /// Install-wide `--project-strategy` default baked into the environment.
+    #[must_use]
+    pub fn project_strategy(&self) -> Option<&str> {
+        self.project_strategy.as_deref()
     }
 
     /// Claude Code lifecycle session id inherited by an stdio MCP subprocess.

--- a/crates/ai-memory-cli/src/config.rs
+++ b/crates/ai-memory-cli/src/config.rs
@@ -198,6 +198,7 @@ pub struct RuntimeEnv {
     server_url: Option<String>,
     auth_token: Option<String>,
     host_cwd: Option<String>,
+    scope_cwd: Option<String>,
     ignore_marker: bool,
     project_strategy: Option<String>,
     claude_code_session_id: Option<String>,
@@ -223,6 +224,7 @@ impl RuntimeEnv {
             server_url: env_string("AI_MEMORY_SERVER_URL"),
             auth_token: env_string("AI_MEMORY_AUTH_TOKEN"),
             host_cwd: env_string("AI_MEMORY_HOST_CWD"),
+            scope_cwd: env_string("AI_MEMORY_SCOPE_CWD"),
             // One-invocation escape hatch: run a command against the fallback
             // scope without editing (or leaving) the marker's tree.
             ignore_marker: env_string("AI_MEMORY_IGNORE_MARKER")
@@ -258,6 +260,18 @@ impl RuntimeEnv {
     #[must_use]
     pub fn host_cwd(&self) -> Option<&str> {
         self.host_cwd.as_deref()
+    }
+
+    /// Container-visible cwd used only for marker discovery.
+    #[must_use]
+    pub fn scope_cwd(&self) -> Option<&str> {
+        self.scope_cwd.as_deref()
+    }
+
+    /// Operator home captured by the single config-read path.
+    #[must_use]
+    pub fn home_dir(&self) -> Option<&str> {
+        self.home_dir.as_deref()
     }
 
     /// Whether `AI_MEMORY_IGNORE_MARKER` asked this invocation to resolve its

--- a/crates/ai-memory-cli/src/main.rs
+++ b/crates/ai-memory-cli/src/main.rs
@@ -19,6 +19,7 @@ mod commands;
 mod config;
 mod http_client;
 mod logging;
+mod marker;
 mod process_guard;
 
 use cli::{Cli, Command};

--- a/crates/ai-memory-cli/src/marker.rs
+++ b/crates/ai-memory-cli/src/marker.rs
@@ -21,16 +21,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::commands::path_util::home_dir;
-
-/// Set when the operator wants a marker ignored for one invocation — an
-/// escape hatch for running a command against the fallback scope without
-/// editing (or moving out of) the marker's tree.
-const IGNORE_MARKER_ENV: &str = "AI_MEMORY_IGNORE_MARKER";
-
-/// Install-wide project strategy, matching what `install-hooks
-/// --project-strategy` bakes into the generated hook commands. Consulted
-/// only when the marker itself does not pin one.
-const PROJECT_STRATEGY_ENV: &str = "AI_MEMORY_PROJECT_STRATEGY";
+use crate::config::RuntimeEnv;
 
 /// The scope fields a marker declares, plus where it was found.
 ///
@@ -69,37 +60,37 @@ impl MarkerScope {
 /// Read the nearest marker's scope declaration, honouring
 /// `AI_MEMORY_IGNORE_MARKER`.
 ///
+/// Both env knobs arrive through [`RuntimeEnv`] rather than being read here:
+/// `Config::load()` is the one config-read path, and routing them through it
+/// is also what makes the caller's unit tests hermetic against a developer's
+/// exported `AI_MEMORY_IGNORE_MARKER`.
+///
 /// Returns `None` when no marker is found, when the operator disabled marker
 /// resolution, or when the marker declares nothing scope-related — callers
 /// then keep their existing fallbacks untouched.
-pub(crate) fn read_scope(cwd: &str) -> Option<MarkerScope> {
-    if marker_ignored() {
+pub(crate) fn read_scope(cwd: &str, env: &RuntimeEnv) -> Option<MarkerScope> {
+    if env.ignore_marker() {
         return None;
     }
     let path = find_marker(cwd)?;
+    // One read, three keys: the marker is re-read per key nowhere else on a
+    // hot path, but this one runs on every client command.
+    let text = std::fs::read_to_string(&path).ok()?;
     let mut scope = MarkerScope {
-        workspace: parse_toml_key(&path, "workspace"),
-        project: parse_toml_key(&path, "project"),
-        project_strategy: parse_toml_key(&path, "project_strategy"),
+        workspace: parse_key_in(&text, "workspace"),
+        project: parse_key_in(&text, "project"),
+        project_strategy: parse_key_in(&text, "project_strategy"),
         path,
     };
     if scope.project_strategy.is_none() {
-        scope.project_strategy = install_default_strategy();
+        // The install-wide `--project-strategy` default, if one was baked into
+        // the environment. Empty values are treated as unset.
+        scope.project_strategy = env
+            .project_strategy()
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_owned);
     }
     scope.declares_scope().then_some(scope)
-}
-
-/// Whether `AI_MEMORY_IGNORE_MARKER` is set to a truthy value.
-pub(crate) fn marker_ignored() -> bool {
-    std::env::var(IGNORE_MARKER_ENV).is_ok_and(|value| is_truthy(&value))
-}
-
-/// The install-wide `--project-strategy` default, if one was baked into the
-/// environment. Empty values are treated as unset.
-fn install_default_strategy() -> Option<String> {
-    std::env::var(PROJECT_STRATEGY_ENV)
-        .ok()
-        .filter(|value| !value.trim().is_empty())
 }
 
 /// Derive a project name from the **main** repository root, so linked
@@ -138,7 +129,12 @@ pub(crate) fn find_marker(cwd: &str) -> Option<PathBuf> {
 /// tables), mirroring `ai_memory_parse_toml_key`. Returns the first
 /// match. Avoids pulling in a TOML parser dependency.
 pub(crate) fn parse_toml_key(file: &Path, key: &str) -> Option<String> {
-    let text = std::fs::read_to_string(file).ok()?;
+    parse_key_in(&std::fs::read_to_string(file).ok()?, key)
+}
+
+/// [`parse_toml_key`] over already-read marker text, so a caller that needs
+/// several keys pays for one read.
+fn parse_key_in(text: &str, key: &str) -> Option<String> {
     for line in text.lines() {
         let trimmed = line.trim_start();
         let Some(after_key) = trimmed.strip_prefix(key) else {

--- a/crates/ai-memory-cli/src/marker.rs
+++ b/crates/ai-memory-cli/src/marker.rs
@@ -1,0 +1,330 @@
+//! `.ai-memory.toml` marker discovery and the scope it declares.
+//!
+//! One reader shared by both entry points that care about a repository's
+//! declared identity:
+//!
+//! - the native hook path (`commands::hook_capture`), which forwards the
+//!   marker's fields to the server as query params, and
+//! - the thin-client CLI commands, which resolve `(workspace, project)`
+//!   locally before calling `/admin/*` (see `commands::resolve_scope`).
+//!
+//! Before this module existed only the hook path read the marker, so a
+//! repository could declare `workspace = "x"` and still have `run`,
+//! `bootstrap`, `search` and friends silently resolve into `default` —
+//! splitting one checkout across two scopes.
+//!
+//! Parsing is deliberately line-based (`parse_toml_key` / `parse_toml_flag`)
+//! and mirrors `hooks/lib/_lib.sh`, so the native binary and the POSIX shell
+//! hooks agree on what a marker means. `[capture]` is the one section parsed
+//! strictly, with a real TOML parser, and stays in `hook_capture`.
+
+use std::path::{Path, PathBuf};
+
+use crate::commands::path_util::home_dir;
+
+/// Set when the operator wants a marker ignored for one invocation — an
+/// escape hatch for running a command against the fallback scope without
+/// editing (or moving out of) the marker's tree.
+const IGNORE_MARKER_ENV: &str = "AI_MEMORY_IGNORE_MARKER";
+
+/// Install-wide project strategy, matching what `install-hooks
+/// --project-strategy` bakes into the generated hook commands. Consulted
+/// only when the marker itself does not pin one.
+const PROJECT_STRATEGY_ENV: &str = "AI_MEMORY_PROJECT_STRATEGY";
+
+/// The scope fields a marker declares, plus where it was found.
+///
+/// `project` is what the marker pins directly; a marker that only sets
+/// `project_strategy = "repo-root"` leaves it `None` and lets the caller
+/// derive the name (see [`repo_root_project`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MarkerScope {
+    /// Absolute path of the marker file the walk settled on.
+    pub(crate) path: PathBuf,
+    /// `workspace = "…"`.
+    pub(crate) workspace: Option<String>,
+    /// `project = "…"`.
+    pub(crate) project: Option<String>,
+    /// `project_strategy = "…"`, or the install-wide env default.
+    pub(crate) project_strategy: Option<String>,
+}
+
+impl MarkerScope {
+    /// Whether this marker declares anything that changes scope resolution.
+    /// A marker that only carries `[capture]` rules does not.
+    pub(crate) fn declares_scope(&self) -> bool {
+        self.workspace.is_some() || self.project.is_some() || self.is_repo_root()
+    }
+
+    /// Whether the effective strategy asks for repo-root project naming.
+    /// Accepts both spellings, matching the shell hooks.
+    pub(crate) fn is_repo_root(&self) -> bool {
+        matches!(
+            self.project_strategy.as_deref(),
+            Some("repo-root" | "repo_root")
+        )
+    }
+}
+
+/// Read the nearest marker's scope declaration, honouring
+/// `AI_MEMORY_IGNORE_MARKER`.
+///
+/// Returns `None` when no marker is found, when the operator disabled marker
+/// resolution, or when the marker declares nothing scope-related — callers
+/// then keep their existing fallbacks untouched.
+pub(crate) fn read_scope(cwd: &str) -> Option<MarkerScope> {
+    if marker_ignored() {
+        return None;
+    }
+    let path = find_marker(cwd)?;
+    let mut scope = MarkerScope {
+        workspace: parse_toml_key(&path, "workspace"),
+        project: parse_toml_key(&path, "project"),
+        project_strategy: parse_toml_key(&path, "project_strategy"),
+        path,
+    };
+    if scope.project_strategy.is_none() {
+        scope.project_strategy = install_default_strategy();
+    }
+    scope.declares_scope().then_some(scope)
+}
+
+/// Whether `AI_MEMORY_IGNORE_MARKER` is set to a truthy value.
+pub(crate) fn marker_ignored() -> bool {
+    std::env::var(IGNORE_MARKER_ENV).is_ok_and(|value| is_truthy(&value))
+}
+
+/// The install-wide `--project-strategy` default, if one was baked into the
+/// environment. Empty values are treated as unset.
+fn install_default_strategy() -> Option<String> {
+    std::env::var(PROJECT_STRATEGY_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+}
+
+/// Derive a project name from the **main** repository root, so linked
+/// worktrees and subdirectories collapse onto one project.
+pub(crate) fn repo_root_project(cwd: &str) -> Option<String> {
+    let root = ai_memory_consolidate::discover_main_repo_root(Path::new(cwd)).ok()?;
+    root.file_name()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+}
+
+/// Walk up from `cwd` toward `$HOME` (or the filesystem root) looking
+/// for `.ai-memory.toml`. Stops at `$HOME` to avoid leaking a parent
+/// user's declaration on shared machines (parity with
+/// `ai_memory_find_marker`).
+pub(crate) fn find_marker(cwd: &str) -> Option<PathBuf> {
+    let home = home_dir();
+    let mut dir = Path::new(cwd);
+    loop {
+        let candidate = dir.join(".ai-memory.toml");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if home.as_deref() == Some(dir) {
+            return None;
+        }
+        match dir.parent() {
+            Some(parent) if parent != dir => dir = parent,
+            _ => return None,
+        }
+    }
+}
+
+/// Parse a root-level `key = "value"` line (no nesting, arrays, or
+/// tables), mirroring `ai_memory_parse_toml_key`. Returns the first
+/// match. Avoids pulling in a TOML parser dependency.
+pub(crate) fn parse_toml_key(file: &Path, key: &str) -> Option<String> {
+    let text = std::fs::read_to_string(file).ok()?;
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        let Some(after_key) = trimmed.strip_prefix(key) else {
+            continue;
+        };
+        let Some(rest) = after_key.trim_start().strip_prefix('=') else {
+            continue;
+        };
+        let Some(rest) = rest.trim_start().strip_prefix('"') else {
+            continue;
+        };
+        if let Some(end) = rest.find('"') {
+            return Some(rest[..end].to_string());
+        }
+    }
+    None
+}
+
+/// Parse a root-level `key = <value>` line, accepting a quoted string
+/// (`key = "true"`) OR a bare token (`key = true` / `key = 1`), so a
+/// `[recall] default_global = true` marker works whether or not the operator
+/// quotes the value. Line-based like [`parse_toml_key`], so section headers
+/// are ignored; strips an optional trailing `# comment`.
+pub(crate) fn parse_toml_flag(file: &Path, key: &str) -> Option<String> {
+    let text = std::fs::read_to_string(file).ok()?;
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        let Some(after_key) = trimmed.strip_prefix(key) else {
+            continue;
+        };
+        let Some(rest) = after_key.trim_start().strip_prefix('=') else {
+            continue;
+        };
+        let val = rest
+            .split('#')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .trim_matches('"');
+        if !val.is_empty() {
+            return Some(val.to_string());
+        }
+    }
+    None
+}
+
+/// Shell-parity truthiness for marker flags and the ignore switch.
+pub(crate) fn is_truthy(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_marker(dir: &Path, body: &str) -> PathBuf {
+        let path = dir.join(".ai-memory.toml");
+        fs::write(&path, body).unwrap();
+        path
+    }
+
+    #[test]
+    fn find_marker_walks_up_from_cwd() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let marker = write_marker(&root, "workspace = \"acme\"\n");
+        let nested = root.join("a").join("b");
+        fs::create_dir_all(&nested).unwrap();
+
+        assert_eq!(
+            find_marker(nested.to_str().unwrap()),
+            Some(marker),
+            "a marker in any ancestor wins"
+        );
+    }
+
+    #[test]
+    fn find_marker_returns_none_without_one() {
+        let tmp = TempDir::new().unwrap();
+        assert_eq!(find_marker(tmp.path().to_str().unwrap()), None);
+    }
+
+    /// Happy-path TOML parser: extracts each declared root-level
+    /// `key = "value"` pair. Mirrors the shell `ai_memory_parse_toml_key`.
+    #[test]
+    fn parse_toml_key_extracts_root_level_strings() {
+        let tmp = TempDir::new().unwrap();
+        let marker = write_marker(
+            tmp.path(),
+            r#"
+workspace = "acme"
+project = "infra"
+project_strategy = "repo-root"
+"#,
+        );
+        assert_eq!(
+            parse_toml_key(&marker, "workspace").as_deref(),
+            Some("acme")
+        );
+        assert_eq!(parse_toml_key(&marker, "project").as_deref(), Some("infra"));
+        assert_eq!(
+            parse_toml_key(&marker, "project_strategy").as_deref(),
+            Some("repo-root")
+        );
+        assert_eq!(parse_toml_key(&marker, "absent"), None);
+    }
+
+    /// Shapes the naive parser deliberately doesn't handle (parity with
+    /// the shell `_lib.sh` helper) — pin the contract so a future
+    /// "robustify" refactor doesn't silently start matching them.
+    #[test]
+    fn parse_toml_key_skips_unsupported_shapes() {
+        let tmp = TempDir::new().unwrap();
+        let marker = write_marker(
+            tmp.path(),
+            r#"
+# Single-quoted values are not honoured.
+workspace = 'acme'
+# Comments after the value are not stripped.
+project = "infra" # this is fine
+"#,
+        );
+        assert_eq!(parse_toml_key(&marker, "workspace"), None);
+        // The trailing comment is appended to the value because the parser
+        // looks for the first `"` — pin it so the contract is explicit.
+        assert_eq!(parse_toml_key(&marker, "project").as_deref(), Some("infra"));
+    }
+
+    #[test]
+    fn parse_toml_flag_accepts_bare_and_quoted_tokens() {
+        let tmp = TempDir::new().unwrap();
+        let marker = write_marker(
+            tmp.path(),
+            "[recall]\ndefault_global = true\nmax_chars = 4000 # budget\n",
+        );
+
+        assert_eq!(
+            parse_toml_flag(&marker, "default_global").as_deref(),
+            Some("true")
+        );
+        assert_eq!(
+            parse_toml_flag(&marker, "max_chars").as_deref(),
+            Some("4000"),
+            "trailing comments are stripped"
+        );
+    }
+
+    #[test]
+    fn is_truthy_matches_shell_parity_tokens() {
+        for value in ["1", "true", "TRUE", " yes ", "on"] {
+            assert!(is_truthy(value), "{value} should be truthy");
+        }
+        for value in ["0", "false", "", "maybe"] {
+            assert!(!is_truthy(value), "{value} should not be truthy");
+        }
+    }
+
+    #[test]
+    fn scope_declares_repo_root_for_both_spellings() {
+        let base = MarkerScope {
+            path: PathBuf::from("/tmp/.ai-memory.toml"),
+            workspace: None,
+            project: None,
+            project_strategy: None,
+        };
+
+        for spelling in ["repo-root", "repo_root"] {
+            let scope = MarkerScope {
+                project_strategy: Some(spelling.to_string()),
+                ..base.clone()
+            };
+            assert!(scope.is_repo_root(), "{spelling} should select repo-root");
+            assert!(
+                scope.declares_scope(),
+                "{spelling} alone still changes resolution"
+            );
+        }
+
+        assert!(
+            !base.declares_scope(),
+            "a marker with only [capture] rules must not change scope"
+        );
+    }
+}

--- a/crates/ai-memory-cli/src/marker.rs
+++ b/crates/ai-memory-cli/src/marker.rs
@@ -72,7 +72,7 @@ pub(crate) fn read_scope(cwd: &str, env: &RuntimeEnv) -> Option<MarkerScope> {
     if env.ignore_marker() {
         return None;
     }
-    let path = find_marker(cwd)?;
+    let path = find_marker_with_home(cwd, env.home_dir().map(Path::new))?;
     // One read, three keys: the marker is re-read per key nowhere else on a
     // hot path, but this one runs on every client command.
     let text = std::fs::read_to_string(&path).ok()?;
@@ -103,20 +103,57 @@ pub(crate) fn repo_root_project(cwd: &str) -> Option<String> {
         .map(str::to_owned)
 }
 
-/// Walk up from `cwd` toward `$HOME` (or the filesystem root) looking
-/// for `.ai-memory.toml`. Stops at `$HOME` to avoid leaking a parent
-/// user's declaration on shared machines (parity with
-/// `ai_memory_find_marker`).
+/// Walk up from `cwd` toward `$HOME` looking for `.ai-memory.toml`.
+/// Checkouts outside `$HOME` stop at their nearest `.git` root; a non-git
+/// directory outside `$HOME` checks only `cwd`. When home is unavailable the
+/// historical filesystem-root walk remains the fallback.
 pub(crate) fn find_marker(cwd: &str) -> Option<PathBuf> {
     let home = home_dir();
-    let mut dir = Path::new(cwd);
+    find_marker_with_home(cwd, home.as_deref())
+}
+
+fn find_marker_with_home(cwd: &str, home: Option<&Path>) -> Option<PathBuf> {
+    let start = absolute_normalized(Path::new(cwd));
+    let home = home.map(absolute_normalized);
+    let boundary = match home.as_deref() {
+        Some(home) if start.starts_with(home) => Some(home.to_path_buf()),
+        Some(_) => Some(checkout_root(&start).unwrap_or_else(|| start.clone())),
+        None => None,
+    };
+
+    let mut dir = start.as_path();
     loop {
         let candidate = dir.join(".ai-memory.toml");
         if candidate.is_file() {
             return Some(candidate);
         }
-        if home.as_deref() == Some(dir) {
+        if boundary.as_deref() == Some(dir) {
             return None;
+        }
+        match dir.parent() {
+            Some(parent) if parent != dir => dir = parent,
+            _ => return None,
+        }
+    }
+}
+
+fn absolute_normalized(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map(|cwd| cwd.join(path))
+                .unwrap_or_else(|_| path.to_path_buf())
+        }
+    })
+}
+
+fn checkout_root(start: &Path) -> Option<PathBuf> {
+    let mut dir = start;
+    loop {
+        if dir.join(".git").exists() {
+            return Some(dir.to_path_buf());
         }
         match dir.parent() {
             Some(parent) if parent != dir => dir = parent,
@@ -210,7 +247,7 @@ mod tests {
         fs::create_dir_all(&nested).unwrap();
 
         assert_eq!(
-            find_marker(nested.to_str().unwrap()),
+            find_marker_with_home(nested.to_str().unwrap(), Some(&root)),
             Some(marker),
             "a marker in any ancestor wins"
         );
@@ -220,6 +257,53 @@ mod tests {
     fn find_marker_returns_none_without_one() {
         let tmp = TempDir::new().unwrap();
         assert_eq!(find_marker(tmp.path().to_str().unwrap()), None);
+    }
+
+    #[test]
+    fn marker_walk_outside_home_stops_at_checkout_root() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path().join("home");
+        let outer = tmp.path().join("outside");
+        let repo = outer.join("repo");
+        let nested = repo.join("src");
+        fs::create_dir_all(repo.join(".git")).unwrap();
+        fs::create_dir_all(&nested).unwrap();
+        fs::create_dir_all(&home).unwrap();
+        let outer_marker = write_marker(&outer, "workspace = \"wrong\"\n");
+        let repo_marker = write_marker(&repo, "workspace = \"right\"\n");
+
+        assert_eq!(
+            find_marker_with_home(nested.to_str().unwrap(), Some(&home)),
+            Some(repo_marker)
+        );
+        fs::remove_file(repo.join(".ai-memory.toml")).unwrap();
+        assert_eq!(
+            find_marker_with_home(nested.to_str().unwrap(), Some(&home)),
+            None,
+            "a marker above the checkout boundary must not leak in"
+        );
+        assert!(outer_marker.exists());
+    }
+
+    #[test]
+    fn marker_walk_outside_home_checks_only_cwd_without_a_checkout() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path().join("home");
+        let outer = tmp.path().join("outside");
+        let cwd = outer.join("plain");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&cwd).unwrap();
+        write_marker(&outer, "workspace = \"wrong\"\n");
+
+        assert_eq!(
+            find_marker_with_home(cwd.to_str().unwrap(), Some(&home)),
+            None
+        );
+        let local = write_marker(&cwd, "workspace = \"right\"\n");
+        assert_eq!(
+            find_marker_with_home(cwd.to_str().unwrap(), Some(&home)),
+            Some(local)
+        );
     }
 
     /// Happy-path TOML parser: extracts each declared root-level

--- a/crates/ai-memory-cli/tests/marker_scope.rs
+++ b/crates/ai-memory-cli/tests/marker_scope.rs
@@ -45,6 +45,7 @@ fn search_stderr(cwd: &Path, data_dir: &Path, extra_env: &[(&str, &str)], args: 
         // exported one on the developer's machine would unpin the walk.
         .env_remove("AI_MEMORY_HOME")
         .env_remove("AI_MEMORY_HOST_CWD")
+        .env_remove("AI_MEMORY_SCOPE_CWD")
         .env_remove("AI_MEMORY_IGNORE_MARKER")
         .env_remove("AI_MEMORY_PROJECT_STRATEGY");
     for (key, value) in extra_env {
@@ -76,8 +77,8 @@ fn marker_workspace_is_used_and_announced() {
         "the notice names the marker that decided it: {stderr}"
     );
     assert!(
-        stderr.contains("workspace from"),
-        "the notice names which half the marker decided: {stderr}"
+        stderr.contains("workspace + project from"),
+        "a workspace-only marker also selects hook-compatible basename(cwd): {stderr}"
     );
 }
 
@@ -125,5 +126,36 @@ fn a_tree_without_a_marker_is_unchanged() {
     assert!(
         !stderr.contains("ai-memory: scope "),
         "no marker means no scope notice and no behaviour change: {stderr}"
+    );
+}
+
+#[test]
+fn mounted_scope_cwd_reads_marker_while_host_cwd_keeps_project_identity() {
+    let root = TempDir::new().expect("scope root");
+    let data = TempDir::new().expect("data dir");
+    std::fs::write(
+        root.path().join(".ai-memory.toml"),
+        "workspace = \"acme\"\n",
+    )
+    .unwrap();
+    let mounted_cwd = root.path().join("crates/cli");
+    std::fs::create_dir_all(&mounted_cwd).unwrap();
+    let mounted_cwd = mounted_cwd.canonicalize().unwrap();
+    let root = real_path(&root);
+    let data = real_path(&data);
+    let stderr = search_stderr(
+        &mounted_cwd,
+        &data,
+        &[
+            ("AI_MEMORY_HOST_CWD", "/host/repo/crates/cli"),
+            ("AI_MEMORY_SCOPE_CWD", mounted_cwd.to_str().unwrap()),
+            ("HOME", root.to_str().unwrap()),
+        ],
+        &[],
+    );
+
+    assert!(
+        stderr.contains("scope acme/cli"),
+        "lookup must use the mounted path and naming must use host cwd: {stderr}"
     );
 }

--- a/crates/ai-memory-cli/tests/marker_scope.rs
+++ b/crates/ai-memory-cli/tests/marker_scope.rs
@@ -9,12 +9,20 @@
 //! server. That is deliberate: resolution happens first, so the stderr notice
 //! is emitted regardless, and the test never needs a live engine.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
 
 fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_ai-memory")
+}
+
+/// The tempdir's real path. `TempDir` hands back `/var/folders/…` on macOS
+/// while the child's `getcwd()` reports the resolved `/private/var/folders/…`
+/// — without canonicalising, `$HOME` never equals any directory the walk
+/// visits and the marker search escapes all the way to `/`.
+fn real_path(dir: &TempDir) -> PathBuf {
+    dir.path().canonicalize().expect("canonicalising tempdir")
 }
 
 /// Run `search` from `cwd` with a deliberately dead server and return stderr.
@@ -33,6 +41,9 @@ fn search_stderr(cwd: &Path, data_dir: &Path, extra_env: &[(&str, &str)], args: 
         // Port 1 is reserved and never listening: the command resolves its
         // scope, prints the notice, then fails on connect.
         .env("AI_MEMORY_SERVER_URL", "http://127.0.0.1:1")
+        // `AI_MEMORY_HOME` outranks `$HOME` in `path_util::home_dir`, so an
+        // exported one on the developer's machine would unpin the walk.
+        .env_remove("AI_MEMORY_HOME")
         .env_remove("AI_MEMORY_HOST_CWD")
         .env_remove("AI_MEMORY_IGNORE_MARKER")
         .env_remove("AI_MEMORY_PROJECT_STRATEGY");
@@ -54,7 +65,7 @@ fn marker_tree(body: &str) -> (TempDir, TempDir) {
 fn marker_workspace_is_used_and_announced() {
     let (cwd, data) = marker_tree("workspace = \"acme\"\n");
 
-    let stderr = search_stderr(cwd.path(), data.path(), &[], &[]);
+    let stderr = search_stderr(&real_path(&cwd), &real_path(&data), &[], &[]);
 
     assert!(
         stderr.contains("scope acme/"),
@@ -64,6 +75,10 @@ fn marker_workspace_is_used_and_announced() {
         stderr.contains(".ai-memory.toml"),
         "the notice names the marker that decided it: {stderr}"
     );
+    assert!(
+        stderr.contains("workspace from"),
+        "the notice names which half the marker decided: {stderr}"
+    );
 }
 
 #[test]
@@ -71,8 +86,8 @@ fn ignore_marker_env_restores_the_default_workspace() {
     let (cwd, data) = marker_tree("workspace = \"acme\"\n");
 
     let stderr = search_stderr(
-        cwd.path(),
-        data.path(),
+        &real_path(&cwd),
+        &real_path(&data),
         &[("AI_MEMORY_IGNORE_MARKER", "1")],
         &[],
     );
@@ -87,7 +102,12 @@ fn ignore_marker_env_restores_the_default_workspace() {
 fn explicit_workspace_flag_beats_the_marker() {
     let (cwd, data) = marker_tree("workspace = \"acme\"\n");
 
-    let stderr = search_stderr(cwd.path(), data.path(), &[], &["--workspace", "default"]);
+    let stderr = search_stderr(
+        &real_path(&cwd),
+        &real_path(&data),
+        &[],
+        &["--workspace", "default"],
+    );
 
     assert!(
         !stderr.contains("scope acme/"),
@@ -100,10 +120,10 @@ fn a_tree_without_a_marker_is_unchanged() {
     let cwd = TempDir::new().expect("tempdir for cwd");
     let data = TempDir::new().expect("tempdir for data dir");
 
-    let stderr = search_stderr(cwd.path(), data.path(), &[], &[]);
+    let stderr = search_stderr(&real_path(&cwd), &real_path(&data), &[], &[]);
 
     assert!(
-        !stderr.contains("declared by"),
+        !stderr.contains("ai-memory: scope "),
         "no marker means no scope notice and no behaviour change: {stderr}"
     );
 }

--- a/crates/ai-memory-cli/tests/marker_scope.rs
+++ b/crates/ai-memory-cli/tests/marker_scope.rs
@@ -1,0 +1,109 @@
+//! Subprocess tests for `.ai-memory.toml` scope resolution in client commands.
+//!
+//! The unit tests in `commands::tests` cover the precedence table directly.
+//! What needs a real process is the env-var wiring — `AI_MEMORY_IGNORE_MARKER`
+//! is read from the process environment, and `$HOME` bounds the marker walk,
+//! so both have to be set before the binary starts.
+//!
+//! Each test runs a command that resolves its scope and then fails to reach a
+//! server. That is deliberate: resolution happens first, so the stderr notice
+//! is emitted regardless, and the test never needs a live engine.
+
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_ai-memory")
+}
+
+/// Run `search` from `cwd` with a deliberately dead server and return stderr.
+///
+/// `$HOME` is pinned to `cwd` so the marker walk cannot reach the developer's
+/// real `~/.ai-memory.toml`, and the data dir is redirected for the same
+/// reason — neither test should read or write the machine's actual install.
+fn search_stderr(cwd: &Path, data_dir: &Path, extra_env: &[(&str, &str)], args: &[&str]) -> String {
+    let mut cmd = Command::new(bin());
+    cmd.arg("search")
+        .arg("anything")
+        .args(args)
+        .current_dir(cwd)
+        .env("HOME", cwd)
+        .env("AI_MEMORY_DATA_DIR", data_dir)
+        // Port 1 is reserved and never listening: the command resolves its
+        // scope, prints the notice, then fails on connect.
+        .env("AI_MEMORY_SERVER_URL", "http://127.0.0.1:1")
+        .env_remove("AI_MEMORY_HOST_CWD")
+        .env_remove("AI_MEMORY_IGNORE_MARKER")
+        .env_remove("AI_MEMORY_PROJECT_STRATEGY");
+    for (key, value) in extra_env {
+        cmd.env(key, value);
+    }
+    let output = cmd.output().expect("running ai-memory search");
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn marker_tree(body: &str) -> (TempDir, TempDir) {
+    let cwd = TempDir::new().expect("tempdir for cwd");
+    let data = TempDir::new().expect("tempdir for data dir");
+    std::fs::write(cwd.path().join(".ai-memory.toml"), body).expect("writing marker");
+    (cwd, data)
+}
+
+#[test]
+fn marker_workspace_is_used_and_announced() {
+    let (cwd, data) = marker_tree("workspace = \"acme\"\n");
+
+    let stderr = search_stderr(cwd.path(), data.path(), &[], &[]);
+
+    assert!(
+        stderr.contains("scope acme/"),
+        "the resolved scope must come from the marker and be announced: {stderr}"
+    );
+    assert!(
+        stderr.contains(".ai-memory.toml"),
+        "the notice names the marker that decided it: {stderr}"
+    );
+}
+
+#[test]
+fn ignore_marker_env_restores_the_default_workspace() {
+    let (cwd, data) = marker_tree("workspace = \"acme\"\n");
+
+    let stderr = search_stderr(
+        cwd.path(),
+        data.path(),
+        &[("AI_MEMORY_IGNORE_MARKER", "1")],
+        &[],
+    );
+
+    assert!(
+        !stderr.contains("scope acme/"),
+        "AI_MEMORY_IGNORE_MARKER=1 must skip the marker entirely: {stderr}"
+    );
+}
+
+#[test]
+fn explicit_workspace_flag_beats_the_marker() {
+    let (cwd, data) = marker_tree("workspace = \"acme\"\n");
+
+    let stderr = search_stderr(cwd.path(), data.path(), &[], &["--workspace", "default"]);
+
+    assert!(
+        !stderr.contains("scope acme/"),
+        "an explicit --workspace wins, so no marker notice: {stderr}"
+    );
+}
+
+#[test]
+fn a_tree_without_a_marker_is_unchanged() {
+    let cwd = TempDir::new().expect("tempdir for cwd");
+    let data = TempDir::new().expect("tempdir for data dir");
+
+    let stderr = search_stderr(cwd.path(), data.path(), &[], &[]);
+
+    assert!(
+        !stderr.contains("declared by"),
+        "no marker means no scope notice and no behaviour change: {stderr}"
+    );
+}

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -283,6 +283,16 @@ fn wrapper_keeps_stdin_attached_when_it_is_a_pipe() {
         !flags.contains(&"-t") && !flags.contains(&"-it"),
         "no TTY may be requested when stdin is a pipe; got {args}"
     );
+    assert!(
+        flags
+            .iter()
+            .any(|arg| arg.starts_with("AI_MEMORY_SCOPE_CWD=/scope")),
+        "an outside-home checkout must expose its bounded marker path; got {args}"
+    );
+    assert!(
+        flags.iter().any(|arg| arg.ends_with(":/scope:ro")),
+        "the marker scope mount must be read-only; got {args}"
+    );
 }
 
 #[test]
@@ -304,6 +314,9 @@ fn docker_wrappers_keep_stdin_attached_independently_of_tty_allocation() {
         posix.contains("CLAUDE_CODE_SESSION_ID"),
         "POSIX wrapper must forward Claude's session id into the bridge container"
     );
+    assert!(posix.contains("git -C \"${PWD}\" rev-parse --show-toplevel"));
+    assert!(posix.contains("AI_MEMORY_SCOPE_CWD=/scope${SCOPE_REL}"));
+    assert!(posix.contains("${SCOPE_ROOT}:/scope:ro"));
 
     let powershell = read_repo("bin/ai-memory.ps1");
     assert!(
@@ -322,6 +335,8 @@ fn docker_wrappers_keep_stdin_attached_independently_of_tty_allocation() {
         powershell.contains("\"CLAUDE_CODE_SESSION_ID\""),
         "PowerShell wrapper must forward Claude's session id into the bridge container"
     );
+    assert!(powershell.contains("AI_MEMORY_SCOPE_CWD=$ScopeCwd"));
+    assert!(powershell.contains("${ScopeRoot}:/scope:ro"));
 }
 
 #[cfg(unix)]

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -4768,7 +4768,7 @@ mod tests {
         //    points at it (exactly the purge-on-live-server scenario).
         state
             .writer
-            .purge_project(ws, proj, "default/heal-project", None)
+            .purge_project(ws, proj, "default/heal-project", None, false)
             .await
             .unwrap();
         assert!(
@@ -4951,7 +4951,7 @@ mod tests {
 
         state
             .writer
-            .purge_project(ws, proj, "default/repo-root-project", None)
+            .purge_project(ws, proj, "default/repo-root-project", None, false)
             .await
             .unwrap();
 

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -4190,6 +4190,25 @@ async fn copy_purge_merge(
         .await
     {
         Ok(s) => s,
+        // A live managed run under the source blocks the second leg exactly
+        // as it blocks a standalone purge. The pages are already copied at
+        // this point, so say so: re-running after the session finishes is
+        // idempotent (copied pages just supersede) and leaves the source
+        // intact meanwhile. `409` matches `handle_purge_project`; a `500`
+        // here would read as a server fault for an operator-fixable state.
+        Err(e @ StoreError::ManagedRunActive { .. }) => {
+            return Err((
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": format!(
+                        "{pages_copied} page(s) were copied to {}/{}, but the source \
+                         {label} could not be purged: {e}. The source is intact — \
+                         re-run the move once the session ends.",
+                        req.to_workspace, req.project,
+                    )
+                })),
+            ));
+        }
         Err(e) => return Err(internal_err(e.to_string())),
     };
 

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -2887,8 +2887,8 @@ pub struct PurgeProjectReport {
     pub workstreams_deleted: u64,
     /// Number of `managed_runs` rows deleted via cascade.
     pub managed_runs_deleted: u64,
-    /// Ids of the deleted workstreams, whose `raw/workstreams/<id>/` segment
-    /// directories the operator may still want to remove.
+    /// Ids of the deleted workstreams whose `raw/workstreams/<id>/` segment
+    /// directories were included in the post-commit cleanup.
     pub workstream_ids: Vec<String>,
     /// Paths removed from disk (the project's UUID-namespaced directory).
     pub files_deleted: Vec<String>,
@@ -2900,6 +2900,60 @@ pub struct PurgeProjectReport {
     /// Post-purge checkpoint, if the purge changed the tree.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checkpoint: Option<String>,
+}
+
+async fn remove_purged_project_storage(
+    state: &AdminState,
+    workspace_id: WorkspaceId,
+    project_id: ProjectId,
+    workstream_ids: &[String],
+    operation: &'static str,
+) -> (Vec<String>, Vec<String>) {
+    let project_root = state.wiki.project_root(workspace_id, project_id);
+    let project_root_display = project_root.display().to_string();
+    let mut deleted = Vec::with_capacity(workstream_ids.len() + 1);
+    let mut failed = Vec::new();
+
+    match state
+        .wiki
+        .remove_project_dir(workspace_id, project_id)
+        .await
+    {
+        Ok(()) => deleted.push(project_root_display.clone()),
+        Err(error) => {
+            warn!(
+                operation,
+                path = %project_root_display,
+                error = %error,
+                "project purge failed to remove wiki directory"
+            );
+            failed.push(project_root_display);
+        }
+    }
+
+    for workstream_id in workstream_ids {
+        let path = state
+            .data_dir
+            .join("raw")
+            .join("workstreams")
+            .join(workstream_id);
+        let path_display = path.display().to_string();
+        match tokio::fs::remove_dir_all(&path).await {
+            Ok(()) => deleted.push(path_display),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                warn!(
+                    operation,
+                    path = %path_display,
+                    error = %error,
+                    "project purge failed to remove workstream segment directory"
+                );
+                failed.push(path_display);
+            }
+        }
+    }
+
+    (deleted, failed)
 }
 
 async fn handle_purge_project(
@@ -2976,25 +3030,17 @@ async fn handle_purge_project(
         Err(e) => return internal_err(e.to_string()),
     };
 
-    // Remove the entire per-project directory: <wiki_root>/<ws_uuid>/<proj_uuid>/.
-    // DB cascade already deleted all rows. Directory removal remains best-effort
-    // and is reported separately, matching the pre-admission purge contract.
-    let proj_root_str = state
-        .wiki
-        .project_root(ws_id, proj_id)
-        .display()
-        .to_string();
-    let mut files_deleted: Vec<String> = Vec::new();
-    let mut files_failed: Vec<String> = Vec::new();
-    match state.wiki.remove_project_dir(ws_id, proj_id).await {
-        Ok(()) => {
-            files_deleted.push(proj_root_str);
-        }
-        Err(e) => {
-            warn!(path = %proj_root_str, error = %e, "purge-project: failed to remove project dir");
-            files_failed.push(proj_root_str);
-        }
-    }
+    // DB cascade already deleted all rows. Remove both the wiki project root
+    // and every raw managed-workstream segment directory best-effort, reporting
+    // partial failures without disguising the committed database purge.
+    let (files_deleted, files_failed) = remove_purged_project_storage(
+        &state,
+        ws_id,
+        proj_id,
+        &summary.workstream_ids,
+        "purge-project",
+    )
+    .await;
     // Mirrors that track filesystem reality (a git-push mirror) want to
     // know the on-disk dir is still present even though the DB rows are
     // gone, so they can refuse to drop their own copy in violation of
@@ -3392,12 +3438,13 @@ struct MoveProjectRequest {
     /// Mandatory confirmation flag. The move PURGES the source after
     /// copying, so without `confirm: true` the server returns 400.
     confirm: bool,
-    /// Override the live-session guard. By default the server refuses (409)
+    /// Override the active-project guard. By default the server refuses (409)
     /// to move the project the hook router is currently writing to, since a
     /// live session's next observation would carry a stale workspace id.
     /// `force: true` proceeds anyway (still safe: the move republishes the
     /// active pointer and the (workspace_id, project_id) trigger makes any
-    /// stale write fail cleanly rather than corrupt).
+    /// stale write fail cleanly rather than corrupt). It never overrides a
+    /// live managed-workstream lease in the destructive copy-purge path.
     #[serde(default)]
     force: bool,
     /// Policy for the copy-purge MERGE path when a source page's path already
@@ -4190,20 +4237,21 @@ async fn copy_purge_merge(
         .await
     {
         Ok(s) => s,
-        // A live managed run under the source blocks the second leg exactly
-        // as it blocks a standalone purge. The pages are already copied at
-        // this point, so say so: re-running after the session finishes is
-        // idempotent (copied pages just supersede) and leaves the source
-        // intact meanwhile. `409` matches `handle_purge_project`; a `500`
-        // here would read as a server fault for an operator-fixable state.
+        // A live managed run under the source always blocks the destructive
+        // second leg. `force` only overrides the active-project guard; unlike
+        // a true move, copy-purge would delete the lease and strand the raw
+        // transcript. The pages are already copied, so a later retry is
+        // idempotent and leaves the source intact meanwhile.
         Err(e @ StoreError::ManagedRunActive { .. }) => {
             return Err((
                 StatusCode::CONFLICT,
                 Json(serde_json::json!({
                     "error": format!(
                         "{pages_copied} page(s) were copied to {}/{}, but the source \
-                         {label} could not be purged: {e}. The source is intact — \
-                         re-run the move once the session ends.",
+                         {label} could not be purged: {e}. The source is intact. \
+                         move-project --force cannot delete a live managed \
+                         workstream during a copy-purge merge; finish or cancel \
+                         the managed run, then retry.",
                         req.to_workspace, req.project,
                     )
                 })),
@@ -4212,24 +4260,17 @@ async fn copy_purge_merge(
         Err(e) => return Err(internal_err(e.to_string())),
     };
 
-    // Remove the source's on-disk dir, then dispatch the non-blocking
-    // purge webhook. Pass the workspace/project NAMES we cached in
-    // `resolved_purge_ctx` — the DB rows have just been deleted, so a
-    // name-resolution lookup at dispatch time would find nothing.
-    let proj_root_str = state
-        .wiki
-        .project_root(src_ws, src_proj)
-        .display()
-        .to_string();
-    let mut files_deleted: Vec<String> = Vec::new();
-    let mut files_failed: Vec<String> = Vec::new();
-    match state.wiki.remove_project_dir(src_ws, src_proj).await {
-        Ok(()) => files_deleted.push(proj_root_str),
-        Err(e) => {
-            warn!(path = %proj_root_str, error = %e, "move-project: failed to remove source dir");
-            files_failed.push(proj_root_str);
-        }
-    }
+    // Remove the source's wiki and raw-workstream directories, then dispatch
+    // the non-blocking purge webhook. Pass the workspace/project names cached
+    // in `resolved_purge_ctx`; the DB rows no longer exist for lookup.
+    let (files_deleted, files_failed) = remove_purged_project_storage(
+        state,
+        src_ws,
+        src_proj,
+        &summary.workstream_ids,
+        "move-project",
+    )
+    .await;
     // See `handle_purge_project` for the rationale on `partial_failure`.
     let mut dispatch_ctx = resolved_purge_ctx;
     if !files_failed.is_empty()

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -2861,6 +2861,11 @@ struct PurgeProjectRequest {
     /// Mandatory confirmation flag. Without `confirm: true` the server
     /// returns 400 — purging is destructive and irreversible.
     confirm: bool,
+    /// Purge even when a managed workstream under this project still holds a
+    /// live run lease. Off by default: the cascade would delete that lease row
+    /// out from under a running agent, which then cannot save its history.
+    #[serde(default)]
+    force: bool,
 }
 
 /// Wire-format summary returned by `POST /admin/purge-project`.
@@ -2878,6 +2883,13 @@ pub struct PurgeProjectReport {
     pub handoffs_deleted: u64,
     /// Number of `page_embeddings` rows deleted.
     pub embeddings_deleted: u64,
+    /// Number of managed `workstreams` rows deleted via cascade.
+    pub workstreams_deleted: u64,
+    /// Number of `managed_runs` rows deleted via cascade.
+    pub managed_runs_deleted: u64,
+    /// Ids of the deleted workstreams, whose `raw/workstreams/<id>/` segment
+    /// directories the operator may still want to remove.
+    pub workstream_ids: Vec<String>,
     /// Paths removed from disk (the project's UUID-namespaced directory).
     pub files_deleted: Vec<String>,
     /// Paths that could not be removed from disk (non-fatal; DB rows are gone).
@@ -2948,10 +2960,19 @@ async fn handle_purge_project(
 
     let summary = match state
         .writer
-        .purge_project(ws_id, proj_id, &label, author_id)
+        .purge_project(ws_id, proj_id, &label, author_id, req.force)
         .await
     {
         Ok(s) => s,
+        // A live managed run is a conflict, not a server fault: the operator
+        // can finish the session or retry with `force`. Same status the
+        // heartbeat itself returns when a lease is gone, so the two agree.
+        Err(e @ StoreError::ManagedRunActive { .. }) => {
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            );
+        }
         Err(e) => return internal_err(e.to_string()),
     };
 
@@ -3000,6 +3021,9 @@ async fn handle_purge_project(
         observations_deleted: summary.observations_deleted,
         handoffs_deleted: summary.handoffs_deleted,
         embeddings_deleted: summary.embeddings_deleted,
+        workstreams_deleted: summary.workstreams_deleted,
+        managed_runs_deleted: summary.managed_runs_deleted,
+        workstream_ids: summary.workstream_ids,
         files_deleted,
         files_failed,
         pre_checkpoint,
@@ -4162,7 +4186,7 @@ async fn copy_purge_merge(
     // `purge_project` here, so the audit author is left NULL.
     let summary = match state
         .writer
-        .purge_project(src_ws, src_proj, &label, None)
+        .purge_project(src_ws, src_proj, &label, None, false)
         .await
     {
         Ok(s) => s,

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -13,9 +13,9 @@
 //! both versions survive), then purge the source — there the episodic rows
 //! (sessions/observations/handoffs) are dropped by the purge.
 
-use ai_memory_core::{PagePath, Sanitized, Sanitizer, Tier};
+use ai_memory_core::{AgentKind, PagePath, Sanitized, Sanitizer, Tier};
 use ai_memory_mcp::{AdminState, admin_router};
-use ai_memory_store::{DecayParams, Store};
+use ai_memory_store::{DecayParams, PrepareWorkstreamRun, Store, WorkstreamSelection};
 use ai_memory_wiki::{
     AdmissionChain, AdmissionOp, FailurePolicy, WebhookConfig, Wiki, WritePageRequest,
 };
@@ -910,6 +910,80 @@ async fn move_active_project_with_force_succeeds_and_republishes() {
         active.get(),
         Some((dst_ws, src_proj)),
         "active republished to dst"
+    );
+}
+
+#[tokio::test]
+async fn copy_purge_force_never_deletes_a_live_managed_workstream() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    seed_page(&store, &state.wiki, "src", "proj", "notes/a.md", "source").await;
+    seed_page(
+        &store,
+        &state.wiki,
+        "dst",
+        "proj",
+        "notes/keep.md",
+        "destination",
+    )
+    .await;
+    let (src_ws, src_proj) = ids(&store, "src", "proj").await;
+    state.active_project.set(src_ws, src_proj);
+    let prepared = store
+        .writer
+        .prepare_workstream_run(PrepareWorkstreamRun {
+            workspace_id: src_ws,
+            project_id: src_proj,
+            repo_fingerprint: "repo".into(),
+            worktree_fingerprint: "worktree".into(),
+            cwd: "/repo".into(),
+            agent: AgentKind::Codex,
+            automatic_harness: false,
+            available_agents: vec![AgentKind::Codex],
+            selection: WorkstreamSelection::Current,
+            lease_owner: "test".into(),
+        })
+        .await
+        .unwrap();
+
+    let resp = post(
+        state,
+        "/admin/move-project",
+        json!({
+            "from_workspace": "src",
+            "project": "proj",
+            "to_workspace": "dst",
+            "confirm": true,
+            "force": true
+        }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let body = body_json(resp).await;
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("--force cannot delete a live managed workstream"),
+        "the force boundary must be explicit: {body}"
+    );
+    assert_eq!(
+        store
+            .reader
+            .find_project(src_ws, "proj".into())
+            .await
+            .unwrap(),
+        Some(src_proj),
+        "the source must remain intact"
+    );
+    assert!(
+        store
+            .reader
+            .managed_run_status(prepared.run_id)
+            .await
+            .unwrap()
+            .is_some(),
+        "the managed lease row must survive"
     );
 }
 

--- a/crates/ai-memory-mcp/tests/admin_purge.rs
+++ b/crates/ai-memory-mcp/tests/admin_purge.rs
@@ -9,7 +9,7 @@ use ai_memory_core::{
     Sanitized, Sanitizer, SessionId, Tier, WorkspaceId,
 };
 use ai_memory_mcp::{AdminState, admin_router};
-use ai_memory_store::{DecayParams, Store};
+use ai_memory_store::{DecayParams, PrepareWorkstreamRun, Store, WorkstreamSelection};
 use ai_memory_wiki::{
     AdmissionChain, AdmissionOp, FailurePolicy, WebhookConfig, Wiki, WritePageRequest,
 };
@@ -306,6 +306,70 @@ async fn purge_project_deletes_data_and_files() {
     assert!(
         !proj_dir.exists(),
         "project directory must be removed after purge"
+    );
+}
+
+#[tokio::test]
+async fn purge_project_removes_raw_workstream_segments() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    let (workspace_id, _keep, project_id) = seed_two_projects(&store, &state.wiki).await;
+    let prepared = store
+        .writer
+        .prepare_workstream_run(PrepareWorkstreamRun {
+            workspace_id,
+            project_id,
+            repo_fingerprint: "repo".into(),
+            worktree_fingerprint: "worktree".into(),
+            cwd: "/repo".into(),
+            agent: AgentKind::Codex,
+            automatic_harness: false,
+            available_agents: vec![AgentKind::Codex],
+            selection: WorkstreamSelection::Current,
+            lease_owner: "test".into(),
+        })
+        .await
+        .unwrap();
+    assert!(
+        store
+            .writer
+            .cancel_managed_run(prepared.run_id)
+            .await
+            .unwrap()
+    );
+    let raw_dir = tmp
+        .path()
+        .join("raw/workstreams")
+        .join(prepared.workstream_id.to_string());
+    std::fs::create_dir_all(&raw_dir).unwrap();
+    std::fs::write(raw_dir.join("000001.jsonl"), "event\n").unwrap();
+
+    let resp = post(
+        state,
+        "/admin/purge-project",
+        json!({ "workspace": "default", "project": "doomed", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+
+    assert!(
+        !raw_dir.exists(),
+        "raw workstream directory must be removed"
+    );
+    assert_eq!(body["workstreams_deleted"], 1);
+    assert_eq!(body["managed_runs_deleted"], 1);
+    assert_eq!(
+        body["workstream_ids"],
+        json!([prepared.workstream_id.to_string()])
+    );
+    assert!(
+        body["files_deleted"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|path| path.as_str() == Some(raw_dir.to_string_lossy().as_ref())),
+        "raw cleanup must be visible in the report: {body}"
     );
 }
 

--- a/crates/ai-memory-store/src/error.rs
+++ b/crates/ai-memory-store/src/error.rs
@@ -82,6 +82,26 @@ pub enum StoreError {
     #[error("workspace still has {0} project(s); pass force to delete anyway")]
     WorkspaceNotEmpty(u64),
 
+    /// A project purge was rejected because one of its managed workstreams
+    /// still holds a live run lease. `workstreams` is `ON DELETE CASCADE` from
+    /// `projects`, and `managed_runs` cascades from `workstreams`, so the
+    /// purge would delete the lease row out from under a running agent — whose
+    /// heartbeat then fails with `409 managed run lease is not active` for the
+    /// rest of the session and whose transcript never reaches the ledger.
+    /// Carries the offending workstream names so the operator can find the
+    /// session before retrying with force.
+    #[error(
+        "project has {count} active managed run(s) in workstream(s) {workstreams}; \
+         finish or cancel them first, or pass force to purge anyway (the running \
+         agent will stop being able to save its history)"
+    )]
+    ManagedRunActive {
+        /// How many `managed_runs` rows are still `state = 'active'`.
+        count: u64,
+        /// Comma-separated workstream names holding those runs.
+        workstreams: String,
+    },
+
     /// A workspace rename was rejected because the destination name is already
     /// in use by another workspace (`workspaces.name` is UNIQUE).
     #[error("workspace name '{0}' is already taken")]

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -55,6 +55,18 @@ pub struct PurgeSummary {
     pub handoffs_deleted: u64,
     /// Number of `page_embeddings` rows deleted (cascades through pages).
     pub embeddings_deleted: u64,
+    /// Number of `workstreams` rows deleted. These cascade from `projects`,
+    /// so a project that looks empty by page/session/observation count can
+    /// still take a managed workstream — and its portable event ledger — down
+    /// with it. Counted so the caller can say so out loud.
+    pub workstreams_deleted: u64,
+    /// Number of `managed_runs` rows deleted (cascades through workstreams).
+    pub managed_runs_deleted: u64,
+    /// Ids of the deleted workstreams. Their `raw/workstreams/<id>/` segment
+    /// directories survive the SQL delete, so the caller removes them the same
+    /// way it removes [`Self::page_paths`]; otherwise they stay orphaned on
+    /// disk with no row pointing at them.
+    pub workstream_ids: Vec<String>,
 }
 use jiff::Timestamp;
 use rusqlite::{Connection, OptionalExtension, Transaction, params};
@@ -1506,6 +1518,7 @@ pub fn purge_project(
     project_id: &ProjectId,
     workspace_project_label: &str,
     author_id: Option<ai_memory_core::UserId>,
+    force: bool,
 ) -> StoreResult<PurgeSummary> {
     let tx = conn.transaction()?;
 
@@ -1517,6 +1530,35 @@ pub fn purge_project(
     };
 
     let pid = project_id.as_bytes();
+
+    // Managed workstreams cascade out of `projects`, and `managed_runs`
+    // cascades out of them. A live run's lease row would go with them, which
+    // leaves the running agent heartbeating a run id that no longer exists —
+    // `409 managed run lease is not active`, every 30s, with its transcript
+    // unable to reach any ledger. Refuse unless the operator insists.
+    let active_runs: Vec<(String, String)> = {
+        let mut stmt = tx.prepare(
+            "SELECT w.name, mr.agent_kind FROM managed_runs mr \
+             JOIN workstreams w ON w.id = mr.workstream_id \
+             WHERE w.project_id = ?1 AND mr.state = 'active'",
+        )?;
+        stmt.query_map(rusqlite::params![&pid[..]], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?
+    };
+    if !active_runs.is_empty() && !force {
+        let mut names: Vec<String> = active_runs
+            .iter()
+            .map(|(workstream, agent)| format!("'{workstream}' ({agent})"))
+            .collect();
+        names.sort();
+        names.dedup();
+        return Err(StoreError::ManagedRunActive {
+            count: active_runs.len() as u64,
+            workstreams: names.join(", "),
+        });
+    }
     let pages_deleted = count("SELECT COUNT(*) FROM pages WHERE project_id = ?1", &pid[..])?;
     let sessions_deleted = count(
         "SELECT COUNT(*) FROM sessions WHERE project_id = ?1",
@@ -1537,6 +1579,16 @@ pub fn purge_project(
         &pid[..],
     )?;
 
+    let workstreams_deleted = count(
+        "SELECT COUNT(*) FROM workstreams WHERE project_id = ?1",
+        &pid[..],
+    )?;
+    let managed_runs_deleted = count(
+        "SELECT COUNT(*) FROM managed_runs WHERE workstream_id IN \
+         (SELECT id FROM workstreams WHERE project_id = ?1)",
+        &pid[..],
+    )?;
+
     // Collect all distinct on-disk paths for the caller to clean up.
     // We use DISTINCT because multiple versions of the same logical page
     // share a path; the file only exists once. The statement must be
@@ -1546,6 +1598,21 @@ pub fn purge_project(
         path_stmt
             .query_map(rusqlite::params![&pid[..]], |row| row.get(0))?
             .collect::<rusqlite::Result<Vec<String>>>()?
+    };
+
+    // Same idea for the workstream segment directories: the rows go with the
+    // cascade but `raw/workstreams/<id>/` does not.
+    let workstream_ids: Vec<String> = {
+        let mut stmt = tx.prepare("SELECT id FROM workstreams WHERE project_id = ?1")?;
+        stmt.query_map(rusqlite::params![&pid[..]], |row| row.get::<_, Vec<u8>>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+            .into_iter()
+            .filter_map(|raw| {
+                <[u8; 16]>::try_from(raw.as_slice())
+                    .ok()
+                    .map(|bytes| uuid::Uuid::from_bytes(bytes).to_string())
+            })
+            .collect()
     };
 
     // Cascade handles pages / sessions / observations / handoffs /
@@ -1578,6 +1645,9 @@ pub fn purge_project(
         observations_deleted,
         handoffs_deleted,
         embeddings_deleted,
+        workstreams_deleted,
+        managed_runs_deleted,
+        workstream_ids,
     })
 }
 
@@ -4003,7 +4073,7 @@ mod tests {
         let (_tmp, mut conn, ws, proj) = fresh_db();
         // Simulate the post-purge state: project row gone.
         // `purge_project` drives the cascading deletes we want here.
-        let _ = purge_project(&mut conn, &ws, &proj, "default/scratch", None)
+        let _ = purge_project(&mut conn, &ws, &proj, "default/scratch", None, false)
             .expect("purge of fresh project should succeed");
         // Now try to rename the project that no longer exists. The
         // pre-fix code returned `Ok(())` because `UPDATE` affected
@@ -4058,8 +4128,15 @@ mod tests {
         let (_tmp, mut conn, ws, proj) = fresh_db();
         let author = seed_user(&conn, "alice");
 
-        purge_project(&mut conn, &ws, &proj, "default/scratch", Some(author))
-            .expect("purge should succeed");
+        purge_project(
+            &mut conn,
+            &ws,
+            &proj,
+            "default/scratch",
+            Some(author),
+            false,
+        )
+        .expect("purge should succeed");
 
         let (count, op_author) = audit_row_for(&conn, "purge_project");
         assert_eq!(count, 1, "exactly one purge_project audit row");
@@ -4067,6 +4144,86 @@ mod tests {
             op_author.as_deref(),
             Some(&author.as_bytes()[..]),
             "audit row must carry the purging operator"
+        );
+    }
+
+    /// Open one managed run on `proj` so the purge guard has something to
+    /// refuse. Mirrors what `ai-memory run` does on launch.
+    fn open_managed_run(
+        conn: &mut Connection,
+        ws: &ai_memory_core::WorkspaceId,
+        proj: &ai_memory_core::ProjectId,
+    ) -> crate::workstream::PreparedWorkstreamRun {
+        crate::workstream::prepare_run(
+            conn,
+            &crate::workstream::PrepareWorkstreamRun {
+                workspace_id: *ws,
+                project_id: *proj,
+                repo_fingerprint: "repo-fp".to_string(),
+                worktree_fingerprint: "worktree-fp".to_string(),
+                cwd: "/tmp/checkout".to_string(),
+                agent: ai_memory_core::AgentKind::ClaudeCode,
+                automatic_harness: false,
+                available_agents: Vec::new(),
+                selection: crate::workstream::WorkstreamSelection::Current,
+                lease_owner: "test".to_string(),
+            },
+        )
+        .expect("opening a managed run should succeed")
+    }
+
+    /// `workstreams` cascades out of `projects` and `managed_runs` cascades
+    /// out of `workstreams`, so purging a project silently tore the lease row
+    /// out from under a live agent: its heartbeat then failed with
+    /// `409 managed run lease is not active` every 30s and its transcript
+    /// never reached the ledger. The purge must refuse instead.
+    #[test]
+    fn purge_project_refuses_while_a_managed_run_is_active() {
+        let (_tmp, mut conn, ws, proj) = fresh_db();
+        open_managed_run(&mut conn, &ws, &proj);
+
+        let err = purge_project(&mut conn, &ws, &proj, "default/scratch", None, false)
+            .expect_err("an active managed run must block the purge");
+
+        match err {
+            StoreError::ManagedRunActive { count, workstreams } => {
+                assert_eq!(count, 1, "one active run");
+                assert!(
+                    workstreams.contains("default"),
+                    "the error names the workstream so the operator can find the session: {workstreams}"
+                );
+            }
+            other => panic!("expected ManagedRunActive, got {other:?}"),
+        }
+
+        let survived: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM projects WHERE id = ?1",
+                rusqlite::params![&proj.as_bytes()[..]],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(survived, 1, "a refused purge must not delete anything");
+    }
+
+    /// `force` is the deliberate override, and the summary must account for
+    /// what the cascade took with it — the counters the pre-fix report showed
+    /// (`0 pages, 0 sessions, …`) made a scope carrying a live workstream look
+    /// safe to delete.
+    #[test]
+    fn forced_purge_reports_the_workstreams_it_cascaded() {
+        let (_tmp, mut conn, ws, proj) = fresh_db();
+        let prepared = open_managed_run(&mut conn, &ws, &proj);
+
+        let summary = purge_project(&mut conn, &ws, &proj, "default/scratch", None, true)
+            .expect("force purges regardless of the live lease");
+
+        assert_eq!(summary.workstreams_deleted, 1);
+        assert_eq!(summary.managed_runs_deleted, 1);
+        assert_eq!(
+            summary.workstream_ids,
+            vec![prepared.workstream_id.to_string()],
+            "the orphaned raw/workstreams/<id>/ dir is reported for cleanup"
         );
     }
 

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -63,9 +63,9 @@ pub struct PurgeSummary {
     /// Number of `managed_runs` rows deleted (cascades through workstreams).
     pub managed_runs_deleted: u64,
     /// Ids of the deleted workstreams. Their `raw/workstreams/<id>/` segment
-    /// directories survive the SQL delete, so the caller removes them the same
-    /// way it removes [`Self::page_paths`]; otherwise they stay orphaned on
-    /// disk with no row pointing at them.
+    /// directories survive the SQL delete and are NOT removed by any caller
+    /// today — they stay on disk with no row pointing at them. Reported so the
+    /// purge can name them instead of leaving them silently orphaned.
     pub workstream_ids: Vec<String>,
 }
 use jiff::Timestamp;
@@ -1509,9 +1509,14 @@ pub fn insert_wiki_migration(
 /// admin handler has the human-readable names; the writer only has IDs) and
 /// forwarded verbatim into [`PurgeSummary::label`] for logging.
 ///
+/// `force` overrides the live-managed-run guard (step 0): `workstreams`
+/// cascades out of `projects`, so purging a scope whose lease is still live
+/// would delete the lease row out from under a running agent.
+///
 /// # Errors
-/// Returns [`StoreError`] if any SQL statement fails. The transaction is
-/// rolled back automatically on error.
+/// Returns [`StoreError::ManagedRunActive`] when a managed run's lease is
+/// still live and `force` is false, or [`StoreError`] if any SQL statement
+/// fails. The transaction is rolled back automatically on error.
 pub fn purge_project(
     conn: &mut Connection,
     workspace_id: &WorkspaceId,
@@ -1536,13 +1541,22 @@ pub fn purge_project(
     // leaves the running agent heartbeating a run id that no longer exists —
     // `409 managed run lease is not active`, every 30s, with its transcript
     // unable to reach any ledger. Refuse unless the operator insists.
+    //
+    // `state = 'active'` alone is NOT liveness: a crashed wrapper leaves that
+    // row untouched, and the only sweep that flips it to `'expired'` runs
+    // inside `workstream::prepare_run`. Without the lease-expiry predicate a
+    // single crashed agent would block every future purge of the project
+    // until someone launched another managed run. The lease is short (90s,
+    // extended by heartbeat), so `lease_expires_at > now` is the real signal.
+    let now = Timestamp::now().as_microsecond();
     let active_runs: Vec<(String, String)> = {
         let mut stmt = tx.prepare(
             "SELECT w.name, mr.agent_kind FROM managed_runs mr \
              JOIN workstreams w ON w.id = mr.workstream_id \
-             WHERE w.project_id = ?1 AND mr.state = 'active'",
+             WHERE w.project_id = ?1 AND mr.state = 'active' \
+               AND mr.lease_expires_at > ?2",
         )?;
-        stmt.query_map(rusqlite::params![&pid[..]], |row| {
+        stmt.query_map(rusqlite::params![&pid[..], now], |row| {
             Ok((row.get(0)?, row.get(1)?))
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?
@@ -1601,18 +1615,18 @@ pub fn purge_project(
     };
 
     // Same idea for the workstream segment directories: the rows go with the
-    // cascade but `raw/workstreams/<id>/` does not.
+    // cascade but `raw/workstreams/<id>/` does not. Decode through the typed
+    // id so the reported string matches the directory name `write_segment`
+    // builds from `WorkstreamId::to_string`; a malformed blob is a corrupt
+    // row, so surface it rather than silently shortening the orphan list.
     let workstream_ids: Vec<String> = {
         let mut stmt = tx.prepare("SELECT id FROM workstreams WHERE project_id = ?1")?;
-        stmt.query_map(rusqlite::params![&pid[..]], |row| row.get::<_, Vec<u8>>(0))?
-            .collect::<rusqlite::Result<Vec<_>>>()?
-            .into_iter()
-            .filter_map(|raw| {
-                <[u8; 16]>::try_from(raw.as_slice())
-                    .ok()
-                    .map(|bytes| uuid::Uuid::from_bytes(bytes).to_string())
-            })
-            .collect()
+        let rows = stmt
+            .query_map(rusqlite::params![&pid[..]], |row| row.get::<_, Vec<u8>>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        rows.into_iter()
+            .map(|raw| ai_memory_core::WorkstreamId::from_slice(&raw).map(|id| id.to_string()))
+            .collect::<Result<Vec<_>, _>>()?
     };
 
     // Cascade handles pages / sessions / observations / handoffs /
@@ -4225,6 +4239,29 @@ mod tests {
             vec![prepared.workstream_id.to_string()],
             "the orphaned raw/workstreams/<id>/ dir is reported for cleanup"
         );
+    }
+
+    /// A crashed wrapper leaves `state = 'active'` behind forever — the only
+    /// sweep that flips it to `'expired'` lives in `prepare_run`. Guarding on
+    /// the state alone would let one dead session block every future purge of
+    /// the project, so the guard must read the lease expiry too.
+    #[test]
+    fn purge_project_ignores_a_managed_run_whose_lease_expired() {
+        let (_tmp, mut conn, ws, proj) = fresh_db();
+        open_managed_run(&mut conn, &ws, &proj);
+        // Simulate the crash: the row still says 'active', but nothing has
+        // heartbeated it, so its lease lapsed.
+        conn.execute(
+            "UPDATE managed_runs SET lease_expires_at = ?1 WHERE state = 'active'",
+            rusqlite::params![Timestamp::now().as_microsecond() - 1],
+        )
+        .unwrap();
+
+        let summary = purge_project(&mut conn, &ws, &proj, "default/scratch", None, false)
+            .expect("a lapsed lease is not a running agent");
+
+        assert_eq!(summary.workstreams_deleted, 1);
+        assert_eq!(summary.managed_runs_deleted, 1);
     }
 
     /// A `rename_project` writes an attributed audit row, committed

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -62,10 +62,9 @@ pub struct PurgeSummary {
     pub workstreams_deleted: u64,
     /// Number of `managed_runs` rows deleted (cascades through workstreams).
     pub managed_runs_deleted: u64,
-    /// Ids of the deleted workstreams. Their `raw/workstreams/<id>/` segment
-    /// directories survive the SQL delete and are NOT removed by any caller
-    /// today — they stay on disk with no row pointing at them. Reported so the
-    /// purge can name them instead of leaving them silently orphaned.
+    /// Ids of the deleted workstreams. The admin layer uses these typed,
+    /// pre-delete identifiers to remove `raw/workstreams/<id>/` after the SQL
+    /// transaction commits and to report any filesystem partial failure.
     pub workstream_ids: Vec<String>,
 }
 use jiff::Timestamp;
@@ -1615,10 +1614,11 @@ pub fn purge_project(
     };
 
     // Same idea for the workstream segment directories: the rows go with the
-    // cascade but `raw/workstreams/<id>/` does not. Decode through the typed
-    // id so the reported string matches the directory name `write_segment`
-    // builds from `WorkstreamId::to_string`; a malformed blob is a corrupt
-    // row, so surface it rather than silently shortening the orphan list.
+    // cascade but `raw/workstreams/<id>/` needs post-commit filesystem
+    // cleanup. Decode through the typed id so the reported string matches the
+    // directory name `write_segment` builds from `WorkstreamId::to_string`; a
+    // malformed blob is a corrupt row, so surface it rather than silently
+    // shortening the cleanup list.
     let workstream_ids: Vec<String> = {
         let mut stmt = tx.prepare("SELECT id FROM workstreams WHERE project_id = ?1")?;
         let rows = stmt
@@ -4237,7 +4237,7 @@ mod tests {
         assert_eq!(
             summary.workstream_ids,
             vec![prepared.workstream_id.to_string()],
-            "the orphaned raw/workstreams/<id>/ dir is reported for cleanup"
+            "the raw/workstreams/<id>/ dir is reported for post-commit cleanup"
         );
     }
 

--- a/crates/ai-memory-store/src/writer.rs
+++ b/crates/ai-memory-store/src/writer.rs
@@ -183,6 +183,8 @@ pub(crate) enum WriteCmd {
         /// Authenticated operator recorded in the `audit_log` row (NULL when
         /// single-user / unauthenticated).
         author_id: Option<ai_memory_core::UserId>,
+        /// Purge even when a managed workstream still holds a live run lease.
+        force: bool,
         reply: oneshot::Sender<StoreResult<PurgeSummary>>,
     },
     /// Delete a workspace row (its `workspace_id` FKs cascade projects/pages/
@@ -751,6 +753,7 @@ impl WriterHandle {
         project_id: ProjectId,
         label: impl Into<String>,
         author_id: Option<ai_memory_core::UserId>,
+        force: bool,
     ) -> StoreResult<PurgeSummary> {
         let (tx, rx) = oneshot::channel();
         self.send(WriteCmd::PurgeProject {
@@ -758,6 +761,7 @@ impl WriterHandle {
             project_id,
             label: label.into(),
             author_id,
+            force,
             reply: tx,
         })
         .await?;
@@ -1461,10 +1465,17 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
                 project_id,
                 label,
                 author_id,
+                force,
                 reply,
             } => {
-                let result =
-                    ops::purge_project(&mut conn, &workspace_id, &project_id, &label, author_id);
+                let result = ops::purge_project(
+                    &mut conn,
+                    &workspace_id,
+                    &project_id,
+                    &label,
+                    author_id,
+                    force,
+                );
                 send_or_warn(reply, result, "purge_project");
             }
             WriteCmd::DeleteWorkspace {

--- a/docs/install.md
+++ b/docs/install.md
@@ -1352,8 +1352,10 @@ remote or uses a custom host/port.
 
 ```
 --repo-path <PATH>         (default: git rev-parse --show-toplevel)
---workspace <NAME>         (default: "default")
---project <NAME>           (default: derived from cwd — main repo root's
+--workspace <NAME>         (default: the nearest `.ai-memory.toml` marker's
+                            `workspace`, else "default")
+--project <NAME>           (default: the marker's `project` when pinned,
+                            else derived from cwd — main repo root's
                             basename via `git rev-parse --show-toplevel`,
                             or basename(cwd) when no repo is found.
                             "scratch" only as a defensive fallback for

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -8,7 +8,7 @@ on a homelab box where mistakes are harder to undo.
 
 | Command | Safe with server **running**? | Wipes data? | Reversible? | Notes |
 |---|---|---|---|---|
-| `purge-project --confirm` | ✅ yes | the one project's data | no | Atomic `rm -rf <project_root>` on the namespaced disk path; sibling projects untouched. Refuses with `409` while a managed workstream under the project holds a live run lease — `--force` overrides. |
+| `purge-project --confirm` | ✅ yes | the one project's data | no | Deletes the UUID-namespaced wiki root and raw workstream segments; sibling projects remain untouched. Refuses with `409` while a managed workstream under the project holds a live run lease — `--force` overrides. |
 | `rename-project --from --to` | ✅ yes | no | yes (rename back) | Column-only update on `projects.name`. The on-disk dir is keyed by `project_id` (UUID), so the rename never moves a file. |
 | `/admin/rename-workspace` | ✅ yes | no | yes (rename back) | Column-only update on `workspaces.name`; refreshes `_meta.md` scope manifests and checkpoints the wiki tree. |
 | `/admin/delete-workspace` | ✅ yes | the workspace and every child project | no | Runs `purge_workspace` admission first, deletes SQLite rows in one cascade, removes the UUID-keyed workspace directory, reports filesystem partial failures, and dispatches mirror notification after durable work. |
@@ -92,17 +92,17 @@ What happens, in order:
 4. Single `DELETE FROM projects WHERE id = ?` - the V01 + V05
    `ON DELETE CASCADE` foreign keys propagate to every dependent
    table in one transaction.
-5. `std::fs::remove_dir_all(<wiki_root>/<workspace_id>/<project_id>)`
-   wipes the on-disk project root.
+5. Best-effort filesystem cleanup removes both the UUID-namespaced wiki root
+   and every `<data_dir>/raw/workstreams/<workstream_id>/` segment directory.
 6. Returns a summary: `{label, pages_deleted, sessions_deleted, …,
    workstreams_deleted, managed_runs_deleted, workstream_ids,
-   files_deleted: [<project_root>], files_failed: [...]}`.
+   files_deleted: [<project_root>, <raw_workstream_dir>, ...],
+   files_failed: [...]}`.
 
-`workstream_ids` is reported, not deleted: the managed-run segment
-directories live under `<data_dir>/raw/workstreams/<workstream_id>/`,
-outside the wiki root the purge removes, so they survive as orphans
-with no row pointing at them. Remove them by hand on the **server's**
-data dir if you want the raw event ledger gone too.
+`workstream_ids` remains in the report for auditability. Each corresponding
+raw segment directory is removed on the server and appears in
+`files_deleted`; a failed removal appears in `files_failed` alongside wiki
+cleanup failures.
 
 Failure modes:
 
@@ -268,6 +268,11 @@ pages are copied into the existing destination project via
 deploy — the admission/git-mirror webhooks all fire), source embeddings
 are carried over verbatim, and only then is the source purged
 (`merged_into_existing: true`, `source_purged: true`).
+
+`--force` overrides only the hook router's active-project guard. It never
+deletes a live managed-workstream lease during this destructive path; finish
+or cancel that run before retrying. A true move keeps the same project and
+lease ids, so it does not need this additional guard.
 
 Copy-before-purge means any copy failure aborts **before** the purge,
 leaving the source intact. An unreadable source file is skipped and also

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -8,7 +8,7 @@ on a homelab box where mistakes are harder to undo.
 
 | Command | Safe with server **running**? | Wipes data? | Reversible? | Notes |
 |---|---|---|---|---|
-| `purge-project --confirm` | ✅ yes | the one project's data | no | Atomic `rm -rf <project_root>` on the namespaced disk path; sibling projects untouched. |
+| `purge-project --confirm` | ✅ yes | the one project's data | no | Atomic `rm -rf <project_root>` on the namespaced disk path; sibling projects untouched. Refuses with `409` while a managed workstream under the project holds a live run lease — `--force` overrides. |
 | `rename-project --from --to` | ✅ yes | no | yes (rename back) | Column-only update on `projects.name`. The on-disk dir is keyed by `project_id` (UUID), so the rename never moves a file. |
 | `/admin/rename-workspace` | ✅ yes | no | yes (rename back) | Column-only update on `workspaces.name`; refreshes `_meta.md` scope manifests and checkpoints the wiki tree. |
 | `/admin/delete-workspace` | ✅ yes | the workspace and every child project | no | Runs `purge_workspace` admission first, deletes SQLite rows in one cascade, removes the UUID-keyed workspace directory, reports filesystem partial failures, and dispatches mirror notification after durable work. |
@@ -77,20 +77,40 @@ What happens, in order:
 
 1. Server looks up `(workspace_id, project_id)` by name. Returns 404
    if either is missing.
-2. Counts rows that will cascade (`pages`, `sessions`,
-   `observations`, `handoffs`, `page_embeddings`).
-3. Single `DELETE FROM projects WHERE id = ?` - the V01 + V05
+2. Refuses with 409 when a managed workstream under the project still
+   holds a **live** run lease (`managed_runs.state = 'active'` AND
+   `lease_expires_at` in the future). `workstreams` cascades out of
+   `projects` and `managed_runs` cascades out of `workstreams`, so
+   purging would delete a running agent's lease row: its heartbeat
+   would then fail with `409 managed run lease is not active` for the
+   rest of the session and the transcript would never reach the ledger.
+   A lapsed lease (crashed wrapper) does **not** block the purge.
+   `--force` purges anyway.
+3. Counts rows that will cascade (`pages`, `sessions`,
+   `observations`, `handoffs`, `page_embeddings`, plus `workstreams`
+   and `managed_runs`).
+4. Single `DELETE FROM projects WHERE id = ?` - the V01 + V05
    `ON DELETE CASCADE` foreign keys propagate to every dependent
    table in one transaction.
-4. `std::fs::remove_dir_all(<wiki_root>/<workspace_id>/<project_id>)`
+5. `std::fs::remove_dir_all(<wiki_root>/<workspace_id>/<project_id>)`
    wipes the on-disk project root.
-5. Returns a summary: `{label, pages_deleted, sessions_deleted, …,
+6. Returns a summary: `{label, pages_deleted, sessions_deleted, …,
+   workstreams_deleted, managed_runs_deleted, workstream_ids,
    files_deleted: [<project_root>], files_failed: [...]}`.
+
+`workstream_ids` is reported, not deleted: the managed-run segment
+directories live under `<data_dir>/raw/workstreams/<workstream_id>/`,
+outside the wiki root the purge removes, so they survive as orphans
+with no row pointing at them. Remove them by hand on the **server's**
+data dir if you want the raw event ledger gone too.
 
 Failure modes:
 
 - **Workspace or project name not found** → 404, no mutation.
 - **Confirmation flag omitted** → 400, no mutation.
+- **Live managed run, no `--force`** → 409 naming the workstreams, no
+   mutation. Finish or cancel the session, or re-run with `--force`
+   (the running agent then stops being able to save its history).
 - **`remove_dir_all` partial failure** (e.g. permissions) → DB
    rows are already gone but `files_failed` is populated. Re-run
    the command with the same args is idempotent; the second call
@@ -252,7 +272,10 @@ are carried over verbatim, and only then is the source purged
 Copy-before-purge means any copy failure aborts **before** the purge,
 leaving the source intact. An unreadable source file is skipped and also
 blocks the purge (`source_purged: false`) so a fixed re-run is safe
-(re-running is idempotent — copied pages just supersede).
+(re-running is idempotent — copied pages just supersede). A **live managed
+run** under the source blocks the purge leg the same way: the move returns
+409 saying how many pages were already copied, and the source stays intact
+until the session ends and the move is re-run.
 
 **Same-path conflicts (`on_conflict`).** When a source page's path already
 exists in the destination with a different body, frontmatter, title, tier, or

--- a/docs/marker-file.md
+++ b/docs/marker-file.md
@@ -325,6 +325,46 @@ runtime override (which was deliberately rejected in #16). The flag accepts
 Precedence is unchanged: a marker's explicit `project_strategy` or `project`
 still wins over the install default.
 
+## Who reads the marker
+
+Both entry points, as of v1.20:
+
+- **Lifecycle hooks** forward the marker's fields to the server on every
+  event, so session captures land in the declared scope.
+- **Client CLI commands** resolve `(workspace, project)` locally before
+  calling the server — `run`, `bootstrap`, `search`, `read-page`,
+  `write-page`, `lint`, `curator`, `embed`, `pending-writes`,
+  `forget-sweep`, `auto-improve`, `purge-project`, `rename-project`,
+  `move-project` (source side), and friends.
+
+Before v1.20 only the hooks read it. A checkout declaring
+`workspace = "acme"` therefore had its captures land in `acme` while every
+CLI command resolved into `default` — the same repository split across two
+scopes, with `ai-memory run`'s managed workstream on the wrong side of the
+split.
+
+Each field is resolved independently:
+
+1. The explicit flag (`--workspace` / `--project`).
+2. The nearest marker: `workspace`, and `project` — or the main repo root's
+   basename when only `project_strategy = "repo-root"` is set.
+3. The previous fallbacks: `default`, and the cwd-derived project name.
+
+When rung 2 decides a field, the command prints one line to stderr naming
+the marker and the resolved scope:
+
+```console
+$ ai-memory search "scope resolver"
+ai-memory: scope acme/api declared by /Users/dev/projects/acme/.ai-memory.toml
+```
+
+`AI_MEMORY_IGNORE_MARKER=1` skips rung 2 for one invocation, restoring the
+pre-v1.20 resolution without editing or leaving the marker's tree.
+
+`ai-memory serve` is deliberately excluded: the server has no caller cwd to
+walk up from, and its `--workspace` / `--project` are the baked fallback for
+hook events that arrive without a usable one.
+
 ## What the marker file does NOT do
 
 - ❌ No glob patterns. Walk-up by literal ancestry only.
@@ -338,6 +378,8 @@ still wins over the install default.
   *default* can still be baked into an install without a marker via
   `install-hooks --project-strategy repo-root`, but that is install-time
   config, not a runtime override the user sets in their shell.)
+- ❌ No reach outside `$HOME`. The walk stops there, so a checkout that
+  lives outside the account's home directory needs its own marker.
 
 ## Troubleshooting
 

--- a/docs/marker-file.md
+++ b/docs/marker-file.md
@@ -23,10 +23,12 @@ ai-memory or running CLI commands per directory.
 
 ## Where to put it
 
-`.ai-memory.toml` in **any ancestor** of your `cwd`. Lifecycle hooks
-walk up from `cwd` toward `$HOME` (or `/` if `$HOME` is unset) and
-use the **first** marker found. Closer markers override outer ones. When
-a marker is found, hook scripts also forward the current `cwd` so
+`.ai-memory.toml` in **any allowed ancestor** of your `cwd`. Lifecycle hooks
+walk up from `cwd` toward `$HOME` (or `/` if `$HOME` is unset) and use the
+**first** marker found. When cwd is outside `$HOME`, the walk stops at the
+nearest checkout root (`.git` file or directory); outside a checkout, only cwd
+itself is checked. Closer markers override outer ones. When a marker is found,
+hook scripts also forward the current `cwd` so
 workspace-only markers can still resolve `project = basename(cwd)` for
 handoff lookups.
 
@@ -383,8 +385,10 @@ hook events that arrive without a usable one.
   *default* can still be baked into an install without a marker via
   `install-hooks --project-strategy repo-root`, but that is install-time
   config, not a runtime override the user sets in their shell.)
-- ❌ No reach outside `$HOME`. The walk stops there, so a checkout that
-  lives outside the account's home directory needs its own marker.
+- ❌ No reach outside the trust boundary. The walk stops at `$HOME`; a
+  checkout outside it stops at that checkout's root and needs a marker inside
+  the checkout. A non-git directory outside `$HOME` needs a marker in its
+  exact cwd.
 
 ## Troubleshooting
 

--- a/docs/marker-file.md
+++ b/docs/marker-file.md
@@ -351,15 +351,20 @@ Each field is resolved independently:
 3. The previous fallbacks: `default`, and the cwd-derived project name.
 
 When rung 2 decides a field, the command prints one line to stderr naming
-the marker and the resolved scope:
+the resolved scope, which half (or halves) the marker decided, and the
+marker that decided it:
 
 ```console
 $ ai-memory search "scope resolver"
-ai-memory: scope acme/api declared by /Users/dev/projects/acme/.ai-memory.toml
+ai-memory: scope acme/api (workspace + project from /Users/dev/projects/acme/.ai-memory.toml)
 ```
 
 `AI_MEMORY_IGNORE_MARKER=1` skips rung 2 for one invocation, restoring the
-pre-v1.20 resolution without editing or leaving the marker's tree.
+pre-v1.20 resolution without editing or leaving the marker's tree. It
+applies to **client commands only** — the lifecycle hooks still forward the
+marker's fields on every event, so an invocation run with it set resolves
+into a different scope than the session captures around it. Use it for
+one-off reads, not as a way to relocate a repository's memory.
 
 `ai-memory serve` is deliberately excluded: the server has no caller cwd to
 walk up from, and its `--workspace` / `--project` are the baked fallback for

--- a/hooks/_lib.sh
+++ b/hooks/_lib.sh
@@ -8,16 +8,37 @@
 # Walk up from "$1" toward $HOME (or /) looking for `.ai-memory.toml`.
 # Prints the absolute path of the first marker found, or nothing.
 # Stops at $HOME to avoid leaking declarations from a shared system
-# user's home into another user's session on multi-user boxes.
+# user's home into another user's session on multi-user boxes. When cwd is
+# outside HOME, stop at the nearest checkout root (`.git` file/dir); a plain
+# non-git directory checks only cwd. This keeps unrelated parent markers out.
 ai_memory_find_marker() {
     dir="$1"
     [ -z "$dir" ] && return 0
+    boundary=""
+    if [ -n "${HOME:-}" ]; then
+        case "$dir" in
+            "$HOME"|"$HOME"/*) boundary="$HOME" ;;
+            *)
+                probe="$dir"
+                while [ -n "$probe" ] && [ "$probe" != "/" ]; do
+                    if [ -e "$probe/.git" ]; then
+                        boundary="$probe"
+                        break
+                    fi
+                    parent=$(dirname "$probe")
+                    [ "$parent" = "$probe" ] && break
+                    probe="$parent"
+                done
+                [ -n "$boundary" ] || boundary="$dir"
+                ;;
+        esac
+    fi
     while [ -n "$dir" ] && [ "$dir" != "/" ]; do
         if [ -f "$dir/.ai-memory.toml" ]; then
             printf '%s\n' "$dir/.ai-memory.toml"
             return 0
         fi
-        if [ -n "${HOME:-}" ] && [ "$dir" = "$HOME" ]; then
+        if [ -n "$boundary" ] && [ "$dir" = "$boundary" ]; then
             return 0
         fi
         parent=$(dirname "$dir")

--- a/hooks/lib/ai-memory-hook.ps1
+++ b/hooks/lib/ai-memory-hook.ps1
@@ -39,11 +39,34 @@ function Get-AiMemoryMarkerToml {
     param([string] $Cwd)
     if (-not $Cwd) { return $null }
     $dir = $Cwd
+    $home = if ($env:HOME) { $env:HOME } else { $env:USERPROFILE }
+    $boundary = $null
+    if ($home) {
+        $homePrefix = $home.TrimEnd([char[]]@('/', '\')) + [IO.Path]::DirectorySeparatorChar
+        $insideHome = ($dir -eq $home) -or $dir.StartsWith(
+            $homePrefix,
+            [StringComparison]::OrdinalIgnoreCase
+        )
+        if ($insideHome) {
+            $boundary = $home
+        } else {
+            $probe = $dir
+            while ($probe -and (Test-Path $probe)) {
+                if (Test-Path (Join-Path $probe ".git")) {
+                    $boundary = $probe
+                    break
+                }
+                $parent = Split-Path $probe -Parent
+                if (-not $parent -or $parent -eq $probe) { break }
+                $probe = $parent
+            }
+            if (-not $boundary) { $boundary = $dir }
+        }
+    }
     while ($dir -and (Test-Path $dir)) {
         $candidate = Join-Path $dir ".ai-memory.toml"
         if (Test-Path $candidate -PathType Leaf) { return $candidate }
-        if ($env:HOME -and $dir -eq $env:HOME) { return $null }
-        if ($env:USERPROFILE -and $dir -eq $env:USERPROFILE) { return $null }
+        if ($boundary -and $dir -eq $boundary) { return $null }
         $parent = Split-Path $dir -Parent
         if (-not $parent -or $parent -eq $dir) { return $null }
         $dir = $parent

--- a/tests/hooks/test_lib.sh
+++ b/tests/hooks/test_lib.sh
@@ -17,6 +17,7 @@ TMP=$(mktemp -d)
 ORIG_HOME=${HOME:-}
 HOME="$TMP"
 export HOME
+unset AI_MEMORY_RUN_ID AI_MEMORY_MANAGED_WORKSTREAM_ID AI_MEMORY_MANAGED_WORKSTREAM_NAME
 trap 'rm -rf "$TMP"; HOME=$ORIG_HOME' EXIT
 
 assert_eq() {
@@ -53,6 +54,27 @@ assert_eq "walks up to find marker" "$TMP/a/.ai-memory.toml" \
     "$(ai_memory_find_marker "$TMP/a/b/c/d")"
 assert_eq "no marker returns empty" "" \
     "$(ai_memory_find_marker "$TMP/nonexistent/path")"
+
+# A checkout outside HOME may inherit a marker inside its own git tree, but
+# never one from an unrelated parent. A plain directory outside HOME checks
+# only its exact cwd.
+OUTSIDE_HOME="$TMP/account-home"
+mkdir -p "$OUTSIDE_HOME" "$TMP/outside/repo/src" "$TMP/outside/plain"
+printf 'workspace = "wrong"\n' >"$TMP/outside/.ai-memory.toml"
+mkdir -p "$TMP/outside/repo/.git"
+printf 'workspace = "right"\n' >"$TMP/outside/repo/.ai-memory.toml"
+HOME="$OUTSIDE_HOME"
+export HOME
+assert_eq "outside HOME finds marker within checkout" \
+    "$TMP/outside/repo/.ai-memory.toml" \
+    "$(ai_memory_find_marker "$TMP/outside/repo/src")"
+rm -f "$TMP/outside/repo/.ai-memory.toml"
+assert_eq "outside HOME stops at checkout root" "" \
+    "$(ai_memory_find_marker "$TMP/outside/repo/src")"
+assert_eq "outside HOME plain dir rejects parent marker" "" \
+    "$(ai_memory_find_marker "$TMP/outside/plain")"
+HOME="$TMP"
+export HOME
 
 # --- extract_cwd ------------------------------------------------------
 PAYLOAD='{"session_id":"x","cwd":"/home/u/foo","tool":"Read"}'


### PR DESCRIPTION
## What

Only the lifecycle hooks read `.ai-memory.toml`. Every client command resolved `--workspace` to the literal `default`, so a checkout declaring `workspace = "acme"` had its captures land in `acme` while `run`, `bootstrap`, `search`, `write-page` and the rest resolved into `default` — one repository split across two scopes.

`ai-memory run` is the worst case: its managed workstream landed in `default/<repo>` while the hook-captured sessions went to `acme/<repo>`, leaving `default/<repo>` rows that look abandoned (`0 pages, 0 sessions, 0 observations`).

Purging one of those is how this was found. `workstreams` cascades from `projects` and `managed_runs` cascades from `workstreams`, so the purge deleted a **live** run's lease row: the wrapper then failed every heartbeat with `409 managed run lease is not active` for the rest of the session, and that workstream's portable ledger was lost — segments stranded under `raw/workstreams/<id>/` with no row pointing at them. The purge report counted pages, sessions, observations, handoffs and embeddings — none of which covered what it actually deleted.

## How

**Scope resolution.** The marker reader moves out of `commands::hook_capture` into a new `marker` module, shared by both entry points. `commands::resolve_scope` resolves each field independently: explicit flag → marker (`workspace`, and `project` or the main repo root under `project_strategy = "repo-root"`) → the previous fallbacks. The defaulted `--workspace` args become `Option<String>` so an explicit `--workspace default` is distinguishable from the default value. When the marker decides a field the command announces the resolved scope on stderr, and `AI_MEMORY_IGNORE_MARKER=1` restores the previous resolution for one invocation.

`serve` keeps its literal default on purpose: it has no caller cwd, and its `--workspace`/`--project` are the baked fallback for hook events without a usable one.

**Purge guard.** `purge-project` now refuses with a 409 naming the offending workstreams while a managed run holds a lease that has not expired, unless `--force` is passed. The report gained `workstreams_deleted`, `managed_runs_deleted` and the `raw/workstreams/<id>/` directories left orphaned on disk. `move-project`'s internal source purge maps the same conflict to a 409 naming how many pages were already copied, rather than a 500 on a half-applied merge.

## Commits

Two, kept separate on purpose:

- `3d8b9b4` — the fix.
- `3fe60ec` — what an adversarial review found in it. Most notably the guard originally treated `state = 'active'` as liveness without checking `lease_expires_at`, so an agent killed by SIGKILL/sleep/OOM would have blocked every future purge of its project forever; and `AI_MEMORY_IGNORE_MARKER` / `AI_MEMORY_PROJECT_STRATEGY` were read with `std::env::var` outside `Config::load()`, violating the config-read invariant.

## Tests

- `marker::tests` — parser and walk contract, moved with the code.
- `commands::tests` — the precedence table, per field.
- `crates/ai-memory-cli/tests/marker_scope.rs` — subprocess coverage for the env wiring and the `$HOME` bound.
- `ops.rs` — purge refuses with a live run, ignores an expired lease, and reports what the cascade removed.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` all pass. `tests/hooks/test_lib.sh` is 29/29.

## Note

The two `CHANGELOG.md` entries still need this PR's `(#NNN)` reference — added in a follow-up commit once the number exists.