### PR TITLE
feat(cli): add `ai-memory continue` for global session resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than silently resuming a different project. It accepts `--workspace`,
   `--yolo`, and `--fresh`; native harness arguments and `--executable` remain
   unavailable because bare mode does not know which harness it will pick
-  (#349).
+  (#350).
 
 ## [1.22.0] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fingerprints, so it requires a `cd` first. `continue` orders the client-local
   checkout links by their `linked_at` stamp, revalidates the newest one's path
   and resolved scope, and then delegates to the same bare-mode launch. Stale,
-  retargeted, or scope-mismatched links are announced on stderr and skipped
-  rather than silently resuming a different project. It accepts `--workspace`,
+  retargeted, scope-mismatched, or corrupt-ordering links are announced on
+  stderr and skipped rather than silently resuming a different project. It
+  accepts `--workspace`,
   `--yolo`, and `--fresh`; native harness arguments and `--executable` remain
-  unavailable because bare mode does not know which harness it will pick
+  unavailable because bare mode does not know which harness it will pick.
+  Docker-wrapper installs route the command through the checksum-verified host
+  client so it can inspect local checkouts, session stores, and harnesses
   (#350).
 - New `GET /admin/sessions/by-agent` endpoint reporting how many sessions
   each agent CLI opened in one scope (`claude-code`, `cursor`, `codex`, …),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `ai-memory continue`, which resumes the most recently launched managed
+  checkout from any directory. `run`'s bare mode already continues the current
+  checkout, but its workstream lookup is keyed by repository and worktree
+  fingerprints, so it requires a `cd` first. `continue` orders the client-local
+  checkout links by their `linked_at` stamp, revalidates the newest one's path
+  and resolved scope, and then delegates to the same bare-mode launch. Stale,
+  retargeted, or scope-mismatched links are announced on stderr and skipped
+  rather than silently resuming a different project. It accepts `--workspace`,
+  `--yolo`, and `--fresh`; native harness arguments and `--executable` remain
+  unavailable because bare mode does not know which harness it will pick
+  (#349).
+
 ## [1.22.0] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -230,6 +230,19 @@ priors are at the [bottom](#influences-and-prior-art).
   Codex, OpenCode, Pi, Crush, Kimi Code, OMP, Grok Build CLI, and Antigravity
   CLI; direct harness launches remain unchanged. See
   [Managed cross-harness workstreams](docs/managed-workstreams.md).
+- **"Just put me back where I was."** From any directory, with no name to
+  type and no list to read:
+
+  ```bash
+  ai-memory continue
+  ```
+
+  It picks the checkout whose managed launch is most recent, revalidates the
+  path and its resolved scope, then continues there exactly as bare
+  `ai-memory run` would. A link whose directory moved, was replaced, or now
+  resolves to a different project is reported on stderr and skipped, so a
+  resume never quietly lands in the wrong project. `--workspace` narrows the
+  search; `--yolo` and `--fresh` are forwarded.
 - **"Quit at 4 PM, pick up at 9 AM in a different agent."** The
   classic. SessionStart hook in the next supported hook client prepends a
   typed handoff with open questions, next steps, and a session summary. Grok

--- a/README.md
+++ b/README.md
@@ -239,10 +239,11 @@ priors are at the [bottom](#influences-and-prior-art).
 
   It picks the checkout whose managed launch is most recent, revalidates the
   path and its resolved scope, then continues there exactly as bare
-  `ai-memory run` would. A link whose directory moved, was replaced, or now
-  resolves to a different project is reported on stderr and skipped, so a
-  resume never quietly lands in the wrong project. `--workspace` narrows the
-  search; `--yolo` and `--fresh` are forwarded.
+  `ai-memory run` would. A link whose directory moved, was replaced, now
+  resolves to a different project, or has a corrupt ordering timestamp is
+  reported on stderr and skipped, so a resume never quietly lands in the wrong
+  project. `--workspace` narrows the search; `--yolo` and `--fresh` are
+  forwarded.
 - **"Quit at 4 PM, pick up at 9 AM in a different agent."** The
   classic. SessionStart hook in the next supported hook client prepends a
   typed handoff with open questions, next steps, and a session summary. Grok
@@ -518,6 +519,8 @@ ai-memory run claude
 ai-memory run codex --yolo
 # omit the name to continue the newest usable local harness session
 ai-memory run
+# or resume the newest managed checkout without changing directories first
+ai-memory continue
 ```
 
 To remove ai-memory later, run `ai-memory uninstall --apply` from the
@@ -553,10 +556,11 @@ one matching entry.
   MCP/hooks. Explicit `--server-url` flags still work, but are no longer
   required when the env vars are set. Any non-loopback server should use
   bearer auth.
-- **Managed-launch wrapper:** `ai-memory run` and `ai-memory show` must be
-  intercepted by the current host wrapper so local checkouts, native harnesses,
-  and session stores remain accessible. An old wrapper may pass either command
-  into Docker and fail to find a checkout or host executable. Run
+- **Managed-launch wrapper:** `ai-memory run`, `ai-memory show`, and
+  `ai-memory continue` must be intercepted by the current host wrapper so local
+  checkouts, native harnesses, and session stores remain accessible. An old
+  wrapper may pass these commands into Docker and fail to find a checkout or
+  host executable. Run
   `ai-memory upgrade` on the agent machine to refresh it. The host-native runner
   inherits `AI_MEMORY_SERVER_URL`, `AI_MEMORY_AUTH_TOKEN`, and the host `PATH`.
 - **Upgrades:** for Docker-wrapper installs, run `ai-memory upgrade` on each

--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -11,6 +11,7 @@
 #   ai-memory upgrade       Pull the latest image + remind to re-stage hooks.
 #   ai-memory run ...       Use a cached native client so it can exec host agents.
 #   ai-memory show ...      Use that client for host project/harness discovery.
+#   ai-memory continue ...  Use that client to resume the newest linked checkout.
 #
 # Env overrides:
 #   AI_MEMORY_IMAGE         docker image (default: akitaonrails/ai-memory:latest)
@@ -23,7 +24,7 @@
 #   COPILOT_GITHUB_TOKEN    GitHub token for AI_MEMORY_LLM_PROVIDER=copilot
 #   AI_MEMORY_NO_TTY=1      force non-interactive even on a real tty
 #   AI_MEMORY_NO_VERSION_CHECK=1  skip the once-per-day update check
-#   AI_MEMORY_NATIVE_BIN    native ai-memory binary used for `run`/`show` (optional)
+#   AI_MEMORY_NATIVE_BIN    native binary used for `run`/`show`/`continue` (optional)
 #   AI_MEMORY_WRAPPER_URL   wrapper release asset override (optional; its
 #                           .sha256 companion is required)
 #   AI_MEMORY_WRAPPER_SHA256_URL  wrapper checksum URL override (optional)
@@ -224,7 +225,7 @@ cmd_upgrade() {
   touch "${VERSION_CHECK_FILE}"
 }
 
-# `ai-memory run` and `show` must execute on the host: checkouts, harnesses,
+# `ai-memory run`, `show`, and `continue` must execute on the host: checkouts, harnesses,
 # and native transcript stores are host resources, not contents of the helper
 # container. Keep a checksum-verified release client beside the wrapper cache.
 native_host_binary() {
@@ -243,7 +244,7 @@ native_host_binary() {
     Darwin) os="macos" ;;
     *)
       echo "ai-memory: the Docker wrapper cannot provide managed host launches on this OS" >&2
-      echo "install the native release binary to use ai-memory run/show" >&2
+      echo "install the native release binary to use ai-memory run/show/continue" >&2
       return 1
       ;;
   esac
@@ -318,7 +319,7 @@ case "${1:-}" in
     cmd_upgrade
     exit 0
     ;;
-  run | show)
+  run | show | continue)
     NATIVE_HOST_COMMAND=$1
     shift
     NATIVE_HOST_BIN=$(native_host_binary)

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -40,6 +40,9 @@ pub enum Command {
     /// Pick a local project and installed harness, then launch from that
     /// checkout. Removes the `cd` step `run` requires.
     Show(ShowArgs),
+    /// Resume the most recently launched managed checkout from anywhere,
+    /// without `cd` and without picking from a list.
+    Continue(ContinueArgs),
     /// Search the complete visible event ledger for a managed workstream.
     WorkstreamSearch(WorkstreamSearchArgs),
     /// Audit the store for likely cross-project contamination (read-only,
@@ -263,6 +266,26 @@ pub struct ShowArgs {
     /// Native harness arguments, forwarded byte-for-byte and in order.
     #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
     pub native_args: Vec<OsString>,
+}
+
+/// Arguments for `continue`.
+///
+/// Deliberately smaller than [`ShowArgs`]: `continue` always delegates to
+/// `run`'s bare mode, which rejects native argv and `--executable` because
+/// their meaning depends on a harness the user did not name.
+#[derive(Debug, Args)]
+pub struct ContinueArgs {
+    /// Only consider checkouts resolving to this workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
+    /// Disable native permission prompts using the resolved harness's
+    /// equivalent dangerous-mode option. Forwarded to `run`.
+    #[arg(long)]
+    pub yolo: bool,
+    /// Start a new native session instead of resuming the linked one.
+    /// Forwarded to `run`.
+    #[arg(long)]
+    pub fresh: bool,
 }
 
 /// Arguments for `workstream-search`.
@@ -1704,6 +1727,34 @@ mod tests {
             documented, visible,
             "docs/ARCHITECTURE.md CLI subcommands must match `ai-memory --help`"
         );
+    }
+
+    /// `continue` always delegates to `run`'s bare mode, which refuses native
+    /// argv and `--executable`. Rejecting them at parse time keeps that
+    /// contract visible in `--help` instead of failing after the launch has
+    /// already started resolving a workstream.
+    #[test]
+    fn continue_takes_wrapper_flags_only() {
+        let parsed =
+            Cli::try_parse_from(["ai-memory", "continue", "--workspace", "work", "--yolo"])
+                .expect("continue parses wrapper flags");
+        let Command::Continue(args) = parsed.command else {
+            panic!("expected continue command");
+        };
+        assert_eq!(args.workspace.as_deref(), Some("work"));
+        assert!(args.yolo);
+        assert!(!args.fresh);
+
+        for rejected in [
+            vec!["ai-memory", "continue", "claude"],
+            vec!["ai-memory", "continue", "--model", "opus"],
+            vec!["ai-memory", "continue", "--executable", "/bin/claude"],
+        ] {
+            assert!(
+                Cli::try_parse_from(&rejected).is_err(),
+                "{rejected:?} must not parse"
+            );
+        }
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/continue_session.rs
+++ b/crates/ai-memory-cli/src/commands/continue_session.rs
@@ -34,8 +34,15 @@ pub async fn run(config: &Config, args: ContinueArgs) -> Result<i32> {
         );
     }
 
-    let mut rejected = Vec::new();
-    for link in newest_first(candidates) {
+    let (candidates, invalid_timestamps) = newest_first(candidates);
+    let mut rejected = invalid_timestamps.len();
+    for link in invalid_timestamps {
+        eprintln!(
+            "skipping {}: client registry has an invalid linked_at timestamp",
+            scope_label(&link)
+        );
+    }
+    for link in candidates {
         let target = match resolve_target(config, &link) {
             Ok(target) => target,
             Err(reason) => {
@@ -47,7 +54,7 @@ pub async fn run(config: &Config, args: ContinueArgs) -> Result<i32> {
                 // the terminal.
                 let label = scope_label(&link);
                 eprintln!("skipping {label}: {}", terminal_text(&reason.to_string()));
-                rejected.push(label);
+                rejected += 1;
                 continue;
             }
         };
@@ -79,7 +86,7 @@ pub async fn run(config: &Config, args: ContinueArgs) -> Result<i32> {
     bail!(
         "no linked checkout is still usable ({} skipped); \
          pick one explicitly with `ai-memory show`",
-        rejected.len()
+        rejected
     )
 }
 
@@ -92,17 +99,25 @@ fn filter_workspace(links: Vec<ProjectLink>, workspace: Option<&str>) -> Vec<Pro
 
 /// Order links newest-first.
 ///
-/// An unparsable `linked_at` sorts last rather than aborting: one corrupt
-/// row must not make every other checkout unreachable. Ties break on
-/// `(workspace, project)` so the choice is deterministic.
-fn newest_first(mut links: Vec<ProjectLink>) -> Vec<ProjectLink> {
-    links.sort_by(|a, b| {
-        linked_at(b)
-            .cmp(&linked_at(a))
-            .then_with(|| a.workspace.cmp(&b.workspace))
-            .then_with(|| a.project.cmp(&b.project))
+/// Corrupt timestamps are returned separately and are never launch candidates.
+/// One bad row must not strand valid checkouts. Ties break on `(workspace,
+/// project)` so the choice is deterministic.
+fn newest_first(links: Vec<ProjectLink>) -> (Vec<ProjectLink>, Vec<ProjectLink>) {
+    let mut valid = Vec::with_capacity(links.len());
+    let mut invalid = Vec::new();
+    for link in links {
+        match linked_at(&link) {
+            Some(timestamp) => valid.push((timestamp, link)),
+            None => invalid.push(link),
+        }
+    }
+    valid.sort_by(|(a_timestamp, a_link), (b_timestamp, b_link)| {
+        b_timestamp
+            .cmp(a_timestamp)
+            .then_with(|| a_link.workspace.cmp(&b_link.workspace))
+            .then_with(|| a_link.project.cmp(&b_link.project))
     });
-    links
+    (valid.into_iter().map(|(_, link)| link).collect(), invalid)
 }
 
 fn linked_at(link: &ProjectLink) -> Option<jiff::Timestamp> {
@@ -152,11 +167,12 @@ mod tests {
 
     #[test]
     fn newest_linked_checkout_wins() {
-        let ordered = newest_first(vec![
+        let (ordered, invalid) = newest_first(vec![
             link("default", "older", "2026-07-01T10:00:00Z"),
             link("default", "newest", "2026-08-01T09:00:00Z"),
             link("default", "middle", "2026-07-20T23:59:59Z"),
         ]);
+        assert!(invalid.is_empty());
         assert_eq!(projects(&ordered), ["newest", "middle", "older"]);
     }
 
@@ -164,41 +180,47 @@ mod tests {
     /// that sorts earlier lexically can still be the newer instant.
     #[test]
     fn ordering_compares_instants_not_raw_strings() {
-        let ordered = newest_first(vec![
+        let (ordered, invalid) = newest_first(vec![
             link("default", "utc", "2026-08-01T09:00:00Z"),
             link("default", "offset", "2026-08-01T11:30:00+02:00"),
         ]);
+        assert!(invalid.is_empty());
         assert_eq!(projects(&ordered), ["offset", "utc"]);
     }
 
     /// One corrupt row must not strand every other checkout.
     #[test]
-    fn unparsable_timestamps_sort_last_without_failing() {
-        let ordered = newest_first(vec![
+    fn unparsable_timestamps_are_rejected_without_stranding_valid_links() {
+        let (ordered, invalid) = newest_first(vec![
             link("default", "corrupt", "not-a-timestamp"),
             link("default", "valid", "2026-01-01T00:00:00Z"),
         ]);
-        assert_eq!(projects(&ordered), ["valid", "corrupt"]);
+        assert_eq!(projects(&ordered), ["valid"]);
+        assert_eq!(projects(&invalid), ["corrupt"]);
     }
 
     #[test]
     fn equal_timestamps_break_ties_deterministically() {
         let same = "2026-08-01T09:00:00Z";
-        let first = newest_first(vec![
+        let (first, first_invalid) = newest_first(vec![
             link("b-workspace", "zeta", same),
             link("a-workspace", "alpha", same),
         ]);
-        let second = newest_first(vec![
+        let (second, second_invalid) = newest_first(vec![
             link("a-workspace", "alpha", same),
             link("b-workspace", "zeta", same),
         ]);
+        assert!(first_invalid.is_empty());
+        assert!(second_invalid.is_empty());
         assert_eq!(projects(&first), ["alpha", "zeta"]);
         assert_eq!(projects(&first), projects(&second));
     }
 
     #[test]
     fn empty_registry_orders_to_nothing() {
-        assert!(newest_first(Vec::new()).is_empty());
+        let (ordered, invalid) = newest_first(Vec::new());
+        assert!(ordered.is_empty());
+        assert!(invalid.is_empty());
     }
 
     fn config_at(path: &std::path::Path) -> Config {

--- a/crates/ai-memory-cli/src/commands/continue_session.rs
+++ b/crates/ai-memory-cli/src/commands/continue_session.rs
@@ -1,0 +1,311 @@
+//! `ai-memory continue` — resume the most recent managed checkout globally.
+//!
+//! `run`'s bare mode already continues the current checkout's newest usable
+//! session, but its workstream lookup is keyed by `(workspace, project,
+//! repo fingerprint, worktree fingerprint)`, so the caller must already be
+//! inside the project. This command supplies the missing step: it picks the
+//! checkout from the client-local registry, then hands the same bare-mode
+//! launch the directory to run in.
+//!
+//! Ordering comes from `ProjectLink::linked_at`, which every successful
+//! managed prepare refreshes. No server round-trip decides the checkout: the
+//! server never exposes host filesystem paths, and a stale or retargeted
+//! link must be rejected on this host anyway.
+
+use std::path::PathBuf;
+
+use anyhow::{Result, bail};
+
+use crate::cli::{ContinueArgs, RunArgs};
+use crate::commands::project_registry::{self, ProjectLink};
+use crate::commands::show::{terminal_text, validate_registered_path};
+use crate::config::Config;
+use crate::http_client::ServerEndpoint;
+
+/// Resolve the newest still-valid checkout and continue it.
+pub async fn run(config: &Config, args: ContinueArgs) -> Result<i32> {
+    let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
+    let links = project_registry::links_for_server(config, &endpoint)?;
+    let candidates = filter_workspace(links, args.workspace.as_deref());
+    if candidates.is_empty() {
+        bail!(
+            "no managed checkout is linked for this server yet; \
+             launch one with `ai-memory show` or `ai-memory run <harness>` first"
+        );
+    }
+
+    let mut rejected = Vec::new();
+    for link in newest_first(candidates) {
+        let target = match resolve_target(config, &link) {
+            Ok(target) => target,
+            Err(reason) => {
+                // Never fall through to an older checkout silently: the user
+                // asked for "where I was", and landing somewhere else without
+                // saying so would attach this session to the wrong project.
+                // The reason quotes the registry's own path, so it is
+                // stripped like every other stored string before it reaches
+                // the terminal.
+                let label = scope_label(&link);
+                eprintln!("skipping {label}: {}", terminal_text(&reason.to_string()));
+                rejected.push(label);
+                continue;
+            }
+        };
+        eprintln!(
+            "continuing {} in {}",
+            scope_label(&link),
+            terminal_text(&target.to_string_lossy())
+        );
+        return crate::commands::run::run_from(
+            config,
+            RunArgs {
+                workspace: Some(link.workspace),
+                project: Some(link.project),
+                workstream: None,
+                new_workstream: None,
+                executable: None,
+                yolo: args.yolo,
+                fresh: args.fresh,
+                // Bare mode: `run` resolves the harness that owns the newest
+                // usable session for this workstream.
+                harness: None,
+                native_args: Vec::new(),
+            },
+            &target,
+        )
+        .await;
+    }
+
+    bail!(
+        "no linked checkout is still usable ({} skipped); \
+         pick one explicitly with `ai-memory show`",
+        rejected.len()
+    )
+}
+
+fn filter_workspace(links: Vec<ProjectLink>, workspace: Option<&str>) -> Vec<ProjectLink> {
+    match workspace {
+        Some(name) => links.into_iter().filter(|l| l.workspace == name).collect(),
+        None => links,
+    }
+}
+
+/// Order links newest-first.
+///
+/// An unparsable `linked_at` sorts last rather than aborting: one corrupt
+/// row must not make every other checkout unreachable. Ties break on
+/// `(workspace, project)` so the choice is deterministic.
+fn newest_first(mut links: Vec<ProjectLink>) -> Vec<ProjectLink> {
+    links.sort_by(|a, b| {
+        linked_at(b)
+            .cmp(&linked_at(a))
+            .then_with(|| a.workspace.cmp(&b.workspace))
+            .then_with(|| a.project.cmp(&b.project))
+    });
+    links
+}
+
+fn linked_at(link: &ProjectLink) -> Option<jiff::Timestamp> {
+    link.linked_at.parse().ok()
+}
+
+/// Revalidate a stored checkout before launching anything inside it.
+///
+/// Both checks matter. The path check rejects a directory that moved or was
+/// replaced by a symlink; the scope check rejects a directory that still
+/// exists but now resolves to a different project, which would otherwise
+/// file this session's memory under the wrong scope.
+fn resolve_target(config: &Config, link: &ProjectLink) -> Result<PathBuf> {
+    let path = validate_registered_path(&link.path)?;
+    let (workspace, project) = super::resolve_scope_for_path(config, &path)?;
+    if workspace != link.workspace || project != link.project {
+        bail!(
+            "checkout now resolves to {}/{}",
+            terminal_text(&workspace),
+            terminal_text(&project)
+        );
+    }
+    Ok(path)
+}
+
+fn scope_label(link: &ProjectLink) -> String {
+    terminal_text(&format!("{}/{}", link.workspace, link.project))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn link(workspace: &str, project: &str, linked_at: &str) -> ProjectLink {
+        ProjectLink {
+            server: "http://127.0.0.1:49374".to_owned(),
+            workspace: workspace.to_owned(),
+            project: project.to_owned(),
+            path: PathBuf::from("/checkout").join(project),
+            linked_at: linked_at.to_owned(),
+        }
+    }
+
+    fn projects(links: &[ProjectLink]) -> Vec<&str> {
+        links.iter().map(|l| l.project.as_str()).collect()
+    }
+
+    #[test]
+    fn newest_linked_checkout_wins() {
+        let ordered = newest_first(vec![
+            link("default", "older", "2026-07-01T10:00:00Z"),
+            link("default", "newest", "2026-08-01T09:00:00Z"),
+            link("default", "middle", "2026-07-20T23:59:59Z"),
+        ]);
+        assert_eq!(projects(&ordered), ["newest", "middle", "older"]);
+    }
+
+    /// Timestamps are compared as instants, not strings: an offset spelling
+    /// that sorts earlier lexically can still be the newer instant.
+    #[test]
+    fn ordering_compares_instants_not_raw_strings() {
+        let ordered = newest_first(vec![
+            link("default", "utc", "2026-08-01T09:00:00Z"),
+            link("default", "offset", "2026-08-01T11:30:00+02:00"),
+        ]);
+        assert_eq!(projects(&ordered), ["offset", "utc"]);
+    }
+
+    /// One corrupt row must not strand every other checkout.
+    #[test]
+    fn unparsable_timestamps_sort_last_without_failing() {
+        let ordered = newest_first(vec![
+            link("default", "corrupt", "not-a-timestamp"),
+            link("default", "valid", "2026-01-01T00:00:00Z"),
+        ]);
+        assert_eq!(projects(&ordered), ["valid", "corrupt"]);
+    }
+
+    #[test]
+    fn equal_timestamps_break_ties_deterministically() {
+        let same = "2026-08-01T09:00:00Z";
+        let first = newest_first(vec![
+            link("b-workspace", "zeta", same),
+            link("a-workspace", "alpha", same),
+        ]);
+        let second = newest_first(vec![
+            link("a-workspace", "alpha", same),
+            link("b-workspace", "zeta", same),
+        ]);
+        assert_eq!(projects(&first), ["alpha", "zeta"]);
+        assert_eq!(projects(&first), projects(&second));
+    }
+
+    #[test]
+    fn empty_registry_orders_to_nothing() {
+        assert!(newest_first(Vec::new()).is_empty());
+    }
+
+    fn config_at(path: &std::path::Path) -> Config {
+        Config {
+            data_dir: path.to_path_buf(),
+            ..Config::default()
+        }
+    }
+
+    fn make_project(root: &std::path::Path, name: &str) -> PathBuf {
+        let path = root.join(name);
+        std::fs::create_dir_all(&path).unwrap();
+        std::fs::write(path.join("Cargo.toml"), b"").unwrap();
+        path.canonicalize().unwrap()
+    }
+
+    fn link_to(path: PathBuf, workspace: &str, project: &str) -> ProjectLink {
+        ProjectLink {
+            server: "http://127.0.0.1:49374".to_owned(),
+            workspace: workspace.to_owned(),
+            project: project.to_owned(),
+            path,
+            linked_at: "2026-08-01T09:00:00Z".to_owned(),
+        }
+    }
+
+    #[test]
+    fn a_checkout_whose_scope_still_matches_resolves() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = make_project(tmp.path(), "app");
+        let link = link_to(project.clone(), "default", "app");
+
+        assert_eq!(
+            resolve_target(&config_at(tmp.path()), &link).unwrap(),
+            project
+        );
+    }
+
+    /// A checkout that was deleted (or renamed) must not resume: the launch
+    /// would otherwise start in whatever now occupies the path.
+    #[test]
+    fn a_missing_checkout_is_rejected() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = make_project(tmp.path(), "app");
+        let link = link_to(project.clone(), "default", "app");
+        std::fs::remove_dir_all(&project).unwrap();
+
+        assert!(resolve_target(&config_at(tmp.path()), &link).is_err());
+    }
+
+    /// The link's recorded scope is authoritative. If the directory now
+    /// resolves elsewhere, resuming would file this session's memory under
+    /// the wrong project.
+    #[test]
+    fn a_checkout_that_changed_scope_is_rejected() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = make_project(tmp.path(), "app");
+        let link = link_to(project, "default", "was-named-differently");
+
+        let error = resolve_target(&config_at(tmp.path()), &link).unwrap_err();
+        assert!(
+            error.to_string().contains("now resolves to"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// Registry strings reach the terminal on the skip path, so an escape
+    /// sequence stored in a checkout path must not be replayed.
+    #[test]
+    fn skip_reasons_are_stripped_before_reaching_the_terminal() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let link = link_to(
+            PathBuf::from("/missing\u{1b}[31m/checkout"),
+            "default",
+            "app",
+        );
+
+        let reason = resolve_target(&config_at(tmp.path()), &link).unwrap_err();
+        let rendered = terminal_text(&reason.to_string());
+        assert!(!rendered.contains('\u{1b}'), "escape survived: {rendered}");
+    }
+
+    /// A recorded directory replaced by a symlink pointing somewhere else
+    /// must not be followed.
+    #[cfg(unix)]
+    #[test]
+    fn a_checkout_replaced_by_a_symlink_is_rejected() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let real = make_project(tmp.path(), "app");
+        let elsewhere = make_project(tmp.path(), "elsewhere");
+        let link = link_to(real.clone(), "default", "app");
+
+        std::fs::remove_dir_all(&real).unwrap();
+        std::os::unix::fs::symlink(&elsewhere, &real).unwrap();
+
+        assert!(resolve_target(&config_at(tmp.path()), &link).is_err());
+    }
+
+    #[test]
+    fn workspace_filter_keeps_only_the_requested_scope() {
+        let links = vec![
+            link("work", "api", "2026-08-01T09:00:00Z"),
+            link("personal", "blog", "2026-08-02T09:00:00Z"),
+        ];
+        let filtered = filter_workspace(links.clone(), Some("work"));
+        assert_eq!(projects(&filtered), ["api"]);
+        assert_eq!(filter_workspace(links.clone(), Some("absent")).len(), 0);
+        assert_eq!(filter_workspace(links, None).len(), 2);
+    }
+}

--- a/crates/ai-memory-cli/src/commands/mod.rs
+++ b/crates/ai-memory-cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod bootstrap;
 pub mod checkpoints;
 pub mod commit;
 pub mod completions;
+pub mod continue_session;
 pub mod curator;
 pub mod data_purge;
 pub mod delete_page;

--- a/crates/ai-memory-cli/src/commands/project_registry.rs
+++ b/crates/ai-memory-cli/src/commands/project_registry.rs
@@ -129,7 +129,6 @@ pub(super) fn rekey_scope(
         if !destination_exists {
             source.workspace = to_workspace.to_owned();
             source.project = to_project.to_owned();
-            source.linked_at = jiff::Timestamp::now().to_string();
             registry.links.push(source);
         }
         Ok(true)
@@ -394,5 +393,29 @@ mod tests {
         let links = links_for_server(&config, &endpoint).unwrap();
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].path, destination.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn rekey_preserves_the_source_link_timestamp() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let source = tmp.path().join("source");
+        fs::create_dir(&source).unwrap();
+        let config = config_at(&tmp.path().join("data"));
+        let endpoint = endpoint("http://memory:49374");
+        record_prepared_checkout(&config, &endpoint, "from", "app", &source).unwrap();
+        let original_linked_at = "2025-01-02T03:04:05Z";
+        update_registry(&config, |registry| {
+            registry.links[0].linked_at = original_linked_at.to_owned();
+            Ok(true)
+        })
+        .unwrap();
+
+        rekey_scope(&config, &endpoint, "from", "app", "to", "renamed").unwrap();
+
+        let links = links_for_server(&config, &endpoint).unwrap();
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].workspace, "to");
+        assert_eq!(links[0].project, "renamed");
+        assert_eq!(links[0].linked_at, original_linked_at);
     }
 }

--- a/crates/ai-memory-cli/src/commands/show.rs
+++ b/crates/ai-memory-cli/src/commands/show.rs
@@ -421,7 +421,12 @@ fn available_harnesses() -> Vec<RunHarnessChoice> {
         .collect()
 }
 
-fn validate_registered_path(path: &Path) -> Result<PathBuf> {
+/// Re-check a stored checkout path immediately before it is used.
+///
+/// The canonical-equality check is the load-bearing one: it rejects a
+/// recorded directory that has since been replaced by a symlink pointing
+/// somewhere else, before any harness is launched inside it.
+pub(super) fn validate_registered_path(path: &Path) -> Result<PathBuf> {
     if !path.is_absolute() {
         bail!("stored checkout path is not absolute");
     }
@@ -633,7 +638,7 @@ fn harness_name(harness: RunHarnessChoice) -> String {
         .map_or_else(|| "unknown".to_owned(), |value| value.get_name().to_owned())
 }
 
-fn terminal_text(text: &str) -> String {
+pub(super) fn terminal_text(text: &str) -> String {
     text.chars()
         .map(|character| {
             if character.is_control() {

--- a/crates/ai-memory-cli/src/main.rs
+++ b/crates/ai-memory-cli/src/main.rs
@@ -88,6 +88,13 @@ async fn main() -> Result<()> {
             }
             Ok(())
         }
+        Command::Continue(args) => {
+            let exit_code = commands::continue_session::run(&config, args).await?;
+            if exit_code != 0 {
+                std::process::exit(exit_code);
+            }
+            Ok(())
+        }
         Command::WorkstreamSearch(args) => commands::workstream_search::run(&config, args).await,
         Command::AuditContamination(args) => {
             commands::audit_contamination::run(&config, args).await

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -769,7 +769,7 @@ fn hook_installer_writes_only_expected_files_from_a_verified_archive() {
 
 #[cfg(unix)]
 #[test]
-fn managed_run_wrapper_uses_host_binary_path_and_remote_server_without_docker() {
+fn managed_host_commands_use_native_path_and_remote_server_without_docker() {
     let tmp = tempfile::tempdir().unwrap();
     let native = tmp.path().join("native-ai-memory");
     let docker = tmp.path().join("docker");
@@ -804,34 +804,40 @@ fn managed_run_wrapper_uses_host_binary_path_and_remote_server_without_docker() 
         shell_path(tmp.path()),
         std::env::var("PATH").unwrap_or_default()
     );
-    let output = shell_script_command(&repo_root().join("bin/ai-memory"))
-        .args(["run", "codex", "--yolo", "resume"])
-        .env("AI_MEMORY_NATIVE_BIN", &native)
-        .env("AI_MEMORY_DOCKER", &docker)
-        .env("AI_MEMORY_SERVER_URL", "http://192.168.0.90:49374")
-        .env("AI_MEMORY_AUTH_TOKEN", "remote-test-token")
-        .env("PATH", &host_path)
-        .output()
-        .unwrap();
-    assert!(
-        output.status.success(),
-        "wrapper failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let record = std::fs::read_to_string(record).unwrap();
-    assert_eq!(
-        record,
-        format!(
+    let commands: &[&[&str]] = &[
+        &["run", "codex", "--yolo", "resume"],
+        &["show", "--json", "--no-scan"],
+        &["continue", "--workspace", "work", "--yolo"],
+    ];
+    for args in commands {
+        let output = shell_script_command(&repo_root().join("bin/ai-memory"))
+            .args(args.iter().copied())
+            .env("AI_MEMORY_NATIVE_BIN", &native)
+            .env("AI_MEMORY_DOCKER", &docker)
+            .env("AI_MEMORY_SERVER_URL", "http://192.168.0.90:49374")
+            .env("AI_MEMORY_AUTH_TOKEN", "remote-test-token")
+            .env("PATH", &host_path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "wrapper failed for {args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let mut expected = format!(
             "server=http://192.168.0.90:49374\n\
              auth=remote-test-token\n\
-             path={host_path}\n\
-             arg=run\n\
-             arg=codex\n\
-             arg=--yolo\n\
-             arg=resume\n"
-        )
+             path={host_path}\n"
+        );
+        for arg in *args {
+            expected.push_str(&format!("arg={arg}\n"));
+        }
+        assert_eq!(std::fs::read_to_string(&record).unwrap(), expected);
+    }
+    assert!(
+        !docker_record.exists(),
+        "managed host command entered Docker"
     );
-    assert!(!docker_record.exists(), "managed run entered Docker");
 }
 
 #[cfg(unix)]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -411,20 +411,20 @@ the explicit `install-mcp --client claude-code --session-aware` option.
 
 ```
 init                 status               run
-show                 workstream-search    audit-contamination
-search               read-page            write-page
-delete-page          serve                reset
-backup               restore              reindex
-install-hooks        hook                 install-mcp
-commit               checkpoints          restore-page
-llm-test             forget-sweep         lint
-curator              auto-improve-report  auto-improve
-finalize-session     pending-writes       embed
-generate-auth-token  setup-agent          bootstrap
-install-instructions install-skills       reorg
-purge-project        rename-project       move-project
-uninstall            auth                 user
-completions
+show                 continue             workstream-search
+audit-contamination  search               read-page
+write-page           delete-page          serve
+reset                backup               restore
+reindex              install-hooks        hook
+install-mcp          commit               checkpoints
+restore-page         llm-test             forget-sweep
+lint                 curator              auto-improve-report
+auto-improve         finalize-session     pending-writes
+embed                generate-auth-token  setup-agent
+bootstrap            install-instructions install-skills
+reorg                purge-project        rename-project
+move-project         uninstall            auth
+user                 completions
 ```
 
 Run `ai-memory --help` for the full tree.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1259,6 +1259,7 @@ docker run --rm akitaonrails/ai-memory:latest --help     # full subcommand tree
 | `serve` | `docker compose up -d` (already done) | Run the HTTP MCP server |
 | `run [harness] [args...]` | host wrapper or native binary | Opt into one managed cross-harness workstream; omit the harness to resume the newest usable local session, or name Claude Code, Codex, OpenCode, Pi, Crush, Kimi Code, OMP, Grok Build CLI, or Antigravity CLI explicitly; exact `--yolo` and `--fresh` flags are wrapper-owned and other native arguments pass through |
 | `show [--json]` | host wrapper or native binary | Choose a client-local checkout and installed managed harness, or return structured discovery data without launching; remote servers never provide checkout paths |
+| `continue [--workspace NAME]` | host wrapper or native binary | From any directory, revalidate and resume the newest client-local managed checkout; accepts `--yolo` and `--fresh` but no harness-native arguments |
 | `workstream-search [query]` | managed child or thin HTTP client | Search the complete visible managed-workstream ledger; the managed child receives its workstream id automatically |
 | `status` | `docker exec` | Counts, paths, derived-index diagnostics, and passive LLM/embedding provider health |
 | `search "<query>"` | `docker exec` | Wiki FTS5 search + bounded source authority; use MCP `memory_query` for entity/graph/vector RRF |
@@ -1522,10 +1523,11 @@ warns that relabeling system directories such as `/home` can make the host
 inoperable. Docker documents `label=disable` in the
 [`docker run` security options](https://docs.docker.com/reference/cli/docker/container/run/#security-opt).
 
-`ai-memory run` and `ai-memory show` are the exceptions: the current wrapper
-intercepts them and starts a cached checksum-verified native client on the host,
-where local checkouts, harness executables, and session stores exist. It
-preserves an explicit remote `AI_MEMORY_SERVER_URL`. If either command logs
+`ai-memory run`, `ai-memory show`, and `ai-memory continue` are the exceptions:
+the current wrapper intercepts them and starts a cached checksum-verified native
+client on the host, where local checkouts, harness executables, and session
+stores exist. It preserves an explicit remote `AI_MEMORY_SERVER_URL`. If one of
+these commands logs
 `data_dir=/data`, cannot find a checkout, or cannot find `codex`, `claude`, or
 another host executable, refresh the stale wrapper with `ai-memory upgrade` on
 that client machine.

--- a/docs/managed-workstreams.md
+++ b/docs/managed-workstreams.md
@@ -106,7 +106,8 @@ still canonicalize to itself (rejecting a directory that moved or was replaced
 by a symlink), and it must still resolve to the same `(workspace, project)`
 (rejecting a checkout that would file this session's memory under a different
 scope). A link failing either check is named on stderr and skipped, and the
-next-newest link is tried. Falling through is never silent: the selected
+next-newest link is tried. A corrupt `linked_at` timestamp is also reported and
+never considered launchable. Falling through is never silent: the selected
 project and path are always printed before the harness starts.
 
 Once a checkout is selected, the launch is exactly bare `ai-memory run` in that
@@ -351,15 +352,15 @@ original config is not modified. ai-memory opens the project database read-only;
 the launched Crush process continues its normal native session writes.
 
 The Linux/macOS Docker shell wrapper cannot inspect host projects or execute a
-host agent from inside its helper container. For `run` and `show`, it downloads
-the matching native release into
+host agent from inside its helper container. For `run`, `show`, and `continue`,
+it downloads the matching native release into
 `~/.cache/ai-memory/native-runner`, verifies the published SHA-256 checksum, and
 executes that host client. Set `AI_MEMORY_NATIVE_BIN=/path/to/ai-memory` to use a
 specific native build. Native package, release, and source installs need no
 shim. On native Windows, use the published `ai-memory.exe` or a source build.
 
-The wrapper intercepts both commands before Docker and preserves the host `PATH`,
-`AI_MEMORY_SERVER_URL`, and authentication environment. The native client's
+The wrapper intercepts all three commands before Docker and preserves the host
+`PATH`, `AI_MEMORY_SERVER_URL`, and authentication environment. The native client's
 startup log shows `server_url` as well as its local config paths; `data_dir` and
 `bind` describe local defaults and do not override a configured remote server.
 If logs show

--- a/docs/managed-workstreams.md
+++ b/docs/managed-workstreams.md
@@ -84,6 +84,36 @@ all setup succeeds. `--yolo`, `--fresh`, and trailing native arguments apply to
 the selected harness. Non-terminal callers must use `--json`; JSON cannot be
 combined with launch arguments.
 
+## Continuing from anywhere
+
+Bare `ai-memory run` continues the current checkout, but its workstream lookup
+is keyed by `(workspace, project, repo fingerprint, worktree fingerprint)`, so
+the caller must already be in the project. `ai-memory continue` supplies the
+missing step and needs no `cd`:
+
+```bash
+ai-memory continue
+ai-memory continue --workspace work
+```
+
+The checkout is chosen entirely on the client, from the `linked_at` stamp that
+every successful managed prepare writes to `client-projects.json`. The server
+is never asked which directory to use — it does not expose host paths, and a
+link can only be trusted after this host revalidates it.
+
+Before launching, the newest link is rechecked twice: the recorded path must
+still canonicalize to itself (rejecting a directory that moved or was replaced
+by a symlink), and it must still resolve to the same `(workspace, project)`
+(rejecting a checkout that would file this session's memory under a different
+scope). A link failing either check is named on stderr and skipped, and the
+next-newest link is tried. Falling through is never silent: the selected
+project and path are always printed before the harness starts.
+
+Once a checkout is selected, the launch is exactly bare `ai-memory run` in that
+directory, including automatic harness selection. `continue` therefore accepts
+`--workspace`, `--yolo`, and `--fresh`, but not native harness arguments or
+`--executable`, whose meaning depends on a harness the user did not name.
+
 ## Automatic harness selection
 
 With no harness name, `ai-memory run` inspects checkout-local sessions for

--- a/scripts/check-native-packaging.sh
+++ b/scripts/check-native-packaging.sh
@@ -94,8 +94,12 @@ main() {
   AI_MEMORY_DOCKER="${fake_docker}" AI_MEMORY_NATIVE_BIN="${fake_native}" \
     AI_MEMORY_WRAPPER_TEST_LOG="${wrapper_log}" \
     bin/ai-memory show --json --no-scan
+  AI_MEMORY_DOCKER="${fake_docker}" AI_MEMORY_NATIVE_BIN="${fake_native}" \
+    AI_MEMORY_WRAPPER_TEST_LOG="${wrapper_log}" \
+    bin/ai-memory continue --workspace work --yolo
   assert_contains "${wrapper_log}" "run codex --yolo"
   assert_contains "${wrapper_log}" "show --json --no-scan"
+  assert_contains "${wrapper_log}" "continue --workspace work --yolo"
 
   log "Creating temporary alternate root"
   mkdir -p \


### PR DESCRIPTION
## What changed

A new `ai-memory continue` subcommand: from any directory, resume the checkout you last worked in.

**This started as a larger idea and got cut down deliberately.** The first sketch was "a command that puts me back where I was" — until I read `docs/managed-workstreams.md` and found bare `ai-memory run` already does exactly that. Shipping a second spelling of an existing command would have been the wrong PR. What is actually missing is narrower: `WorkstreamSelection::Current` keys its lookup on `(workspace_id, project_id, repo_fingerprint, worktree_fingerprint)`, so bare `run` can only continue the checkout you are already standing in. Nothing resolves *which* checkout that should be from an arbitrary directory.

That is the whole gap this fills, and the implementation is sized to it:

```bash
ai-memory continue
ai-memory continue --workspace work
```

**No new server state.** `ProjectLink::linked_at` is already refreshed by every successful managed prepare, so the newest link *is* the last checkout used. The command orders the client-local links by that stamp, revalidates the newest, and delegates to `run_from` with `harness: None` — the same bare-mode launch, including automatic harness selection. No new endpoint, no schema migration, nothing added to the store.

**The client decides, and re-earns the decision.** The server is never asked which directory to use; it does not expose host paths, and a link is only trustworthy after this host revalidates it. Two checks run before anything launches:

- the recorded path must still canonicalize to itself — rejecting a checkout that moved or was replaced by a symlink;
- it must still resolve to the same `(workspace, project)` — rejecting a directory that would file this session's memory under a different scope.

A link failing either check is named on stderr and skipped in favour of the next-newest. **Falling through is never silent:** the selected project and path are always printed before the harness starts, because a resume that quietly lands in the wrong project is worse than one that fails.

**Ordering** compares parsed instants, not raw strings, so an offset spelling cannot sort wrong. An unparsable `linked_at` sorts last instead of aborting — one corrupt row must not strand every other checkout. Ties break on `(workspace, project)` so the choice is deterministic across runs.

**Surface is deliberately smaller than `show`'s.** Native harness arguments and `--executable` are rejected at parse time, because bare mode does not know which harness it will pick — the same reason `run` rejects them. Making that a parse error keeps the contract visible in `--help` instead of failing after a workstream is already being resolved.

## Security

Reviewed as a distinct pass over the diff, not folded into the general review. **No HIGH or MEDIUM findings.** What was traced and why each is closed:

- **Command injection** — not reachable. `native_args` is `Vec::new()` by construction and `run_from` builds a `Command` from an argument vector, never a shell.
- **Path traversal** — the stored path must be absolute, canonicalize to itself, and be a directory (`validate_registered_path`, reused from `show` rather than reimplemented).
- **Symlink swap** — caught by the canonical-equality check. Regression test `a_checkout_replaced_by_a_symlink_is_rejected`.
- **Scope contamination** — `resolve_target` refuses a checkout whose resolved scope no longer matches the link, which is the check that keeps a resumed session from writing memory into the wrong project. Regression test `a_checkout_that_changed_scope_is_rejected`.
- **Terminal escape injection** — every string sourced from the registry passes through `terminal_text()` before display. This one was a real fix during development, not a box ticked: the first version printed the skip reason raw, and that reason quotes the registry's own path. Regression test `skip_reasons_are_stripped_before_reaching_the_terminal`.
- **Deserialization** — reads only; the registry's existing symlink refusal, size cap, exclusive lock and private permissions are untouched.
- **Data exposure** — nothing sensitive printed. `endpoint.identity()` is credential-free and is not displayed.

Two items I considered and consciously did **not** treat as vulnerabilities, flagged here so you can disagree:

1. **`continue` launches without a human confirming the path**, unlike `show`. Someone who can write `client-projects.json` controls where a harness starts, and since they author both sides of the comparison, the scope check does not stop them. I did not harden against this because the precondition is write access to the user's data dir — which already permits installing hooks and rewriting config. No new privilege boundary is crossed. The printed project and path give visibility, not a gate. If you would rather `continue` prompt before launching, say so and I will add it.
2. **TOCTOU between canonicalization and the spawn's `current_dir`.** A real window, but identical to the pre-existing pattern in `show` and requiring local write access to the parent directory.

## Bug review

Beyond the security pass, the diff was re-read for correctness. Three things changed as a result:

- ordering originally compared `linked_at` as strings; it now parses to `jiff::Timestamp`, with a test using a `+02:00` offset that sorts wrong lexically but right as an instant;
- an unparsable timestamp originally propagated an error and made the whole command fail; it now sorts last;
- equal timestamps had no tiebreak, so the selected project could vary between runs on the same data.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `git diff --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes — 614 tests in the CLI binary, 0 failures
- [x] `cargo deny check` passes (advisories, bans, licenses, sources)
- [x] No new dependencies

11 new tests. Six are pure selection logic (recency ordering, instant-vs-string comparison, unparsable stamps, deterministic tiebreak, empty registry, workspace filter). Four cover revalidation against real temp directories (matching scope resolves, missing checkout rejected, changed scope rejected, escape sequences stripped). One locks the CLI contract, asserting `continue claude`, `continue --model opus` and `continue --executable ...` all fail to parse.

**Manual end-to-end on Windows 11.** Seeded a registry with two links — a newer one pointing at a deleted path and an older valid one — and confirmed the observable behaviour:

```
skipping default/gone: checkout \\?\C:\does-not-exist-xyz no longer resolves
continuing default/ai-memory in \\?\C:\Users\...\ai-memory
Error: opening managed workstream; the agent was not started
    server returned 409 Conflict: {"error":"workstream is already active: owned by ...}
```

The stale link is skipped with its reason, the next-newest is selected and announced, and the delegation reaches the real lease logic — the 409 is the agent session I was running in already owning that workstream. Also verified the empty-registry path exits with the guidance message rather than a panic.

**One coverage gap, stated plainly:** `a_checkout_replaced_by_a_symlink_is_rejected` is `#[cfg(unix)]` and did not execute on my Windows machine. The canonical-equality check it exercises is cross-platform, but empirical confirmation of that case depends on your Linux CI.

## Commit attribution

- [x] Verified on the commit in this PR.

## CHANGELOG (merge gate)

- [x] `[Unreleased] / Added` entry included.
- [x] Additive-only: new subcommand, no changed defaults, no response-shape changes. Minor under the project's semver rule; no version bump made.

## Notes for reviewers

- **Two functions in `show.rs` widened from private to `pub(super)`** (`validate_registered_path`, `terminal_text`) so the revalidation and terminal-stripping rules have one implementation rather than two that can drift. Both stay crate-internal. If you would rather they move to a shared module than be re-exported from `show`, I will move them.
- **`docs/ARCHITECTURE.md`'s subcommand block is reflowed** because `architecture_lists_every_visible_cli_subcommand` gates it against `--help`. The diff looks larger than it is: one entry added, three-column layout re-wrapped.
- **The `(#NNN)` reference in the CHANGELOG** is corrected to this PR's real number in a follow-up commit here; my first guess collided with #349. Tell me if you would rather fold those in on merge instead.
