### PR TITLE
fix(core): isolate slot paths across filesystem semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and can be fixture-tested (#355).
 
 ### Fixed
+- Mixed-case and trailing-period usernames now use deterministic hashed
+  per-operator slot namespaces, preventing distinct identities from sharing one
+  physical directory on case-insensitive filesystems (#364).
 - Native-session checkout matching now fails closed when either path cannot be
   canonicalized, instead of treating two missing or inaccessible paths as the
   same checkout during managed resume or adoption (#356).

--- a/crates/ai-memory-cli/src/config.rs
+++ b/crates/ai-memory-cli/src/config.rs
@@ -672,9 +672,10 @@ pub struct SlotSettings {
     /// Namespace engine-written slots under the operator that produced them
     /// (`_slots/u-alice/current-focus.md` instead of
     /// `_slots/current-focus.md`). The segment is the operator's
-    /// `IdentityKey::path_segment()` — `u-<name>` for safe usernames and a
-    /// bounded deterministic identifier for path-hostile usernames or complete
-    /// OIDC issuer/subject pairs — never a raw OIDC value.
+    /// `IdentityKey::path_segment()` — `u-<name>` for lowercase safe usernames
+    /// and a bounded deterministic identifier for mixed-case, Windows-unsafe,
+    /// or otherwise path-hostile usernames and complete OIDC issuer/subject
+    /// pairs — never a raw OIDC value.
     ///
     /// Off by default, so nothing changes for an existing install: with the
     /// flag off a nested slot path carries no ownership meaning at all, and

--- a/crates/ai-memory-core/src/actor.rs
+++ b/crates/ai-memory-core/src/actor.rs
@@ -370,20 +370,21 @@ impl IdentityKey {
 
     /// A bounded, filesystem-safe namespace component for operator-owned data.
     ///
-    /// Readable usernames are retained when they are short and contain only
-    /// path/GLOB-safe ASCII. All other usernames, and every OIDC identity, use
-    /// a deterministic UUIDv5 derived from the fully qualified storage key.
-    /// This keeps the OIDC issuer in the identity while avoiding filesystem
-    /// component limits for long or path-hostile values.
+    /// Readable usernames are retained when they are short, contain only
+    /// lowercase path/GLOB-safe ASCII, and do not end in a period. Mixed-case
+    /// and all other usernames, plus every OIDC identity, use a deterministic
+    /// UUIDv5 derived from the fully qualified storage key. This avoids
+    /// platform pathname equivalences between distinct identities.
     #[must_use]
     pub fn path_segment(&self) -> String {
         match self {
             Self::User(user)
                 if user.len() <= 64
                     && !user.is_empty()
-                    && user
-                        .bytes()
-                        .all(|byte| byte.is_ascii_alphanumeric() || b"._-".contains(&byte)) =>
+                    && !user.ends_with('.')
+                    && user.bytes().all(|byte| {
+                        byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"._-".contains(&byte)
+                    }) =>
             {
                 format!("u-{user}")
             }
@@ -712,6 +713,35 @@ mod tests {
             );
             assert_eq!(segment, identity.path_segment());
         }
+    }
+
+    #[test]
+    fn username_path_segments_remain_distinct_under_ascii_case_folding() {
+        let lowercase = IdentityKey::User("alice".into()).path_segment();
+        let titlecase = IdentityKey::User("Alice".into()).path_segment();
+        let uppercase = IdentityKey::User("ALICE".into()).path_segment();
+        let trailing_dot = IdentityKey::User("alice.".into()).path_segment();
+
+        assert_eq!(lowercase, "u-alice");
+        assert!(titlecase.starts_with("uh-"), "{titlecase}");
+        assert!(uppercase.starts_with("uh-"), "{uppercase}");
+        assert!(trailing_dot.starts_with("uh-"), "{trailing_dot}");
+        assert_ne!(
+            lowercase.to_ascii_lowercase(),
+            titlecase.to_ascii_lowercase()
+        );
+        assert_ne!(
+            lowercase.to_ascii_lowercase(),
+            uppercase.to_ascii_lowercase()
+        );
+        assert_ne!(
+            titlecase.to_ascii_lowercase(),
+            uppercase.to_ascii_lowercase()
+        );
+        assert_ne!(
+            lowercase.to_ascii_lowercase(),
+            trailing_dot.trim_end_matches('.').to_ascii_lowercase()
+        );
     }
 
     #[test]

--- a/docs/users.md
+++ b/docs/users.md
@@ -179,11 +179,11 @@ The "absent means shared" rule extends to memory slots, so a single-operator
 server behaves exactly as it always has. `_slots/current-focus.md` is injected
 into every operator's context; `_slots/<segment>/current-focus.md` is injected
 only into the operator whose `path_segment()` is `<segment>` (`u-alice`,
-`uh-<uuid>` for a path-hostile username, or `o-<uuid>` for a complete OIDC
-issuer/subject pair). What the feature scopes is injection, not access: a slot
-is an ordinary wiki page, so exact reads and searches remain project-wide like
-every other page. Every slot written before this is unnamespaced, therefore
-shared.
+`uh-<uuid>` for a mixed-case, trailing-period, or otherwise path-hostile
+username, or `o-<uuid>` for a complete OIDC issuer/subject pair). What the
+feature scopes is injection, not access: a slot is an ordinary wiki page, so
+exact reads and searches remain project-wide like every other page. Every slot
+written before this is unnamespaced, therefore shared.
 
 `[slots] per_user` (default off) is the switch for the whole regime. With it
 ON:
@@ -205,9 +205,13 @@ With it OFF a nested slot path means nothing in particular — every slot goes
 into every brief, exactly as before the feature existed — so turning it back
 off makes personal slots visible to everyone again rather than stranding them.
 
-The `<segment>` is derived from the qualified identity on this server: a safe
-username stays readable, while a path-hostile username or complete OIDC
-issuer/subject pair becomes a bounded deterministic identifier. The OIDC pair
+The `<segment>` is derived from the qualified identity on this server: a short,
+lowercase, path-safe ASCII username stays readable, while a mixed-case,
+trailing-period, or otherwise path-hostile username or complete OIDC
+issuer/subject pair becomes a bounded deterministic identifier. Restricting
+readable segments to lowercase without trailing periods prevents distinct
+identities from producing pathnames that compare alike on supported
+case-insensitive filesystems. The OIDC pair
 outranks the username; see "Identity keys" above. Every named operator owns a
 working namespace, and long or path-hostile values never fall back onto the
 shared slot. One consequence of qualified segments is worth stating: a nested
@@ -215,6 +219,16 @@ path written before the feature
 (`_slots/backend/…`) spells a segment no qualified identity can produce, so
 with the flag ON it belongs to nobody and reaches no brief until the flag is
 turned back off or an admin re-homes it.
+
+Before the case-insensitive namespace fix, a mixed-case username such as
+`Alice` used the readable segment `u-Alice`, and a username ending in a period
+kept that period; both now use deterministic `uh-<uuid>` segments. ai-memory
+cannot safely move the old directory automatically because a case-insensitive
+filesystem may already have combined it with another identity. Administrators
+upgrading a shared deployment with `[slots] per_user = true` must inspect any
+affected `u-…` slot directories and re-home confirmed content into the owning
+operator's new namespace. Preserve the old pages until ownership is
+established; do not infer it from filename casing alone.
 
 One gap is deliberate and documented rather than closed: `ai-memory bootstrap`
 writes pages at paths the model picks from the repository's own README, docs


### PR DESCRIPTION
## Summary

- keep readable per-operator slot segments only for lowercase, path-safe usernames
- route mixed-case and trailing-period usernames through the existing deterministic UUIDv5 namespace
- document the manual inspection/re-home requirement for affected existing slot directories

## Why

Database ownership keys preserve username case, while supported case-insensitive filesystems do not necessarily preserve that distinction in physical path lookup. Windows also treats trailing periods specially. This could make distinct operator identities share one slot directory.

Automatic migration is intentionally omitted: an old directory may already contain content from more than one identity, so filename casing is not sufficient evidence of ownership.

## Verification

- `TAILWIND_SKIP=1 cargo test -p ai-memory-core`
- `cargo fmt --all -- --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- `cargo deny check`
- security surface and changed-boundary review

Closes #364
