### PR TITLE
fix(hooks): allow Antigravity native tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Antigravity CLI's generated native `PreToolUse` hook now returns the required
+  `{"decision":"allow"}` response on normal capture, malformed input, and
+  capture-policy drops. Local installs default to the native spool-based hook
+  command, whose generic `{}` response caused Antigravity to deny every tool
+  call even though the staged shell and PowerShell hooks already returned the
+  correct decision (#352).
+
 ### Added
 - Added `ai-memory continue`, which resumes the most recently launched managed
   checkout from any directory. `run`'s bare mode already continues the current

--- a/crates/ai-memory-cli/src/commands/hook.rs
+++ b/crates/ai-memory-cli/src/commands/hook.rs
@@ -367,6 +367,18 @@ fn should_process_hook_event(agent: AgentKind, event: HookEvent, raw: &serde_jso
     true
 }
 
+fn write_success_response<W: std::io::Write>(
+    stdout: &mut W,
+    agent: AgentKind,
+    event: HookEvent,
+) -> std::io::Result<()> {
+    if agent == AgentKind::AntigravityCli && event == HookEvent::PreToolUse {
+        writeln!(stdout, r#"{{"decision": "allow"}}"#)
+    } else {
+        writeln!(stdout, "{{}}")
+    }
+}
+
 fn session_start_handoff_envelope(agent: AgentKind, handoff: String) -> serde_json::Value {
     if agent == AgentKind::AntigravityCli {
         serde_json::json!({
@@ -414,24 +426,24 @@ where
     W: std::io::Write,
     S: FnOnce(&Path) -> std::io::Result<()>,
 {
+    let agent_kind = AgentKind::from_wire(&args.agent);
+    let hook_event = HookEvent::parse(&args.event);
     let (mut payload, mut json) = match parse_hook_payload(payload) {
         Ok(parsed) => parsed,
         Err(_) => {
             eprintln!(
                 "ai-memory hook warning: could not parse event payload as JSON; nothing was captured"
             );
-            writeln!(stdout, "{{}}")?;
+            write_success_response(stdout, agent_kind, hook_event)?;
             return Ok(());
         }
     };
-    let agent_kind = AgentKind::from_wire(&args.agent);
-    let hook_event = HookEvent::parse(&args.event);
     // Antigravity exposes PreInvocation rather than a true SessionStart. It
     // fires before every model call; invocation zero is the only startup
     // boundary. Fail closed when the documented counter is absent so a later
     // invocation can never consume a handoff intended for the next session.
     if !should_process_hook_event(agent_kind, hook_event, &json) {
-        writeln!(stdout, "{{}}")?;
+        write_success_response(stdout, agent_kind, hook_event)?;
         return Ok(());
     }
     // Assistant/Stop capture (#196). On an opted-in install
@@ -483,7 +495,7 @@ where
     if let Some(decision) = decision {
         match decision.protocol().disposition() {
             CaptureDisposition::Drop => {
-                writeln!(stdout, "{{}}")?;
+                write_success_response(stdout, agent_kind, hook_event)?;
                 return Ok(());
             }
             CaptureDisposition::MetadataOnly => {
@@ -707,7 +719,7 @@ where
         );
     }
 
-    writeln!(stdout, "{{}}")?;
+    write_success_response(stdout, agent_kind, hook_event)?;
     Ok(())
 }
 
@@ -877,6 +889,74 @@ mod tests {
             HookEvent::PostToolUse,
             &serde_json::json!({})
         ));
+    }
+
+    #[test]
+    fn hook_success_response_is_specific_to_antigravity_pre_tool_use() {
+        for (agent, event, expected) in [
+            (
+                AgentKind::AntigravityCli,
+                HookEvent::PreToolUse,
+                b"{\"decision\": \"allow\"}\n".as_slice(),
+            ),
+            (
+                AgentKind::AntigravityCli,
+                HookEvent::PostToolUse,
+                b"{}\n".as_slice(),
+            ),
+            (
+                AgentKind::ClaudeCode,
+                HookEvent::PreToolUse,
+                b"{}\n".as_slice(),
+            ),
+        ] {
+            let mut output = Vec::new();
+            write_success_response(&mut output, agent, event).unwrap();
+            assert_eq!(output, expected, "{agent:?} {event:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn antigravity_native_pre_tool_use_allows_and_spools_valid_input() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        let mut stdout = Vec::new();
+        run_with_payload(
+            Some(data_dir.clone()),
+            antigravity_hook_args("pre-tool-use", "http://127.0.0.1:1"),
+            serde_json::json!({
+                "conversationId": "agy-session",
+                "workspacePaths": [tmp.path()],
+                "toolCall": {"name": "view_file", "args": {"AbsolutePath": "README.md"}}
+            })
+            .to_string(),
+            &mut stdout,
+            |_| Ok(()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(stdout, b"{\"decision\": \"allow\"}\n");
+        assert_eq!(hook_spool::spool_len(&hook_spool::spool_dir(&data_dir)), 1);
+    }
+
+    #[tokio::test]
+    async fn antigravity_native_pre_tool_use_fails_open_on_malformed_input() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        let mut stdout = Vec::new();
+        run_with_payload(
+            Some(data_dir.clone()),
+            antigravity_hook_args("pre-tool-use", "http://127.0.0.1:1"),
+            "not-json".into(),
+            &mut stdout,
+            |_| Ok(()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(stdout, b"{\"decision\": \"allow\"}\n");
+        assert_eq!(hook_spool::spool_len(&hook_spool::spool_dir(&data_dir)), 0);
     }
 
     #[test]
@@ -1657,7 +1737,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn antigravity_workspace_path_drops_before_side_effects() {
+    async fn antigravity_pre_tool_capture_drop_still_allows_the_tool() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(
             tmp.path().join(".ai-memory.toml"),
@@ -1665,7 +1745,7 @@ mod tests {
         )
         .unwrap();
         let data_dir = tmp.path().join("data");
-        let mut args = devin_hook_args("post-tool-use");
+        let mut args = devin_hook_args("pre-tool-use");
         args.agent = "antigravity-cli".into();
         let mut stdout = Vec::new();
         let raw = serde_json::json!({"workspacePaths":[tmp.path()],"toolCall":{"name":"Edit","args":{"path":"secret/a"}}});
@@ -1679,7 +1759,7 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(stdout, b"{}\n");
+        assert_eq!(stdout, b"{\"decision\": \"allow\"}\n");
         assert_eq!(hook_spool::spool_len(&hook_spool::spool_dir(&data_dir)), 0);
     }
 
@@ -1732,9 +1812,9 @@ mod tests {
         }
     }
 
-    fn antigravity_hook_args(server_url: &str) -> HookArgs {
+    fn antigravity_hook_args(event: &str, server_url: &str) -> HookArgs {
         HookArgs {
-            event: "session-start".into(),
+            event: event.into(),
             agent: "antigravity-cli".into(),
             server_url: server_url.into(),
             auth_token: None,
@@ -1791,7 +1871,7 @@ mod tests {
         let mut stdout = Vec::new();
         run_with_payload(
             Some(tmp.path().join("data")),
-            antigravity_hook_args(&base),
+            antigravity_hook_args("session-start", &base),
             serde_json::json!({
                 "invocationNum": 0,
                 "initialNumSteps": 0,
@@ -1839,7 +1919,7 @@ mod tests {
         let mut stdout = Vec::new();
         run_with_payload(
             Some(data_dir.clone()),
-            antigravity_hook_args(&base),
+            antigravity_hook_args("session-start", &base),
             serde_json::json!({
                 "invocationNum": 4,
                 "initialNumSteps": 12,


### PR DESCRIPTION
## Summary
- return Antigravity's required allow decision from the native `PreToolUse` hook path
- apply the response consistently to valid input, malformed input, and capture-policy drops
- preserve all other agent/event output contracts and add regression coverage

Closes #352

## Validation
- `TAILWIND_SKIP=1 cargo test -p ai-memory-cli`
- `TAILWIND_SKIP=1 cargo clippy -p ai-memory-cli --all-targets -- -D warnings`
- `cargo fmt --all`
- `git diff --check`