### PR TITLE
release: v1.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.2] - 2026-07-28
+
 ### Fixed
 - Source installation no longer fails when `cargo install --path` resolves
   rmcp 1.8, whose `peer_info()` return type differs from rmcp 1.7. CI now checks
@@ -2509,7 +2511,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidator used server startup default project instead of the
   session's actual project.
 
-[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.19.1...HEAD
+[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.19.2...HEAD
+[1.19.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.19.2
 [1.19.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.19.1
 [1.19.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.19.0
 [1.18.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.18.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-cli"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-consolidate"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-core"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "jiff",
  "regex",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-eval"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-hooks"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-llm"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-mcp"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-store"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-web"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "ai-memory-core",
  "ai-memory-store",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-wiki"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-workstream"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "ai-memory-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.19.1"
+version = "1.19.2"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"
@@ -26,15 +26,15 @@ authors = ["Fabio Akita <boss@akitaonrails.com>"]
 
 [workspace.dependencies]
 # Inter-crate dependencies.
-ai-memory-core = { path = "crates/ai-memory-core", version = "1.19.1" }
-ai-memory-store = { path = "crates/ai-memory-store", version = "1.19.1" }
-ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.19.1" }
-ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.19.1" }
-ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.19.1" }
-ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.19.1" }
-ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.19.1" }
-ai-memory-web = { path = "crates/ai-memory-web", version = "1.19.1" }
-ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.19.1" }
+ai-memory-core = { path = "crates/ai-memory-core", version = "1.19.2" }
+ai-memory-store = { path = "crates/ai-memory-store", version = "1.19.2" }
+ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.19.2" }
+ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.19.2" }
+ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.19.2" }
+ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.19.2" }
+ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.19.2" }
+ai-memory-web = { path = "crates/ai-memory-web", version = "1.19.2" }
+ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.19.2" }
 
 # (Workspace shared deps follow below)
 


### PR DESCRIPTION
## Release v1.19.2

Patch release for the two audited fixes merged after v1.19.1:
- expose the existing agent-aware finalizer for Antigravity CLI and clarify SessionEnd/manual-handoff behavior (#284)
- restore unlocked source installation across rmcp 1.7/1.8 and add fresh-resolution CI coverage (#285)

Also includes the docs-only frontend overview response correction found during live acceptance (#288).

## Release gate
- `cargo fmt --all -- --check`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `cargo deny check`
- `cargo audit`
- workspace metadata confirms every package is `1.19.2`
- changelog and compare links audited

The release tag will be placed on the audited merge commit after this PR merges; the local pre-PR tag has not been pushed.