### PR TITLE
ci: verify full-history secret scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,8 +202,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Full history so the scan covers every commit reachable
-          # from the pushed ref, not just the last one.
+          # The action scans the pushed/PR commit range. Full history is
+          # checked separately by secret-scan.yml on a schedule or on demand.
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,24 @@
+name: full-history secret scan
+
+on:
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: gitleaks (full history)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      # workflow_dispatch and schedule events make this pinned action scan the
+      # complete reachable history. Push/PR scans remain differential in ci.yml.
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -12,6 +12,7 @@ jobs:
   gitleaks:
     name: gitleaks (full history)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,13 +1,14 @@
 # gitleaks configuration for ai-memory.
 #
-# Wired into CI via `.github/workflows/ci.yml`'s `gitleaks` job. Runs
-# on every push and PR; fails the build if a credential-shaped value
-# lands in any tracked file.
+# Wired into CI via `.github/workflows/ci.yml` for changed commits and
+# `.github/workflows/secret-scan.yml` for scheduled/manual full-history
+# scans. Both fail if a credential-shaped value is not explicitly reviewed.
 #
 # The default ruleset (Google API keys, Anthropic, OpenAI, Slack, AWS,
 # GitHub PATs, …) covers what ai-memory's own sanitiser covers. We
 # inherit it and only ADD an allowlist for the specific test fixtures
-# we deliberately ship.
+# we deliberately ship. `.gitleaksignore` contains exact fingerprints for
+# reviewed legacy findings; never add broad commit, path, or rule exclusions.
 #
 # Lesson from M18: a previous iteration of sanitize.rs used a live
 # Gemini key as a test fixture and Google's automated scanner caught

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -52,10 +52,3 @@ regexes = [
     '''sk-REPLACE_ME''',
     '''REPLACE_WITH_OUTPUT_OF_GENERATE_AUTH_TOKEN''',
 ]
-
-# Path-based exemptions — kept minimal. tests/e2e/ uses a few canary
-# strings we want to ship intentionally; the regexes above already
-# cover them but excluding the path is cheap defence-in-depth.
-paths = [
-    '''tests/e2e/.*\.sh''',
-]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,6 @@
+6004869ea350546a8aefcf1237895e708cc51557:crates/ai-memory-cli/src/commands/hook.rs:generic-api-key:389
+16e87742aeb51ac34a44f71392b05579865e9b9e:crates/ai-memory-wiki/src/wiki.rs:github-pat:1719
+747c32d50f824cae665f2e35bbd62c8502438903:crates/ai-memory-hooks/src/sanitize.rs:generic-api-key:125
+747c32d50f824cae665f2e35bbd62c8502438903:crates/ai-memory-hooks/src/sanitize.rs:jwt:107
+d8361d3c3a86f870f74841b53c568c64fe42ab1f:crates/ai-memory-core/src/sanitize.rs:gcp-api-key:226
+d8361d3c3a86f870f74841b53c568c64fe42ab1f:crates/ai-memory-core/src/sanitize.rs:generic-api-key:257

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,5 +1,6 @@
 6004869ea350546a8aefcf1237895e708cc51557:crates/ai-memory-cli/src/commands/hook.rs:generic-api-key:389
 16e87742aeb51ac34a44f71392b05579865e9b9e:crates/ai-memory-wiki/src/wiki.rs:github-pat:1719
+a861ec3d598885d43500713d21d4e1aafbf46645:tests/e2e/handoff_smoke.sh:curl-auth-header:188
 747c32d50f824cae665f2e35bbd62c8502438903:crates/ai-memory-hooks/src/sanitize.rs:generic-api-key:125
 747c32d50f824cae665f2e35bbd62c8502438903:crates/ai-memory-hooks/src/sanitize.rs:jwt:107
 d8361d3c3a86f870f74841b53c568c64fe42ab1f:crates/ai-memory-core/src/sanitize.rs:gcp-api-key:226

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,8 +221,9 @@ cargo deny check                                          # dependency policy (i
   `tests/e2e/handoff_smoke.sh`, `scripts/check-native-packaging.sh`.
 - CI additionally runs `cargo build --release --bin ai-memory` on
   Linux/macOS, a Docker image smoke test, `cargo audit` (with the ignores
-  listed in `ci.yml`), gitleaks secret scanning, and a non-gating Windows
-  test job.
+  listed in `ci.yml`), differential gitleaks scanning, and a non-gating
+  Windows test job. `.github/workflows/secret-scan.yml` runs the separate
+  weekly/manual full-history gitleaks scan.
 
 ## Code style guidelines
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -101,7 +101,11 @@ what the project is and is not designed to defend against.
 - **Published executable integrity.** Docker wrapper and standalone hook
   installs use GitHub Release assets with SHA-256 companions. GitHub Actions
   are pinned to reviewed commits and release jobs default to read-only token
-  permissions except the GitHub Release publisher.
+  permissions except the GitHub Release publisher. Gitleaks checks each pushed
+  or proposed commit range and a separate weekly/manual workflow checks the
+  complete reachable history. The full-history scan recognizes only reviewed,
+  exact fingerprints in `.gitleaksignore`; adding an entry never substitutes
+  for removing the value from the current tree and rotating a real credential.
 
 ### Out of scope for v1
 


### PR DESCRIPTION
## Summary

- correct the PR/push gitleaks documentation: those events scan their commit range
- add a cheap weekly/manual workflow that scans every commit reachable from the default branch
- baseline seven exact, reviewed historical fingerprints without rewriting published history
- document that fingerprint baselines never replace removing current values or rotating credentials

Six baseline entries are synthetic historical test fixtures. The seventh is the removed credential incident already documented by the repository; this PR does not expose its value or broaden any path/rule exclusion. New findings still fail both differential and full-history scans.

## Verification

- `gitleaks git --redact --log-level=warn`
- changed-content scan through `gitleaks stdin --redact --log-level=warn`
- YAML parse for both workflows
- `git diff --check`

The Rust source, dependency graph, migrations, and release artifacts are unchanged, so the complete Rust gate from the immediately preceding v1.21.0 candidate remains applicable; hosted CI will independently test this exact head.