### PR TITLE
fix: exclude deployment secrets from Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,9 @@ perf.data*
 
 # Sandbox marker.
 .ai-jail
+
+# Operator-specific deployment files. Keep this block last so a later negation
+# cannot re-include credentials or host configuration in the build context.
+/bin/deploy.env
+/docker/.env.production
+/docker/docker-compose.prod.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.20.2] - 2026-07-30
 
 ### Fixed
+- Docker build contexts now exclude the gitignored operator deployment files,
+  preventing local server configuration and production environment secrets
+  from being sent to the Docker builder. A packaging regression test keeps the
+  exclusions as the final ignore rules so later negations cannot re-include
+  them. (#314)
 - Managed workstream heartbeats now bound each server request and condense an
   outage into one short notice plus one recovery notice. Active launchers keep
   the lease-safe 30-second retry cadence without printing the same timeout on

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -161,6 +161,23 @@ fn docker_source_build_uses_vendored_tailwind() {
 }
 
 #[test]
+fn docker_context_excludes_operator_deployment_files() {
+    let dockerignore = read_repo(".dockerignore");
+    let protected_suffix = concat!(
+        "# Operator-specific deployment files. Keep this block last so a later negation\n",
+        "# cannot re-include credentials or host configuration in the build context.\n",
+        "/bin/deploy.env\n",
+        "/docker/.env.production\n",
+        "/docker/docker-compose.prod.yml\n",
+    );
+
+    assert!(
+        dockerignore.ends_with(protected_suffix),
+        "operator deployment exclusions must remain the final Docker ignore rules"
+    );
+}
+
+#[test]
 fn docker_publish_jobs_use_prebuilt_binaries() {
     let dockerfile = read_repo("docker/Dockerfile");
     assert!(dockerfile.contains("FROM runtime-base AS runtime-prebuilt-amd64"));


### PR DESCRIPTION
## Summary

- exclude the three gitignored operator deployment files from Docker build contexts
- keep the protected exclusions as the final `.dockerignore` rules so later negations cannot re-include them
- add a packaging regression test and include the hardening in the v1.20.2 changelog

Closes #314

## Verification

- real Docker build probes confirmed all three paths are excluded
- cargo fmt --all -- --check
- git diff --check
- TAILWIND_SKIP=1 cargo test --workspace
- TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings
- cargo deny check
- companion fmt/test/clippy
- scripts/check-native-packaging.sh