### PR TITLE
fix(opencode): capture user prompts from message.updated bus events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1155,6 +1155,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of being indistinguishable from "no pending handoff" — exit code
   stays 0, hooks never break the agent. Malformed-payload/BOM diagnostics are
   tracked separately in [#197] ([#188]).
+- The generated OpenCode plugin now captures user prompts from current
+  `message.updated` bus events as well as the legacy `chat.message` hook, and
+  deduplicates by message id. This keeps automatic SessionEnd handoffs from
+  degrading into generic "N observations recorded" summaries when newer
+  OpenCode versions stop delivering prompt text through `chat.message` output.
 - `install-mcp --server-url` now appends the `/mcp` path when given a base
   URL (the same value `install-hooks --server-url` takes), instead of
   rendering a client config that points at the server root and 404s. The

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -2551,10 +2551,16 @@ function textFromParts(parts: unknown): string {{
     .trim();
 }}
 
+function textFromMessage(value: unknown): string {{
+  const message = value as any;
+  return textFromParts(message?.parts ?? message?.message?.parts ?? message?.info?.parts ?? message?.message?.info?.parts);
+}}
+
 const sessionCwds = new Map<string, string>();
 const startedSessions = new Set<string>();
 const handoffFetches = new Map<string, Promise<string | undefined>>();
 const preCompactLast = new Map<string, number>();
+const postedUserMessages = new Set<string>();
 
 function cwdFor(id: string | undefined, directory: string): string {{
   return (id && sessionCwds.get(id)) || directory;
@@ -2583,6 +2589,25 @@ function endSession(id: string | undefined, directory: string, cwd?: string): vo
   sessionCwds.delete(id);
   handoffFetches.delete(id);
   preCompactLast.delete(id);
+  for (const key of Array.from(postedUserMessages)) {{
+    if (key.startsWith(`${{id}}:`)) postedUserMessages.delete(key);
+  }}
+}}
+
+function postUserPrompt(id: string | undefined, cwd: string, messageID: unknown, prompt: string, extra: Record<string, unknown> = {{}}): void {{
+  if (!prompt) return;
+  const key = typeof messageID === "string" && id ? `${{id}}:${{messageID}}` : undefined;
+  if (key) {{
+    if (postedUserMessages.has(key)) return;
+    postedUserMessages.add(key);
+  }}
+  postHook("user-prompt", {{
+    sessionID: id,
+    cwd,
+    messageID,
+    prompt,
+    ...extra,
+  }});
 }}
 
 function postPreCompact(id: string | undefined, directory: string): void {{
@@ -2661,18 +2686,23 @@ export const AiMemoryHooks: Plugin = async ({{ directory }}) => {{
         const id = properties.sessionID;
         postPreCompact(id, directory);
       }}
+      if (event?.type === "message.updated") {{
+        const info = properties.info ?? {{}};
+        if (info.role === "user") {{
+          const id = properties.sessionID ?? info.sessionID ?? info.metadata?.sessionID;
+          const cwd = cwdFor(id, directory);
+          startSession(id, cwd);
+          postUserPrompt(id, cwd, info.id, textFromMessage(info));
+        }}
+      }}
     }},
     "chat.message": async (input, output) => {{
       const id = sessionID(input);
       const cwd = cwdFor(id, directory);
       startSession(id, cwd, {{ agent: (input as any).agent, model: (input as any).model }});
-      postHook("user-prompt", {{
-        sessionID: id,
-        cwd,
+      postUserPrompt(id, cwd, (input as any).messageID, textFromMessage(input) || textFromMessage(output), {{
         agent: (input as any).agent,
         model: (input as any).model,
-        messageID: (input as any).messageID,
-        prompt: textFromParts((output as any).parts),
       }});
     }},
     "tool.execute.before": async (input, output) => {{
@@ -5450,6 +5480,8 @@ model = "gpt-5"
         assert!(!plugin.contains("handoffChecked"));
         assert!(plugin.contains("function startSession"));
         assert!(plugin.contains("function endSession"));
+        assert!(plugin.contains("function textFromMessage"));
+        assert!(plugin.contains("function postUserPrompt"));
         assert!(plugin.contains("fetchHandoff"));
         assert!(plugin.contains("function applyMarkerParams"));
         assert!(plugin.contains("readFileSync(marker, \"utf8\")"));
@@ -5487,6 +5519,11 @@ model = "gpt-5"
         assert!(plugin.contains("sessionCwds.delete(id);"));
         assert!(plugin.contains("handoffFetches.delete(id);"));
         assert!(plugin.contains("preCompactLast.delete(id);"));
+        assert!(plugin.contains("const postedUserMessages = new Set<string>();"));
+        assert!(plugin.contains("postedUserMessages.delete(key);"));
+        assert!(plugin.contains(r#"event?.type === "message.updated""#));
+        assert!(plugin.contains("info.role === \"user\""));
+        assert!(plugin.contains("postUserPrompt(id, cwd, info.id, textFromMessage(info));"));
         assert!(plugin.contains("postHook(\"user-prompt\""));
         assert!(plugin.contains("Bearer ${TOKEN}"));
         assert!(plugin.contains("tok"));
@@ -5517,7 +5554,9 @@ model = "gpt-5"
         assert!(plugin.contains("const TOKEN: string | null = null;"));
         assert!(plugin.contains("sessionID: id,"));
         assert!(plugin.contains("cwd,"));
-        assert!(plugin.contains("prompt: textFromParts"));
+        assert!(plugin.contains("prompt,"));
+        assert!(plugin.contains("textFromMessage(input) || textFromMessage(output)"));
+        assert!(plugin.contains("message?.parts ?? message?.message?.parts"));
         assert!(plugin.contains("output: (output as any).output"));
         assert!(plugin.contains("if (typeof AbortSignal === \"undefined\")"));
         assert!(


### PR DESCRIPTION
## Problem
OpenCode now emits assistant/user message updates through `message.updated` (and `message.part.updated`) bus events. The `chat.message` hook the generated OpenCode plugin relied on for prompt text stops reliably delivering it on current OpenCode versions - the sibling claude-mem plugin hit the same API drift (thedotmack/claude-mem#2986). Without prompt text, automatic SessionEnd handoffs degrade into generic "N observations recorded" summaries instead of a real "where you left off" narrative.

## Changes
- The generated OpenCode plugin now also listens for `message.updated` events with `role: "user"` and posts a `user-prompt` hook from the parsed message parts, alongside the existing `chat.message` capture.
- Both paths go through a new `postUserPrompt()` helper that dedupes by (sessionID, messageID) so a prompt delivered through both events never double-posts. The dedup set is cleared on session end.
- `textFromMessage()` extracts parts from the different shapes OpenCode's message/info payloads can take (message.parts, message.info.parts, etc.), since the bus event and the chat.message hook do not share one schema.
- CHANGELOG entry under [Unreleased] / Fixed.

## Testing
- Added/updated unit assertions in crates/ai-memory-cli/src/commands/install_hooks.rs covering textFromMessage, postUserPrompt, the message.updated listener, and the dedup set lifecycle.
- Local gates: cargo fmt --all -- --check passed, cargo clippy --workspace --all-targets -- -D warnings passed, cargo test --workspace passed (all green), cargo deny check passed (advisories/bans/licenses/sources ok).