### PR TITLE
Add Zed MCP client support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Zed editor as an MCP-only client. `install-mcp --client zed` renders,
+  and `--apply` idempotently merges, a native remote HTTP entry under the
+  top-level `context_servers` map in Zed's platform user `settings.json`,
+  with optional bearer headers. The JSONC-aware apply and uninstall paths
+  preserve user comments, trailing commas, unrelated settings, and sibling
+  servers while changing only the matching ai-memory entry. Zed does not
+  provide lifecycle hooks or managed-workstream continuity. (#321)
 - Entity-match retrieval as a fourth RRF stream (V38 `entities` +
   `entity_page_links`). Consolidation emits up to 10 normalized technologies,
   components, services, files, or domain nouns per page into frontmatter;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,7 @@ dependencies = [
  "flate2",
  "fs2",
  "jiff",
+ "jsonc-parser",
  "reqwest 0.12.28",
  "rmcp",
  "secrecy",
@@ -1558,6 +1559,15 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonc-parser"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0560e3f9a9a03ea6b6e90b41138c5db9e21526c99eb192c1a26c68176593285"
+dependencies = [
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ serde = { version = "1", features = ["derive"] }
 # cosmetic diff the user didn't ask for.
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml = "0.9"
+# Zed's settings.json is JSONC despite the .json suffix. Its CST lets
+# install/uninstall preserve comments, trailing commas, and unrelated layout.
+jsonc-parser = { version = "0.33", features = ["cst", "serde_json"] }
 
 # Async runtime.
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 | Zero | Supported | `install-mcp --client zero` (native HTTP + bearer in `~/.config/zero/config.json`) + lifecycle hooks via `install-hooks --agent zero --apply` (exec-form native commands in `~/.config/zero/hooks.json`, JSON payload on stdin, no shell). Capture works incl. specialist (subagent) events; no handoff injection — Zero discards `sessionStart` stdout, so recover handoffs via MCP `memory_handoff_accept`. |
 | Kimi Code | Supported | MCP config (`url` entry in `~/.kimi-code/mcp.json`) + lifecycle hooks (`[[hooks]]` in `~/.kimi-code/config.toml`, 10 events including subagent start/stop and `PostToolUseFailure` for tool-failure capture); both paths honor `$KIMI_CODE_HOME`. Handoffs inject via `UserPromptSubmit` stdout (Kimi Code discards `SessionStart` hook stdout); `ai-memory run kimi` adds managed workstream resume. |
 | VS Code Copilot | MCP-only | `.vscode/mcp.json` for Copilot agent mode; no lifecycle hooks (Copilot does not expose them yet). |
+| Zed | MCP-only | Native remote MCP under `context_servers` in Zed's user `settings.json`; no lifecycle hooks or managed-workstream support. |
 | Hermes Agent | Community | A community-maintained [`ai-memory-hermes-plugin`](https://github.com/MrLuciano/ai-memory-hermes-plugin) is available. It is not part of ai-memory's first-party install surface; review its compatibility matrix, install/uninstall scripts, and secret handling before using it. |
 | LLM/auth providers | Supported | Anthropic, OpenAI, OpenAI OAuth/Codex, GitHub Copilot, Gemini, OpenCode Zen/Go, OpenAI-compatible endpoints, and generic OIDC device auth for native hooks. |
 | Embedding providers | Supported | OpenAI, Voyage, Google Gemini, and keyless OpenAI-compatible endpoints such as Ollama, LM Studio, and vLLM. |
@@ -130,9 +131,9 @@ priors are at the [bottom](#influences-and-prior-art).
 - **Multi-agent + multi-machine ready.** Supported clients: Claude
   Code, Codex, Devin CLI, OpenCode, Cursor, Claude Desktop (via `mcp-remote`),
   Gemini CLI, Antigravity CLI, Grok Build CLI, Kimi Code, OpenClaw, Oh My Pi
-  / OMP (`omp` / `oh-my-pi`), Pi via generated bridge extension, and VS Code
-  GitHub Copilot agent mode
-  (MCP-only, workspace `.vscode/mcp.json`).
+  / OMP (`omp` / `oh-my-pi`), Pi via generated bridge extension, VS Code
+  GitHub Copilot agent mode (MCP-only, workspace `.vscode/mcp.json`), and Zed
+  (MCP-only, user `settings.json`).
   Server runs local (loopback) OR on a homelab box (LAN/VPN/cloud)
   with bearer-token auth. Shared servers can opt into
   [`[auto_scope]` modes](docs/auto-scope.md) for per-user or

--- a/crates/ai-memory-cli/Cargo.toml
+++ b/crates/ai-memory-cli/Cargo.toml
@@ -41,6 +41,7 @@ toml_edit.workspace = true
 sysinfo.workspace = true
 tar.workspace = true
 jiff.workspace = true
+jsonc-parser.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower.workspace = true

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -1081,6 +1081,11 @@ pub enum McpClient {
     /// design. See `install-mcp --client vscode-copilot`.
     #[value(name = "vscode-copilot", alias = "copilot", alias = "github-copilot")]
     VsCodeCopilot,
+    /// Zed editor - user-level `settings.json` under the platform config
+    /// directory. Zed reads remote MCP servers from the top-level
+    /// `context_servers` map. This integration is MCP-only because Zed
+    /// does not expose ai-memory-compatible lifecycle hooks.
+    Zed,
 }
 
 /// Arguments for `commit`.
@@ -2119,6 +2124,24 @@ mod tests {
                 "alias {alias} must resolve to the VS Code Copilot MCP client"
             );
         }
+    }
+
+    #[test]
+    fn zed_mcp_client_parses() {
+        let cli = Cli::try_parse_from([
+            "ai-memory",
+            "install-mcp",
+            "--client",
+            "zed",
+            "--server-url",
+            "http://example.test:49374/mcp",
+        ])
+        .unwrap();
+
+        let Command::InstallMcp(args) = cli.command else {
+            panic!("expected install-mcp command");
+        };
+        assert!(matches!(args.client, McpClient::Zed));
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -689,6 +689,12 @@ fn infer_installed_mcp_config(agent: AgentChoice) -> Result<Option<InferredMcpCo
             &["servers", "ai-memory"],
             "url",
         )),
+        // MCP-only client: no AgentChoice counterpart routes here.
+        McpClient::Zed => Ok(infer_json_mcp_config(
+            &content,
+            &["context_servers", "ai-memory"],
+            "url",
+        )),
     }
 }
 

--- a/crates/ai-memory-cli/src/commands/install_mcp.rs
+++ b/crates/ai-memory-cli/src/commands/install_mcp.rs
@@ -17,6 +17,8 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
+use jsonc_parser::ParseOptions;
+use jsonc_parser::cst::{CstInputValue, CstRootNode};
 use serde_json::json;
 
 use crate::cli::{InstallMcpArgs, McpClient};
@@ -38,6 +40,8 @@ enum JsonMcpLocation {
     /// Code documents `servers`, not `mcpServers`, and writing the
     /// wrong key produces a silent no-op rather than an error.
     RootServers,
+    /// Top-level `context_servers` key used by Zed's settings.json.
+    RootContextServers,
 }
 
 /// Run the `install-mcp` subcommand.
@@ -72,6 +76,7 @@ pub fn run(config: &Config, args: InstallMcpArgs) -> Result<()> {
         McpClient::Devin => render_devin(&args)?,
         McpClient::KimiCode => render_kimi_code(&args)?,
         McpClient::VsCodeCopilot => render_vscode_copilot(&args)?,
+        McpClient::Zed => render_zed(&args)?,
     };
     println!("{snippet}");
     Ok(())
@@ -182,7 +187,22 @@ pub(crate) fn mcp_config_path(client: crate::cli::McpClient) -> Result<PathBuf> 
             .context("could not resolve current dir for .vscode/mcp.json default")?
             .join(".vscode")
             .join("mcp.json"),
+        McpClient::Zed => {
+            let config_dir = if cfg!(target_os = "macos") {
+                home()?.join(".config")
+            } else {
+                dirs::config_dir().context("could not locate user config directory for Zed")?
+            };
+            zed_config_path_in(&config_dir, std::env::consts::OS)
+        }
     })
+}
+
+/// Resolve Zed's user settings from the platform config root. The root is
+/// injected so path behavior can be tested without consulting the real home.
+fn zed_config_path_in(config_dir: &Path, target_os: &str) -> PathBuf {
+    let app_dir = if target_os == "windows" { "Zed" } else { "zed" };
+    config_dir.join(app_dir).join("settings.json")
 }
 
 #[cfg(any(target_os = "windows", test))]
@@ -332,6 +352,7 @@ fn apply_to_config_file(args: &InstallMcpArgs) -> Result<()> {
         McpClient::Grok => apply_atomic(&path, |existing| {
             mutate_toml(existing, |doc| grok_upsert_mcp_server(doc, args))
         })?,
+        McpClient::Zed => apply_atomic(&path, |existing| zed_upsert_mcp_server(existing, args))?,
         _ => apply_atomic(&path, |existing| {
             mutate_json(existing, |root| upsert_json_mcp_entry(root, args))
         })?,
@@ -349,6 +370,44 @@ fn apply_to_config_file(args: &InstallMcpArgs) -> Result<()> {
     Ok(())
 }
 
+/// Merge ai-memory into Zed's JSONC settings without discarding comments,
+/// trailing commas, or unrelated formatting.
+fn zed_upsert_mcp_server(existing: &str, args: &InstallMcpArgs) -> Result<String> {
+    let root = CstRootNode::parse(existing, &ParseOptions::default())
+        .context("parsing Zed settings.json as JSONC")?;
+    let settings = root
+        .object_value_or_create()
+        .context("Zed settings.json root is present but not an object")?;
+    let servers = settings
+        .object_value_or_create("context_servers")
+        .context("`context_servers` is present but not an object")?;
+    let entry = serde_json_to_cst(build_json_mcp_entry(args)?);
+    if let Some(existing_entry) = servers.get(&args.name) {
+        existing_entry.set_value(entry);
+    } else {
+        servers.append(&args.name, entry);
+    }
+    Ok(root.to_string())
+}
+
+fn serde_json_to_cst(value: serde_json::Value) -> CstInputValue {
+    match value {
+        serde_json::Value::Null => CstInputValue::Null,
+        serde_json::Value::Bool(value) => CstInputValue::Bool(value),
+        serde_json::Value::Number(value) => CstInputValue::Number(value.to_string()),
+        serde_json::Value::String(value) => CstInputValue::String(value),
+        serde_json::Value::Array(values) => {
+            CstInputValue::Array(values.into_iter().map(serde_json_to_cst).collect())
+        }
+        serde_json::Value::Object(values) => CstInputValue::Object(
+            values
+                .into_iter()
+                .map(|(key, value)| (key, serde_json_to_cst(value)))
+                .collect(),
+        ),
+    }
+}
+
 fn json_mcp_location(client: McpClient) -> Option<JsonMcpLocation> {
     match client {
         McpClient::ClaudeCode
@@ -364,6 +423,7 @@ fn json_mcp_location(client: McpClient) -> Option<JsonMcpLocation> {
         // shape OpenClaw uses.
         McpClient::Openclaw | McpClient::Zero => Some(JsonMcpLocation::NestedMcpServers),
         McpClient::VsCodeCopilot => Some(JsonMcpLocation::RootServers),
+        McpClient::Zed => Some(JsonMcpLocation::RootContextServers),
         McpClient::Codex | McpClient::Grok | McpClient::Pi => None,
     }
 }
@@ -424,6 +484,14 @@ fn upsert_json_mcp_entry(
                 .context("`servers` is present but not an object")?;
             servers.insert(args.name.clone(), entry);
         }
+        JsonMcpLocation::RootContextServers => {
+            let servers = root
+                .entry("context_servers")
+                .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()))
+                .as_object_mut()
+                .context("`context_servers` is present but not an object")?;
+            servers.insert(args.name.clone(), entry);
+        }
     }
     Ok(())
 }
@@ -443,6 +511,9 @@ fn render_json_mcp_fragment(args: &InstallMcpArgs) -> Result<String> {
             }),
             JsonMcpLocation::RootServers => json!({
                 "servers": { args.name.as_str(): entry }
+            }),
+            JsonMcpLocation::RootContextServers => json!({
+                "context_servers": { args.name.as_str(): entry }
             }),
         };
     Ok(serde_json::to_string_pretty(&fragment)?)
@@ -507,7 +578,7 @@ fn build_mcp_entry(args: &InstallMcpArgs) -> Result<serde_json::Value> {
             entry.insert("command".into(), json!("npx"));
             entry.insert("args".into(), serde_json::Value::Array(cmd_args));
         }
-        McpClient::Cursor => {
+        McpClient::Cursor | McpClient::Zed => {
             entry.insert("url".into(), json!(server_url));
             if let Some(b) = &bearer {
                 entry.insert("headers".into(), json!({"Authorization": b}));
@@ -1032,6 +1103,23 @@ fn render_vscode_copilot(args: &InstallMcpArgs) -> Result<String> {
     ))
 }
 
+fn render_zed(args: &InstallMcpArgs) -> Result<String> {
+    Ok(format!(
+        "# Zed - merge into settings.json:\n\
+         #   - macOS:   ~/.config/zed/settings.json\n\
+         #   - Linux:   $XDG_CONFIG_HOME/zed/settings.json\n\
+         #              (defaults to ~/.config/zed/settings.json)\n\
+         #   - Windows: %APPDATA%\\Zed\\settings.json\n\
+         #\n\
+         # Zed reads remote MCP servers from the top-level\n\
+         # `context_servers` map. This is MCP-only: Zed does not expose\n\
+         # ai-memory-compatible lifecycle hooks, so automatic capture and\n\
+         # managed-workstream continuity are not active.\n\
+         {snippet}\n",
+        snippet = render_json_mcp_fragment(args)?,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1093,6 +1181,114 @@ mod tests {
                 path.display()
             );
         }
+    }
+
+    #[test]
+    fn zed_config_path_uses_platform_conventions() {
+        for (target_os, root, expected) in [
+            (
+                "linux",
+                "/home/alice/.config",
+                "/home/alice/.config/zed/settings.json",
+            ),
+            (
+                "macos",
+                "/Users/alice/.config",
+                "/Users/alice/.config/zed/settings.json",
+            ),
+            (
+                "windows",
+                "C:/Users/alice/AppData/Roaming",
+                "C:/Users/alice/AppData/Roaming/Zed/settings.json",
+            ),
+        ] {
+            assert_eq!(
+                zed_config_path_in(Path::new(root), target_os),
+                PathBuf::from(expected),
+                "target OS: {target_os}"
+            );
+        }
+    }
+
+    #[test]
+    fn zed_renderer_uses_context_servers_and_native_remote_http() {
+        let fragment = render_json_mcp_fragment(&args_with_token(McpClient::Zed)).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&fragment).unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "context_servers": {
+                    "ai-memory": {
+                        "url": "http://127.0.0.1:49374/mcp",
+                        "headers": {
+                            "Authorization": "Bearer test-token-deadbeef"
+                        }
+                    }
+                }
+            })
+        );
+        assert!(
+            render_zed(&args_for(McpClient::Zed))
+                .unwrap()
+                .contains("MCP-only")
+        );
+    }
+
+    #[test]
+    fn zed_apply_preserves_settings_and_siblings_and_is_idempotent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config_path = tmp.path().join("settings.json");
+        fs::write(
+            &config_path,
+            r#"{
+  // Keep this user comment.
+  "theme": "One Dark",
+  "context_servers": {
+    // Keep this sibling comment.
+    "other": { "url": "https://other.example/mcp" },
+  },
+}
+"#,
+        )
+        .unwrap();
+        let mut args = args_with_token(McpClient::Zed);
+        args.config_file = Some(config_path.clone());
+
+        apply_to_config_file(&args).unwrap();
+        let first = fs::read_to_string(&config_path).unwrap();
+        apply_to_config_file(&args).unwrap();
+        let second = fs::read_to_string(&config_path).unwrap();
+
+        assert_eq!(first, second);
+        assert!(second.contains("// Keep this user comment."));
+        assert!(second.contains("// Keep this sibling comment."));
+        let root = CstRootNode::parse(&second, &ParseOptions::default()).unwrap();
+        let value = root.to_serde_value().unwrap();
+        assert_eq!(value["theme"], "One Dark");
+        assert_eq!(
+            value["context_servers"]["other"]["url"],
+            "https://other.example/mcp"
+        );
+        assert_eq!(
+            value["context_servers"]["ai-memory"]["headers"]["Authorization"],
+            "Bearer test-token-deadbeef"
+        );
+    }
+
+    #[test]
+    fn zed_apply_rejects_non_object_context_servers_without_writing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config_path = tmp.path().join("settings.json");
+        let original = "{\n  // User-owned invalid shape.\n  \"context_servers\": false,\n}\n";
+        fs::write(&config_path, original).unwrap();
+        let mut args = args_for(McpClient::Zed);
+        args.config_file = Some(config_path.clone());
+
+        let error = apply_to_config_file(&args).unwrap_err();
+
+        assert!(error.to_string().contains("not an object"));
+        assert_eq!(fs::read_to_string(config_path).unwrap(), original);
     }
 
     #[test]
@@ -1289,6 +1485,7 @@ mod tests {
             McpClient::Devin => render_devin(&args).unwrap(),
             McpClient::KimiCode => render_kimi_code(&args).unwrap(),
             McpClient::VsCodeCopilot => render_vscode_copilot(&args).unwrap(),
+            McpClient::Zed => render_zed(&args).unwrap(),
         }
     }
 
@@ -1311,6 +1508,7 @@ mod tests {
             McpClient::Devin,
             McpClient::KimiCode,
             McpClient::VsCodeCopilot,
+            McpClient::Zed,
         ] {
             let out = render_with_token(client);
             // Every client embeds the token as `Authorization:
@@ -1347,6 +1545,7 @@ mod tests {
             McpClient::Devin,
             McpClient::KimiCode,
             McpClient::VsCodeCopilot,
+            McpClient::Zed,
         ] {
             let out = render_for_test(client);
             assert!(
@@ -1376,6 +1575,7 @@ mod tests {
             McpClient::Devin => render_devin(&args).unwrap(),
             McpClient::KimiCode => render_kimi_code(&args).unwrap(),
             McpClient::VsCodeCopilot => render_vscode_copilot(&args).unwrap(),
+            McpClient::Zed => render_zed(&args).unwrap(),
         }
     }
 
@@ -1536,6 +1736,10 @@ mod tests {
         assert!(vsc.contains("\"servers\""));
         assert!(!vsc.contains("\"mcpServers\""));
         assert!(vsc.contains("\"type\": \"http\""));
+        let zed = render_for_test(McpClient::Zed);
+        assert!(zed.contains("\"context_servers\""));
+        assert!(!zed.contains("\"mcpServers\""));
+        assert!(!zed.contains("\"type\": \"http\""));
     }
 
     /// Kimi Code resolves its mcp.json under $KIMI_CODE_HOME when the env

--- a/crates/ai-memory-cli/src/commands/uninstall.rs
+++ b/crates/ai-memory-cli/src/commands/uninstall.rs
@@ -281,6 +281,7 @@ fn build_plan(args: &UninstallArgs) -> anyhow::Result<Vec<PlannedChange>> {
             AntigravityCli,
             Zero,
             VsCodeCopilot,
+            Zed,
             Devin,
             KimiCode,
         ] {
@@ -941,6 +942,7 @@ fn mcp_servers_path(client: McpClient) -> Option<&'static [&'static str]> {
         McpClient::OpenCode => Some(&["mcp"]),
         McpClient::Openclaw | McpClient::Zero => Some(&["mcp", "servers"]),
         McpClient::VsCodeCopilot => Some(&["servers"]),
+        McpClient::Zed => Some(&["context_servers"]),
         McpClient::Codex | McpClient::Grok | McpClient::Pi => None,
     }
 }
@@ -996,11 +998,55 @@ fn strip_mcp_json_client(
     let mut new_content = content.to_string();
     let mut removed = Vec::new();
     for candidate in mcp_url_candidates(client, url) {
-        let (next, mut hits) = strip_mcp_json(&new_content, client, name, &candidate)?;
+        let (next, mut hits) = if matches!(client, McpClient::Zed) {
+            strip_zed_mcp_jsonc(&new_content, name, &candidate)?
+        } else {
+            strip_mcp_json(&new_content, client, name, &candidate)?
+        };
         new_content = next;
         removed.append(&mut hits);
     }
     Ok((new_content, removed))
+}
+
+/// Remove matching entries from Zed's JSONC settings while preserving user
+/// comments, trailing commas, and unrelated formatting.
+fn strip_zed_mcp_jsonc(
+    content: &str,
+    name: Option<&str>,
+    url: &str,
+) -> Result<(String, Vec<String>)> {
+    use jsonc_parser::ParseOptions;
+    use jsonc_parser::cst::CstRootNode;
+
+    let root = CstRootNode::parse(content, &ParseOptions::default())
+        .context("parsing Zed settings.json as JSONC")?;
+    let Some(settings) = root.object_value() else {
+        return Ok((content.to_string(), Vec::new()));
+    };
+    let Some(servers) = settings.object_value("context_servers") else {
+        return Ok((content.to_string(), Vec::new()));
+    };
+
+    let mut removed = Vec::new();
+    for property in servers.properties() {
+        let Some(key) = property.name().and_then(|key| key.decoded_value().ok()) else {
+            continue;
+        };
+        let Some(entry) = property.to_serde_value() else {
+            continue;
+        };
+        if mcp_entry_is_ours(&key, &entry, name, url) {
+            property.remove();
+            removed.push(key);
+        }
+    }
+    if servers.properties().is_empty()
+        && let Some(context_servers) = settings.get("context_servers")
+    {
+        context_servers.remove();
+    }
+    Ok((root.to_string(), removed))
 }
 
 /// Remove ai-memory's MCP server from a JSON client config. Returns
@@ -1763,6 +1809,37 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert!(v["servers"].get("ai-memory").is_none());
         assert!(v["servers"].get("other").is_some());
+    }
+
+    #[test]
+    fn strip_mcp_zed_context_servers_preserves_other_settings() {
+        let content = r#"{
+  // Keep this user comment.
+  "theme": "One Dark",
+  "context_servers": {
+    "ai-memory": { "url": "http://127.0.0.1:49374/mcp" },
+    // Keep this sibling comment.
+    "other": { "url": "http://x" },
+  },
+}"#;
+        let (out, removed) = strip_mcp_json_client(
+            content,
+            McpClient::Zed,
+            Some("ai-memory"),
+            "http://127.0.0.1:49374/mcp",
+        )
+        .unwrap();
+
+        assert_eq!(removed, vec!["ai-memory".to_string()]);
+        assert!(out.contains("// Keep this user comment."));
+        assert!(out.contains("// Keep this sibling comment."));
+        let root =
+            jsonc_parser::cst::CstRootNode::parse(&out, &jsonc_parser::ParseOptions::default())
+                .unwrap();
+        let value = root.to_serde_value().unwrap();
+        assert_eq!(value["theme"], "One Dark");
+        assert!(value["context_servers"].get("ai-memory").is_none());
+        assert!(value["context_servers"].get("other").is_some());
     }
 
     #[test]

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,7 +9,7 @@ path (docker + Claude Code). This page covers everything else:
 - [Arch Linux native packages (AUR)](#arch-linux-native-packages-aur)
   (systemd system service or user service)
 - [Configuring other agent CLIs](#configuring-other-agent-clis)
-  (Codex, Devin CLI, OpenCode, OMP, Pi, Cursor, Claude Desktop, Gemini CLI, Antigravity CLI, Grok Build CLI, Zero, Kimi Code, OpenClaw, VS Code Copilot)
+  (Codex, Devin CLI, OpenCode, OMP, Pi, Cursor, Claude Desktop, Gemini CLI, Antigravity CLI, Grok Build CLI, Zero, Kimi Code, OpenClaw, VS Code Copilot, Zed)
 - [Installing hooks without docker](#installing-hooks-without-docker)
   (curl-based installer)
 - [Running ai-memory without docker](#running-ai-memory-without-docker)
@@ -599,9 +599,9 @@ Each agent CLI needs two things:
    Without this, the agent can still query memory but capture
    becomes manual.
 
-Claude Desktop and VS Code Copilot are MCP-only today. The hook-capable clients
-in the [README Support Matrix](../README.md#support-matrix), including Pi and
-Zero, have lifecycle capture paths through `install-hooks`.
+Claude Desktop, VS Code Copilot, and Zed are MCP-only today. The hook-capable
+clients in the [README Support Matrix](../README.md#support-matrix), including
+Pi and Zero, have lifecycle capture paths through `install-hooks`.
 
 > **Hook install pattern.** Local supported profiles default to host-native
 > commands. Claude Code may use its supported Windows exec form (`command` =
@@ -823,7 +823,7 @@ files owned by the user running the command. Prefer it as the
 default; reach for `setup-agent` only when your docker setup is
 known not to remap UIDs.
 
-### Cursor, Gemini CLI, Claude Desktop, OpenClaw, Antigravity CLI, Grok Build CLI, Zero, VS Code Copilot
+### Other MCP clients
 
 See [**`docs/mcp-install.md`**](mcp-install.md) for the per-client MCP
 config file path and snippet, or one-shot it via:
@@ -876,6 +876,10 @@ docker run --rm akitaonrails/ai-memory:latest \
 docker run --rm akitaonrails/ai-memory:latest \
     install-mcp --client vscode-copilot  --auth-token "$TOKEN" \
     --server-url "http://homelab:49374/mcp"
+
+docker run --rm akitaonrails/ai-memory:latest \
+    install-mcp --client zed             --auth-token "$TOKEN" \
+    --server-url "http://homelab:49374/mcp"
 ```
 
 Cursor, Gemini CLI, Antigravity CLI, Grok Build CLI, and OpenClaw support both
@@ -884,8 +888,8 @@ Cursor, Gemini CLI, Antigravity CLI, Grok Build CLI, and OpenClaw support both
 `$GROK_HOME/hooks` (default `~/.grok/hooks`). `install-hooks --agent grok`
 captures lifecycle events.
 Grok ignores `SessionStart` stdout, so handoffs must be accepted through MCP with
-`memory_handoff_accept` when resuming. Claude Desktop and VS Code Copilot are MCP-only here,
-so you'll need to nudge the model to call `memory_query` /
+`memory_handoff_accept` when resuming. Claude Desktop, VS Code Copilot, and Zed
+are MCP-only here, so you'll need to nudge the model to call `memory_query` /
 `memory_handoff_accept` itself.
 For clients with `install-hooks` support, the capture path handles
 handoff injection at session start or the client's closest equivalent, except

--- a/docs/mcp-install.md
+++ b/docs/mcp-install.md
@@ -38,7 +38,7 @@ ignore_paths`; legacy shell/PowerShell and remote-only/Docker script bundles do
 not. Reinstall/refresh an existing hook or plugin to gain it; see
 [Capture exclusions](marker-file.md#capture-exclusions).
 
-Claude Desktop and VS Code Copilot are **MCP-only** here: they expose
+Claude Desktop, VS Code Copilot, and Zed are **MCP-only** here: they expose
 long-term memory to their LLMs via ai-memory's MCP tools
 (`memory_query`, `memory_recent`, `memory_handoff_accept`, etc.), but
 they do not auto-capture session events into ai-memory's `/hook`
@@ -111,7 +111,7 @@ metadata.
 > **One-shot tip:** every snippet below is also reachable from the
 > CLI:
 > ```bash
-> ai-memory install-mcp --client gemini-cli   # or cursor / claude-desktop / openclaw / omp / pi / antigravity-cli / grok / kimi-code / devin / zero / vscode-copilot
+> ai-memory install-mcp --client gemini-cli   # or cursor / claude-desktop / openclaw / omp / pi / antigravity-cli / grok / kimi-code / devin / zero / vscode-copilot / zed
 > ```
 
 ---
@@ -275,6 +275,56 @@ Aliases: `copilot`, `github-copilot`.
 - Sources:
   <https://code.visualstudio.com/docs/copilot/customization/mcp-servers>,
   <https://code.visualstudio.com/docs/agents/reference/mcp-configuration>
+
+---
+
+## Zed
+
+**Status:** MCP supported through Zed's native remote context-server
+configuration. No lifecycle hooks or managed-workstream adapter.
+
+**Config file:** Zed stores MCP servers in its user `settings.json`:
+
+- macOS: `~/.config/zed/settings.json`
+- Linux: `$XDG_CONFIG_HOME/zed/settings.json`, defaulting to
+  `~/.config/zed/settings.json`
+- Windows: `%APPDATA%\Zed\settings.json`
+
+The server map is the top-level `context_servers` key. Remote servers use a
+`url` and may include bearer authentication in `headers`:
+
+```json
+{
+  "context_servers": {
+    "ai-memory": {
+      "url": "http://127.0.0.1:49374/mcp",
+      "headers": {
+        "Authorization": "Bearer <token>"
+      }
+    }
+  }
+}
+```
+
+Print or apply the configuration with:
+
+```bash
+ai-memory install-mcp --client zed
+ai-memory install-mcp --client zed --apply \
+  --server-url "http://homelab:49374/mcp" \
+  --auth-token "$TOKEN"
+```
+
+`--apply` preserves JSONC comments, trailing commas, unrelated Zed settings,
+and other context servers. Zed can call ai-memory's MCP tools, but it does not
+expose compatible session or tool lifecycle hooks. Automatic capture,
+automatic handoff injection, and
+`ai-memory run` continuity are therefore not available; ask the agent to call
+`memory_handoff_begin` before leaving and `memory_handoff_accept` when
+resuming when you need manual continuity.
+
+Sources: <https://zed.dev/docs/ai/mcp>,
+<https://zed.dev/docs/configuring-zed>.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -252,8 +252,9 @@ Client cleanup hints:
   MCP or hook entries.
 - OpenCode, OpenClaw, and OMP: check MCP config and plugin/extension directories;
   move old memory plugins to a disabled/quarantine directory before deleting.
-- VS Code Copilot and Claude Desktop: these are usually MCP-only, so confirm
-  whether the old tool was providing capture hooks elsewhere.
+- VS Code Copilot, Claude Desktop, and Zed: these are MCP-only, so confirm
+  whether the old tool was providing capture hooks elsewhere. Zed's MCP
+  entries live under `context_servers` in its user `settings.json`.
 
 If you want a visible startup reminder during the transition, keep it small. A
 rules-file note such as “Active memory: ai-memory; legacy export is historical


### PR DESCRIPTION
## Summary

- add native remote MCP rendering and JSONC-aware `--apply` support for Zed
- preserve comments, trailing commas, unrelated settings, and sibling context servers during install/uninstall
- document Zed as MCP-only, with current platform paths and no lifecycle or managed-workstream claims

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- `cargo deny check`
- `cargo audit`
- companion importer fmt/test/clippy
- `scripts/check-native-packaging.sh`
- `tests/hooks/test_lib.sh` (44 passed)
- `tests/e2e/handoff_smoke.sh` (9 passed)
- gitleaks exact-commit scan

Closes #321