### PR TITLE
Fix hybrid authority candidate window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   including subdirectories and linked worktrees. (#259)
 
 ### Fixed
+- Hybrid search now gives its FTS, vector, and graph streams the same bounded
+  candidate window used by authority-aware FTS search. Small result limits no
+  longer exclude a canonical page before post-fusion authority ranking can
+  promote it, and candidate-limit arithmetic is saturating throughout. (#276)
 - Forced workspace deletion now removes the immutable managed-workstream
   segment directories whose database rows are removed by the workspace
   cascade. Its admin report includes workstream/run counts and IDs, and raw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,18 +42,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hybrid search now gives its FTS, vector, and graph streams the same bounded
   candidate window used by authority-aware FTS search. Small result limits no
   longer exclude a canonical page before post-fusion authority ranking can
-  promote it, and candidate-limit arithmetic is saturating throughout. (#276)
+  promote it, and candidate-limit arithmetic is saturating throughout. (#277)
 - Forced workspace deletion now removes the immutable managed-workstream
   segment directories whose database rows are removed by the workspace
   cascade. Its admin report includes workstream/run counts and IDs, and raw
   segment cleanup participates in the existing filesystem partial-failure
-  reporting instead of leaving transcript data orphaned. (#274)
+  reporting instead of leaving transcript data orphaned. (#275)
 - Lossless `move-project` true moves now re-stamp managed workstreams into the
   destination workspace in the same transaction as the project and its other
   denormalized child rows. Previously the project moved while its managed
   workstreams retained the source `workspace_id`, hiding portable history from
   destination-scope lookup and violating the project/workspace pairing
-  invariant. The admin response now reports `workstreams_moved`. (#272)
+  invariant. The admin response now reports `workstreams_moved`. (#273)
 - SessionEnd recovery now commits the ended generation and automatic handoff in
   one SQLite transaction, then lets an already-ended native replay converge the
   remaining wiki commit, durable consolidation enqueue, and ingest-key

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -2214,7 +2214,7 @@ mod tests {
                 String::new(),
                 String::new(),
                 0,
-                10,
+                1,
             )
             .await
             .unwrap();

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -2139,14 +2139,15 @@ impl ReaderPool {
         dim: u32,
         limit: usize,
     ) -> StoreResult<Vec<PageHit>> {
+        // Authority is applied after RRF, so every stream needs the same
+        // bounded candidate window used by FTS-only search. A `limit * 2`
+        // window was too narrow at small limits for a canonical page to enter
+        // the fused pool and receive its bounded promotion.
+        let candidate_limit = authority_candidate_limit(limit);
+
         // Fetch FTS5 hits first.
         let fts_candidates = self
-            .search_page_candidates_for_project(
-                workspace_id,
-                project_id,
-                query,
-                limit.saturating_mul(2),
-            )
+            .search_page_candidates_for_project(workspace_id, project_id, query, candidate_limit)
             .await?;
         let mut authorities: std::collections::HashMap<PageId, PageAuthority> = fts_candidates
             .iter()
@@ -2166,7 +2167,7 @@ impl ReaderPool {
                     provider,
                     model,
                     dim,
-                    limit * 2,
+                    candidate_limit,
                 )
                 .await?;
         }
@@ -2183,7 +2184,7 @@ impl ReaderPool {
             }
         }
         let graph_hits = self
-            .graph_neighbors_for_project(workspace_id, project_id, seed_ids, limit * 2)
+            .graph_neighbors_for_project(workspace_id, project_id, seed_ids, candidate_limit)
             .await?;
 
         // RRF fuse: score(d) = Σ 1/(k + rank_i(d)) over rankers.
@@ -5435,6 +5436,17 @@ mod tests {
     use ai_memory_core::{
         AgentKind, Handoff, HandoffId, HandoffState, NewHandoff, ProjectId, SessionId, WorkspaceId,
     };
+
+    #[test]
+    fn authority_candidate_window_is_bounded_and_saturating() {
+        use super::authority_candidate_limit;
+
+        assert_eq!(authority_candidate_limit(0), 0);
+        assert_eq!(authority_candidate_limit(1), 20);
+        assert_eq!(authority_candidate_limit(10), 40);
+        assert_eq!(authority_candidate_limit(1_000), 1_300);
+        assert_eq!(authority_candidate_limit(usize::MAX), usize::MAX);
+    }
 
     /// Build an open handoff for the pure-selection tests. `manual` toggles
     /// the manual (`from_session_id == None`) vs auto distinction; `t` is the

--- a/docs/vector-backend-policy.md
+++ b/docs/vector-backend-policy.md
@@ -11,9 +11,10 @@ pages per project. At that size, brute-force cosine is simple,
 inspectable, and fast enough, especially because vector retrieval is only
 one signal in the query path. `memory_query` already combines FTS5,
 graph-neighbor expansion, optional vector RRF, and raw observation
-fallback. A bounded page-authority adjustment runs after those candidate
-streams, so semantic similarity cannot by itself declare a session page more
-canonical than a maintained decision.
+fallback. Each stream contributes through the same bounded candidate window,
+then a page-authority adjustment runs after fusion, so semantic similarity
+cannot by itself declare a session page more canonical than a maintained
+decision.
 
 Adding `sqlite-vec` would add operational surface before it has proven
 value:


### PR DESCRIPTION
## Summary

- use the bounded authority candidate window for every hybrid RRF stream
- preserve zero-limit behavior and saturate candidate arithmetic
- cover small-limit canonical promotion and pure window boundaries
- update retrieval policy docs and changelog

## Regression

Before the implementation change, the tightened `limit = 1` hybrid test returned `sessions/noisy-0.md` instead of `decisions/embedding-policy.md` because the canonical page fell outside the old two-candidate pool.

## Tests

- `cargo fmt --all -- --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo test -p ai-memory-store authority_candidate -- --nocapture`
- `TAILWIND_SKIP=1 cargo test -p ai-memory-store search_ranks_page_authority_without_hiding_session_evidence -- --nocapture`
- `TAILWIND_SKIP=1 cargo test -p ai-memory-store hybrid_search_includes_linked_neighbors -- --nocapture`
- `TAILWIND_SKIP=1 cargo clippy -p ai-memory-store --all-targets -- -D warnings`

Fixes #276