### PR TITLE
release: v1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.0] - 2026-07-30
+
 ### Added
 - New `openai-compat` embedding provider for self-hosted engines
   (Ollama, LM Studio, vLLM). Set
@@ -2551,7 +2553,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidator used server startup default project instead of the
   session's actual project.
 
-[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.19.2...HEAD
+[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.20.0...HEAD
+[1.20.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.20.0
 [1.19.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.19.2
 [1.19.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.19.1
 [1.19.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.19.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-cli"
-version = "1.19.2"
+version = "1.20.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-consolidate"
-version = "1.19.2"
+version = "1.20.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-core"
-version = "1.19.2"
+version = "1.20.0"
 dependencies = [
  "jiff",
  "regex",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-eval"
-version = "1.19.2"
+version = "1.20.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-hooks"
-version = "1.19.2"
+version = "1.20.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-llm"
-version = "1.19.2"
+version = "1.20.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-mcp"
-version = "1.19.2"
+version = "1.20.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-store"
-version = "1.19.2"
+version = "1.20.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-web"
-version = "1.19.2"
+version = "1.20.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-store",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-wiki"
-version = "1.19.2"
+version = "1.20.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-workstream"
-version = "1.19.2"
+version = "1.20.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.19.2"
+version = "1.20.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"
@@ -26,15 +26,15 @@ authors = ["Fabio Akita <boss@akitaonrails.com>"]
 
 [workspace.dependencies]
 # Inter-crate dependencies.
-ai-memory-core = { path = "crates/ai-memory-core", version = "1.19.2" }
-ai-memory-store = { path = "crates/ai-memory-store", version = "1.19.2" }
-ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.19.2" }
-ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.19.2" }
-ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.19.2" }
-ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.19.2" }
-ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.19.2" }
-ai-memory-web = { path = "crates/ai-memory-web", version = "1.19.2" }
-ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.19.2" }
+ai-memory-core = { path = "crates/ai-memory-core", version = "1.20.0" }
+ai-memory-store = { path = "crates/ai-memory-store", version = "1.20.0" }
+ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.20.0" }
+ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.20.0" }
+ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.20.0" }
+ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.20.0" }
+ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.20.0" }
+ai-memory-web = { path = "crates/ai-memory-web", version = "1.20.0" }
+ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.20.0" }
 
 # (Workspace shared deps follow below)
 


### PR DESCRIPTION
## Summary

- bump the workspace and internal path dependencies to `1.20.0`
- move the audited Unreleased entries into the dated `1.20.0` changelog section
- keep the public release tag unpublished until the merged commit passes homeserver deployment and live testing

This is a minor release because #300 adds the new `openai-compat` embedding provider and configuration value.

## Included

- #294 Antigravity native tool capture
- #295 / #292 schema-constrained OpenAI-compatible structured output
- #297 / #293 automatic handoff supersession
- #296 hermetic Devin cwd tests
- #299 / #298 Antigravity initial-invocation handoff gating
- #300 keyless OpenAI-compatible embeddings

## Verification

- `bin/release 1.20.0` release gates
- `cargo fmt --all -- --check`
- `git diff --check main...HEAD`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- `cargo deny check`
- companion importer fmt/test/clippy

The temporary local tag produced by `bin/release` was deleted. The final annotated `v1.20.0` tag will point to the GitHub merge commit after deployment and live tests pass.