### PR TITLE
docs: reconcile retrieval release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Per-page TTL via a frontmatter `expires_at:` key (RFC3339, or a bare
+  `YYYY-MM-DD` meaning end of that day UTC), mirrored into a new
+  `pages.expires_at` column (V36) and settable through a new optional
+  `expires_at` parameter on `memory_write_page`. Expired pages are hidden
+  from `memory_query`/`memory_recent`/briefing/session-brief surfaces —
+  `memory_query` gains `include_expired: true` to still see them — while
+  exact-path reads still return the page, annotated `expired: true`,
+  because an explicit read is not a search. The forget sweep hard-deletes
+  them through the wiki layer, so the markdown file goes too, not just
+  the rows. An explicit TTL outranks `pinned` (a pin means "don't decay
+  this", not "keep it past the date its author set"); `memory_lint`
+  flags pinned+expiring pages so the combination is visible rather than
+  silent. (#309)
 - Zed editor as an MCP-only client. `install-mcp --client zed` renders,
   and `--apply` idempotently merges, a native remote HTTP entry under the
   top-level `context_servers` map in Zed's platform user `settings.json`,
@@ -60,9 +73,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   feedback call; agents treat it as untrusted data. (#318)
 - `memory_query` gained an optional `explain: true` mode for project and
   explicit-scope searches. Each compiled-page hit then includes its 1-based
-  FTS5, vector, and graph ranks; raw BM25/cosine values; graph seed and link
-  direction; per-stream RRF contributions; fused score; and bounded authority
-  multiplier. `streams_active` makes vector degradation visible. Global
+  FTS5, entity, vector, and graph ranks; raw BM25/cosine/entity values; matched
+  entity names; graph seed and link direction; per-stream RRF contributions;
+  fused score; and bounded authority multiplier. `streams_active` makes vector
+  degradation visible. Global
   cross-project search reports its distinct FTS-only stream but does not attach
   RRF details to `global_hits`. Explain provenance is computed only when
   requested. (#317)
@@ -78,6 +92,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   TTL-expired standing pages are ignored. (#316)
 
 ### Fixed
+- Zero-embedding startup and current retrieval descriptions now include the
+  entity-match stream, and release notes attribute per-page TTL to the release
+  where it shipped. (#329)
 - Retrieved `_rules/`, `gotchas/`, `procedures/`, and `decisions/` pages are now
   described consistently across MCP and installed skill prompts as untrusted
   historical evidence, removing contradictory language that elevated stored
@@ -126,19 +143,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.20.0] - 2026-07-30
 
 ### Added
-- Per-page TTL via a frontmatter `expires_at:` key (RFC3339, or a bare
-  `YYYY-MM-DD` meaning end of that day UTC), mirrored into a new
-  `pages.expires_at` column (V36) and settable through a new optional
-  `expires_at` parameter on `memory_write_page`. Expired pages are hidden
-  from `memory_query`/`memory_recent`/briefing/session-brief surfaces —
-  `memory_query` gains `include_expired: true` to still see them — while
-  exact-path reads still return the page, annotated `expired: true`,
-  because an explicit read is not a search. The forget sweep hard-deletes
-  them through the wiki layer, so the markdown file goes too, not just
-  the rows. An explicit TTL outranks `pinned` (a pin means "don't decay
-  this", not "keep it past the date its author set"); `memory_lint`
-  flags pinned+expiring pages so the combination is visible rather than
-  silent ([#309]).
 - New `openai-compat` embedding provider for self-hosted engines
   (Ollama, LM Studio, vLLM). Set
   `AI_MEMORY_EMBEDDING_PROVIDER=openai-compat` together with explicit

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -1200,7 +1200,9 @@ async fn configure_embedder(
     // M9 — pluggable embedder. Stored rows carry provider/model/dim so
     // query paths can ignore stale vectors after an embedding config change.
     let Some(cfg) = config.embedder_config()? else {
-        info!("AI_MEMORY_EMBEDDING_PROVIDER unset; vector search disabled (FTS5 + graph active)");
+        info!(
+            "AI_MEMORY_EMBEDDING_PROVIDER unset; vector search disabled (FTS5 + entity + graph active)"
+        );
         return Ok((wiki, None));
     };
     let provider_name = cfg.provider.name().to_string();

--- a/crates/ai-memory-consolidate/tests/embeddings.rs
+++ b/crates/ai-memory-consolidate/tests/embeddings.rs
@@ -154,7 +154,7 @@ async fn m9_embeddings_roundtrip_via_synthetic() {
         "the karpathy page should be the top hybrid hit; got {top_path}",
     );
 
-    // 4. Without a query vector, FTS5 + graph still work through the
+    // 4. Without a query vector, FTS5 + entity + graph still work through the
     //    same method; only the vector stream is absent.
     let lexical_graph = store
         .reader
@@ -173,7 +173,7 @@ async fn m9_embeddings_roundtrip_via_synthetic() {
         .expect("hybrid (no query vec)");
     assert!(
         !lexical_graph.is_empty(),
-        "FTS5 + graph fallback should still return Karpathy page",
+        "FTS5 + entity + graph fallback should still return Karpathy page",
     );
 
     // 5. Re-writing a page produces a fresh embedding row (the

--- a/crates/ai-memory-consolidate/tests/recall_eval.rs
+++ b/crates/ai-memory-consolidate/tests/recall_eval.rs
@@ -1,9 +1,10 @@
 //! Recall@5 eval harness.
 //!
 //! Loads a small hand-crafted corpus + a probe set, measures recall@5
-//! against both the pure-FTS5 path and the hybrid (FTS5 + graph RRF +
-//! vector) path, and asserts a baseline. It also pins graph-neighbor
-//! expansion and raw observation fallback. The point is *the framework*: once the
+//! against both the pure-FTS5 path and the hybrid (FTS5 + entity + graph RRF +
+//! vector) path, and asserts a baseline. It also pins entity-only recall,
+//! graph-neighbor expansion, and raw observation fallback. The point is *the
+//! framework*: once the
 //! harness is in CI, anyone can drop in real embeddings (set the
 //! `AI_MEMORY_EMBEDDING_PROVIDER` env vars + plug in a real model) and
 //! watch the numbers move. The synthetic embedder shipped for tests is

--- a/crates/ai-memory-llm/src/embedding.rs
+++ b/crates/ai-memory-llm/src/embedding.rs
@@ -79,7 +79,7 @@ impl OpenAiEmbedder {
         // (small model, but still up to ~30s on first request after
         // unload). Subsequent requests with OLLAMA_KEEP_ALIVE warm are
         // sub-second. When the embedder still fails, memory_query
-        // degrades gracefully to FTS5 + graph (see server.rs).
+        // degrades gracefully to FTS5 + entity + graph (see server.rs).
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(120))
             .build()?;
@@ -365,7 +365,7 @@ impl VoyageEmbedder {
         // (small model, but still up to ~30s on first request after
         // unload). Subsequent requests with OLLAMA_KEEP_ALIVE warm are
         // sub-second. When the embedder still fails, memory_query
-        // degrades gracefully to FTS5 + graph (see server.rs).
+        // degrades gracefully to FTS5 + entity + graph (see server.rs).
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(120))
             .build()?;

--- a/crates/ai-memory-llm/src/reranker.rs
+++ b/crates/ai-memory-llm/src/reranker.rs
@@ -1,6 +1,6 @@
 //! Optional post-retrieval reranking.
 //!
-//! Hybrid RRF fuses independent FTS5, cosine, and graph ranks without
+//! Hybrid RRF fuses independent FTS5, entity, cosine, and graph ranks without
 //! jointly judging the query against each candidate snippet. A reranker
 //! adds that final comparison, which can recover a relevant page below
 //! the caller's requested cut.

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -2477,7 +2477,12 @@ mod tests {
                 "rank must equal -(fused * authority): {hit:?} {details:?}"
             );
             assert!(
-                (details.fused - (details.rrf.fts + details.rrf.vector + details.rrf.graph)).abs()
+                (details.fused
+                    - (details.rrf.fts
+                        + details.rrf.entity
+                        + details.rrf.vector
+                        + details.rrf.graph))
+                    .abs()
                     < f64::EPSILON
             );
         }
@@ -5529,6 +5534,13 @@ mod tests {
         assert!(explain.entity_weight.is_some_and(|weight| weight > 0.0));
         assert_eq!(explain.matched_entities, vec!["turbopuffer".to_string()]);
         assert!(explain.rrf.entity > 0.0);
+        assert!(
+            (explain.fused
+                - (explain.rrf.fts + explain.rrf.entity + explain.rrf.vector + explain.rrf.graph))
+                .abs()
+                < f64::EPSILON,
+            "fused score must include the entity stream: {explain:?}",
+        );
         assert!(
             explain.fts_rank.is_none(),
             "the body has no query term, so FTS must miss it",

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -320,7 +320,7 @@ struct GraphNeighbor {
 /// direction. Part of [`SearchExplain`].
 #[derive(Debug, Clone, Serialize)]
 pub struct GraphVia {
-    /// Path of the FTS/vector seed page the link was followed from.
+    /// Path of the FTS/entity/vector seed page the link was followed from.
     pub seed_path: String,
     /// `outgoing` = seed links to the hit; `incoming` = hit links to
     /// the seed (backlink).

--- a/crates/ai-memory-web/src/routes/api.rs
+++ b/crates/ai-memory-web/src/routes/api.rs
@@ -256,13 +256,14 @@ async fn search_post_handler(
 }
 
 // NOTE (deferred): vector/semantic search. `ReaderPool::hybrid_search` already
-// RRF-fuses FTS5 + cosine over stored embeddings + link-graph expansion, but it
-// needs a query embedding — and `WebState` is read-only (reader + wiki), with no
-// embedder. Wiring true semantic search means injecting an embedding client into
-// `WebState` (touching `lib.rs`/`serve.rs`/`Cargo.toml`) and confirming the
-// embedding provider (Ollama) is reachable from the deployment. Until then this
-// handler stays FTS5-only. Link-graph "related pages" already ship via the
-// page-view `links`/`backlinks` (`ReaderPool::page_links`).
+// RRF-fuses FTS5 + entity matching + cosine over stored embeddings + link-graph
+// expansion, but it needs a query embedding — and `WebState` is read-only
+// (reader + wiki), with no embedder. Wiring true semantic search means injecting
+// an embedding client into `WebState` (touching `lib.rs`/`serve.rs`/`Cargo.toml`)
+// and confirming the embedding provider (Ollama) is reachable from the
+// deployment. Until then this handler stays FTS5-only. Link-graph "related
+// pages" already ship via the page-view `links`/`backlinks`
+// (`ReaderPool::page_links`).
 async fn search_with_request(
     state: &WebState,
     request: SearchRequest,

--- a/crates/ai-memory-wiki/src/wiki.rs
+++ b/crates/ai-memory-wiki/src/wiki.rs
@@ -150,7 +150,7 @@ impl Wiki {
     /// the SQL/file fan-out atomic and leaves vector completeness to
     /// admin or scheduled embedding backfill. Without an embedder,
     /// vector search is skipped and `ReaderPool::hybrid_search` uses
-    /// FTS5 + graph expansion.
+    /// FTS5 + entity + graph expansion.
     #[must_use]
     pub fn with_embedder(mut self, embedder: Arc<dyn Embedder>) -> Self {
         self.embedder = Some(embedder);

--- a/docs/prior-art-implementation-findings.md
+++ b/docs/prior-art-implementation-findings.md
@@ -35,7 +35,7 @@ The follow-up implementation landed the pragmatic subset of this roadmap:
 | Links / graph | Markdown and wikilinks are parsed into `links`; unresolved forward links resolve when targets appear; query uses graph-neighbor RRF. |
 | Raw fallback | `observations_fts` provides bounded raw fallback when compiled wiki search misses. |
 | Diagnostics | `status` includes FTS row counts, missing embeddings, embedding triples, and unresolved/stale link counts. |
-| Retrieval evals | Recall harness now covers FTS/vector, graph expansion, and raw fallback. |
+| Retrieval evals | Recall harness now covers FTS/entity/vector, graph expansion, and raw fallback. |
 | Procedural learning | Consolidation can classify procedural memory; auto-improvement creates or patches bounded `procedures/` pages. |
 | SessionEnd consolidation | The deterministic summary/handoff completes before optional provider work enters a durable, retryable queue outside hook latency. |
 


### PR DESCRIPTION
## Summary

- move the per-page TTL entry from the historical v1.20.0 section to Unreleased
- describe entity retrieval consistently in current logs, comments, tests, and implementation notes
- assert that fused scores include a nonzero entity-stream contribution

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- `cargo deny check`
- `cargo audit --ignore RUSTSEC-2025-0141 --ignore RUSTSEC-2024-0320 --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195`
- companion importer fmt/clippy/test
- native packaging, 44 hook checks, and end-to-end handoff smoke
- exact-commit gitleaks scan

Closes #329
