### PR TITLE
release: v1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.24.0] - 2026-08-04
+
 ### Added
 - MCP-only clients are now visible in the operator's traffic picture.
   Every MCP tool call is counted against its caller — the sanitized
@@ -3019,7 +3021,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidator used server startup default project instead of the
   session's actual project.
 
-[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.23.0...HEAD
+[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.24.0...HEAD
+[1.24.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.24.0
 [1.23.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.23.0
 [1.22.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.22.0
 [1.21.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.21.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-cli"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-consolidate"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-core"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "jiff",
  "regex",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-eval"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-hooks"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-llm"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-mcp"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "ai-memory-consolidate",
  "ai-memory-core",
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-store"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-web"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-store",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-wiki"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "ai-memory-core",
  "ai-memory-llm",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory-workstream"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "ai-memory-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.23.0"
+version = "1.24.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"
@@ -26,15 +26,15 @@ authors = ["Fabio Akita <boss@akitaonrails.com>"]
 
 [workspace.dependencies]
 # Inter-crate dependencies.
-ai-memory-core = { path = "crates/ai-memory-core", version = "1.23.0" }
-ai-memory-store = { path = "crates/ai-memory-store", version = "1.23.0" }
-ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.23.0" }
-ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.23.0" }
-ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.23.0" }
-ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.23.0" }
-ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.23.0" }
-ai-memory-web = { path = "crates/ai-memory-web", version = "1.23.0" }
-ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.23.0" }
+ai-memory-core = { path = "crates/ai-memory-core", version = "1.24.0" }
+ai-memory-store = { path = "crates/ai-memory-store", version = "1.24.0" }
+ai-memory-wiki = { path = "crates/ai-memory-wiki", version = "1.24.0" }
+ai-memory-mcp = { path = "crates/ai-memory-mcp", version = "1.24.0" }
+ai-memory-hooks = { path = "crates/ai-memory-hooks", version = "1.24.0" }
+ai-memory-llm = { path = "crates/ai-memory-llm", version = "1.24.0" }
+ai-memory-consolidate = { path = "crates/ai-memory-consolidate", version = "1.24.0" }
+ai-memory-web = { path = "crates/ai-memory-web", version = "1.24.0" }
+ai-memory-workstream = { path = "crates/ai-memory-workstream", version = "1.24.0" }
 
 # (Workspace shared deps follow below)
 


### PR DESCRIPTION
## Summary

- publish Kiro CLI v2 lifecycle-hook and managed-workstream support, MCP client activity reporting, prompt-budget controls with zero-LLM fallback, safer native-session matching, and case-insensitive slot isolation as v1.24.0
- bump the workspace and internal crate versions to 1.24.0
- date the release changelog and update comparison links

## Verification

- combined post-audit of `v1.23.0..aad60cbe1c53badecb053f51428f15012de9f367` found no blocking regression or substantiated security finding
- all audited contributor commits retained provenance, and the final Kiro documentation correction avoided incorrectly closing the two intentionally deferred Kiro v3 research issues
- the exact runtime tree passed the full local workspace, clippy, dependency-policy, companion-importer, hosted platform, Docker, CodeQL, secret, and security gates
- the exact audited runtime tree was deployed and live-tested against the authenticated homeserver before this release PR
- live checks covered server health and migration, MCP auth and 17-tool discovery, Bedrock/Moonshot schema flavors, client-activity authorization and delayed flushing, database/index consistency, and a real configured-provider LLM call
- the exact release candidate passed `cargo fmt --all -- --check`, `git diff --check`, `TAILWIND_SKIP=1 cargo test --workspace`, `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`, and `cargo deny check`
- `TAILWIND_SKIP=1 cargo run --quiet --locked -p ai-memory-cli -- --version` reports `ai-memory 1.24.0`
- every local workspace package reports version 1.24.0

This release commit changes only `Cargo.toml`, `Cargo.lock`, and `CHANGELOG.md`. Runtime evidence is reused from the byte-identical audited main tree; this PR exact head runs the complete hosted matrix before merge.