### PR TITLE
feat: add Kiro CLI MCP support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   correct decision (#352).
 
 ### Added
+- Kiro CLI is now supported as an MCP-only client through `install-mcp
+  --client kiro-cli` (alias `kiro`). The installer preserves existing
+  `$KIRO_HOME/settings/mcp.json` content, adds bearer headers when configured,
+  honors `$KIRO_HOME`, and appends a Bedrock schema flavor that removes only
+  unsupported root-level JSON Schema combinators. Non-loopback Kiro endpoints
+  must use HTTPS and are rejected before `--apply` writes an unusable config.
+  Kiro lifecycle hooks and managed workstreams remain deferred because its v2
+  and early-access v3 engines use incompatible hook and session formats
+  (#351).
 - Added `ai-memory continue`, which resumes the most recently launched managed
   checkout from any directory. `run`'s bare mode already continues the current
   checkout, but its workstream lookup is keyed by repository and worktree

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 | Grok Build CLI | Supported | MCP config (`install-mcp --client grok` → `$GROK_HOME/config.toml`, default `~/.grok/config.toml`) + lifecycle hooks (`install-hooks --agent grok` → `$GROK_HOME/hooks/ai-memory.json`, default `~/.grok/hooks/ai-memory.json`, Grok-specific hook bundle). Capture works; no hook handoff injection — Grok ignores `SessionStart` stdout, so recover handoffs via MCP `memory_handoff_accept`. `ai-memory run grok` adds managed workstream resume with the context packet delivered natively through `--rules`. Skills root: `.grok/skills` / `$GROK_HOME/skills` (default `~/.grok/skills`). |
 | Zero | Supported | `install-mcp --client zero` (native HTTP + bearer in `~/.config/zero/config.json`) + lifecycle hooks via `install-hooks --agent zero --apply` (exec-form native commands in `~/.config/zero/hooks.json`, JSON payload on stdin, no shell). Capture works incl. specialist (subagent) events; no handoff injection — Zero discards `sessionStart` stdout, so recover handoffs via MCP `memory_handoff_accept`. |
 | Kimi Code | Supported | MCP config (`url` entry in `~/.kimi-code/mcp.json`) + lifecycle hooks (`[[hooks]]` in `~/.kimi-code/config.toml`, 10 events including subagent start/stop and `PostToolUseFailure` for tool-failure capture); both paths honor `$KIMI_CODE_HOME`. Handoffs inject via `UserPromptSubmit` stdout (Kimi Code discards `SessionStart` hook stdout); `ai-memory run kimi` adds managed workstream resume. |
+| Kiro CLI | MCP-only | `install-mcp --client kiro-cli` (alias `kiro`) merges a native remote entry into `$KIRO_HOME/settings/mcp.json` (default `~/.kiro/settings/mcp.json`). Kiro's Bedrock-compatible schema flavor is applied automatically. Remote endpoints must use HTTPS; plain HTTP is accepted only on loopback. Hooks and managed workstreams are not yet supported because Kiro v2 and v3 use incompatible hook and session formats. |
 | VS Code Copilot | MCP-only | `.vscode/mcp.json` for Copilot agent mode; no lifecycle hooks (Copilot does not expose them yet). |
 | Zed | MCP-only | Native remote MCP under `context_servers` in Zed's user `settings.json`; no lifecycle hooks or managed-workstream support. |
 | Hermes Agent | Community | Core hook ingestion recognizes `agent=hermes` and Hermes' documented shell-hook `tool_name` / `tool_input` payload for concrete session attribution, tool-family titles, and capture exclusions. A community-maintained [`ai-memory-hermes-plugin`](https://github.com/MrLuciano/ai-memory-hermes-plugin) is available, but no first-party installer is shipped; review its compatibility matrix, install/uninstall scripts, and secret handling before using it. Hermes ignores session-start hook stdout, so recover handoffs through MCP. |
@@ -140,8 +141,9 @@ priors are at the [bottom](#influences-and-prior-art).
   Code, Codex, Devin CLI, OpenCode, Cursor, Claude Desktop (via `mcp-remote`),
   Gemini CLI, Antigravity CLI, Grok Build CLI, Kimi Code, OpenClaw, Oh My Pi
   / OMP (`omp` / `oh-my-pi`), Pi via generated bridge extension, VS Code
-  GitHub Copilot agent mode (MCP-only, workspace `.vscode/mcp.json`), and Zed
-  (MCP-only, user `settings.json`).
+  GitHub Copilot agent mode (MCP-only, workspace `.vscode/mcp.json`), Kiro CLI
+  (MCP-only, `$KIRO_HOME/settings/mcp.json`), and Zed (MCP-only, user
+  `settings.json`).
   Server runs local (loopback) OR on a homelab box (LAN/VPN/cloud)
   with bearer-token auth. Shared servers can opt into
   [`[auto_scope]` modes](docs/auto-scope.md) for per-user or
@@ -443,7 +445,7 @@ docker run -d --name ai-memory \
 #    mounts and each client's config-path detection. Re-run with
 #    `--agent codex`, `--agent devin`, `--agent opencode`, `--agent gemini-cli`,
 #    `--agent grok`, `--agent kimi-code`, `--agent omp`, `--agent oh-my-pi`, `--client cursor`,
-#    `--client gemini-cli`, `--client grok`, etc.
+#    `--client gemini-cli`, `--client grok`, `--client kiro-cli`, etc.
 #    for additional agents; full list in docs/install.md.
 ai-memory install-mcp   --client claude-code --apply
 ai-memory install-hooks --agent  claude-code --apply

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -1130,6 +1130,11 @@ pub enum McpClient {
     /// Kimi Code CLI (Moonshot AI).
     #[value(alias = "kimi")]
     KimiCode,
+    /// Kiro CLI - `$KIRO_HOME/settings/mcp.json` (default
+    /// `~/.kiro/settings/mcp.json`). MCP-only: Kiro v2 and v3 use
+    /// incompatible hook and session formats.
+    #[value(alias = "kiro")]
+    KiroCli,
     /// VS Code GitHub Copilot (agent mode) — per-workspace
     /// `.vscode/mcp.json`. Copilot's agent mode reads MCP servers
     /// from VS Code's own MCP framework (top-level `servers` key),
@@ -2109,6 +2114,25 @@ mod tests {
             panic!("expected install-mcp command for grok");
         };
         assert!(matches!(mcp_args.client, McpClient::Grok));
+    }
+
+    #[test]
+    fn kiro_mcp_aliases_parse() {
+        for alias in ["kiro-cli", "kiro"] {
+            let cli = Cli::try_parse_from([
+                "ai-memory",
+                "install-mcp",
+                "--client",
+                alias,
+                "--server-url",
+                "https://memory.example/mcp",
+            ])
+            .unwrap_or_else(|e| panic!("failed to parse Kiro MCP alias {alias}: {e}"));
+            let Command::InstallMcp(args) = cli.command else {
+                panic!("expected install-mcp command for Kiro alias {alias}");
+            };
+            assert!(matches!(args.client, McpClient::KiroCli));
+        }
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -675,7 +675,7 @@ fn infer_installed_mcp_config(agent: AgentChoice) -> Result<Option<InferredMcpCo
             &["mcpServers", "ai-memory"],
             "url",
         )),
-        McpClient::KimiCode => Ok(infer_json_mcp_config(
+        McpClient::KimiCode | McpClient::KiroCli => Ok(infer_json_mcp_config(
             &content,
             &["mcpServers", "ai-memory"],
             "url",

--- a/crates/ai-memory-cli/src/commands/install_mcp.rs
+++ b/crates/ai-memory-cli/src/commands/install_mcp.rs
@@ -75,6 +75,7 @@ pub fn run(config: &Config, args: InstallMcpArgs) -> Result<()> {
         McpClient::Zero => render_zero(&args)?,
         McpClient::Devin => render_devin(&args)?,
         McpClient::KimiCode => render_kimi_code(&args)?,
+        McpClient::KiroCli => render_kiro_cli(&args)?,
         McpClient::VsCodeCopilot => render_vscode_copilot(&args)?,
         McpClient::Zed => render_zed(&args)?,
     };
@@ -111,7 +112,35 @@ fn validate_args(args: &InstallMcpArgs) -> Result<()> {
     if args.session_aware && !matches!(args.client, McpClient::ClaudeCode) {
         bail!("--session-aware is supported only for --client claude-code");
     }
+    if matches!(args.client, McpClient::KiroCli) {
+        validate_kiro_remote_url(args.server_url.as_deref().unwrap_or(DEFAULT_MCP_URL))?;
+    }
     Ok(())
+}
+
+/// Kiro accepts HTTPS remote MCP endpoints and plain HTTP only on loopback.
+/// Reject an unusable registration before `--apply` mutates user config.
+fn validate_kiro_remote_url(server_url: &str) -> Result<()> {
+    let parsed = reqwest::Url::parse(server_url).context("Kiro MCP URL is not a valid URL")?;
+    if parsed.scheme() == "https" {
+        return Ok(());
+    }
+    let loopback = parsed.host_str().is_some_and(|host| {
+        let normalized = host
+            .strip_prefix('[')
+            .and_then(|host| host.strip_suffix(']'))
+            .unwrap_or(host);
+        normalized.eq_ignore_ascii_case("localhost")
+            || normalized
+                .parse::<std::net::IpAddr>()
+                .is_ok_and(|address| address.is_loopback())
+    });
+    if parsed.scheme() == "http" && loopback {
+        return Ok(());
+    }
+    bail!(
+        "Kiro CLI requires HTTPS for remote MCP servers (plain HTTP is accepted only on localhost); configure an HTTPS reverse proxy or pass a loopback URL"
+    )
 }
 
 /// Default MCP config-file path for a client (ignores any
@@ -178,6 +207,9 @@ pub(crate) fn mcp_config_path(client: crate::cli::McpClient) -> Result<PathBuf> 
         // falling back to ~/.kimi-code; MCP servers live in mcp.json at
         // that root.
         McpClient::KimiCode => kimi_code_home(std::env::var_os("KIMI_CODE_HOME"))?.join("mcp.json"),
+        McpClient::KiroCli => kiro_home(std::env::var_os("KIRO_HOME"))?
+            .join("settings")
+            .join("mcp.json"),
         // VS Code MCP is workspace-scoped by default: `.vscode/mcp.json`
         // at the current workspace root. The user-profile alternative
         // lives under VS Code's profile-specific data dir; use VS
@@ -317,6 +349,17 @@ fn kimi_code_home(env_override: Option<std::ffi::OsString>) -> Result<PathBuf> {
         .join(".kimi-code"))
 }
 
+/// Kiro CLI's global configuration root: `$KIRO_HOME` when set, otherwise
+/// `~/.kiro`. The override is injected to keep path tests process-local.
+fn kiro_home(env_override: Option<std::ffi::OsString>) -> Result<PathBuf> {
+    if let Some(dir) = env_override.filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(dir));
+    }
+    Ok(home_dir()
+        .context("could not locate $HOME for Kiro configuration")?
+        .join(".kiro"))
+}
+
 /// Resolve Grok Build CLI's user configuration root. Grok honours
 /// `GROK_HOME`; otherwise it uses `~/.grok`.
 pub(crate) fn grok_home() -> Result<PathBuf> {
@@ -417,7 +460,8 @@ fn json_mcp_location(client: McpClient) -> Option<JsonMcpLocation> {
         | McpClient::Omp
         | McpClient::AntigravityCli
         | McpClient::Devin
-        | McpClient::KimiCode => Some(JsonMcpLocation::RootMcpServers),
+        | McpClient::KimiCode
+        | McpClient::KiroCli => Some(JsonMcpLocation::RootMcpServers),
         McpClient::OpenCode => Some(JsonMcpLocation::RootMcp),
         // Zero's config.json nests servers under `mcp.servers`, the same
         // shape OpenClaw uses.
@@ -524,17 +568,25 @@ fn render_json_mcp_fragment(args: &InstallMcpArgs) -> Result<String> {
 /// in tool parameter schemas (issue #155's `anyOf` on `memory_read_page`),
 /// and the server answers flavored requests with flat schemas. Idempotent
 /// so re-runs never stack duplicate query pairs.
-pub(crate) fn moonshot_flavored_mcp_url(server_url: &str) -> String {
-    const FLAVOR: &str = "flavor=moonshot";
+fn flavored_mcp_url(server_url: &str, flavor: &str) -> String {
+    let marker = format!("flavor={flavor}");
     let url = server_url.trim();
     let already_marked = url
         .split_once('?')
-        .is_some_and(|(_, query)| query.split('&').any(|pair| pair == FLAVOR));
+        .is_some_and(|(_, query)| query.split('&').any(|pair| pair == marker));
     if already_marked {
         return url.to_string();
     }
     let separator = if url.contains('?') { '&' } else { '?' };
-    format!("{url}{separator}{FLAVOR}")
+    format!("{url}{separator}{marker}")
+}
+
+pub(crate) fn moonshot_flavored_mcp_url(server_url: &str) -> String {
+    flavored_mcp_url(server_url, "moonshot")
+}
+
+pub(crate) fn bedrock_flavored_mcp_url(server_url: &str) -> String {
+    flavored_mcp_url(server_url, "bedrock")
 }
 
 /// JSON entry shape used by Claude Code, Claude Desktop, Cursor, and
@@ -618,6 +670,12 @@ fn build_mcp_entry(args: &InstallMcpArgs) -> Result<serde_json::Value> {
             // field as streamable-HTTP; `transport` is only for legacy
             // SSE endpoints.
             entry.insert("url".into(), json!(moonshot_flavored_mcp_url(server_url)));
+            if let Some(b) = &bearer {
+                entry.insert("headers".into(), json!({"Authorization": b}));
+            }
+        }
+        McpClient::KiroCli => {
+            entry.insert("url".into(), json!(bedrock_flavored_mcp_url(server_url)));
             if let Some(b) = &bearer {
                 entry.insert("headers".into(), json!({"Authorization": b}));
             }
@@ -1079,6 +1137,22 @@ fn render_kimi_code(args: &InstallMcpArgs) -> Result<String> {
     ))
 }
 
+fn render_kiro_cli(args: &InstallMcpArgs) -> Result<String> {
+    Ok(format!(
+        "# Kiro CLI - merge into $KIRO_HOME/settings/mcp.json\n\
+         # (defaults to ~/.kiro/settings/mcp.json):\n\
+         #\n\
+         # Kiro accepts HTTPS remote endpoints and plain HTTP only on\n\
+         # localhost. `?flavor=bedrock` removes unsupported root-level\n\
+         # schema combinators while handler validation remains unchanged.\n\
+         # This integration is MCP-only; Kiro v2 and v3 use incompatible\n\
+         # hook and session formats, so lifecycle capture and managed\n\
+         # workstreams are not installed.\n\
+         {snippet}\n",
+        snippet = render_json_mcp_fragment(args)?,
+    ))
+}
+
 fn render_vscode_copilot(args: &InstallMcpArgs) -> Result<String> {
     Ok(format!(
         "# VS Code GitHub Copilot (agent mode) — write to one of:\n\
@@ -1484,6 +1558,7 @@ mod tests {
             McpClient::Zero => render_zero(&args).unwrap(),
             McpClient::Devin => render_devin(&args).unwrap(),
             McpClient::KimiCode => render_kimi_code(&args).unwrap(),
+            McpClient::KiroCli => render_kiro_cli(&args).unwrap(),
             McpClient::VsCodeCopilot => render_vscode_copilot(&args).unwrap(),
             McpClient::Zed => render_zed(&args).unwrap(),
         }
@@ -1507,6 +1582,7 @@ mod tests {
             McpClient::Zero,
             McpClient::Devin,
             McpClient::KimiCode,
+            McpClient::KiroCli,
             McpClient::VsCodeCopilot,
             McpClient::Zed,
         ] {
@@ -1544,6 +1620,7 @@ mod tests {
             McpClient::Zero,
             McpClient::Devin,
             McpClient::KimiCode,
+            McpClient::KiroCli,
             McpClient::VsCodeCopilot,
             McpClient::Zed,
         ] {
@@ -1574,6 +1651,7 @@ mod tests {
             McpClient::Zero => render_zero(&args).unwrap(),
             McpClient::Devin => render_devin(&args).unwrap(),
             McpClient::KimiCode => render_kimi_code(&args).unwrap(),
+            McpClient::KiroCli => render_kiro_cli(&args).unwrap(),
             McpClient::VsCodeCopilot => render_vscode_copilot(&args).unwrap(),
             McpClient::Zed => render_zed(&args).unwrap(),
         }
@@ -1728,6 +1806,13 @@ mod tests {
         let kimi_with_token = render_with_token(McpClient::KimiCode);
         assert!(kimi_with_token.contains("\"headers\""));
         assert!(kimi_with_token.contains("\"Authorization\": \"Bearer test-token-deadbeef\""));
+        let kiro = render_for_test(McpClient::KiroCli);
+        assert!(kiro.contains("\"mcpServers\""));
+        assert!(kiro.contains("http://127.0.0.1:49374/mcp?flavor=bedrock"));
+        assert!(!kiro.contains("\"transport\""));
+        assert!(kiro.contains("MCP-only"));
+        let kiro_with_token = render_with_token(McpClient::KiroCli);
+        assert!(kiro_with_token.contains("\"Authorization\": \"Bearer test-token-deadbeef\""));
         // VS Code Copilot must use the `servers` top-level key — the
         // `mcpServers` form is silently ignored by VS Code's MCP
         // framework. Regression guard against a future copy-paste
@@ -1756,6 +1841,17 @@ mod tests {
         // An empty override falls back to the default home-based dir.
         assert_eq!(kimi_code_home(Some("".into())).unwrap(), default);
         assert_eq!(kimi_code_home(None).unwrap(), default);
+    }
+
+    #[test]
+    fn kiro_home_honours_env_override() {
+        assert_eq!(
+            kiro_home(Some("/tmp/custom-kiro-home".into())).unwrap(),
+            PathBuf::from("/tmp/custom-kiro-home")
+        );
+        let default = home_dir().unwrap().join(".kiro");
+        assert_eq!(kiro_home(Some("".into())).unwrap(), default);
+        assert_eq!(kiro_home(None).unwrap(), default);
     }
 
     /// Pin the append rules: `?` on a bare endpoint, `&` with an existing
@@ -1787,6 +1883,72 @@ mod tests {
         ] {
             assert_eq!(moonshot_flavored_mcp_url(input), expected, "input: {input}");
         }
+    }
+
+    #[test]
+    fn bedrock_flavored_mcp_url_appends_marker_idempotently() {
+        assert_eq!(
+            bedrock_flavored_mcp_url("https://memory.example/mcp"),
+            "https://memory.example/mcp?flavor=bedrock"
+        );
+        assert_eq!(
+            bedrock_flavored_mcp_url("https://memory.example/mcp?token=x"),
+            "https://memory.example/mcp?token=x&flavor=bedrock"
+        );
+        assert_eq!(
+            bedrock_flavored_mcp_url("https://memory.example/mcp?flavor=bedrock"),
+            "https://memory.example/mcp?flavor=bedrock"
+        );
+    }
+
+    #[test]
+    fn kiro_rejects_plain_http_for_non_loopback_servers() {
+        for allowed in [
+            "http://localhost:49374/mcp",
+            "http://127.0.0.1:49374/mcp",
+            "http://[::1]:49374/mcp",
+            "https://memory.example/mcp",
+        ] {
+            let mut args = args_for(McpClient::KiroCli);
+            args.server_url = Some(allowed.into());
+            validate_args(&args).unwrap_or_else(|error| panic!("{allowed}: {error:#}"));
+        }
+
+        let mut args = args_for(McpClient::KiroCli);
+        args.server_url = Some("http://192.168.0.90:49374/mcp".into());
+        let error = validate_args(&args).unwrap_err();
+        assert!(error.to_string().contains("requires HTTPS"), "{error:#}");
+    }
+
+    #[test]
+    fn kiro_apply_preserves_siblings_and_is_idempotent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config_path = tmp.path().join("mcp.json");
+        fs::write(
+            &config_path,
+            r#"{"mcpServers":{"other":{"url":"https://other.example/mcp"}},"userSetting":true}"#,
+        )
+        .unwrap();
+        let mut args = args_with_token(McpClient::KiroCli);
+        args.server_url = Some("https://memory.example/mcp".into());
+        args.config_file = Some(config_path.clone());
+
+        apply_to_config_file(&args).unwrap();
+        let first = fs::read_to_string(&config_path).unwrap();
+        apply_to_config_file(&args).unwrap();
+        let second = fs::read_to_string(&config_path).unwrap();
+
+        assert_eq!(first, second);
+        let value: serde_json::Value = serde_json::from_str(&second).unwrap();
+        assert_eq!(value["userSetting"], true);
+        assert_eq!(
+            value["mcpServers"]["other"]["url"],
+            "https://other.example/mcp"
+        );
+        assert_eq!(
+            value["mcpServers"]["ai-memory"]["url"],
+            "https://memory.example/mcp?flavor=bedrock"
+        );
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/uninstall.rs
+++ b/crates/ai-memory-cli/src/commands/uninstall.rs
@@ -284,6 +284,7 @@ fn build_plan(args: &UninstallArgs) -> anyhow::Result<Vec<PlannedChange>> {
             Zed,
             Devin,
             KimiCode,
+            KiroCli,
         ] {
             let paths = if matches!(client, ClaudeCode) {
                 claude_config_paths(
@@ -938,6 +939,7 @@ fn mcp_servers_path(client: McpClient) -> Option<&'static [&'static str]> {
         | McpClient::Omp
         | McpClient::AntigravityCli
         | McpClient::KimiCode
+        | McpClient::KiroCli
         | McpClient::Devin => Some(&["mcpServers"]),
         McpClient::OpenCode => Some(&["mcp"]),
         McpClient::Openclaw | McpClient::Zero => Some(&["mcp", "servers"]),
@@ -974,13 +976,19 @@ fn mcp_entry_is_ours(key: &str, entry: &serde_json::Value, name: Option<&str>, u
 }
 
 /// URL forms uninstall matches for `client`: the endpoint as given, plus
-/// for KimiCode the `flavor=moonshot` form install-mcp actually writes
-/// (`--mcp-url` keeps the unflavored default). Every other client keeps
-/// exact-match semantics.
+/// for clients whose installer appends a schema flavor, the form
+/// `install-mcp` actually writes (`--mcp-url` keeps the unflavored default).
+/// Every other client keeps exact-match semantics.
 fn mcp_url_candidates(client: McpClient, url: &str) -> Vec<String> {
     let mut candidates = vec![url.to_string()];
     if matches!(client, McpClient::KimiCode) {
         let flavored = install_mcp::moonshot_flavored_mcp_url(url);
+        if !candidates.contains(&flavored) {
+            candidates.push(flavored);
+        }
+    }
+    if matches!(client, McpClient::KiroCli) {
+        let flavored = install_mcp::bedrock_flavored_mcp_url(url);
         if !candidates.contains(&flavored) {
             candidates.push(flavored);
         }
@@ -1989,7 +1997,7 @@ command = "'/usr/local/bin/ai-memory' hook --event stop --agent kimi-code --serv
     }
 
     #[test]
-    fn mcp_url_candidates_adds_moonshot_flavor_for_kimi_code_only() {
+    fn mcp_url_candidates_adds_client_schema_flavors() {
         assert_eq!(
             mcp_url_candidates(McpClient::KimiCode, "http://127.0.0.1:49374/mcp"),
             vec![
@@ -2003,6 +2011,13 @@ command = "'/usr/local/bin/ai-memory' hook --event stop --agent kimi-code --serv
                 "http://127.0.0.1:49374/mcp?flavor=moonshot"
             ),
             vec!["http://127.0.0.1:49374/mcp?flavor=moonshot".to_string()]
+        );
+        assert_eq!(
+            mcp_url_candidates(McpClient::KiroCli, "https://memory.example/mcp"),
+            vec![
+                "https://memory.example/mcp".to_string(),
+                "https://memory.example/mcp?flavor=bedrock".to_string()
+            ]
         );
         assert_eq!(
             mcp_url_candidates(McpClient::Cursor, "http://127.0.0.1:49374/mcp"),
@@ -2026,6 +2041,22 @@ command = "'/usr/local/bin/ai-memory' hook --event stop --agent kimi-code --serv
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert!(v["mcpServers"].get("ai-memory").is_none());
         assert!(v["mcpServers"].get("other").is_some());
+    }
+
+    #[test]
+    fn strip_mcp_kiro_matches_bedrock_flavored_url() {
+        let content = r#"{"mcpServers":{"ai-memory":{"url":"https://memory.example/mcp?flavor=bedrock"},"other":{"url":"https://other.example/mcp"}}}"#;
+        let (out, removed) = strip_mcp_json_client(
+            content,
+            McpClient::KiroCli,
+            Some("ai-memory"),
+            "https://memory.example/mcp",
+        )
+        .unwrap();
+        assert_eq!(removed, vec!["ai-memory".to_string()]);
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(value["mcpServers"].get("ai-memory").is_none());
+        assert!(value["mcpServers"].get("other").is_some());
     }
 
     /// The plan matched the flavored Kimi Code entry but apply dispatched

--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -3429,28 +3429,27 @@ impl ServerHandler for AiMemoryServer {
         // rmcp injects `http::request::Parts` into request extensions in
         // both stateless and stateful modes, so the flavor marker is
         // available even without peer clientInfo.
-        let moonshot = context
+        let restricted_schema = context
             .extensions
             .get::<http::request::Parts>()
             .and_then(|parts| parts.uri.query())
-            .is_some_and(|query| query.split('&').any(|pair| pair == "flavor=moonshot"));
-        if moonshot {
-            Ok(ListToolsResult::with_all_items(moonshot_safe_tool_list(
-                tools,
-            )))
+            .is_some_and(has_restricted_schema_flavor);
+        if restricted_schema {
+            Ok(ListToolsResult::with_all_items(
+                restricted_schema_tool_list(tools),
+            ))
         } else {
             Ok(ListToolsResult::with_all_items(tools))
         }
     }
 }
 
-/// Moonshot ("moonshot flavored json schema") rejects root-level
+/// Bedrock and Moonshot reject root-level
 /// `anyOf`/`oneOf`/`allOf` in tool parameter schemas with a 400 at
-/// `tools/list` time. Requests marked `?flavor=moonshot` (the URL
-/// `install-mcp --client kimi-code` writes) get the tool list with
-/// those root keys stripped; nested combinators stay, and the handlers'
-/// runtime validation still enforces the arg contracts.
-fn moonshot_safe_tool_list(tools: Vec<Tool>) -> Vec<Tool> {
+/// `tools/list` time. Kimi's legacy `?flavor=moonshot` and Kiro's
+/// `?flavor=bedrock` both get schemas with those root keys stripped;
+/// nested combinators stay, and runtime validation remains unchanged.
+fn restricted_schema_tool_list(tools: Vec<Tool>) -> Vec<Tool> {
     const ROOT_COMBINATORS: [&str; 3] = ["anyOf", "oneOf", "allOf"];
     tools
         .into_iter()
@@ -3469,6 +3468,12 @@ fn moonshot_safe_tool_list(tools: Vec<Tool>) -> Vec<Tool> {
             tool
         })
         .collect()
+}
+
+fn has_restricted_schema_flavor(query: &str) -> bool {
+    query
+        .split('&')
+        .any(|pair| matches!(pair, "flavor=moonshot" | "flavor=bedrock"))
 }
 
 /// A page's access counter is bumped at most once per this window. Repeated
@@ -6434,7 +6439,7 @@ mod tests {
 
     // Pins what the patch strips (root combinators) and what it preserves.
     #[test]
-    fn moonshot_safe_tool_list_strips_root_combinators_only() {
+    fn restricted_schema_tool_list_strips_root_combinators_only() {
         let schema: serde_json::Map<String, serde_json::Value> =
             serde_json::from_value(serde_json::json!({
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -6453,7 +6458,7 @@ mod tests {
             .unwrap();
         let tool = Tool::new("memory_read_page", "Read a wiki page", schema);
 
-        let patched = moonshot_safe_tool_list(vec![tool]);
+        let patched = restricted_schema_tool_list(vec![tool]);
         let out = &patched[0].input_schema;
 
         for key in ["anyOf", "oneOf", "allOf"] {
@@ -6473,7 +6478,7 @@ mod tests {
     }
 
     #[test]
-    fn moonshot_safe_tool_list_leaves_flat_tools_untouched() {
+    fn restricted_schema_tool_list_leaves_flat_tools_untouched() {
         let schema: serde_json::Map<String, serde_json::Value> =
             serde_json::from_value(serde_json::json!({
                 "type": "object",
@@ -6483,10 +6488,22 @@ mod tests {
         let tool = Tool::new("memory_status", "Status counts", schema);
         let before = serde_json::to_value(&tool).unwrap();
 
-        let patched = moonshot_safe_tool_list(vec![tool]);
+        let patched = restricted_schema_tool_list(vec![tool]);
         let after = serde_json::to_value(&patched[0]).unwrap();
 
         assert_eq!(before, after, "flat tools must pass through unchanged");
+    }
+
+    #[test]
+    fn restricted_schema_flavor_matches_complete_query_pairs_only() {
+        assert!(has_restricted_schema_flavor("flavor=moonshot"));
+        assert!(has_restricted_schema_flavor(
+            "client=kiro&flavor=bedrock&debug=false"
+        ));
+        assert!(!has_restricted_schema_flavor("flavor=unknown"));
+        assert!(!has_restricted_schema_flavor(
+            "note=flavor=bedrock&client=kiro"
+        ));
     }
 
     // Issue #155: the neither-arg error must teach a looping model what a

--- a/crates/ai-memory-mcp/tests/mcp_stateless_http.rs
+++ b/crates/ai-memory-mcp/tests/mcp_stateless_http.rs
@@ -215,6 +215,28 @@ async fn stateless_moonshot_flavor_strips_root_any_of() {
     );
 }
 
+/// Kiro's Bedrock requests use the same restricted root-schema dialect while
+/// retaining a provider-specific marker for diagnostics and compatibility.
+#[tokio::test]
+async fn stateless_bedrock_flavor_strips_root_any_of() {
+    let tmp = TempDir::new().unwrap();
+    let (router, _store) = make_router(&tmp, false).await;
+
+    let resp = router
+        .oneshot(post_to("/mcp?flavor=bedrock", TOOLS_LIST))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let schema = read_page_input_schema(&body_string(resp).await);
+    for key in ["anyOf", "oneOf", "allOf"] {
+        assert!(
+            schema.get(key).is_none(),
+            "bedrock flavor must strip root `{key}`: {schema}"
+        );
+    }
+    assert!(schema.get("properties").is_some());
+}
+
 /// Control: without the marker, tools/list keeps the upstream root `anyOf`.
 #[tokio::test]
 async fn stateless_tools_list_without_flavor_keeps_root_any_of() {

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,7 +9,7 @@ path (docker + Claude Code). This page covers everything else:
 - [Arch Linux native packages (AUR)](#arch-linux-native-packages-aur)
   (systemd system service or user service)
 - [Configuring other agent CLIs](#configuring-other-agent-clis)
-  (Codex, Devin CLI, OpenCode, OMP, Pi, Cursor, Claude Desktop, Gemini CLI, Antigravity CLI, Grok Build CLI, Zero, Kimi Code, OpenClaw, VS Code Copilot, Zed)
+  (Codex, Devin CLI, OpenCode, OMP, Pi, Cursor, Claude Desktop, Gemini CLI, Antigravity CLI, Grok Build CLI, Zero, Kimi Code, Kiro CLI, OpenClaw, VS Code Copilot, Zed)
 - [Installing hooks without docker](#installing-hooks-without-docker)
   (curl-based installer)
 - [Running ai-memory without docker](#running-ai-memory-without-docker)
@@ -599,9 +599,9 @@ Each agent CLI needs two things:
    Without this, the agent can still query memory but capture
    becomes manual.
 
-Claude Desktop, VS Code Copilot, and Zed are MCP-only today. The hook-capable
-clients in the [README Support Matrix](../README.md#support-matrix), including
-Pi and Zero, have lifecycle capture paths through `install-hooks`.
+Claude Desktop, Kiro CLI, VS Code Copilot, and Zed are MCP-only today. The
+hook-capable clients in the [README Support Matrix](../README.md#support-matrix),
+including Pi and Zero, have lifecycle capture paths through `install-hooks`.
 
 > **Hook install pattern.** Local supported profiles default to host-native
 > commands. Claude Code may use its supported Windows exec form (`command` =
@@ -734,6 +734,33 @@ script-fallback installation so its staged scripts are refreshed.
 Kimi Code hook entries accept only `event`, `matcher`, `command`, and
 `timeout`; extra fields make the whole `config.toml` fail to load, so prefer
 `install-hooks --apply` over hand edits.
+
+### Kiro CLI
+
+Kiro CLI is MCP-only in this release. Its global MCP file is
+`$KIRO_HOME/settings/mcp.json`, defaulting to `~/.kiro/settings/mcp.json`;
+pass `--config-file .kiro/settings/mcp.json` for a project-scoped entry.
+
+```bash
+ai-memory install-mcp --client kiro-cli --apply \
+    --server-url "https://memory.example/mcp" \
+    --auth-token "$TOKEN"
+```
+
+The `kiro` alias is equivalent. The installed URL includes
+`?flavor=bedrock` so Kiro's Bedrock backend receives schemas without
+root-level `anyOf`, `oneOf`, or `allOf`; nested schemas and runtime validation
+remain intact. Kiro requires HTTPS for non-loopback remote servers, so the CLI
+rejects a plain-HTTP homelab URL before changing the file. Configure a reverse
+proxy as described in [HTTPS via reverse proxy](https-via-proxy.md).
+
+Kiro v2 and the early-access v3 engine use incompatible hook and persisted
+session formats. `install-hooks --agent kiro-cli` and `ai-memory run kiro` are
+therefore deferred until both formats have fixtures and explicit compatibility
+tests; this MCP registration does not claim automatic capture or managed
+resume. Follow [#355](https://github.com/akitaonrails/ai-memory/issues/355) for
+hooks and [#356](https://github.com/akitaonrails/ai-memory/issues/356) for the
+managed-workstream adapter.
 
 ### OpenCode
 
@@ -874,6 +901,10 @@ docker run --rm akitaonrails/ai-memory:latest \
     --server-url "http://homelab:49374"
 
 docker run --rm akitaonrails/ai-memory:latest \
+    install-mcp --client kiro-cli        --auth-token "$TOKEN" \
+    --server-url "https://memory.example/mcp"
+
+docker run --rm akitaonrails/ai-memory:latest \
     install-mcp --client vscode-copilot  --auth-token "$TOKEN" \
     --server-url "http://homelab:49374/mcp"
 
@@ -888,9 +919,9 @@ Cursor, Gemini CLI, Antigravity CLI, Grok Build CLI, and OpenClaw support both
 `$GROK_HOME/hooks` (default `~/.grok/hooks`). `install-hooks --agent grok`
 captures lifecycle events.
 Grok ignores `SessionStart` stdout, so handoffs must be accepted through MCP with
-`memory_handoff_accept` when resuming. Claude Desktop, VS Code Copilot, and Zed
-are MCP-only here, so you'll need to nudge the model to call `memory_query` /
-`memory_handoff_accept` itself.
+`memory_handoff_accept` when resuming. Claude Desktop, Kiro CLI, VS Code
+Copilot, and Zed are MCP-only here, so you'll need to nudge the model to call
+`memory_query` / `memory_handoff_accept` itself.
 For clients with `install-hooks` support, the capture path handles
 handoff injection at session start or the client's closest equivalent, except
 for Grok's (and Zero's) no-stdout SessionStart behavior (Antigravity CLI uses `PreInvocation`).

--- a/docs/mcp-install.md
+++ b/docs/mcp-install.md
@@ -38,8 +38,8 @@ ignore_paths`; legacy shell/PowerShell and remote-only/Docker script bundles do
 not. Reinstall/refresh an existing hook or plugin to gain it; see
 [Capture exclusions](marker-file.md#capture-exclusions).
 
-Claude Desktop, VS Code Copilot, and Zed are **MCP-only** here: they expose
-long-term memory to their LLMs via ai-memory's MCP tools
+Claude Desktop, Kiro CLI, VS Code Copilot, and Zed are **MCP-only** here: they
+expose long-term memory to their LLMs via ai-memory's MCP tools
 (`memory_query`, `memory_recent`, `memory_handoff_accept`, etc.), but
 they do not auto-capture session events into ai-memory's `/hook`
 endpoint. The trade-off:
@@ -120,7 +120,7 @@ metadata.
 > **One-shot tip:** every snippet below is also reachable from the
 > CLI:
 > ```bash
-> ai-memory install-mcp --client gemini-cli   # or cursor / claude-desktop / openclaw / omp / pi / antigravity-cli / grok / kimi-code / devin / zero / vscode-copilot / zed
+> ai-memory install-mcp --client gemini-cli   # or cursor / claude-desktop / openclaw / omp / pi / antigravity-cli / grok / kimi-code / kiro-cli / devin / zero / vscode-copilot / zed
 > ```
 
 ---
@@ -792,6 +792,57 @@ same pattern as Gemini CLI.
   same event. `PostToolUse` and `PostToolUseFailure` reuse one handler command,
   but are mutually exclusive event triggers, so successful and failed calls
   are both captured once.
+
+## Kiro CLI
+
+**Status:** MCP supported. Lifecycle hooks and managed workstreams are not yet
+supported.
+
+**Config file:** `$KIRO_HOME/settings/mcp.json`, defaulting to
+`~/.kiro/settings/mcp.json`. Use `--config-file .kiro/settings/mcp.json` when
+you intentionally want Kiro's lower-scope project configuration instead.
+
+```bash
+ai-memory install-mcp --client kiro-cli --apply \
+    --server-url "https://memory.example/mcp" --auth-token "$TOKEN"
+```
+
+The `kiro` alias is equivalent. The command preserves unrelated settings and
+servers, and merges this entry idempotently:
+
+```json
+{
+  "mcpServers": {
+    "ai-memory": {
+      "url": "https://memory.example/mcp?flavor=bedrock",
+      "headers": { "Authorization": "Bearer <token>" }
+    }
+  }
+}
+```
+
+Kiro sends MCP tool schemas through Amazon Bedrock, which rejects root-level
+`anyOf`, `oneOf`, and `allOf`. The installer appends `?flavor=bedrock`; the
+server strips only those root combinators for that request while preserving
+nested schemas and the handlers' runtime validation. Kimi Code's existing
+`?flavor=moonshot` behavior remains supported independently.
+
+Kiro permits remote MCP URLs over HTTPS. Plain HTTP is accepted only for
+`localhost`, `127.0.0.1`, or another loopback address; `install-mcp` rejects a
+non-loopback HTTP URL before writing the config. See
+[HTTPS via reverse proxy](https-via-proxy.md) for a homelab deployment.
+
+Kiro CLI v3 changes both its hook schema and its persisted session format from
+v2. Until each version has fixtures and an explicit compatibility contract,
+`install-hooks --agent kiro-cli` and `ai-memory run kiro` are intentionally not
+advertised or accepted. Follow
+[#355](https://github.com/akitaonrails/ai-memory/issues/355) for hooks and
+[#356](https://github.com/akitaonrails/ai-memory/issues/356) for managed
+workstreams.
+
+Sources: <https://kiro.dev/docs/cli/mcp/configuration/>,
+<https://kiro.dev/docs/cli/reference/settings/>,
+<https://kiro.dev/docs/cli/v3/>.
 
 ## OpenClaw
 


### PR DESCRIPTION
## Summary
- add `install-mcp --client kiro-cli` with the `kiro` alias, `$KIRO_HOME` path resolution, bearer headers, idempotent JSON merge, and uninstall support
- add a Bedrock schema flavor that removes only unsupported root-level JSON Schema combinators while preserving legacy Kimi behavior and runtime validation
- reject non-loopback plain-HTTP Kiro endpoints before config mutation and document the HTTPS requirement
- document Kiro as MCP-only and split version-specific hooks and managed sessions into #355 and #356

## Verification
- `TAILWIND_SKIP=1 cargo test -p ai-memory-cli -p ai-memory-mcp`
- `TAILWIND_SKIP=1 cargo clippy -p ai-memory-cli -p ai-memory-mcp --all-targets -- -D warnings`
- binary acceptance: render, apply, idempotent reapply, sibling preservation, uninstall, and remote-HTTP fail-closed behavior against a temporary `$KIRO_HOME`

Closes #351