### PR TITLE
fix(cli): support fresh rmcp source installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,23 @@ jobs:
           name: ci-ai-memory-${{ matrix.artifact }}
           path: target/release/ai-memory
 
+  # `cargo install --path` deliberately resolves without the workspace lockfile.
+  # Keep that user-facing path visible alongside the normal lock-aware gates so
+  # an allowed upstream dependency update cannot break source installation.
+  source-install:
+    name: cargo install --path (fresh resolution)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.95
+      - uses: Swatinem/rust-cache@v2
+      - name: Install with a fresh dependency resolution
+        env:
+          TAILWIND_SKIP: "1"
+        run: cargo install --path crates/ai-memory-cli --debug --root target/source-install
+      - name: Smoke test installed binary
+        run: target/source-install/bin/ai-memory --version
+
   native-packaging:
     name: native packaging assets
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Source installation no longer fails when `cargo install --path` resolves
+  rmcp 1.8, whose `peer_info()` return type differs from rmcp 1.7. CI now checks
+  the unlocked source-install resolution separately from the workspace's
+  lock-aware gates, while the documented persistent Windows install uses
+  `--locked` for reproducibility. (#285)
 - Antigravity CLI hook installation and documentation now expose the existing
   agent-aware manual finalizer:
   `ai-memory finalize-session --agent antigravity-cli`. Antigravity's `Stop`

--- a/crates/ai-memory-cli/src/commands/mcp_bridge.rs
+++ b/crates/ai-memory-cli/src/commands/mcp_bridge.rs
@@ -106,7 +106,7 @@ pub async fn run(config: &Config, args: McpBridgeArgs) -> Result<()> {
         .with_context(|| format!("connecting session-aware bridge to {server_url}"))?;
     let server_info = upstream
         .peer_info()
-        .cloned()
+        .map(|info| (*info).clone())
         .context("upstream MCP server completed initialization without server info")?;
     let bridge = SessionAwareBridge {
         upstream: upstream.peer().clone(),
@@ -261,7 +261,7 @@ mod tests {
         let upstream = ().serve(upstream_transport).await.unwrap();
         let bridge = SessionAwareBridge {
             upstream: upstream.peer().clone(),
-            server_info: upstream.peer_info().cloned().unwrap(),
+            server_info: upstream.peer_info().map(|info| (*info).clone()).unwrap(),
         };
         let (client_io, server_io) = tokio::io::duplex(64 * 1024);
         let downstream_server = tokio::spawn(async move { bridge.serve(server_io).await.unwrap() });

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -245,7 +245,7 @@ path is roughly 3-5× faster per hook (measured ~735 ms shell → ~150-205 ms
 native on an i7-6700HQ). Notes:
 
 - The binary path comes from the `ai-memory` that runs `install-hooks`, so
-  `cargo install --path crates/ai-memory-cli` puts it on a stable
+  `cargo install --locked --path crates/ai-memory-cli` puts it on a stable
   `~/.cargo/bin` path.
 - Exec form requires a real executable path (`.exe`). It does not run `.cmd` or
   `.bat` shims through a shell. `install-hooks` uses the path of the running


### PR DESCRIPTION
Closes #285.

## What changed
- clone `peer_info()` through the dereferenced value so the MCP bridge compiles with rmcp 1.7 and 1.8 return shapes
- add an unlocked `cargo install --path` CI job to cover fresh dependency resolution
- document `--locked` for reproducible persistent Windows source installs
- record the fix in the changelog

## Verification
- reproduced the v1.19.1 failure with an isolated unlocked source install resolving rmcp 1.8
- confirmed the patched unlocked install resolves rmcp 1.8, installs successfully, and reports `ai-memory 1.19.1`
- `cargo fmt --all -- --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- `cargo deny check`
- companion importer fmt/test/clippy
- `scripts/check-native-packaging.sh`
- `tests/hooks/test_lib.sh`