### PR TITLE
fix: preserve workstreams across true project moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   including subdirectories and linked worktrees. (#259)
 
 ### Fixed
+- Lossless `move-project` true moves now re-stamp managed workstreams into the
+  destination workspace in the same transaction as the project and its other
+  denormalized child rows. Previously the project moved while its managed
+  workstreams retained the source `workspace_id`, hiding portable history from
+  destination-scope lookup and violating the project/workspace pairing
+  invariant. The admin response now reports `workstreams_moved`. (#272)
 - SessionEnd recovery now commits the ended generation and automatic handoff in
   one SQLite transaction, then lets an already-ended native replay converge the
   remaining wiki commit, durable consolidation enqueue, and ingest-key

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -3493,6 +3493,9 @@ pub struct MoveProjectReport {
     /// Number of latest pages copied into the destination (copy-purge) or
     /// re-stamped in place (true-move).
     pub pages_copied: u64,
+    /// Managed workstreams re-stamped in place by a lossless true move.
+    /// Copy-purge reports zero because it does not transfer managed history.
+    pub workstreams_moved: u64,
     /// Source paths whose on-disk file could not be read (copy skipped).
     /// When non-empty the source is NOT purged so a fixed re-run is safe.
     pub pages_skipped: Vec<String>,
@@ -3645,6 +3648,7 @@ async fn true_move_project(
         merged_into_existing: false,
         moved_via: "true-move",
         pages_copied: summary.pages_moved,
+        workstreams_moved: summary.workstreams_moved,
         pages_skipped: Vec::new(),
         // Nothing is purged in a true move — the source rows ARE the
         // destination rows, just re-stamped.
@@ -4189,6 +4193,7 @@ async fn copy_purge_merge(
             merged_into_existing: true,
             moved_via: "copy-purge",
             pages_copied,
+            workstreams_moved: 0,
             pages_skipped,
             source_purged: false,
             source_pages_deleted: 0,
@@ -4306,6 +4311,7 @@ async fn copy_purge_merge(
         merged_into_existing: true,
         moved_via: "copy-purge",
         pages_copied,
+        workstreams_moved: 0,
         pages_skipped: Vec::new(),
         source_purged: true,
         source_pages_deleted: summary.pages_deleted,

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -210,6 +210,22 @@ async fn move_project_true_move_into_fresh_dest() {
         .await
         .unwrap()
         .expect("src project exists");
+    let managed = store
+        .writer
+        .prepare_workstream_run(PrepareWorkstreamRun {
+            workspace_id: src_ws,
+            project_id: src_proj,
+            repo_fingerprint: "repo".into(),
+            worktree_fingerprint: "worktree".into(),
+            cwd: "/repo".into(),
+            agent: AgentKind::Codex,
+            automatic_harness: false,
+            available_agents: vec![AgentKind::Codex],
+            selection: WorkstreamSelection::Current,
+            lease_owner: "test".into(),
+        })
+        .await
+        .unwrap();
     let src_dir = state.wiki.project_root(src_ws, src_proj);
     assert!(src_dir.exists(), "source dir must exist before move");
 
@@ -223,6 +239,7 @@ async fn move_project_true_move_into_fresh_dest() {
 
     let body = body_json(resp).await;
     assert_eq!(body["pages_copied"].as_u64().unwrap_or(0), 2, "{body}");
+    assert_eq!(body["workstreams_moved"].as_u64().unwrap_or(0), 1, "{body}");
     assert_eq!(body["moved_via"], "true-move", "{body}");
     // Nothing is purged in a true move — the rows are re-stamped, not copied.
     assert_eq!(body["source_purged"], false, "{body}");
@@ -244,6 +261,15 @@ async fn move_project_true_move_into_fresh_dest() {
     assert_eq!(
         dst_proj_check, src_proj,
         "true move keeps the same project_id"
+    );
+    assert!(
+        store
+            .reader
+            .managed_run_status(managed.run_id)
+            .await
+            .unwrap()
+            .is_some(),
+        "the existing managed run must remain attached after the move"
     );
 
     // Both pages now belong to dst/proj (latest), content preserved.

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -1855,6 +1855,9 @@ pub struct MoveSummary {
     pub auto_improve_scheduler_claims_moved: u64,
     /// Durable SessionEnd consolidation jobs re-stamped.
     pub session_consolidation_jobs_moved: u64,
+    /// Managed workstreams re-stamped. Native sessions, runs, and events stay
+    /// attached through `workstream_id` and need no direct update.
+    pub workstreams_moved: u64,
 }
 
 /// Re-stamp a project's `workspace_id` across every domain table in ONE
@@ -1928,6 +1931,10 @@ pub fn move_project_workspace(
         "UPDATE session_consolidation_jobs SET workspace_id = ?1 WHERE project_id = ?2 AND workspace_id = ?3",
         params![&to[..], &pid[..], &from[..]],
     )? as u64;
+    let workstreams_moved = tx.execute(
+        "UPDATE workstreams SET workspace_id = ?1 WHERE project_id = ?2 AND workspace_id = ?3",
+        params![&to[..], &pid[..], &from[..]],
+    )? as u64;
 
     let projects_updated = tx.execute(
         "UPDATE projects SET workspace_id = ?1 WHERE id = ?2 AND workspace_id = ?3",
@@ -1951,6 +1958,7 @@ pub fn move_project_workspace(
         auto_improve_scheduler_state_moved,
         auto_improve_scheduler_claims_moved,
         session_consolidation_jobs_moved,
+        workstreams_moved,
     })
 }
 
@@ -3214,12 +3222,29 @@ mod tests {
         .unwrap();
         end_session(&mut conn, &sid, None).unwrap();
         crate::session_consolidation::enqueue(&mut conn, src_ws, proj, sid).unwrap();
+        let managed = crate::workstream::prepare_run(
+            &mut conn,
+            &crate::PrepareWorkstreamRun {
+                workspace_id: src_ws,
+                project_id: proj,
+                repo_fingerprint: "repo".into(),
+                worktree_fingerprint: "worktree".into(),
+                cwd: "/repo".into(),
+                agent: AgentKind::Codex,
+                automatic_harness: false,
+                available_agents: vec![AgentKind::Codex],
+                selection: crate::WorkstreamSelection::Current,
+                lease_owner: "test".into(),
+            },
+        )
+        .unwrap();
 
         let summary = move_project_workspace(&mut conn, &proj, &src_ws, &dst_ws).unwrap();
         assert_eq!(summary.pages_moved, 1);
         assert_eq!(summary.sessions_moved, 1);
         assert_eq!(summary.observations_moved, 1);
         assert_eq!(summary.session_consolidation_jobs_moved, 1);
+        assert_eq!(summary.workstreams_moved, 1);
 
         // The project_id is unchanged; every row now points at dst_ws.
         // `projects` keys the project by `id`; child tables by `project_id`.
@@ -3242,10 +3267,25 @@ mod tests {
             "sessions",
             "observations",
             "session_consolidation_jobs",
+            "workstreams",
         ] {
             assert_eq!(count_in(table, &dst_ws), 1, "{table} must move to dst ws");
             assert_eq!(count_in(table, &src_ws), 0, "{table} must leave src ws");
         }
+        let managed_run_still_attached: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM managed_runs mr \
+                 JOIN workstreams w ON w.id = mr.workstream_id \
+                 WHERE mr.id = ?1 AND w.workspace_id = ?2 AND w.project_id = ?3",
+                params![
+                    managed.run_id.as_bytes(),
+                    dst_ws.as_bytes(),
+                    proj.as_bytes(),
+                ],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(managed_run_still_attached, 1);
         // The page keeps its id (embeddings/links follow via page_id).
         let still_there: i64 = conn
             .query_row(

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -1849,6 +1849,8 @@ pub struct MoveSummary {
     pub auto_improve_runs_moved: u64,
     /// `auto_improve_proposals` rows re-stamped.
     pub auto_improve_proposals_moved: u64,
+    /// `auto_improve_rejections` rows re-stamped.
+    pub auto_improve_rejections_moved: u64,
     /// `auto_improve_scheduler_state` rows re-stamped.
     pub auto_improve_scheduler_state_moved: u64,
     /// `auto_improve_scheduler_claims` rows re-stamped.
@@ -1919,6 +1921,10 @@ pub fn move_project_workspace(
         "UPDATE auto_improve_proposals SET workspace_id = ?1 WHERE project_id = ?2 AND workspace_id = ?3",
         params![&to[..], &pid[..], &from[..]],
     )? as u64;
+    let auto_improve_rejections_moved = tx.execute(
+        "UPDATE auto_improve_rejections SET workspace_id = ?1 WHERE project_id = ?2 AND workspace_id = ?3",
+        params![&to[..], &pid[..], &from[..]],
+    )? as u64;
     let auto_improve_scheduler_state_moved = tx.execute(
         "UPDATE auto_improve_scheduler_state SET workspace_id = ?1 WHERE project_id = ?2 AND workspace_id = ?3",
         params![&to[..], &pid[..], &from[..]],
@@ -1955,6 +1961,7 @@ pub fn move_project_workspace(
         audit_log_moved,
         auto_improve_runs_moved,
         auto_improve_proposals_moved,
+        auto_improve_rejections_moved,
         auto_improve_scheduler_state_moved,
         auto_improve_scheduler_claims_moved,
         session_consolidation_jobs_moved,
@@ -3222,6 +3229,17 @@ mod tests {
         .unwrap();
         end_session(&mut conn, &sid, None).unwrap();
         crate::session_consolidation::enqueue(&mut conn, src_ws, proj, sid).unwrap();
+        conn.execute(
+            "INSERT INTO auto_improve_rejections \
+             (id, workspace_id, project_id, reason, normalized_fingerprint, summary, created_at) \
+             VALUES (?1, ?2, ?3, 'rejected', 'fingerprint', 'summary', 1)",
+            params![
+                uuid::Uuid::new_v4().as_bytes(),
+                src_ws.as_bytes(),
+                proj.as_bytes(),
+            ],
+        )
+        .unwrap();
         let managed = crate::workstream::prepare_run(
             &mut conn,
             &crate::PrepareWorkstreamRun {
@@ -3243,6 +3261,7 @@ mod tests {
         assert_eq!(summary.pages_moved, 1);
         assert_eq!(summary.sessions_moved, 1);
         assert_eq!(summary.observations_moved, 1);
+        assert_eq!(summary.auto_improve_rejections_moved, 1);
         assert_eq!(summary.session_consolidation_jobs_moved, 1);
         assert_eq!(summary.workstreams_moved, 1);
 
@@ -3266,6 +3285,7 @@ mod tests {
             "pages",
             "sessions",
             "observations",
+            "auto_improve_rejections",
             "session_consolidation_jobs",
             "workstreams",
         ] {

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -234,9 +234,11 @@ a low-level re-stamp:
    wiki root).
 6. Re-stamp `workspace_id` across every domain table for the project in
    **one transaction**, keeping the same `project_id`
-   (`projects`, `pages`, `sessions`, `observations`, `handoffs`,
-   `audit_log`). `page_embeddings` and `links` are keyed by `page_id`, so
-   they follow with no re-stamp.
+   (`projects`, `pages`, `sessions`, `observations`, `handoffs`, `audit_log`,
+   auto-improvement state, SessionEnd consolidation jobs, and managed
+   `workstreams`). Native workstream sessions, runs, and events remain attached
+   through `workstream_id`; `page_embeddings` and `links` remain attached
+   through `page_id`, so none of those rows need a direct re-stamp.
 
 Ordering is **rename-FIRST, SQL-commit-LAST**, so the **DB is never ahead of
 disk**: a rename failure touches nothing; a crash between the two steps leaves


### PR DESCRIPTION
Closes #272.

## What changed
- re-stamp managed workstreams in the same transaction as a lossless project move
- include the previously omitted auto-improvement rejection buffer in the same all-domain-row move
- keep native sessions, active runs, and ledger events attached through the existing workstream id
- expose `workstreams_moved` in the admin response
- add store and HTTP regression coverage
- update lifecycle documentation and the changelog

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- `cargo deny check`
- companion importer fmt/test/clippy