### PR TITLE
Fix workspace workstream segment cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   including subdirectories and linked worktrees. (#259)
 
 ### Fixed
+- Forced workspace deletion now removes the immutable managed-workstream
+  segment directories whose database rows are removed by the workspace
+  cascade. Its admin report includes workstream/run counts and IDs, and raw
+  segment cleanup participates in the existing filesystem partial-failure
+  reporting instead of leaving transcript data orphaned. (#274)
 - Lossless `move-project` true moves now re-stamp managed workstreams into the
   destination workspace in the same transaction as the project and its other
   denormalized child rows. Previously the project moved while its managed

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -2902,6 +2902,39 @@ pub struct PurgeProjectReport {
     pub checkpoint: Option<String>,
 }
 
+async fn remove_workstream_segment_storage(
+    state: &AdminState,
+    workstream_ids: &[String],
+    operation: &'static str,
+) -> (Vec<String>, Vec<String>) {
+    let mut deleted = Vec::with_capacity(workstream_ids.len());
+    let mut failed = Vec::new();
+
+    for workstream_id in workstream_ids {
+        let path = state
+            .data_dir
+            .join("raw")
+            .join("workstreams")
+            .join(workstream_id);
+        let path_display = path.display().to_string();
+        match tokio::fs::remove_dir_all(&path).await {
+            Ok(()) => deleted.push(path_display),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                warn!(
+                    operation,
+                    path = %path_display,
+                    error = %error,
+                    "scope purge failed to remove workstream segment directory"
+                );
+                failed.push(path_display);
+            }
+        }
+    }
+
+    (deleted, failed)
+}
+
 async fn remove_purged_project_storage(
     state: &AdminState,
     workspace_id: WorkspaceId,
@@ -2931,27 +2964,10 @@ async fn remove_purged_project_storage(
         }
     }
 
-    for workstream_id in workstream_ids {
-        let path = state
-            .data_dir
-            .join("raw")
-            .join("workstreams")
-            .join(workstream_id);
-        let path_display = path.display().to_string();
-        match tokio::fs::remove_dir_all(&path).await {
-            Ok(()) => deleted.push(path_display),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => {
-                warn!(
-                    operation,
-                    path = %path_display,
-                    error = %error,
-                    "project purge failed to remove workstream segment directory"
-                );
-                failed.push(path_display);
-            }
-        }
-    }
+    let (raw_deleted, raw_failed) =
+        remove_workstream_segment_storage(state, workstream_ids, operation).await;
+    deleted.extend(raw_deleted);
+    failed.extend(raw_failed);
 
     (deleted, failed)
 }
@@ -3178,7 +3194,14 @@ pub struct DeleteWorkspaceResult {
     pub projects_deleted: u64,
     /// `pages` rows removed via cascade (all versions).
     pub pages_deleted: u64,
-    /// Paths removed from disk (the workspace's UUID-namespaced directory).
+    /// Managed `workstreams` rows removed via cascade.
+    pub workstreams_deleted: u64,
+    /// `managed_runs` rows removed via cascade.
+    pub managed_runs_deleted: u64,
+    /// Ids of the deleted workstreams whose raw segment directories were
+    /// included in the post-commit cleanup.
+    pub workstream_ids: Vec<String>,
+    /// Paths removed from disk (the workspace directory and raw segments).
     pub files_deleted: Vec<String>,
     /// Paths that could not be removed from disk (non-fatal; DB rows are gone).
     pub files_failed: Vec<String>,
@@ -3279,7 +3302,7 @@ async fn delete_workspace_core(
         .join(ws_id.to_string())
         .display()
         .to_string();
-    let mut files_deleted = Vec::new();
+    let mut files_deleted = Vec::with_capacity(summary.workstream_ids.len() + 1);
     let mut files_failed = Vec::new();
     match state.wiki.remove_workspace_dir(ws_id).await {
         Ok(()) => files_deleted.push(ws_root_str.clone()),
@@ -3288,6 +3311,10 @@ async fn delete_workspace_core(
             files_failed.push(ws_root_str);
         }
     }
+    let (raw_deleted, raw_failed) =
+        remove_workstream_segment_storage(state, &summary.workstream_ids, "delete-workspace").await;
+    files_deleted.extend(raw_deleted);
+    files_failed.extend(raw_failed);
 
     let mut dispatch_ctx = resolved_purge_ctx;
     if !files_failed.is_empty()
@@ -3304,6 +3331,9 @@ async fn delete_workspace_core(
         workspace: workspace.to_string(),
         projects_deleted: summary.projects_deleted,
         pages_deleted: summary.pages_deleted,
+        workstreams_deleted: summary.workstreams_deleted,
+        managed_runs_deleted: summary.managed_runs_deleted,
+        workstream_ids: summary.workstream_ids,
         files_deleted,
         files_failed,
         pre_checkpoint,

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -24,6 +24,7 @@ use axum::http::{HeaderMap, Request, StatusCode};
 use axum::routing::post as axum_post;
 use axum::{Json, Router};
 use serde_json::json;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
 use tower::ServiceExt;
@@ -1840,6 +1841,47 @@ async fn delete_workspace_force_removes_everything() {
     let tmp = TempDir::new().unwrap();
     let (state, store) = make_state(&tmp).await;
     seed_page(&store, &state.wiki, "victim", "proj", "notes/a.md", "body").await;
+    let workspace_id = store
+        .reader
+        .find_workspace("victim".into())
+        .await
+        .unwrap()
+        .expect("workspace exists");
+    let project_id = store
+        .reader
+        .find_project(workspace_id, "proj".into())
+        .await
+        .unwrap()
+        .expect("project exists");
+    let prepared = store
+        .writer
+        .prepare_workstream_run(PrepareWorkstreamRun {
+            workspace_id,
+            project_id,
+            repo_fingerprint: "repo".into(),
+            worktree_fingerprint: "worktree".into(),
+            cwd: "/repo".into(),
+            agent: AgentKind::Codex,
+            automatic_harness: false,
+            available_agents: vec![AgentKind::Codex],
+            selection: WorkstreamSelection::Current,
+            lease_owner: "test".into(),
+        })
+        .await
+        .unwrap();
+    assert!(
+        store
+            .writer
+            .cancel_managed_run(prepared.run_id)
+            .await
+            .unwrap()
+    );
+    let raw_dir = tmp
+        .path()
+        .join("raw/workstreams")
+        .join(prepared.workstream_id.to_string());
+    std::fs::create_dir_all(&raw_dir).unwrap();
+    std::fs::write(raw_dir.join("000001.jsonl"), "event\n").unwrap();
 
     let resp = post(
         state,
@@ -1851,6 +1893,29 @@ async fn delete_workspace_force_removes_everything() {
     let body = body_json(resp).await;
     assert_eq!(body["projects_deleted"].as_u64().unwrap_or(0), 1, "{body}");
     assert!(body["pages_deleted"].as_u64().unwrap_or(0) >= 1, "{body}");
+    assert_eq!(body["workstreams_deleted"], 1, "{body}");
+    assert_eq!(body["managed_runs_deleted"], 1, "{body}");
+    assert_eq!(
+        body["workstream_ids"],
+        json!([prepared.workstream_id.to_string()]),
+        "{body}"
+    );
+    assert!(
+        !raw_dir.exists(),
+        "workspace deletion must remove raw workstream segments"
+    );
+    let raw_suffix = Path::new("raw")
+        .join("workstreams")
+        .join(prepared.workstream_id.to_string());
+    assert!(
+        body["files_deleted"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|path| path.as_str())
+            .any(|path| Path::new(path).ends_with(&raw_suffix)),
+        "raw cleanup must be visible in the report: {body}"
+    );
     assert!(
         store
             .reader

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -1743,14 +1743,20 @@ pub struct DeleteWorkspaceSummary {
     pub projects_deleted: u64,
     /// `pages` rows removed via cascade (all versions).
     pub pages_deleted: u64,
+    /// Managed `workstreams` rows removed via cascade.
+    pub workstreams_deleted: u64,
+    /// `managed_runs` rows removed via cascade.
+    pub managed_runs_deleted: u64,
+    /// Pre-delete identifiers for post-commit raw-segment cleanup.
+    pub workstream_ids: Vec<String>,
 }
 
 /// Delete a workspace row. Refuses a workspace that still holds projects
 /// unless `force` is set (the guard exists so a stray typo can't wipe a live
 /// workspace). The `workspace_id` FKs are `ON DELETE CASCADE`, so a single
 /// `DELETE FROM workspaces` also removes its projects / pages / sessions /
-/// observations / handoffs. The caller removes the on-disk workspace dir
-/// afterwards.
+/// observations / handoffs / managed workstreams. The caller removes the
+/// on-disk workspace and raw workstream directories afterwards.
 ///
 /// # Errors
 /// [`StoreError::WorkspaceNotEmpty`] when it still holds projects and `force`
@@ -1774,6 +1780,21 @@ pub fn delete_workspace(
         return Err(StoreError::WorkspaceNotEmpty(projects_deleted));
     }
     let pages_deleted = count("SELECT COUNT(*) FROM pages WHERE workspace_id = ?1")?;
+    let workstreams_deleted = count("SELECT COUNT(*) FROM workstreams WHERE workspace_id = ?1")?;
+    let managed_runs_deleted = count(
+        "SELECT COUNT(*) FROM managed_runs mr \
+         JOIN workstreams w ON w.id = mr.workstream_id \
+         WHERE w.workspace_id = ?1",
+    )?;
+    let workstream_ids: Vec<String> = {
+        let mut stmt = tx.prepare("SELECT id FROM workstreams WHERE workspace_id = ?1")?;
+        let rows = stmt
+            .query_map(rusqlite::params![&wid[..]], |row| row.get::<_, Vec<u8>>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        rows.into_iter()
+            .map(|raw| ai_memory_core::WorkstreamId::from_slice(&raw).map(|id| id.to_string()))
+            .collect::<Result<Vec<_>, _>>()?
+    };
 
     let removed = tx.execute(
         "DELETE FROM workspaces WHERE id = ?1",
@@ -1786,6 +1807,9 @@ pub fn delete_workspace(
     Ok(DeleteWorkspaceSummary {
         projects_deleted,
         pages_deleted,
+        workstreams_deleted,
+        managed_runs_deleted,
+        workstream_ids,
     })
 }
 
@@ -2233,6 +2257,7 @@ mod tests {
     fn delete_workspace_refuses_non_empty_then_cascades_with_force() {
         let (_tmp, mut conn, ws, proj) = fresh_db();
         upsert_page(&mut conn, &page(ws, proj, "notes/a.md", "body")).unwrap();
+        let prepared = open_managed_run(&mut conn, &ws, &proj);
 
         // Non-empty (holds the "scratch" project + a page) → refused w/o force.
         let err = delete_workspace(&mut conn, &ws, false).unwrap_err();
@@ -2254,6 +2279,12 @@ mod tests {
         assert!(
             summary.projects_deleted >= 1 && summary.pages_deleted >= 1,
             "{summary:?}"
+        );
+        assert_eq!(summary.workstreams_deleted, 1);
+        assert_eq!(summary.managed_runs_deleted, 1);
+        assert_eq!(
+            summary.workstream_ids,
+            vec![prepared.workstream_id.to_string()]
         );
         let proj_left: i64 = conn
             .query_row(
@@ -2278,6 +2309,9 @@ mod tests {
         let summary = delete_workspace(&mut conn, &empty, false).unwrap();
         assert_eq!(summary.projects_deleted, 0);
         assert_eq!(summary.pages_deleted, 0);
+        assert_eq!(summary.workstreams_deleted, 0);
+        assert_eq!(summary.managed_runs_deleted, 0);
+        assert!(summary.workstream_ids.is_empty());
     }
 
     #[test]

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -11,7 +11,7 @@ on a homelab box where mistakes are harder to undo.
 | `purge-project --confirm` | ✅ yes | the one project's data | no | Deletes the UUID-namespaced wiki root and raw workstream segments; sibling projects remain untouched. Refuses with `409` while a managed workstream under the project holds a live run lease — `--force` overrides. |
 | `rename-project --from --to` | ✅ yes | no | yes (rename back) | Column-only update on `projects.name`. The on-disk dir is keyed by `project_id` (UUID), so the rename never moves a file. |
 | `/admin/rename-workspace` | ✅ yes | no | yes (rename back) | Column-only update on `workspaces.name`; refreshes `_meta.md` scope manifests and checkpoints the wiki tree. |
-| `/admin/delete-workspace` | ✅ yes | the workspace and every child project | no | Runs `purge_workspace` admission first, deletes SQLite rows in one cascade, removes the UUID-keyed workspace directory, reports filesystem partial failures, and dispatches mirror notification after durable work. |
+| `/admin/delete-workspace` | ✅ yes | the workspace and every child project | no | Runs `purge_workspace` admission first, deletes SQLite rows in one cascade, removes the UUID-keyed workspace directory and managed-workstream raw segments, reports filesystem partial failures, and dispatches mirror notification after durable work. |
 | `move-project --confirm` | ✅ yes | source only in the merge case (a `Reject`-policy `purge_project` webhook can still abort the source teardown leaving everything intact) | no | Fresh destination → lossless **true move** (re-stamp `workspace_id`, keep `project_id`, rename the dir): sessions/observations/handoffs + history all survive. Destination with a same-named project → **copy+purge merge**: only latest pages migrate. |
 | `backup --output-path` | ✅ yes | no | n/a | Streams a gzipped tarball from the server's online `sqlite3 .backup` plus the wiki tree. Safe alongside the live writer. |
 | `checkpoints` | ✅ yes | no | n/a | Lists recent wiki git checkpoints. Read-only. |
@@ -179,17 +179,20 @@ Failure modes:
 
 ### `/admin/delete-workspace`
 
-Deletes a workspace row and all child projects/pages/sessions through the
-`workspace_id` cascade. The route is guarded by `force: true` for non-empty
-workspaces and follows the destructive-operation ordering used by project
-purges:
+Deletes a workspace row and all child projects/pages/sessions/managed
+workstreams through the `workspace_id` cascade. The route is guarded by
+`force: true` for non-empty workspaces and follows the destructive-operation
+ordering used by project purges:
 
 1. Look up the workspace without creating missing scopes.
 2. Run blocking `op=purge_workspace` admission. A reject-policy webhook aborts
    before DB rows or files are removed.
 3. Take a pre-delete checkpoint if the wiki tree is dirty.
 4. Delete the workspace in one writer-actor transaction.
-5. Remove `<wiki_root>/<workspace_id>` from disk.
+5. Remove `<wiki_root>/<workspace_id>` and every affected
+   `<data_dir>/raw/workstreams/<workstream_id>` directory from disk. The
+   response reports `workstreams_deleted`, `managed_runs_deleted`, and the
+   cleaned `workstream_ids` alongside the filesystem results.
 6. Dispatch non-blocking `purge_workspace` mirror notifications after durable
    work. If the DB delete committed but disk removal failed, the response
    includes `files_failed` and webhook `ctx.partial_failure: true`.


### PR DESCRIPTION
## Summary

- collect managed workstream IDs and run counts before the workspace cascade
- remove affected raw transcript segment directories after the SQL commit
- expose cleanup counts/IDs and preserve filesystem partial-failure reporting
- add store/HTTP regressions and update lifecycle docs/changelog

## Tests

- `cargo fmt --all -- --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo test -p ai-memory-store delete_workspace -- --nocapture`
- `TAILWIND_SKIP=1 cargo test -p ai-memory-mcp --test admin_move delete_workspace_force_removes_everything -- --nocapture`
- `TAILWIND_SKIP=1 cargo clippy -p ai-memory-store -p ai-memory-mcp --all-targets -- -D warnings`

Fixes #274