### PR TITLE
fix(workstream): fail closed on unresolved checkout paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   capture remains unsupported until its command-input payload is documented
   and can be fixture-tested (#355).
 
+### Fixed
+- Native-session checkout matching now fails closed when either path cannot be
+  canonicalized, instead of treating two missing or inaccessible paths as the
+  same checkout during managed resume or adoption (#356).
+
 ## [1.23.0] - 2026-08-03
 
 ### Changed

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -39,6 +39,15 @@ fn shell_script_command(script: &Path) -> Command {
 }
 
 #[cfg(unix)]
+// Preserve the script path as `$0` without directly execing a just-written file,
+// which can transiently return ETXTBSY under parallel Linux test load.
+fn freshly_written_shell_script_command(script: &Path) -> Command {
+    let mut command = Command::new("bash");
+    command.arg(script);
+    command
+}
+
+#[cfg(unix)]
 fn shell_path(path: &Path) -> String {
     path.display().to_string()
 }
@@ -513,7 +522,7 @@ fn wrapper_self_upgrade_rejects_a_checksum_mismatch() {
         shell_path(&bin_dir),
         std::env::var("PATH").unwrap_or_default()
     );
-    let output = shell_script_command(&wrapper)
+    let output = freshly_written_shell_script_command(&wrapper)
         .arg("upgrade")
         .env("PATH", path)
         .env("HOME", tmp.path())
@@ -581,7 +590,7 @@ fn wrapper_self_upgrade_installs_and_runs_a_verified_payload() {
         shell_path(&bin_dir),
         std::env::var("PATH").unwrap_or_default()
     );
-    let output = shell_script_command(&wrapper)
+    let output = freshly_written_shell_script_command(&wrapper)
         .arg("upgrade")
         .env("PATH", path)
         .env("HOME", tmp.path())

--- a/crates/ai-memory-workstream/src/transcript.rs
+++ b/crates/ai-memory-workstream/src/transcript.rs
@@ -2418,7 +2418,10 @@ fn valid_native_session_id(value: &str) -> bool {
 }
 
 fn same_path(left: &Path, right: &Path) -> bool {
-    left.canonicalize().ok() == right.canonicalize().ok()
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
 }
 
 fn deduplicate_losses(losses: Vec<String>) -> Vec<String> {
@@ -2434,6 +2437,20 @@ fn deduplicate_losses(losses: Vec<String>) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn checkout_path_comparison_fails_closed_when_canonicalization_fails() {
+        let temp = tempfile::tempdir().unwrap();
+        let existing = temp.path().join("existing");
+        fs::create_dir(&existing).unwrap();
+
+        assert!(same_path(&existing, &existing));
+        assert!(!same_path(&existing, &temp.path().join("missing")));
+        assert!(!same_path(
+            &temp.path().join("missing-left"),
+            &temp.path().join("missing-right")
+        ));
+    }
 
     #[tokio::test]
     async fn jsonl_candidate_discovery_covers_every_file_adapter_and_checkout_scope() {
@@ -2664,20 +2681,22 @@ mod tests {
     #[test]
     fn omp_adapter_reads_complete_atomic_write_temp_transcript() {
         let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path().join("repo");
+        fs::create_dir(&cwd).unwrap();
         let session = "019f80c5-0148-7000-82d5-9a3c4c9b9be3";
         let path = temp
             .path()
             .join(format!(".session_{session}.jsonl.nonce.tmp"));
         std::fs::write(
             &path,
-            format!("{{\"type\":\"session\",\"id\":\"{session}\",\"cwd\":\"/repo\"}}\n"),
+            format!("{}\n", json!({"type":"session","id":session,"cwd":cwd})),
         )
         .unwrap();
 
         let found = locate_session_file(
             ManagedHarness::Omp,
             temp.path(),
-            Path::new("/repo"),
+            &cwd,
             Some(temp.path()),
             session,
         )

--- a/docs/mcp-install.md
+++ b/docs/mcp-install.md
@@ -795,8 +795,10 @@ same pattern as Gemini CLI.
 
 ## Kiro CLI
 
-**Status:** MCP and v2 lifecycle hooks supported. Managed workstreams are
-tracked separately.
+**Status:** MCP, v2 lifecycle hooks, and explicit v2 managed workstreams are
+supported. Bare automatic workstream selection remains unsupported pending a
+logged-in current-format v2 acceptance run. V3 hooks and managed sessions need
+their own documented, fixture-tested payload and store contracts.
 
 **Config file:** `$KIRO_HOME/settings/mcp.json`, defaulting to
 `~/.kiro/settings/mcp.json`. Use `--config-file .kiro/settings/mcp.json` when
@@ -850,8 +852,11 @@ agents, so `--config-file` is required when the active definition lives under
 through `agentSpawn` stdout, and honors `$KIRO_HOME`. Kiro v3 hook capture is
 not installed because its registration migration guide does not document the
 command-input payload needed to validate capture and exclusion behavior. Follow
-[#356](https://github.com/akitaonrails/ai-memory/issues/356) for managed
-workstreams.
+[#355](https://github.com/akitaonrails/ai-memory/issues/355) for v3 hook support
+and [#356](https://github.com/akitaonrails/ai-memory/issues/356) for automatic
+selection and broader version-aware managed support. Explicit
+`ai-memory run kiro` (alias `kiro-cli`) manages the default v2 engine;
+non-v2 engine selections pass through without session injection or import.
 
 Sources: <https://kiro.dev/docs/cli/mcp/configuration/>,
 <https://kiro.dev/docs/cli/reference/settings/>,


### PR DESCRIPTION
## Post-audit scope

Follow-up to the combined release audit of #361 and #362.

- Makes native checkout matching fail closed when either path cannot be canonicalized. The prior `canonicalize().ok() == canonicalize().ok()` expression treated two failures as equal and could make a missing or inaccessible recorded checkout look like the current checkout.
- Adds a regression test with valid, one-missing, and two-missing controls.
- Corrects the OMP atomic-write fixture so it uses a real checkout instead of depending on the old fail-open behavior.
- Updates the Kiro MCP/install reference to describe explicit v2 managed support and assigns remaining v3 hook work to #355 and automatic/version-aware managed work to #356.
- Removes a repeated Linux `ETXTBSY` packaging-test race by invoking freshly written wrapper fixtures through `bash <path>`, preserving the wrapper path as `$0` and therefore preserving the self-upgrade target.

No dependencies, lockfiles, migrations, workflows, production wrapper code, auth, network, or release tooling changed.

## Verification

Final candidate `cbcc188`:

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- `cargo deny check`
- all 79 `ai-memory-workstream` tests
- packaging integration suite passed 5/5 parallel stress runs

Issues #355 and #356 intentionally remain open for their documented unsupported scope.