### PR TITLE
release: v1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.22.0] - 2026-08-01
+
 ### Added
 - Added `ai-memory show`, a project-first managed launcher that joins private
   client-local checkout links with public server project metadata and a bounded
@@ -2898,7 +2900,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidator used server startup default project instead of the
   session's actual project.
 
-[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.21.0...HEAD
+[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.22.0...HEAD
+[1.22.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.22.0
 [1.21.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.21.0
 [1.20.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.20.2
 [1.20.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.20.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-cli"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-consolidate"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-core"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "jiff",
  "regex",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-eval"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-hooks"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-llm"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-mcp"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-store"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-web"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-store",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-wiki"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-workstream"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.21.0"
+version = "1.22.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"
@@ -26,15 +26,15 @@ authors = ["Fabio Akita <boss@akitaonrails.com>"]
 
 [workspace.dependencies]
 # Inter-crate dependencies.
-ai-memory-core = { path = "crates/ai-memory-core", version = "1.21.0" }
-ai-memory-store = { path = "crates/ai-memory-store", version = "1.21.0" }
-ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.21.0" }
-ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.21.0" }
-ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.21.0" }
-ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.21.0" }
-ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.21.0" }
-ai-memory-web = { path = "crates/ai-memory-web", version = "1.21.0" }
-ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.21.0" }
+ai-memory-core = { path = "crates/ai-memory-core", version = "1.22.0" }
+ai-memory-store = { path = "crates/ai-memory-store", version = "1.22.0" }
+ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.22.0" }
+ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.22.0" }
+ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.22.0" }
+ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.22.0" }
+ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.22.0" }
+ai-memory-web = { path = "crates/ai-memory-web", version = "1.22.0" }
+ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.22.0" }
 
 # (Workspace shared deps follow below)
 


### PR DESCRIPTION
## Summary

- publish the additive project-first launcher, Antigravity managed-workstream support, and Windows PATHEXT launch fix as v1.22.0
- include the accumulated post-v1.21.0 authentication, handoff ownership, learning, Hermes, and maintenance changes already merged on main
- bump the workspace and internal crate versions to 1.22.0
- date the release changelog and update comparison links

## Verification

- combined post-audit of `651256824fbf274599c7da0357e679dc278bfbc5..3e0742faec194f5fc790a6b4e554f7f7ce36e782` found no blocking regression or substantiated security finding
- exact-main CI and CodeQL passed on `3e0742faec194f5fc790a6b4e554f7f7ce36e782`, including Linux, macOS, Windows, Docker, packaging, dependency, audit, and secret gates
- deterministic managed-workstream acceptance passed on the byte-identical final runtime tree
- the exact audited runtime tree was deployed and live-tested against the authenticated homeserver before this release PR
- `cargo fmt --all -- --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo check --workspace --locked`
- `TAILWIND_SKIP=1 cargo run --locked -p ai-memory-cli -- --version` reports `ai-memory 1.22.0`
- every local workspace package reports version 1.22.0
- exact release-commit gitleaks scan found no leaks

The release commit changes only `Cargo.toml`, `Cargo.lock`, and `CHANGELOG.md`. Runtime tests are reused from the byte-identical audited main tree; this PR exact head runs the complete hosted matrix before merge.