### PR TITLE
fix: preserve workstream projects during maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   including subdirectories and linked worktrees. (#259)
 
 ### Fixed
+- Scheduled hollow-project cleanup now treats managed workstreams as project
+  data. Older projects whose only history is a managed workstream, including
+  those with a live run, are no longer cascade-deleted out from under the
+  workstream heartbeat or left with orphaned transcript segments. (#278)
 - Hybrid search now gives its FTS, vector, and graph streams the same bounded
   candidate window used by authority-aware FTS search. Small result limits no
   longer exclude a canonical page before post-fusion authority ranking can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scheduled hollow-project cleanup now treats managed workstreams as project
   data. Older projects whose only history is a managed workstream, including
   those with a live run, are no longer cascade-deleted out from under the
-  workstream heartbeat or left with orphaned transcript segments. (#278)
+  workstream heartbeat or left with orphaned transcript segments. (#279)
 - Hybrid search now gives its FTS, vector, and graph streams the same bounded
   candidate window used by authority-aware FTS search. Small result limits no
   longer exclude a canonical page before post-fusion authority ranking can

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -809,12 +809,13 @@ async fn start_maintenance_scheduler(
         }));
     }
 
-    // Hollow-project sweep: deletes project rows with zero data of any
-    // kind (pages, sessions, observations, handoffs) once they are older
-    // than HOLLOW_PROJECT_MIN_AGE_DAYS. Safe by construction — nothing
-    // exists to lose — which is why it runs unconditionally under the
-    // maintenance flag with no extra config. Runs once shortly after
-    // startup (so upgrades clean up immediately) and then daily.
+    // Hollow-project sweep: deletes project rows with no pages, sessions,
+    // observations, handoffs, managed workstreams, or auto-improvement data
+    // once they are older than HOLLOW_PROJECT_MIN_AGE_DAYS. Safe by
+    // construction — nothing exists to lose — which is why it runs
+    // unconditionally under the maintenance flag with no extra config. Runs
+    // once shortly after startup (so upgrades clean up immediately) and then
+    // daily.
     if maintenance_enabled {
         /// A week of grace before a hollow row is considered noise, so a
         /// project created moments before its first real event is never

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -210,16 +210,15 @@ pub fn get_or_create_project(
 }
 
 /// Delete "hollow" project rows: zero pages (any version), zero sessions,
-/// zero observations, zero handoffs, zero auto-improve runs/proposals/
-/// rejections, and older than `min_age_days`. (The per-project
-/// scheduler-state row is bookkeeping created for every project and does
-/// not count as data.) These
-/// are pure bookkeeping noise left behind by probes, renames, and failed
-/// first events — nothing exists to lose, which is what makes this safe to
-/// run on a schedule (the operator-driven `purge-project` covers everything
-/// that actually holds data). Reserved projects (`scratch`, the cwd-less
-/// fallback; `_global`, the preferences scope) are exempt even when empty.
-/// Returns the deleted names for logging.
+/// zero observations, zero handoffs, zero managed workstreams, zero
+/// auto-improve runs/proposals/rejections, and older than `min_age_days`.
+/// (The per-project scheduler-state row is bookkeeping created for every
+/// project and does not count as data.) These are pure bookkeeping noise left
+/// behind by probes, renames, and failed first events — nothing exists to lose,
+/// which is what makes this safe to run on a schedule (the operator-driven
+/// `purge-project` covers everything that actually holds data). Reserved
+/// projects (`scratch`, the cwd-less fallback; `_global`, the preferences
+/// scope) are exempt even when empty. Returns the deleted names for logging.
 ///
 /// # Errors
 /// Propagates SQLite failures.
@@ -236,6 +235,7 @@ pub fn sweep_hollow_projects(conn: &mut Connection, min_age_days: u32) -> StoreR
                AND NOT EXISTS (SELECT 1 FROM sessions     WHERE project_id = projects.id)
                AND NOT EXISTS (SELECT 1 FROM observations WHERE project_id = projects.id)
                AND NOT EXISTS (SELECT 1 FROM handoffs     WHERE project_id = projects.id)
+               AND NOT EXISTS (SELECT 1 FROM workstreams  WHERE project_id = projects.id)
                AND NOT EXISTS (SELECT 1 FROM auto_improve_runs      WHERE project_id = projects.id)
                AND NOT EXISTS (SELECT 1 FROM auto_improve_proposals WHERE project_id = projects.id)
                AND NOT EXISTS (SELECT 1 FROM auto_improve_rejections WHERE project_id = projects.id)",
@@ -255,6 +255,7 @@ pub fn sweep_hollow_projects(conn: &mut Connection, min_age_days: u32) -> StoreR
                AND NOT EXISTS (SELECT 1 FROM sessions     WHERE project_id = projects.id)
                AND NOT EXISTS (SELECT 1 FROM observations WHERE project_id = projects.id)
                AND NOT EXISTS (SELECT 1 FROM handoffs     WHERE project_id = projects.id)
+               AND NOT EXISTS (SELECT 1 FROM workstreams  WHERE project_id = projects.id)
                AND NOT EXISTS (SELECT 1 FROM auto_improve_runs      WHERE project_id = projects.id)
                AND NOT EXISTS (SELECT 1 FROM auto_improve_proposals WHERE project_id = projects.id)
                AND NOT EXISTS (SELECT 1 FROM auto_improve_rejections WHERE project_id = projects.id)",
@@ -3546,13 +3547,15 @@ mod tests {
         let fresh = get_or_create_project(&mut conn, &ws, "new-probe", None).unwrap();
         // Old but has a session: keep (not hollow).
         let with_data = get_or_create_project(&mut conn, &ws, "one-off", None).unwrap();
+        // Old but has a managed workstream: keep (not hollow).
+        let with_workstream = get_or_create_project(&mut conn, &ws, "managed-only", None).unwrap();
         // Reserved + hollow + old: keep.
         let global =
             get_or_create_project(&mut conn, &ws, ai_memory_core::GLOBAL_SCOPE_PROJECT, None)
                 .unwrap();
 
         let eight_days_us: i64 = 8 * 24 * 60 * 60 * 1_000_000;
-        for id in [&hollow, &with_data, &global] {
+        for id in [&hollow, &with_data, &with_workstream, &global] {
             conn.execute(
                 "UPDATE projects SET created_at = created_at - ?1 WHERE id = ?2",
                 params![eight_days_us, &id.as_bytes()[..]],
@@ -3570,6 +3573,7 @@ mod tests {
             },
         )
         .unwrap();
+        let managed = open_managed_run(&mut conn, &ws, &with_workstream);
 
         let deleted = sweep_hollow_projects(&mut conn, 7).unwrap();
         assert_eq!(deleted, vec!["zt".to_string()]);
@@ -3585,7 +3589,28 @@ mod tests {
         assert_eq!(exists(&hollow), 0, "old hollow row deleted");
         assert_eq!(exists(&fresh), 1, "fresh hollow row kept (grace window)");
         assert_eq!(exists(&with_data), 1, "data-bearing row kept");
+        assert_eq!(
+            exists(&with_workstream),
+            1,
+            "managed-workstream-bearing row kept"
+        );
         assert_eq!(exists(&global), 1, "reserved _global kept even when hollow");
+        let workstream_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM workstreams WHERE id = ?1",
+                params![&managed.workstream_id.as_bytes()[..]],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(workstream_rows, 1, "managed workstream kept");
+        let run_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM managed_runs WHERE id = ?1",
+                params![&managed.run_id.as_bytes()[..]],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(run_rows, 1, "managed run kept");
 
         // Idempotent: a second pass deletes nothing.
         assert!(sweep_hollow_projects(&mut conn, 7).unwrap().is_empty());

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -123,7 +123,11 @@ from hook paths.
    access get purged. Semantic / pinned / freshly-touched pages survive.
    Scheduled sweep, rule-based lint, and opt-in embedding backfill ticks
    enumerate every existing workspace/project scope before doing per-project
-   work, matching the auto-improvement scheduler's store-wide scope model.
+   work, matching the auto-improvement scheduler's store-wide scope model. A
+   separate daily cleanup removes week-old project rows only when they contain
+   no pages, sessions, observations, handoffs, managed workstreams, or
+   auto-improvement data; managed continuity history therefore keeps its
+   project scope alive even when no lifecycle-hook session has been captured.
 8. Backups: `ai-memory backup --to <tarball>` uses SQLite's online
    backup API so the source stays writable; `ai-memory restore`
    reverses. Or: `git push` the wiki dir + `rsync` the data dir.


### PR DESCRIPTION
## Summary

- exclude projects with managed workstreams from hollow-project maintenance selection and deletion
- cover an old managed-only project with an active run in the store regression
- document the complete scheduled cleanup boundary

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- `cargo deny check`
- companion importer fmt, test, and clippy gates

Closes #278