### PR TITLE
release: v1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.0] - 2026-07-31
+
 ### Added
 - Per-page TTL via a frontmatter `expires_at:` key (RFC3339, or a bare
   `YYYY-MM-DD` meaning end of that day UTC), mirrored into a new
@@ -2686,7 +2688,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidator used server startup default project instead of the
   session's actual project.
 
-[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.20.2...HEAD
+[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.21.0...HEAD
+[1.21.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.21.0
 [1.20.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.20.2
 [1.20.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.20.1
 [1.20.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.20.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-cli"
-version = "1.20.2"
+version = "1.21.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-consolidate"
-version = "1.20.2"
+version = "1.21.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-core"
-version = "1.20.2"
+version = "1.21.0"
 dependencies = [
  "jiff",
  "regex",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-eval"
-version = "1.20.2"
+version = "1.21.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-hooks"
-version = "1.20.2"
+version = "1.21.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-llm"
-version = "1.20.2"
+version = "1.21.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-mcp"
-version = "1.20.2"
+version = "1.21.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-store"
-version = "1.20.2"
+version = "1.21.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-web"
-version = "1.20.2"
+version = "1.21.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-store",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-wiki"
-version = "1.20.2"
+version = "1.21.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-workstream"
-version = "1.20.2"
+version = "1.21.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.20.2"
+version = "1.21.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"
@@ -26,15 +26,15 @@ authors = ["Fabio Akita <boss@akitaonrails.com>"]
 
 [workspace.dependencies]
 # Inter-crate dependencies.
-ai-memory-core = { path = "crates/ai-memory-core", version = "1.20.2" }
-ai-memory-store = { path = "crates/ai-memory-store", version = "1.20.2" }
-ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.20.2" }
-ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.20.2" }
-ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.20.2" }
-ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.20.2" }
-ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.20.2" }
-ai-memory-web = { path = "crates/ai-memory-web", version = "1.20.2" }
-ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.20.2" }
+ai-memory-core = { path = "crates/ai-memory-core", version = "1.21.0" }
+ai-memory-store = { path = "crates/ai-memory-store", version = "1.21.0" }
+ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.21.0" }
+ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.21.0" }
+ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.21.0" }
+ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.21.0" }
+ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.21.0" }
+ai-memory-web = { path = "crates/ai-memory-web", version = "1.21.0" }
+ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.21.0" }
 
 # (Workspace shared deps follow below)
 


### PR DESCRIPTION
## Summary

- finalize the additive TTL, feedback, explain, reranking, entity retrieval, project-instruction, and Zed changes as v1.21.0
- bump the workspace and internal crate versions to 1.21.0
- date the release changelog and update comparison links

## Verification

- the unchanged source tree passed the complete local gate on PR #330
- `cargo fmt --all -- --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo check --workspace --locked`
- `TAILWIND_SKIP=1 cargo run --locked -p ai-memory-cli -- --version` reports `ai-memory 1.21.0`
- exact-commit gitleaks scan

The full cross-platform test, release-build, Docker smoke, dependency, audit, and CodeQL matrix is delegated to this PR exact head to avoid repeating the unchanged source suite locally.
