### PR TITLE
feat(cli): add `ai-memory show` project and harness picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `ai-memory show`: an interactive launcher that lists projects, asks which
+  harness to start, enters that project's directory, and delegates to
+  `ai-memory run`. It exists because project scope is derived from the working
+  directory, so opening an agent from a parent directory holding many checkouts
+  resolved all of them into that parent's basename and piled unrelated sessions
+  into one scope. The menu merges two sources: projects the server already
+  tracks (newest activity first, with page counts, from a new `repo_path` field
+  on `/api/v1/projects` rows), and a depth-1 scan of the current directory for
+  directories carrying a recognised project marker — so the picker is useful on
+  a machine where ai-memory has not run yet, instead of staying empty until
+  every project has been opened the long way once. Dependency, build, and
+  dot-directories are skipped, and the scan is disabled with `--no-scan`. A
+  scanned directories are ordered by mtime, newest first, matching the tracked
+  half's activity ordering — alphabetical order buried a just-created project
+  under every checkout whose name sorted earlier. A
+  tracked pick pins both scope halves; a scanned pick passes neither, so `run`
+  derives the scope from the checkout exactly as the lifecycle hooks would. The
+  The list always leads with a **new-project** entry that asks for a name,
+  creates the directory, pins both scope halves in a `.ai-memory.toml` marker,
+  and installs the routing block plus the managed Agent Skills into the
+  instruction file the chosen harness actually reads (`CLAUDE.md` for Claude
+  Code, `AGENTS.md` otherwise) by delegating to `install-instructions`. The name
+  is validated against the server's own `^[a-z0-9][a-z0-9._-]*$` rule and
+  against the directory before anything is written, so a rejection is corrected
+  by typing instead of surfacing later as a hook warning on a session that
+  already started. Both marker keys are pinned because the defaults follow the
+  directory name, so a rename or a subdirectory `cd` would otherwise fork the
+  memory into a second, empty project. The
+  harness menu is filtered to the harnesses actually present in `PATH`, reusing
+  the same lookup `run` enforces at launch, so the picker cannot offer an agent
+  that would fail to start once a project has already been chosen. A failed
+  listing degrades to scan-only results with a warning rather than aborting. With stdin or stdout redirected it prints the same candidates as
+  tab-separated `label`/`path`/`detail` lines instead of drawing a menu, so the
+  list stays greppable. `--workspace` narrows the tracked list, and `--yolo`,
+  `--fresh`, and trailing native arguments are forwarded to `run` unchanged.
+  (#NNN)
+
 ### Fixed
 - `run` on Windows no longer reports a harness as installed and then fails to
   start it. npm-style installs drop three files side by side — `opencode`,
@@ -16,10 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `program not found`. Availability now resolves to a concrete file, counting
   only `PATHEXT` matches (or a path whose extension was given explicitly), and
   the spawn uses that resolved path instead of the bare name, so the check and
-  the launch can no longer disagree. Spawning the resolved path also stops
-  `CreateProcess` from searching the working directory before `PATH`, so a
-  binary planted in the launched checkout can no longer take the harness's
-  place. Unix behaviour is unchanged. (#NNN)
+  the launch can no longer disagree. Unix behaviour is unchanged. (#NNN)
 
 ## [1.21.0] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `run` on Windows no longer reports a harness as installed and then fails to
+  start it. npm-style installs drop three files side by side — `opencode`,
+  `opencode.cmd`, `opencode.ps1` — and the availability probe accepted the
+  extension-less shell script, which exists for Git Bash and which
+  `CreateProcess` cannot execute; the launch then died with
+  `program not found`. Availability now resolves to a concrete file, counting
+  only `PATHEXT` matches (or a path whose extension was given explicitly), and
+  the spawn uses that resolved path instead of the bare name, so the check and
+  the launch can no longer disagree. Spawning the resolved path also stops
+  `CreateProcess` from searching the working directory before `PATH`, so a
+  binary planted in the launched checkout can no longer take the harness's
+  place. Unix behaviour is unchanged. (#NNN)
+
 ## [1.21.0] - 2026-07-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ dependencies = [
  "base64",
  "clap",
  "clap_complete",
+ "crossterm",
  "dirs",
  "figment",
  "flate2",
@@ -718,6 +719,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -1660,6 +1686,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2437,6 +2469,19 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2444,7 +2489,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2685,6 +2730,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,7 +2896,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3930,7 +3996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,12 @@ clap = { version = "4", features = ["derive", "env"] }
 # same derived `Command` the parser uses, so completions can never drift
 # from the actual CLI surface.
 clap_complete = "4"
+# Raw-mode key reading for `ai-memory show`'s interactive picker. The CLI had
+# no terminal crate before this: `anstyle` arrives transitively through clap
+# and only styles text, it cannot read arrow keys. crossterm is the portable
+# option that keeps one code path across Linux, macOS, and Windows consoles
+# instead of a `#[cfg]` split over termios and the Win32 console API.
+crossterm = "0.28"
 dirs = "5"
 # Format-preserving TOML editor for install-mcp --apply against
 # Codex's config.toml. Plain `toml` round-trips destroy comments;

--- a/README.md
+++ b/README.md
@@ -177,6 +177,39 @@ priors are at the [bottom](#influences-and-prior-art).
   ai-memory run --fresh codex
   ```
 
+- **"Pick the project instead of remembering where it lives."** Project scope
+  comes from the working directory, so launching from a parent directory that
+  holds many checkouts resolves all of them into that parent's basename. Start
+  from the menu instead, from anywhere:
+
+  ```bash
+  ai-memory show
+  ```
+
+  The menu merges two sources: projects ai-memory already tracks (newest
+  activity first, with page counts) and a fast depth-1 scan of the current
+  directory for anything carrying a project marker (`.git`, `Cargo.toml`,
+  `package.json`, `go.mod`, `pyproject.toml`, and friends). Dependency and build
+  directories are skipped. So running it from a folder full of checkouts works
+  on day one, before ai-memory has seen any of them — pick one, pick a harness,
+  and it enters that directory and hands off to `ai-memory run`.
+
+  The list always leads with **`+ New project`**: type a name and ai-memory
+  creates the directory, pins the workspace and project in a `.ai-memory.toml`
+  marker, and installs the routing block and managed Agent Skills into the
+  instruction file the agent you picked actually reads — then launches it there.
+  So a brand-new project starts with its memory context already wired, without a
+  `mkdir` / `install-instructions` detour.
+
+  The harness menu only offers agents actually installed on the host, using the
+  same `PATH` lookup `run` enforces at launch.
+
+  `--no-scan` restricts the list to tracked projects; `--workspace` narrows that
+  half; `--yolo`, `--fresh`, and any trailing native arguments are forwarded
+  unchanged. With output redirected it prints the same candidates as
+  tab-separated lines instead of drawing a menu, so `ai-memory show | grep …`
+  works; launching from a script stays the job of `ai-memory run <harness>`.
+
   The first explicit run can offer an existing session from this exact checkout
   or start a new one. Switching harnesses starts or resumes the native session
   linked to the shared workstream, so an obsolete local session cannot replace

--- a/crates/ai-memory-cli/Cargo.toml
+++ b/crates/ai-memory-cli/Cargo.toml
@@ -30,6 +30,7 @@ anyhow.workspace = true
 axum.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
+crossterm.workspace = true
 dirs.workspace = true
 figment.workspace = true
 flate2.workspace = true

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -37,6 +37,9 @@ pub enum Command {
     /// Native arguments are forwarded except exact wrapper flags such as
     /// `--yolo` and `--fresh`.
     Run(RunArgs),
+    /// Pick a known project and harness from an interactive menu, then launch
+    /// it there. Removes the `cd` step `run` requires.
+    Show(ShowArgs),
     /// Search the complete visible event ledger for a managed workstream.
     WorkstreamSearch(WorkstreamSearchArgs),
     /// Audit the store for likely cross-project contamination (read-only,
@@ -231,6 +234,29 @@ pub enum RunHarnessChoice {
     /// Grok Build CLI (xAI).
     #[value(alias = "grok-build")]
     Grok,
+}
+
+/// Arguments for `show`.
+#[derive(Debug, Args)]
+pub struct ShowArgs {
+    /// Only list projects from this workspace. Defaults to every workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
+    /// List only projects the server already tracks, skipping the depth-1
+    /// scan of the current directory for untracked project directories.
+    #[arg(long)]
+    pub no_scan: bool,
+    /// Disable native permission prompts using the selected harness's
+    /// equivalent dangerous-mode option. Forwarded to `run`.
+    #[arg(long)]
+    pub yolo: bool,
+    /// Start a new native session instead of resuming or adopting an existing
+    /// harness session. Forwarded to `run`.
+    #[arg(long)]
+    pub fresh: bool,
+    /// Native harness arguments, forwarded byte-for-byte and in order.
+    #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+    pub native_args: Vec<OsString>,
 }
 
 /// Arguments for `workstream-search`.

--- a/crates/ai-memory-cli/src/commands/mod.rs
+++ b/crates/ai-memory-cli/src/commands/mod.rs
@@ -50,6 +50,7 @@ pub mod run;
 pub mod search;
 pub mod serve;
 pub mod setup_agent;
+pub mod show;
 pub mod status;
 pub mod uninstall;
 pub mod user;

--- a/crates/ai-memory-cli/src/commands/run.rs
+++ b/crates/ai-memory-cli/src/commands/run.rs
@@ -325,7 +325,12 @@ pub async fn run(config: &Config, args: RunArgs) -> Result<i32> {
     }
 
     let started_at = SystemTime::now();
-    let mut command = Command::new(&plan.program);
+    // Spawn the resolved file rather than the bare name: on Windows the name
+    // alone can match an unlaunchable extension-less shim (see
+    // `resolve_program`). Falling back to the plan's own value keeps an
+    // unresolvable program reaching the spawn error below, which explains it.
+    let program = resolve_program(&plan.program).unwrap_or_else(|| plan.program.clone().into());
+    let mut command = Command::new(&program);
     command
         .args(&plan.args)
         .current_dir(&repository.cwd)
@@ -689,32 +694,51 @@ fn ensure_executable_available(harness: ManagedHarness, executable: Option<&OsSt
 }
 
 fn executable_available(program: &OsStr) -> bool {
+    resolve_program(program).is_some()
+}
+
+/// Resolve `program` to a concrete path the OS can actually start, or `None`
+/// when nothing launchable matches.
+///
+/// The bare name is not enough on Windows. An npm-style install drops three
+/// files next to each other — `opencode`, `opencode.cmd`, `opencode.ps1` — and
+/// only the ones carrying a `PATHEXT` extension are launchable: `CreateProcess`
+/// refuses the extension-less shell script, which exists for Git Bash. Probing
+/// for mere existence therefore reported harnesses as present that then failed
+/// to spawn with "program not found". Resolving to the concrete file keeps the
+/// availability check and the launch agreeing on one answer, and lets the
+/// launch use a path that works.
+pub(super) fn resolve_program(program: &OsStr) -> Option<std::path::PathBuf> {
     let path = Path::new(program);
     if path.components().count() > 1 {
-        return executable_path_available(path);
+        return resolve_candidate(path);
     }
-    std::env::var_os("PATH").is_some_and(|path_value| {
-        std::env::split_paths(&path_value)
-            .map(|dir| dir.join(path))
-            .any(|candidate| executable_path_available(&candidate))
+    std::env::var_os("PATH").and_then(|path_value| {
+        std::env::split_paths(&path_value).find_map(|dir| resolve_candidate(&dir.join(path)))
     })
 }
 
-fn executable_path_available(path: &Path) -> bool {
-    if executable_file(path) {
-        return true;
-    }
+/// Concrete launchable file for one candidate location.
+fn resolve_candidate(path: &Path) -> Option<std::path::PathBuf> {
     #[cfg(windows)]
-    if path.extension().is_none() {
+    {
+        // An explicit extension is taken at face value; otherwise only a
+        // PATHEXT match counts. Never the extension-less sibling.
+        if path.extension().is_some() && executable_file(path) {
+            return Some(path.to_path_buf());
+        }
         let extensions =
             std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
-        return extensions
+        extensions
             .split(';')
             .filter(|extension| !extension.is_empty())
             .map(|extension| path.with_extension(extension.trim_start_matches('.')))
-            .any(|candidate| executable_file(&candidate));
+            .find(|candidate| executable_file(candidate))
     }
-    false
+    #[cfg(not(windows))]
+    {
+        executable_file(path).then(|| path.to_path_buf())
+    }
 }
 
 fn executable_file(path: &Path) -> bool {
@@ -1202,6 +1226,67 @@ mod tests {
 
     use super::*;
     use crate::cli::{Cli, Command as CliCommand};
+
+    /// A false positive here reports a harness as installed and then fails to
+    /// spawn it, which is the bug this resolution exists to prevent.
+    #[test]
+    fn executable_available_rejects_a_program_that_is_not_installed() {
+        assert!(!executable_available(OsStr::new(
+            "ai-memory-no-such-harness-binary"
+        )));
+    }
+
+    /// An absolute path that exists resolves without consulting `PATH`, which
+    /// is the branch `--executable` relies on.
+    #[test]
+    fn executable_available_accepts_an_existing_absolute_path() {
+        let current = std::env::current_exe().unwrap();
+        assert!(executable_available(current.as_os_str()));
+        assert_eq!(
+            resolve_program(current.as_os_str()).as_deref(),
+            Some(current.as_path())
+        );
+    }
+
+    /// npm-style installs drop an extension-less shell script beside the
+    /// `.cmd` wrapper. On Windows only the wrapper is launchable, so probing
+    /// for mere existence reported the harness as available and the launch
+    /// then failed with "program not found".
+    #[cfg(windows)]
+    #[test]
+    fn windows_resolution_skips_the_extension_less_shim() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("faux-harness"), "#!/bin/sh\n").unwrap();
+
+        assert_eq!(
+            resolve_candidate(&tmp.path().join("faux-harness")),
+            None,
+            "an extension-less script is not launchable by CreateProcess"
+        );
+
+        std::fs::write(tmp.path().join("faux-harness.cmd"), "@echo off\n").unwrap();
+        let resolved =
+            resolve_candidate(&tmp.path().join("faux-harness")).expect("the wrapper resolves");
+        // PATHEXT is upper-case, and Windows paths are case-insensitive, so the
+        // resolved name carries whichever casing the probe used.
+        assert_eq!(
+            resolved
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(str::to_ascii_lowercase),
+            Some("faux-harness.cmd".to_string()),
+            "the PATHEXT sibling is what should be launched"
+        );
+        assert!(resolved.is_file());
+    }
+
+    /// Unix has no PATHEXT: the file itself is the answer.
+    #[cfg(not(windows))]
+    #[test]
+    fn unix_resolution_returns_the_file_itself() {
+        let current = std::env::current_exe().unwrap();
+        assert_eq!(resolve_candidate(&current), Some(current));
+    }
 
     fn candidates() -> Vec<NativeSessionCandidate> {
         vec![

--- a/crates/ai-memory-cli/src/commands/run.rs
+++ b/crates/ai-memory-cli/src/commands/run.rs
@@ -693,6 +693,16 @@ fn ensure_executable_available(harness: ManagedHarness, executable: Option<&OsSt
     ))
 }
 
+/// Whether this harness's default executable resolves through `PATH`.
+///
+/// Shared with `show`, so the picker offers exactly the harnesses that
+/// [`ensure_executable_available`] would accept a moment later. Harnesses
+/// reached only through `--executable` are not covered: the picker has no way
+/// to ask for that path.
+pub(super) fn harness_available(choice: RunHarnessChoice) -> bool {
+    executable_available(OsStr::new(managed_harness(choice).executable()))
+}
+
 fn executable_available(program: &OsStr) -> bool {
     resolve_program(program).is_some()
 }
@@ -1227,8 +1237,8 @@ mod tests {
     use super::*;
     use crate::cli::{Cli, Command as CliCommand};
 
-    /// A false positive here reports a harness as installed and then fails to
-    /// spawn it, which is the bug this resolution exists to prevent.
+    /// `show` filters its harness menu with this, so a false positive would
+    /// offer an agent that cannot start.
     #[test]
     fn executable_available_rejects_a_program_that_is_not_installed() {
         assert!(!executable_available(OsStr::new(

--- a/crates/ai-memory-cli/src/commands/show.rs
+++ b/crates/ai-memory-cli/src/commands/show.rs
@@ -1,0 +1,1253 @@
+//! `ai-memory show` — pick a project and a harness, then launch it.
+//!
+//! Thin HTTP client for the listing half: calls `GET /api/v1/projects` and
+//! renders the rows the server already aggregates. The launch half delegates
+//! to [`crate::commands::run`] so managed workstreams, handoff delivery, and
+//! native-argument forwarding keep exactly one implementation.
+//!
+//! The picker exists because project scope is resolved from the working
+//! directory. Opening an agent from a parent directory that holds many
+//! checkouts resolves every one of them to that parent's basename, so the
+//! sessions pile into a single scope. Choosing the project first and entering
+//! its recorded `repo_path` makes the scope explicit before the agent starts.
+
+use std::io::{IsTerminal, Write};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use anyhow::{Context, Result, bail};
+use clap::ValueEnum;
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::style::Stylize;
+use crossterm::{cursor, execute, terminal};
+use serde::Deserialize;
+
+use crate::cli::{InstallInstructionsArgs, RunArgs, RunHarnessChoice, ShowArgs};
+use crate::commands::apply_shared::apply_atomic;
+use crate::commands::install_instructions;
+use crate::config::Config;
+use crate::http_client::{ServerEndpoint, get_json};
+
+/// Server-shaped row. Mirrors `ai_memory_store::ProjectSummary`.
+#[derive(Debug, Deserialize)]
+struct ProjectRow {
+    /// Workspace the project belongs to.
+    workspace_name: String,
+    /// Project name within the workspace.
+    project_name: String,
+    /// Number of `is_latest = 1` pages.
+    page_count: u64,
+    /// ISO-8601 timestamp of the newest page update, when any page exists.
+    last_updated: Option<String>,
+    /// Absolute checkout path, when one was recorded.
+    repo_path: Option<String>,
+}
+
+/// One selectable line: what the user reads, plus the dimmed trailer.
+struct Choice {
+    /// Primary label, rendered at full brightness.
+    label: String,
+    /// Secondary detail, rendered dim. Empty renders nothing.
+    detail: String,
+}
+
+/// Directory entries that mark a subdirectory as a project worth offering.
+/// Matched by name, so recognising a candidate costs one `exists()` per marker
+/// and never a directory walk.
+const PROJECT_MARKERS: [&str; 12] = [
+    ".git",
+    ".ai-memory.toml",
+    "Cargo.toml",
+    "package.json",
+    "pyproject.toml",
+    "requirements.txt",
+    "go.mod",
+    "Gemfile",
+    "composer.json",
+    "pom.xml",
+    "docker-compose.yml",
+    "compose.yml",
+];
+
+/// Label of the always-present first entry that creates a project.
+const NEW_PROJECT_LABEL: &str = "+ New project";
+
+/// Workspace a created project is filed under when `--workspace` is absent.
+/// Matches the scope resolver's own default, so a project created here lands
+/// where a project created by the lifecycle hooks would.
+const DEFAULT_WORKSPACE: &str = "default";
+
+/// Directory names that hold dependencies or build output, never projects.
+const SKIPPED_DIRS: [&str; 8] = [
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    "vendor",
+    "venv",
+    ".venv",
+    "__pycache__",
+];
+
+/// One launchable entry: a project the server already tracks, or a directory
+/// the scan just found.
+struct Candidate {
+    /// Workspace name when the server already tracks this checkout. `None`
+    /// for a scanned directory, which lets `run` derive the scope from the
+    /// checkout itself exactly as the lifecycle hooks would.
+    workspace: Option<String>,
+    /// Project name: the server's for tracked rows, the directory name for
+    /// scanned ones.
+    project: String,
+    /// Directory to enter before launching.
+    path: PathBuf,
+    /// Dimmed trailer shown next to the label.
+    detail: String,
+}
+
+/// Run the `show` subcommand.
+///
+/// # Errors
+/// Returns an error if nothing launchable is found, stdin/stdout is not a
+/// terminal, or the delegated launch fails. Returns the launched harness's
+/// exit code.
+pub async fn run(config: &Config, args: ShowArgs) -> Result<i32> {
+    let mut candidates = tracked_projects(config, args.workspace.as_deref()).await;
+
+    // The scan is what makes the picker useful on a machine where ai-memory
+    // has not run yet: without it the menu stays empty until every project has
+    // been opened once the long way, which is the very step this command
+    // exists to remove.
+    if !args.no_scan {
+        let root = std::env::current_dir().context("reading the current directory")?;
+        let mut seen: Vec<PathBuf> = candidates.iter().map(|c| normalize(&c.path)).collect();
+        for path in scan_for_projects(&root) {
+            let key = normalize(&path);
+            if seen.contains(&key) {
+                continue;
+            }
+            let Some(project) = directory_name(&path) else {
+                continue;
+            };
+            seen.push(key);
+            candidates.push(Candidate {
+                workspace: None,
+                project,
+                path,
+                detail: "not tracked yet".to_string(),
+            });
+        }
+    }
+
+    // Redirected output means nobody is there to press a key. Printing what
+    // the menu would have offered is more useful than refusing: it makes the
+    // list greppable, and `show` still answers "which projects can I launch?".
+    // Creating a project needs a name nobody can type here, so that entry is
+    // interactive-only and the printed list stays exactly the launchable set.
+    if !std::io::stdout().is_terminal() || !std::io::stdin().is_terminal() {
+        if candidates.is_empty() {
+            bail!(
+                "nothing to launch: the server tracks no project with a \
+                 checkout path, and no project directory was found under {}. \
+                 Run `ai-memory show` on a terminal to create one, or use \
+                 `ai-memory run <harness>` directly",
+                std::env::current_dir()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|_| "the current directory".to_string())
+            );
+        }
+        // Projects on stdout so the list stays greppable; the harness summary
+        // on stderr so it never contaminates a pipeline.
+        let detected: Vec<String> = RunHarnessChoice::value_variants()
+            .iter()
+            .filter(|choice| crate::commands::run::harness_available(**choice))
+            .map(|choice| harness_name(*choice))
+            .collect();
+        eprintln!(
+            "ai-memory: harnesses found in PATH: {}",
+            if detected.is_empty() {
+                "none".to_string()
+            } else {
+                detected.join(", ")
+            }
+        );
+        for candidate in &candidates {
+            println!(
+                "{}\t{}\t{}",
+                match &candidate.workspace {
+                    Some(workspace) => format!("{workspace}/{}", candidate.project),
+                    None => candidate.project.clone(),
+                },
+                candidate.path.display(),
+                candidate.detail
+            );
+        }
+        return Ok(0);
+    }
+
+    banner()?;
+
+    // Creating a project leads the list because an empty machine has nothing
+    // else to offer, and because the alternative — leave the menu, `mkdir`,
+    // write a marker by hand, come back — is the same detour this command
+    // exists to remove.
+    let mut project_choices = vec![Choice {
+        label: NEW_PROJECT_LABEL.to_string(),
+        detail: "create the directory and its agent context files".to_string(),
+    }];
+    project_choices.extend(candidates.iter().map(|c| Choice {
+        label: match &c.workspace {
+            Some(workspace) => format!("{workspace}/{}", c.project),
+            None => c.project.clone(),
+        },
+        detail: c.detail.clone(),
+    }));
+    let Some(picked) = select("Project", &project_choices)? else {
+        return Ok(0);
+    };
+
+    // Ask for the name before the harness question: the answer decides which
+    // directory the rest of the flow is about, and a name rejected after the
+    // harness pick would throw that pick away.
+    let root = std::env::current_dir().context("reading the current directory")?;
+    let new_project = if picked == 0 {
+        let Some(name) = prompt_project_name(&root)? else {
+            return Ok(0);
+        };
+        Some(name)
+    } else {
+        None
+    };
+
+    // Offering a harness that is not installed only moves the failure one step
+    // later, after the user has already committed to a project. Ask the same
+    // question `run` would ask at launch, and ask it before the menu.
+    let harnesses: Vec<RunHarnessChoice> = RunHarnessChoice::value_variants()
+        .iter()
+        .copied()
+        .filter(|choice| crate::commands::run::harness_available(*choice))
+        .collect();
+    if harnesses.is_empty() {
+        bail!(
+            "no supported agent harness was found in PATH (looked for: {}). \
+             Install one, or use `ai-memory run <harness> --executable <path>` \
+             for a harness installed somewhere else",
+            RunHarnessChoice::value_variants()
+                .iter()
+                .map(|h| harness_name(*h))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    let harness_choices: Vec<Choice> = harnesses
+        .iter()
+        .map(|h| Choice {
+            label: harness_name(*h),
+            detail: String::new(),
+        })
+        .collect();
+    let Some(picked_harness) = select(
+        &format!(
+            "Agent  ·  {}",
+            new_project
+                .as_deref()
+                .unwrap_or(&project_choices[picked].label)
+        ),
+        &harness_choices,
+    )?
+    else {
+        return Ok(0);
+    };
+    let harness = harnesses[picked_harness];
+
+    // A created project pins nothing here: the marker written below already
+    // declares both scope halves, so letting `run` read it keeps one source of
+    // truth — the same one the lifecycle hooks will read on every later
+    // session, whether or not it was launched from this menu.
+    let (target, workspace, project) = match &new_project {
+        Some(name) => {
+            let workspace = args.workspace.as_deref().unwrap_or(DEFAULT_WORKSPACE);
+            (create_project(&root, name, workspace)?, None, None)
+        }
+        None => {
+            let chosen = &candidates[picked - 1];
+            if !chosen.path.is_dir() {
+                bail!(
+                    "project {} records checkout {}, which no longer exists. \
+                     Move it back, or launch from the new location once so the \
+                     path is re-recorded",
+                    chosen.project,
+                    chosen.path.display()
+                );
+            }
+            // A tracked row pins both scope halves, so a marker in the target
+            // tree cannot retarget a launch the listing already resolved. A
+            // scanned directory deliberately passes neither: `run` then derives
+            // the scope from the checkout, honouring its `.ai-memory.toml`, and
+            // the first session lands in the same scope the hooks would have
+            // chosen on their own.
+            (
+                chosen.path.clone(),
+                chosen.workspace.clone(),
+                chosen.workspace.as_ref().map(|_| chosen.project.clone()),
+            )
+        }
+    };
+
+    // Entering the checkout is what makes every cwd-derived resolution inside
+    // `run` (marker discovery, hook scope, transcript adoption) agree with the
+    // project the user just picked.
+    std::env::set_current_dir(&target).with_context(|| format!("entering {}", target.display()))?;
+
+    // After the `cd`, because project-scoped skills resolve their root from the
+    // working directory: installing from the parent would drop the skills next
+    // to the sibling checkouts instead of inside the new project.
+    if new_project.is_some() {
+        install_context_files(config, harness, &target)?;
+    }
+
+    crate::commands::run::run(
+        config,
+        RunArgs {
+            workspace,
+            project,
+            workstream: None,
+            new_workstream: None,
+            executable: None,
+            yolo: args.yolo,
+            fresh: args.fresh,
+            harness: Some(harness),
+            native_args: args.native_args,
+        },
+    )
+    .await
+}
+
+/// Whether `name` is accepted by the server's workspace/project rule
+/// (`^[a-z0-9][a-z0-9._-]*$`).
+///
+/// Checked here rather than at launch because a name the server rejects fails
+/// inside the lifecycle hooks, as a warning on a session that already started —
+/// long after the directory carrying that name exists on disk.
+fn valid_scope_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_lowercase() || first.is_ascii_digit()) {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '.' | '-' | '_'))
+}
+
+/// Marker contents pinning both scope halves for a freshly created project.
+///
+/// Both keys are written even though `project` defaults to the directory
+/// basename: the default follows the directory, so a later rename or a
+/// `cd` into a subdirectory would silently fork the memory into a second
+/// project. Pinning them means the scope survives both.
+fn marker_body(workspace: &str, project: &str) -> String {
+    format!(
+        "# Created by `ai-memory show`. Declares the scope every wiki page,\n\
+         # observation, and handoff from this directory is filed under.\n\
+         # Both keys are pinned on purpose: the defaults follow the directory\n\
+         # name, so renaming or working from a subdirectory would otherwise\n\
+         # start a second, empty project. See docs/marker-file.md.\n\
+         workspace = \"{workspace}\"\n\
+         project = \"{project}\"\n"
+    )
+}
+
+/// Instruction file the routing block belongs in for `harness`.
+///
+/// Claude Code reads `CLAUDE.md`; every other supported harness converged on
+/// `AGENTS.md`. Writing the one the chosen agent actually reads is what makes
+/// the block take effect on the very first session.
+const fn instruction_file(harness: RunHarnessChoice) -> &'static str {
+    match harness {
+        RunHarnessChoice::Claude => "CLAUDE.md",
+        _ => "AGENTS.md",
+    }
+}
+
+/// Create `name` under `parent` with its scope marker.
+///
+/// # Errors
+/// Returns an error when the directory already exists or cannot be created,
+/// or when the marker cannot be written.
+fn create_project(parent: &Path, name: &str, workspace: &str) -> Result<PathBuf> {
+    // Both halves land inside a quoted TOML string, so an unchecked value can
+    // close the quote and append keys of its own. The name comes from the
+    // prompt, which already rejects it; `--workspace` reaches here verbatim and
+    // is checked at the same boundary, before anything is written.
+    for (label, value) in [("project name", name), ("workspace", workspace)] {
+        if !valid_scope_name(value) {
+            bail!(
+                "invalid {label} {value:?}: lowercase letters, digits, dot,                  dash and underscore only, starting with a letter or digit"
+            );
+        }
+    }
+    let path = parent.join(name);
+    // `create_dir` rather than `create_dir_all`: it fails when the directory
+    // already exists, which is the check that keeps a mistyped name from
+    // adopting an unrelated tree between the prompt's look and this write.
+    std::fs::create_dir(&path)
+        .with_context(|| format!("creating project directory {}", path.display()))?;
+    apply_atomic(&path.join(".ai-memory.toml"), |_| {
+        Ok(marker_body(workspace, name))
+    })
+    .with_context(|| format!("writing the scope marker in {}", path.display()))?;
+    println!("✓ created {}", path.display());
+    Ok(path)
+}
+
+/// Write the agent context files into the new project: the routing block in
+/// the instruction file the chosen harness reads, plus the managed ai-memory
+/// Agent Skills that block refers to.
+///
+/// Delegates to `install-instructions` so a project created here is byte-for-
+/// byte what `ai-memory install-instructions` produces, and stays that way as
+/// the snippet evolves.
+///
+/// # Errors
+/// Propagates instruction/skill installation failures.
+fn install_context_files(config: &Config, harness: RunHarnessChoice, path: &Path) -> Result<()> {
+    install_instructions::run(
+        config,
+        InstallInstructionsArgs {
+            target: Some(path.join(instruction_file(harness))),
+            print: false,
+            no_skills: false,
+            skills_scope: None,
+            skills_agent: None,
+            skills_target_dir: None,
+            skills_force: false,
+        },
+    )
+}
+
+/// Projects the server already tracks, newest activity first.
+///
+/// A listing failure is reported and treated as empty rather than fatal: the
+/// scan alone still produces a usable menu, and a first run on a machine whose
+/// server is not up yet is exactly when the picker is most useful.
+async fn tracked_projects(config: &Config, workspace: Option<&str>) -> Vec<Candidate> {
+    let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
+    let query: Vec<(&str, &str)> = match workspace {
+        Some(workspace) if !workspace.is_empty() => vec![("workspace", workspace)],
+        _ => Vec::new(),
+    };
+    let rows: Vec<ProjectRow> = match get_json(&endpoint, "/api/v1/projects", &query).await {
+        Ok(rows) => rows,
+        Err(error) => {
+            eprintln!("ai-memory: listing tracked projects failed ({error:#}); showing scan only");
+            return Vec::new();
+        }
+    };
+    rows.into_iter()
+        .filter_map(|row| {
+            // A row without `repo_path` has no directory to enter — it was
+            // created by explicit scope arguments, or its checkout moved.
+            let path = row.repo_path.filter(|p| !p.is_empty())?;
+            Some(Candidate {
+                detail: format!(
+                    "{}  ·  {} page{}",
+                    humanize_age(row.last_updated.as_deref()),
+                    row.page_count,
+                    if row.page_count == 1 { "" } else { "s" }
+                ),
+                workspace: Some(row.workspace_name),
+                project: row.project_name,
+                path: PathBuf::from(path),
+            })
+        })
+        .collect()
+}
+
+/// Immediate subdirectories of `root` that look like projects, plus `root`
+/// itself when it is one. Depth 1 only — deep trees are what make a scan slow
+/// enough to be noticed, and a workspace directory holds its checkouts flat.
+fn scan_for_projects(root: &std::path::Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    if is_project_dir(root) {
+        found.push(root.to_path_buf());
+    }
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return found;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        // Dot-directories are configuration and caches; the skip list covers
+        // dependency and build trees that can each hold thousands of entries.
+        if name.starts_with('.') || SKIPPED_DIRS.contains(&name) {
+            continue;
+        }
+        if entry.file_type().is_ok_and(|t| t.is_dir()) && is_project_dir(&path) {
+            found.push(path);
+        }
+    }
+    sort_by_recency(&mut found, directory_modified);
+    found
+}
+
+/// Newest first, then by path.
+///
+/// The tracked half of the menu is ordered by activity, and the scanned half
+/// used to be alphabetical — which buried the project you just created under
+/// every checkout whose name sorts earlier. Both halves now answer the same
+/// question: what did I touch most recently? Directories whose timestamp
+/// cannot be read sort last rather than to the top, and the path tiebreak
+/// keeps the order stable when timestamps match.
+fn sort_by_recency(paths: &mut [PathBuf], at: impl Fn(&Path) -> Option<SystemTime>) {
+    paths.sort_by(|left, right| at(right).cmp(&at(left)).then_with(|| left.cmp(right)));
+}
+
+/// Directory mtime, or `None` when the filesystem will not report one.
+fn directory_modified(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .ok()
+}
+
+/// Whether a directory carries any recognised project marker.
+fn is_project_dir(path: &std::path::Path) -> bool {
+    PROJECT_MARKERS
+        .iter()
+        .any(|marker| path.join(marker).exists())
+}
+
+/// Canonical form for duplicate detection, falling back to the path as given
+/// when the filesystem cannot resolve it.
+fn normalize(path: &std::path::Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Directory name as a project name, or `None` for a path without one.
+fn directory_name(path: &std::path::Path) -> Option<String> {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .filter(|n| !n.is_empty())
+        .map(ToString::to_string)
+}
+
+/// Print the start-up banner.
+///
+/// # Errors
+/// Returns an error if stdout cannot be written or flushed.
+fn banner() -> Result<()> {
+    let mut out = std::io::stdout();
+    let art = [
+        r"        _        _ __ ___   ___ _ __ ___   ___  _ __ _   _ ",
+        r"  __ _ (_)      | '_ ` _ \ / _ \ '_ ` _ \ / _ \| '__| | | |",
+        r" / _` || |_____ | | | | | |  __/ | | | | | (_) | |  | |_| |",
+        r" \__,_||_|      |_| |_| |_|\___|_| |_| |_|\___/|_|   \__, |",
+        r"                                                     |___/ ",
+    ];
+    writeln!(out)?;
+    for line in art {
+        writeln!(out, "{}", line.green().bold())?;
+    }
+    writeln!(
+        out,
+        "{}",
+        "  long-term memory for AI coding agents".dark_green()
+    )?;
+    writeln!(
+        out,
+        "{}",
+        "  by Fabio Akita · github.com/akitaonrails/ai-memory".dark_green()
+    )?;
+    writeln!(out)?;
+    out.flush()?;
+    Ok(())
+}
+
+/// Human-readable age of an ISO-8601 timestamp.
+fn humanize_age(timestamp: Option<&str>) -> String {
+    let Some(raw) = timestamp else {
+        return "no pages yet".to_string();
+    };
+    let Ok(then) = raw.parse::<jiff::Timestamp>() else {
+        return raw.to_string();
+    };
+    let seconds = (jiff::Timestamp::now() - then).get_seconds();
+    if seconds < 0 {
+        return "just now".to_string();
+    }
+    let (value, unit) = match seconds {
+        s if s < 60 => return "just now".to_string(),
+        s if s < 3_600 => (s / 60, "minute"),
+        s if s < 86_400 => (s / 3_600, "hour"),
+        s if s < 2_592_000 => (s / 86_400, "day"),
+        s => (s / 2_592_000, "month"),
+    };
+    format!("{value} {unit}{} ago", if value == 1 { "" } else { "s" })
+}
+
+/// Display name for a harness variant, taken from the same clap metadata the
+/// parser accepts, so the menu can never drift from the CLI surface.
+fn harness_name(harness: RunHarnessChoice) -> String {
+    harness
+        .to_possible_value()
+        .map_or_else(|| "unknown".to_string(), |v| v.get_name().to_string())
+}
+
+/// Restores raw mode and cursor visibility even when the caller bails early.
+struct TerminalGuard;
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        // Best-effort: the process is already unwinding or finishing, and a
+        // failed restore must not mask the original error.
+        let _ = terminal::disable_raw_mode();
+        let _ = execute!(std::io::stdout(), cursor::Show);
+    }
+}
+
+/// Draw an arrow-key menu and return the chosen index, or `None` when the
+/// user cancels with `Esc`, `q`, or `Ctrl-C`.
+///
+/// # Errors
+/// Returns an error when stdout/stdin is not a terminal, or when raw mode
+/// cannot be entered.
+fn select(title: &str, choices: &[Choice]) -> Result<Option<usize>> {
+    if choices.is_empty() {
+        bail!("nothing to choose from");
+    }
+    if !std::io::stdout().is_terminal() || !std::io::stdin().is_terminal() {
+        bail!(
+            "`ai-memory show` needs an interactive terminal. Use \
+             `ai-memory run <harness>` from the project directory in scripts \
+             and pipelines"
+        );
+    }
+
+    terminal::enable_raw_mode().context("entering raw mode")?;
+    let _guard = TerminalGuard;
+    execute!(std::io::stdout(), cursor::Hide)?;
+
+    // Windows reports a release event for every press. The previous menu's
+    // Enter release is still queued when this one opens, and reading it here
+    // would select the first entry before the user sees the list. Discard
+    // whatever is already pending before taking input.
+    while event::poll(std::time::Duration::from_millis(0))? {
+        let _ = event::read()?;
+    }
+
+    let mut cursor_at = 0usize;
+    let mut offset = 0usize;
+    let mut drawn = 0u16;
+    loop {
+        drawn = draw(title, choices, cursor_at, &mut offset, drawn)?;
+        // Only key presses matter. Releases and repeats are what made every
+        // arrow move two entries on Windows; resize and mouse events fall
+        // through and redraw on the next iteration.
+        let Event::Key(KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            ..
+        }) = event::read()?
+        else {
+            continue;
+        };
+        match code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                cursor_at = cursor_at.checked_sub(1).unwrap_or(choices.len() - 1);
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                cursor_at = (cursor_at + 1) % choices.len();
+            }
+            KeyCode::Home => cursor_at = 0,
+            KeyCode::End => cursor_at = choices.len() - 1,
+            KeyCode::PageUp => cursor_at = cursor_at.saturating_sub(viewport_rows()),
+            KeyCode::PageDown => {
+                cursor_at = (cursor_at + viewport_rows()).min(choices.len() - 1);
+            }
+            KeyCode::Enter => {
+                clear(drawn)?;
+                return Ok(Some(cursor_at));
+            }
+            KeyCode::Esc | KeyCode::Char('q') => {
+                clear(drawn)?;
+                return Ok(None);
+            }
+            KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
+                clear(drawn)?;
+                return Ok(None);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Ask for the new project's name, returning `None` when the user cancels
+/// with `Esc` or `Ctrl-C`.
+///
+/// Rejections are shown in place and leave the typed text alone: the name is
+/// validated against the same rule the server enforces, and against `parent`,
+/// so every reason the creation could fail is answered while it can still be
+/// corrected by typing.
+///
+/// # Errors
+/// Returns an error when raw mode cannot be entered or the terminal cannot be
+/// written.
+fn prompt_project_name(parent: &Path) -> Result<Option<String>> {
+    terminal::enable_raw_mode().context("entering raw mode")?;
+    let _guard = TerminalGuard;
+    execute!(std::io::stdout(), cursor::Hide)?;
+    while event::poll(std::time::Duration::from_millis(0))? {
+        let _ = event::read()?;
+    }
+
+    let mut name = String::new();
+    let mut problem: Option<String> = None;
+    let mut drawn = 0u16;
+    loop {
+        drawn = draw_prompt("New project name", &name, problem.as_deref(), drawn)?;
+        let Event::Key(KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            ..
+        }) = event::read()?
+        else {
+            continue;
+        };
+        match code {
+            KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
+                clear(drawn)?;
+                return Ok(None);
+            }
+            KeyCode::Esc => {
+                clear(drawn)?;
+                return Ok(None);
+            }
+            KeyCode::Backspace => {
+                name.pop();
+                problem = None;
+            }
+            KeyCode::Enter => {
+                problem = rejection(parent, &name);
+                if problem.is_none() {
+                    clear(drawn)?;
+                    return Ok(Some(name));
+                }
+            }
+            // Control-modified keys are shortcuts, not text. Everything the
+            // rule rejects is still accepted into the buffer so the reason
+            // shows up under the line the user is looking at.
+            KeyCode::Char(c) if !modifiers.contains(KeyModifiers::CONTROL) => {
+                name.push(c);
+                problem = None;
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Why `name` cannot be created under `parent`, or `None` when it can.
+fn rejection(parent: &Path, name: &str) -> Option<String> {
+    if name.is_empty() {
+        return Some("type a name".to_string());
+    }
+    if !valid_scope_name(name) {
+        return Some(
+            "lowercase letters, digits, dot, dash and underscore only, \
+             starting with a letter or digit"
+                .to_string(),
+        );
+    }
+    if parent.join(name).exists() {
+        return Some(format!("{name} already exists here"));
+    }
+    None
+}
+
+/// Render the name prompt in place and return how many lines it occupies.
+fn draw_prompt(title: &str, name: &str, problem: Option<&str>, previous: u16) -> Result<u16> {
+    let (cols, _) = terminal::size().unwrap_or((80, 24));
+    let width = usize::from(cols.max(20)).saturating_sub(1);
+
+    let mut out = std::io::stdout();
+    if previous > 0 {
+        execute!(out, cursor::MoveUp(previous))?;
+    }
+    write!(out, "\r")?;
+    execute!(out, terminal::Clear(terminal::ClearType::FromCursorDown))?;
+    write!(out, "  {}\r\n", truncate(title, width).green().bold())?;
+    // A block stands in for the cursor, which stays hidden so the redraw
+    // cannot leave it parked on a line it already erased.
+    write!(
+        out,
+        "  > {}{}\r\n",
+        truncate(name, width.saturating_sub(5)).as_str().bold(),
+        "▏".green()
+    )?;
+    let footer = match problem {
+        Some(problem) => format!("  {problem}"),
+        None => "  enter create · esc cancel".to_string(),
+    };
+    let footer = truncate(&footer, width);
+    match problem {
+        Some(_) => write!(out, "{}\r\n", footer.as_str().red())?,
+        None => write!(out, "{}\r\n", footer.as_str().dark_grey())?,
+    }
+    out.flush()?;
+
+    Ok(3)
+}
+
+/// How many entries fit on screen at once.
+///
+/// The redraw walks the cursor back up over the block it just printed, which
+/// only lands on the right line while the whole block fits in the window. A
+/// list taller than the terminal scrolls the top away and every later redraw
+/// then targets the wrong row — which is what made a long project list flash
+/// and disappear.
+fn viewport_rows() -> usize {
+    let (_, rows) = terminal::size().unwrap_or((80, 24));
+    // Title, hint, and one row of slack for the line the cursor rests on.
+    usize::from(rows).saturating_sub(3).max(3)
+}
+
+/// First visible entry that keeps `cursor_at` inside a `viewport`-tall window,
+/// moving `current` as little as possible so the list does not jump around
+/// while the cursor travels within the window.
+fn scroll_offset(cursor_at: usize, total: usize, viewport: usize, current: usize) -> usize {
+    let mut offset = current;
+    if cursor_at < offset {
+        offset = cursor_at;
+    } else if cursor_at >= offset + viewport {
+        offset = cursor_at + 1 - viewport;
+    }
+    offset.min(total.saturating_sub(viewport))
+}
+
+/// Shorten to `width` characters, marking the cut with an ellipsis. Keeps each
+/// rendered line inside the terminal so nothing wraps onto a second row and
+/// desynchronises the redraw's line count.
+fn truncate(text: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    if text.chars().count() <= width {
+        return text.to_string();
+    }
+    let mut out: String = text.chars().take(width.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+/// Render the menu in place and return how many lines it occupies.
+///
+/// `offset` is the first visible entry, carried between draws so the window
+/// only moves when the cursor would leave it.
+fn draw(
+    title: &str,
+    choices: &[Choice],
+    cursor_at: usize,
+    offset: &mut usize,
+    previous: u16,
+) -> Result<u16> {
+    let (cols, _) = terminal::size().unwrap_or((80, 24));
+    let width = usize::from(cols.max(20)).saturating_sub(1);
+    let viewport = viewport_rows().min(choices.len());
+
+    *offset = scroll_offset(cursor_at, choices.len(), viewport, *offset);
+
+    let mut out = std::io::stdout();
+    if previous > 0 {
+        execute!(out, cursor::MoveUp(previous))?;
+    }
+    // Raw mode disables the implicit carriage return, so every line needs an
+    // explicit `\r`.
+    write!(out, "\r")?;
+    execute!(out, terminal::Clear(terminal::ClearType::FromCursorDown))?;
+    write!(out, "  {}\r\n", truncate(title, width).green().bold())?;
+
+    for (index, choice) in choices.iter().enumerate().skip(*offset).take(viewport) {
+        let marker = if index == cursor_at { "  > " } else { "    " };
+        let label = truncate(&choice.label, width.saturating_sub(marker.len()));
+        let used = marker.len() + label.chars().count();
+        if index == cursor_at {
+            write!(
+                out,
+                "{}{}",
+                marker.green().bold(),
+                label.as_str().green().bold()
+            )?;
+        } else {
+            write!(out, "{marker}{}", label.as_str().reset())?;
+        }
+        if !choice.detail.is_empty() && used + 2 < width {
+            let detail = truncate(&choice.detail, width - used - 2);
+            write!(out, "  {}", detail.as_str().dark_grey())?;
+        }
+        write!(out, "\r\n")?;
+    }
+
+    let hint = if choices.len() > viewport {
+        format!(
+            "  ↑/↓ move · pgup/pgdn page · enter select · esc cancel   [{}/{}]",
+            cursor_at + 1,
+            choices.len()
+        )
+    } else {
+        "  ↑/↓ move · enter select · esc cancel".to_string()
+    };
+    write!(out, "{}\r\n", truncate(&hint, width).dark_grey())?;
+    out.flush()?;
+
+    // title + visible entries + hint
+    Ok(u16::try_from(viewport)
+        .unwrap_or(u16::MAX)
+        .saturating_add(2))
+}
+
+/// Erase the menu block so the launched agent starts on a clean screen.
+fn clear(drawn: u16) -> Result<()> {
+    let mut out = std::io::stdout();
+    if drawn > 0 {
+        execute!(out, cursor::MoveUp(drawn))?;
+    }
+    execute!(out, terminal::Clear(terminal::ClearType::FromCursorDown))?;
+    out.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn humanize_age_reports_missing_pages() {
+        assert_eq!(humanize_age(None), "no pages yet");
+    }
+
+    #[test]
+    fn humanize_age_passes_through_unparseable_timestamps() {
+        assert_eq!(humanize_age(Some("not-a-timestamp")), "not-a-timestamp");
+    }
+
+    #[test]
+    fn humanize_age_singularises_and_pluralises() {
+        let two_days = jiff::Timestamp::now() - std::time::Duration::from_secs(2 * 86_400);
+        assert_eq!(humanize_age(Some(&two_days.to_string())), "2 days ago");
+
+        let one_hour = jiff::Timestamp::now() - std::time::Duration::from_secs(3_600);
+        assert_eq!(humanize_age(Some(&one_hour.to_string())), "1 hour ago");
+    }
+
+    /// A clock skew that puts a page in the future must not underflow into a
+    /// nonsensical age.
+    #[test]
+    fn humanize_age_clamps_future_timestamps() {
+        let ahead = jiff::Timestamp::now() + std::time::Duration::from_secs(600);
+        assert_eq!(humanize_age(Some(&ahead.to_string())), "just now");
+    }
+
+    /// The menu labels come from clap's own metadata, so every harness the
+    /// parser accepts can be named by the picker.
+    #[test]
+    fn harness_names_cover_every_parser_variant() {
+        for harness in RunHarnessChoice::value_variants() {
+            assert_ne!(harness_name(*harness), "unknown");
+        }
+    }
+
+    /// Availability must not panic or depend on the working directory: the
+    /// picker calls it for every variant before drawing the menu, from
+    /// whatever directory the user happened to be in.
+    #[test]
+    fn availability_is_answerable_for_every_variant() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let restore = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let answers: Vec<bool> = RunHarnessChoice::value_variants()
+            .iter()
+            .map(|h| crate::commands::run::harness_available(*h))
+            .collect();
+
+        std::env::set_current_dir(restore).unwrap();
+        assert_eq!(answers.len(), RunHarnessChoice::value_variants().len());
+    }
+
+    #[test]
+    fn selecting_from_an_empty_list_is_an_error() {
+        assert!(select("empty", &[]).is_err());
+    }
+
+    /// The redraw walks back up over exactly the block it printed, so the
+    /// window must never expose more entries than fit — a taller block scrolls
+    /// the top away and every later redraw targets the wrong row.
+    #[test]
+    fn scroll_offset_keeps_the_cursor_inside_the_window() {
+        // Cursor within the current window leaves it untouched.
+        assert_eq!(scroll_offset(2, 24, 5, 0), 0);
+        // Falling off the bottom scrolls by the minimum.
+        assert_eq!(scroll_offset(5, 24, 5, 0), 1);
+        assert_eq!(scroll_offset(6, 24, 5, 1), 2);
+        // Falling off the top scrolls back up to the cursor.
+        assert_eq!(scroll_offset(3, 24, 5, 7), 3);
+        // The window never runs past the end of the list.
+        assert_eq!(scroll_offset(23, 24, 5, 22), 19);
+    }
+
+    #[test]
+    fn scroll_offset_is_zero_when_everything_fits() {
+        for cursor in 0..5 {
+            assert_eq!(scroll_offset(cursor, 5, 10, 0), 0);
+        }
+    }
+
+    #[test]
+    fn truncate_marks_the_cut_and_respects_the_width() {
+        assert_eq!(truncate("short", 10), "short");
+        assert_eq!(truncate("exactfit", 8), "exactfit");
+        assert_eq!(truncate("truncate-me", 5), "trun…");
+        assert_eq!(truncate("anything", 0), "");
+    }
+
+    /// A wrapped line would occupy two rows and desynchronise the line count
+    /// the redraw walks back over, so nothing may exceed the given width.
+    #[test]
+    fn truncate_never_exceeds_the_requested_width() {
+        for width in 0..12 {
+            assert!(
+                truncate("a considerably longer label", width)
+                    .chars()
+                    .count()
+                    <= width
+            );
+        }
+    }
+
+    /// Create `dir` and drop `marker` inside it when one is given.
+    fn make_dir(root: &std::path::Path, name: &str, marker: Option<&str>) -> PathBuf {
+        let dir = root.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        if let Some(marker) = marker {
+            std::fs::write(dir.join(marker), "").unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn scan_finds_marked_subdirectories_and_ignores_plain_ones() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_dir(tmp.path(), "with-git", Some(".git"));
+        make_dir(tmp.path(), "with-cargo", Some("Cargo.toml"));
+        make_dir(tmp.path(), "just-a-folder", None);
+
+        let found = scan_for_projects(tmp.path());
+        let names: Vec<String> = found.iter().filter_map(|p| directory_name(p)).collect();
+
+        assert!(names.contains(&"with-git".to_string()));
+        assert!(names.contains(&"with-cargo".to_string()));
+        assert!(
+            !names.contains(&"just-a-folder".to_string()),
+            "a directory with no marker is not a project"
+        );
+    }
+
+    /// Dependency and build trees can hold thousands of entries and are never
+    /// projects; descending into them is what would make the scan noticeable.
+    #[test]
+    fn scan_skips_dependency_build_and_dot_directories() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_dir(tmp.path(), "node_modules", Some("package.json"));
+        make_dir(tmp.path(), "target", Some("Cargo.toml"));
+        make_dir(tmp.path(), ".cache", Some("package.json"));
+
+        assert!(scan_for_projects(tmp.path()).is_empty());
+    }
+
+    /// Running the picker from inside a single checkout should still offer
+    /// that checkout, not just its children.
+    #[test]
+    fn scan_includes_the_root_when_the_root_is_itself_a_project() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("go.mod"), "").unwrap();
+
+        let found = scan_for_projects(tmp.path());
+
+        assert_eq!(found.len(), 1);
+        assert_eq!(normalize(&found[0]), normalize(tmp.path()));
+    }
+
+    #[test]
+    fn scan_of_an_unreadable_root_is_empty_rather_than_an_error() {
+        let missing = std::path::Path::new("definitely-not-a-real-directory-xyz");
+        assert!(scan_for_projects(missing).is_empty());
+    }
+
+    /// The rule the server enforces at `get_or_create_project`. A name that
+    /// passes here and fails there would only surface as a hook warning on a
+    /// session that already started.
+    #[test]
+    fn scope_names_follow_the_server_rule() {
+        for ok in ["ai-memory", "app2", "my_project", "a", "web.api", "0day"] {
+            assert!(valid_scope_name(ok), "{ok} should be accepted");
+        }
+        for bad in [
+            "",
+            "-leading-dash",
+            ".dotfile",
+            "_underscore",
+            "UpperCase",
+            "with space",
+            "acentuação",
+            "sub/dir",
+        ] {
+            assert!(!valid_scope_name(bad), "{bad} should be rejected");
+        }
+    }
+
+    /// Every reason creation could fail is answered while the name can still
+    /// be corrected by typing.
+    #[test]
+    fn rejection_explains_empty_invalid_and_taken_names() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_dir(tmp.path(), "taken", None);
+
+        assert_eq!(rejection(tmp.path(), "").as_deref(), Some("type a name"));
+        assert!(
+            rejection(tmp.path(), "Bad Name").is_some_and(|p| p.contains("lowercase")),
+            "an invalid name names the rule"
+        );
+        assert!(
+            rejection(tmp.path(), "taken").is_some_and(|p| p.contains("already exists")),
+            "an occupied directory is refused before it can be adopted"
+        );
+        assert_eq!(rejection(tmp.path(), "brand-new"), None);
+    }
+
+    /// Both scope halves are pinned so a rename or a subdirectory `cd` cannot
+    /// fork the memory into a second, empty project.
+    #[test]
+    fn created_marker_pins_both_scope_halves() {
+        let body = marker_body("acme", "portal");
+        assert!(body.contains("workspace = \"acme\""));
+        assert!(body.contains("project = \"portal\""));
+    }
+
+    #[test]
+    fn creating_a_project_writes_the_directory_and_its_marker() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        let path = create_project(tmp.path(), "fresh", "default").unwrap();
+
+        assert!(path.is_dir());
+        let marker = std::fs::read_to_string(path.join(".ai-memory.toml")).unwrap();
+        assert!(marker.contains("project = \"fresh\""));
+        // The marker is itself a recognised marker, so the project shows up in
+        // the scan on the next run even before the server has tracked it.
+        assert!(is_project_dir(&path));
+    }
+
+    /// An existing directory must not be adopted: it can hold an unrelated
+    /// project whose own marker the creation would overwrite.
+    #[test]
+    fn creating_over_an_existing_directory_fails() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_dir(tmp.path(), "occupied", Some("Cargo.toml"));
+
+        assert!(create_project(tmp.path(), "occupied", "default").is_err());
+    }
+
+    /// The routing block only takes effect in the file the chosen agent reads.
+    #[test]
+    fn instruction_file_matches_the_harness_convention() {
+        assert_eq!(instruction_file(RunHarnessChoice::Claude), "CLAUDE.md");
+        for other in RunHarnessChoice::value_variants()
+            .iter()
+            .filter(|h| !matches!(h, RunHarnessChoice::Claude))
+        {
+            assert_eq!(instruction_file(*other), "AGENTS.md");
+        }
+    }
+
+    /// `--workspace` reaches the marker verbatim, so an unvalidated value can
+    /// close the TOML string and append keys of its own. The name typed into
+    /// the prompt is checked; this argument must be held to the same rule.
+    #[test]
+    fn workspace_names_are_validated_before_reaching_the_marker() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        let injected = "default\"
+project = \"hijacked";
+        let error = create_project(tmp.path(), "victim", injected).unwrap_err();
+
+        assert!(
+            error.to_string().contains("workspace"),
+            "the failure must name the offending argument: {error}"
+        );
+        assert!(
+            !tmp.path().join("victim").exists(),
+            "nothing may be created when the scope is invalid"
+        );
+    }
+
+    /// The project you just created has to be near the top: alphabetical order
+    /// buried it under every checkout whose name sorts earlier, which is the
+    /// one case the picker exists to serve.
+    #[test]
+    fn scanned_projects_are_ordered_newest_first() {
+        let base = SystemTime::UNIX_EPOCH;
+        let mut paths: Vec<PathBuf> = ["alpha", "personal", "zulu", "unreadable"]
+            .iter()
+            .map(PathBuf::from)
+            .collect();
+
+        sort_by_recency(&mut paths, |path| {
+            match path.to_str().unwrap() {
+                "alpha" => Some(base + std::time::Duration::from_secs(10)),
+                "personal" => Some(base + std::time::Duration::from_secs(90)),
+                "zulu" => Some(base + std::time::Duration::from_secs(50)),
+                // A directory whose timestamp cannot be read must not win the
+                // top slot by default.
+                _ => None,
+            }
+        });
+
+        assert_eq!(
+            paths
+                .iter()
+                .map(|p| p.to_str().unwrap())
+                .collect::<Vec<_>>(),
+            ["personal", "zulu", "alpha", "unreadable"]
+        );
+    }
+
+    /// Equal timestamps must not reorder between runs.
+    #[test]
+    fn equal_timestamps_fall_back_to_a_stable_path_order() {
+        let mut paths: Vec<PathBuf> = ["b", "c", "a"].iter().map(PathBuf::from).collect();
+        sort_by_recency(&mut paths, |_| Some(SystemTime::UNIX_EPOCH));
+        assert_eq!(
+            paths
+                .iter()
+                .map(|p| p.to_str().unwrap())
+                .collect::<Vec<_>>(),
+            ["a", "b", "c"]
+        );
+    }
+
+    /// The same checkout reached by two spellings must dedupe, otherwise a
+    /// tracked project would also appear as an untracked scan hit.
+    #[test]
+    fn normalize_matches_equivalent_paths() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let nested = tmp.path().join("child");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let indirect = tmp.path().join("child").join("..").join("child");
+
+        assert_eq!(normalize(&nested), normalize(&indirect));
+    }
+}

--- a/crates/ai-memory-cli/src/main.rs
+++ b/crates/ai-memory-cli/src/main.rs
@@ -81,6 +81,13 @@ async fn main() -> Result<()> {
             }
             Ok(())
         }
+        Command::Show(args) => {
+            let exit_code = commands::show::run(&config, args).await?;
+            if exit_code != 0 {
+                std::process::exit(exit_code);
+            }
+            Ok(())
+        }
         Command::WorkstreamSearch(args) => commands::workstream_search::run(&config, args).await,
         Command::AuditContamination(args) => {
             commands::audit_contamination::run(&config, args).await

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -768,6 +768,10 @@ pub struct ProjectSummary {
     /// ISO-8601 timestamp of the newest `updated_at`, or `None` when
     /// the project has no pages yet.
     pub last_updated: Option<String>,
+    /// Absolute checkout path recorded for cwd matching, or `None` when the
+    /// project was created without one (the `scratch` fallback, explicit
+    /// scope creation, or a checkout that has since moved).
+    pub repo_path: Option<String>,
 }
 
 /// One workspace scope with the id + name needed to write its
@@ -4053,7 +4057,8 @@ impl ReaderPool {
                 "SELECT w.name AS workspace_name, \
                         p.name AS project_name, \
                         COUNT(pg.id) AS page_count, \
-                        MAX(pg.updated_at) AS last_updated_us \
+                        MAX(pg.updated_at) AS last_updated_us, \
+                        p.repo_path AS repo_path \
                  FROM workspaces w \
                  JOIN projects p ON p.workspace_id = w.id \
                  LEFT JOIN pages pg ON pg.project_id = p.id AND pg.is_latest = 1 \
@@ -4066,11 +4071,18 @@ impl ReaderPool {
                 let project_name: String = row.get(1)?;
                 let page_count: i64 = row.get(2)?;
                 let last_updated_us: Option<i64> = row.get(3)?;
-                Ok((workspace_name, project_name, page_count, last_updated_us))
+                let repo_path: Option<String> = row.get(4)?;
+                Ok((
+                    workspace_name,
+                    project_name,
+                    page_count,
+                    last_updated_us,
+                    repo_path,
+                ))
             })?;
             let mut out = Vec::new();
             for r in rows {
-                let (workspace_name, project_name, page_count, last_updated_us) = r?;
+                let (workspace_name, project_name, page_count, last_updated_us, repo_path) = r?;
                 let last_updated = last_updated_us
                     .and_then(|us| jiff::Timestamp::from_microsecond(us).ok())
                     .map(|ts| ts.to_string());
@@ -4079,6 +4091,7 @@ impl ReaderPool {
                     project_name,
                     page_count: u64::try_from(page_count).unwrap_or(0),
                     last_updated,
+                    repo_path,
                 });
             }
             Ok(out)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -396,19 +396,20 @@ the explicit `install-mcp --client claude-code --session-aware` option.
 
 ```
 init                 status               run
-workstream-search    audit-contamination  search
-read-page            write-page           delete-page
-serve                reset                backup
-restore              reindex              install-hooks
-hook                 install-mcp          commit
-checkpoints          restore-page         llm-test
-forget-sweep         lint                 curator
-auto-improve-report  auto-improve         finalize-session
-pending-writes       embed                generate-auth-token
-setup-agent          bootstrap            install-instructions
-install-skills       reorg                purge-project
-rename-project       move-project         uninstall
-auth                 user                 completions
+show                 workstream-search    audit-contamination
+search               read-page            write-page
+delete-page          serve                reset
+backup               restore              reindex
+install-hooks        hook                 install-mcp
+commit               checkpoints          restore-page
+llm-test             forget-sweep         lint
+curator              auto-improve-report  auto-improve
+finalize-session     pending-writes       embed
+generate-auth-token  setup-agent          bootstrap
+install-instructions install-skills       reorg
+purge-project        rename-project       move-project
+uninstall            auth                 user
+completions
 ```
 
 Run `ai-memory --help` for the full tree.

--- a/docs/managed-workstreams.md
+++ b/docs/managed-workstreams.md
@@ -45,6 +45,83 @@ and worktree, creating one named `default` on first use. `--new NAME` starts an
 independent line of work; `--workstream NAME` returns to one. These are optional
 branching controls, not harness-switch controls.
 
+## Choosing the project first
+
+`run` resolves its project from the working directory, which is why the synopsis
+above starts with `cd`. Launching from a parent directory that holds many
+checkouts resolves every one of them to that parent's basename, so unrelated
+sessions accumulate in a single scope.
+
+`ai-memory show` inverts the order: it presents a menu, enters the chosen
+project's directory, and delegates to `run`.
+
+```text
+ai-memory show [--workspace NAME] [--no-scan] [--yolo] [--fresh]
+               [native arguments...]
+```
+
+The list always leads with a **new-project** entry. It asks for a name, creates
+the directory under the current one, writes a `.ai-memory.toml` marker pinning
+both scope halves, and delegates to `install-instructions` for the routing block
+and the managed Agent Skills — into `CLAUDE.md` when the chosen harness is
+Claude Code and `AGENTS.md` for every other, since that is the file each one
+reads. `--workspace` names the workspace the project is filed under; without it
+the marker uses `default`.
+
+The name is checked against the server's `^[a-z0-9][a-z0-9._-]*$` rule and
+against the parent directory before anything is written, so a rejection is
+corrected by typing rather than surfacing later as a hook warning on a session
+that already started. Both marker keys are pinned deliberately: the defaults
+follow the directory name, so a rename or a `cd` into a subdirectory would
+otherwise start a second, empty project. An existing directory is never adopted
+— it may hold an unrelated project whose own marker the creation would replace.
+
+Below that entry the menu merges two sources:
+
+- **Tracked projects** — every project with a recorded `repo_path`, newest
+  activity first, annotated with page counts. `--workspace` narrows this half.
+  Rows without a checkout path are omitted; there is no directory to enter.
+- **Scanned directories** — a depth-1 pass over the current directory for
+  entries carrying a project marker (`.git`, `.ai-memory.toml`, `Cargo.toml`,
+  `package.json`, `pyproject.toml`, `requirements.txt`, `go.mod`, `Gemfile`,
+  `composer.json`, `pom.xml`, `docker-compose.yml`, `compose.yml`), including
+  the current directory itself. Dot-directories and dependency/build trees
+  (`node_modules`, `target`, `dist`, `build`, `vendor`, `venv`, `.venv`,
+  `__pycache__`) are skipped, so the cost is one `exists()` per marker per
+  candidate and never a directory walk. Ordered by directory mtime, newest
+  first, so both halves of the menu answer the same question — what was touched
+  most recently — and a project created a moment ago is not buried under every
+  checkout whose name sorts earlier. Directories with no readable timestamp sort
+  last, and equal timestamps fall back to path order so the list is stable
+  across runs. `--no-scan` turns this half off.
+
+Duplicates are resolved by canonical path, so a tracked project inside the
+scanned directory appears once, with its tracked annotation.
+
+The harness menu is filtered to what is actually installed, using the same
+`PATH` lookup `run` enforces at launch — offering an agent that is not on the
+host only moves the failure to after the user has committed to a project. When
+no supported harness resolves, `show` says so and names every one it looked
+for. Harnesses reachable only through `--executable` are not offered, since the
+picker has no way to ask for that path.
+
+Scope handling differs by source, deliberately. A **tracked** pick pins both
+`--workspace` and `--project`, so a marker in the target tree cannot retarget a
+launch the listing already resolved. A **scanned** pick passes neither: `run`
+derives the scope from the checkout itself, honouring its `.ai-memory.toml`, so
+the first session lands in the same scope the lifecycle hooks would have chosen
+on their own.
+
+A failed listing is not fatal — it prints a warning and falls back to scan-only
+results, which is the state a machine is in before the server has ever run.
+
+With stdin or stdout redirected there is nobody to press a key, so instead of
+drawing a menu `show` prints the same candidates as tab-separated
+`label`, `path`, `detail` lines and exits, leaving the list greppable. Creating
+a project needs a name nobody can type there, so that entry is interactive-only
+and the printed list stays exactly the launchable set. Launching from a script
+stays the job of `run` from the project directory.
+
 ## Automatic harness selection
 
 With no harness name, `ai-memory run` inspects checkout-local sessions for
@@ -247,6 +324,7 @@ internals and are never read as transcripts; discovery reads
 `summary.json`'s `info.cwd` and never parses the URL-encoded bucket name. The
 managed launcher accepts `grok` and `grok-build`. The native contract was
 verified against Grok Build CLI v0.2.111.
+
 
 Crush needs no ai-memory hook installation for managed mode. The launcher reads
 its one-time context from the server, copies the existing global Crush JSON into


### PR DESCRIPTION
Implements #342.

## What changed

A new `ai-memory show` subcommand: pick a project, pick a harness, and it enters that directory and delegates to `ai-memory run`.

Project scope is resolved from the working directory, so opening an agent from a parent directory holding many checkouts resolves all of them to that parent's basename and piles unrelated sessions into one scope. `show` inverts the order so the scope is settled before the agent starts. The rationale is in #342.

```
  Project
  > + New project              create the directory and its agent context files
    default/ai-memory          38 minutes ago  ·  2 pages
    default/simulai            57 minutes ago  ·  5 pages
    personal                   not tracked yet
  ↑/↓ move · pgup/pgdn page · enter select · esc cancel   [1/26]
```

**Two sources.** Tracked projects come from `/api/v1/projects`, newest activity first, with page counts. A depth-1 scan of the current directory then adds anything carrying a project marker, so the picker works on a machine where ai-memory has never run. Dependency/build and dot-directories are skipped; the cost is one `exists()` per marker per candidate, never a walk. `--no-scan` disables it.

**Ordering.** Both halves are newest-first. Scanned entries use directory mtime; unreadable timestamps sort last and ties fall back to path order, so the list is stable across runs.

**New-project entry.** Asks for a name, creates the directory, pins both scope halves in `.ai-memory.toml`, and delegates to `install-instructions` for the routing block and managed Agent Skills — `CLAUDE.md` for Claude Code, `AGENTS.md` otherwise. Both marker keys are pinned because the defaults follow the directory name, so a rename or a subdirectory `cd` would otherwise fork the memory into a second, empty project.

**Scope by source.** A tracked pick pins `--workspace` and `--project`, so a marker in the target tree cannot retarget a launch the listing already resolved. A scanned or created pick passes neither, so `run` derives the scope from the checkout exactly as the lifecycle hooks would.

**Harness menu** is filtered to what resolves in `PATH`, reusing the lookup `run` enforces at launch. A failed listing degrades to scan-only with a warning. With stdin or stdout redirected, the same candidates print as tab-separated lines instead of drawing a menu.

## Changed default / response shape

`ProjectSummary` gains `repo_path`, so `GET /api/v1/projects` rows now carry the absolute checkout path. The picker needs it — a row with no checkout path has no directory to enter.

**This is worth a decision from you.** That route is public and read-only, and `docs/https-via-proxy.md` contemplates exposing `/web` behind a proxy, so the field discloses host filesystem paths (including the OS username) to anyone who can reach the API. `/admin/projects` already serves the same `ProjectSummary` under a root-only gate in multi-user mode. I kept it on the public route because that is where the CLI's other read-only listings come from, but I am happy to move the picker to the admin route, or split a DTO so `repo_path` only appears there. Say which you prefer and I will push it.

## Security

The name typed into the new-project prompt is validated against the server's own `^[a-z0-9][a-z0-9._-]*$` rule and against the parent directory before anything is written, so an invalid scope is corrected by typing rather than surfacing later as a hook warning on a session that already started. It also keeps `..`, `/` and `\` out of the joined path.

During development the `--workspace` argument reached the `.ai-memory.toml` template unvalidated while the prompted name was checked. Since both land inside a quoted TOML string, a value like `default"\nproject = "hijacked` could close the quote and append its own key, silently retargeting the project's memory — and marker files are often committed, so a forged value would propagate. Both halves are now validated at the same boundary, before `create_dir`, so a rejected scope leaves nothing behind. Regression test: `workspace_names_are_validated_before_reaching_the_marker`, written before the fix and confirmed failing against the unvalidated version.

Directory creation uses `create_dir`, not `create_dir_all`, so an existing directory is never adopted — it may hold an unrelated project whose marker the creation would replace.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `cargo deny check` passes (advisories, bans, licenses, sources)
- [x] Manual test: ran the picker from a directory holding 23 checkouts on Windows 11; created a project through the new-project entry and confirmed `.ai-memory.toml`, `CLAUDE.md` and `.claude/skills` land in it and that the launched agent resolves to that project rather than the parent directory. Also ran it with output redirected and confirmed the tab-separated listing.

25 unit tests cover the picker: scope-name validation, the rejection messages, marker contents, directory creation and refusal over an existing directory, harness-to-instruction-file mapping, scan inclusion/exclusion rules, recency ordering and its stable tiebreak, path normalisation for dedup, viewport scrolling maths, and truncation width.

Two notes on how they are written: `sort_by_recency` takes the timestamp provider as a parameter so ordering is tested against fixed values instead of `sleep`-ing between `mkdir`s, and the terminal-drawing helpers are tested through their pure parts (`scroll_offset`, `truncate`) since the raw-mode loop itself needs a TTY.

## Commit attribution

- [x] Verified on every commit in this PR.

## CHANGELOG (merge gate)

- [x] `[Unreleased] / Added` entry included.
- [x] The `/api/v1/projects` response-shape change is called out above.

## Notes for reviewers

**Stacked on #343** (the Windows `PATHEXT` fix), whose commit appears in this diff until that merges — `show` filters its harness menu with the resolution introduced there.

Two things I would like your call on, beyond the `repo_path` question above:

1. **New dependency.** `crossterm` is added for raw-mode key reading. The CLI had no terminal crate before; `anstyle` arrives transitively through clap but only styles text. `run` already has an interactive picker in `choose_native_session` using a numbered prompt on stderr with injectable `input`/`output` — a very different style, and testable in a way an arrow-key menu is not. I went with arrow keys for a 25-item list, but reusing the numbered prompt and dropping the dependency is a reasonable call and I will make the change if you prefer it. If `crossterm` stays, `0.29` would avoid a duplicate `rustix 0.38` alongside the workspace's `1.x` (`cargo deny` does not flag it today).

2. **`(#NNN)` placeholders** in the CHANGELOG entry — tell me whether to push the real numbers or fold them in on merge.
