### PR TITLE
release: v1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-08-03
+
 ### Changed
 - Documented provider-neutral coexistence with structural code-intelligence
   tools: use ai-memory for historical intent and continuity, use the current
@@ -2953,7 +2955,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidator used server startup default project instead of the
   session's actual project.
 
-[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.22.0...HEAD
+[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.23.0...HEAD
+[1.23.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.23.0
 [1.22.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.22.0
 [1.21.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.21.0
 [1.20.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.20.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-cli"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-consolidate"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-core"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "jiff",
  "regex",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-eval"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-hooks"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-llm"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-mcp"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-store"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-web"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-store",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-wiki"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-workstream"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.22.0"
+version = "1.23.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"
@@ -26,15 +26,15 @@ authors = ["Fabio Akita <boss@akitaonrails.com>"]
 
 [workspace.dependencies]
 # Inter-crate dependencies.
-ai-memory-core = { path = "crates/ai-memory-core", version = "1.22.0" }
-ai-memory-store = { path = "crates/ai-memory-store", version = "1.22.0" }
-ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.22.0" }
-ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.22.0" }
-ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.22.0" }
-ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.22.0" }
-ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.22.0" }
-ai-memory-web = { path = "crates/ai-memory-web", version = "1.22.0" }
-ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.22.0" }
+ai-memory-core = { path = "crates/ai-memory-core", version = "1.23.0" }
+ai-memory-store = { path = "crates/ai-memory-store", version = "1.23.0" }
+ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.23.0" }
+ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.23.0" }
+ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.23.0" }
+ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.23.0" }
+ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.23.0" }
+ai-memory-web = { path = "crates/ai-memory-web", version = "1.23.0" }
+ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.23.0" }
 
 # (Workspace shared deps follow below)
 


### PR DESCRIPTION
## Summary

- publish the additive `ai-memory continue` launcher, Kiro MCP-only client support, Antigravity native-hook allow fix, session-by-agent admin reporting, and provider-neutral code-intelligence guidance as v1.23.0
- bump the workspace and internal crate versions to 1.23.0
- date the release changelog and update comparison links

## Verification

- combined post-audit of `e714d992993b5ee76a76e09e64ac5cb441e14aed..a319339dd5fe04282de300ecb86e0ed7584249a9` found no blocking regression or substantiated security finding
- all six merged PRs preserved exact contributor provenance; PR #359 corrected two release-gate documentation defects found by the combined audit
- the exact runtime tree passed the full local workspace, clippy, dependency, importer, hook, packaging, handoff, hosted platform, Docker, CodeQL, and secret gates
- the exact audited runtime tree was deployed and live-tested against the authenticated homeserver before this release PR
- live checks covered MCP authentication, 17-tool discovery, Kiro/Bedrock and Kimi/Moonshot schema flavors, session-by-agent reporting, unknown-scope fail-closed behavior, Kiro install/idempotence/uninstall/refusal, and Antigravity fail-open output
- `cargo fmt --all -- --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo check --workspace --locked`
- `TAILWIND_SKIP=1 cargo run --locked -p ai-memory-cli -- --version` reports `ai-memory 1.23.0`
- every local workspace package reports version 1.23.0
- exact release-commit gitleaks scan found no leaks

The release commit changes only `Cargo.toml`, `Cargo.lock`, and `CHANGELOG.md`. Runtime tests are reused from the byte-identical audited main tree; this PR exact head runs the complete hosted matrix before merge.