### PR TITLE
fix(anthropic): omit temperature on models that deprecated it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,18 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   session starts, user prompts, and pre-tool events now advance shared or
   identity-only fallbacks; other events refresh exact session mappings, and
   dropped-subagent preflight no longer publishes scope (#372).
-- The Anthropic provider no longer sends `temperature` to models that
-  rejected it. Claude 5 (Opus / Sonnet / Fable) and Opus 4.7+ answer any
-  request carrying a sampling parameter with a 400 reporting `temperature`
-  as deprecated for that model, which the server surfaced as a 502 — so
-  `bootstrap`, consolidation, `lint`, and the auto-improvement loop all
-  failed on those models, since every structured call site sets 0.1-0.2.
-  The field is now omitted for the affected models (the API applies its own
-  default) and forwarded unchanged everywhere else, mirroring the existing
-  gpt-5 / o-series handling in the OpenAI provider. Affects both
-  `anthropic` and `anthropic-oauth`. Note that `llm-test` sends no
-  `temperature`, so it reported these models as healthy while every real
-  pipeline call failed ([#377]).
+- The Anthropic provider stopped sending `temperature` to Claude 4.7 and later
+  models, including the Claude 5 families, and to Claude Mythos Preview. Those
+  models reject non-default sampling parameters, which made `bootstrap`,
+  consolidation, `lint`, and auto-improvement fail with an upstream 400. Both
+  `anthropic` and `anthropic-oauth` now omit the field for affected models and
+  preserve it elsewhere. `llm-test` also sends a representative 0.2 value
+  before provider normalization, so it exercises the same compatibility path
+  as the real pipeline (#377).
 - Both wrappers (`bin/ai-memory` and `bin/ai-memory.ps1`) now forward
   `ANTHROPIC_OAUTH_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN` to the helper
   container. Their API-key counterparts were already in the passthrough list,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   session starts, user prompts, and pre-tool events now advance shared or
   identity-only fallbacks; other events refresh exact session mappings, and
   dropped-subagent preflight no longer publishes scope (#372).
+- The Anthropic provider no longer sends `temperature` to models that
+  rejected it. Claude 5 (Opus / Sonnet / Fable) and Opus 4.7+ answer any
+  request carrying a sampling parameter with a 400 reporting `temperature`
+  as deprecated for that model, which the server surfaced as a 502 — so
+  `bootstrap`, consolidation, `lint`, and the auto-improvement loop all
+  failed on those models, since every structured call site sets 0.1-0.2.
+  The field is now omitted for the affected models (the API applies its own
+  default) and forwarded unchanged everywhere else, mirroring the existing
+  gpt-5 / o-series handling in the OpenAI provider. Affects both
+  `anthropic` and `anthropic-oauth`. Note that `llm-test` sends no
+  `temperature`, so it reported these models as healthy while every real
+  pipeline call failed ([#377]).
 
 ## [1.24.0] - 2026-08-04
 

--- a/README.md
+++ b/README.md
@@ -884,6 +884,13 @@ setup-token` writes automatically). No `ANTHROPIC_API_KEY` is needed. The Docker
 wrappers forward either token by name to short-lived helper commands such as
 `llm-test`; configure the long-lived server container separately as shown in the
 installation guide.
+
+For both Anthropic providers, ai-memory omits `temperature` for Claude
+4.7 and later models and Claude Mythos Preview because those models reject
+non-default sampling parameters. `llm-test` sends the same representative 0.2
+value as the normal pipeline before the provider applies that compatibility
+rule.
+
 **⚠️ Unofficial and against Anthropic's usage policies — use at your own risk;
 it may get your account rate-limited or banned. See
 [the warning in `docs/install.md`](docs/install.md#anthropic-via-claude-subscription-oauth).**

--- a/crates/ai-memory-cli/src/commands/llm_test.rs
+++ b/crates/ai-memory-cli/src/commands/llm_test.rs
@@ -32,7 +32,7 @@ pub async fn run(config: &Config, args: LlmTestArgs) -> Result<()> {
         "sending prompt",
     );
     let resp = client
-        .complete(ChatRequest::user_prompt(args.prompt))
+        .complete(representative_request(args.prompt))
         .await
         .context("calling provider")?;
 
@@ -45,6 +45,14 @@ pub async fn run(config: &Config, args: LlmTestArgs) -> Result<()> {
     }
     println!("{}", resp.text);
     Ok(())
+}
+
+/// Use the same sampling value as bootstrap and consolidation so this smoke
+/// test exercises provider-specific request normalization.
+fn representative_request(prompt: String) -> ChatRequest {
+    let mut request = ChatRequest::user_prompt(prompt);
+    request.temperature = Some(0.2);
+    request
 }
 
 impl From<LlmProviderChoice> for ProviderChoice {
@@ -72,5 +80,13 @@ mod tests {
             ProviderChoice::from(LlmProviderChoice::AnthropicOauth),
             ProviderChoice::AnthropicOAuth
         );
+    }
+
+    #[test]
+    fn llm_test_exercises_pipeline_sampling_compatibility() {
+        let request = representative_request("diagnostic".into());
+
+        assert_eq!(request.temperature, Some(0.2));
+        assert_eq!(request.messages[0].content, "diagnostic");
     }
 }

--- a/crates/ai-memory-llm/src/anthropic.rs
+++ b/crates/ai-memory-llm/src/anthropic.rs
@@ -163,26 +163,7 @@ impl LlmProvider for AnthropicProvider {
     }
 
     async fn complete(&self, request: ChatRequest) -> LlmResult<ChatResponse> {
-        let messages: Vec<AnthropicMsg<'_>> = request
-            .messages
-            .iter()
-            .map(|m| AnthropicMsg {
-                role: match m.role {
-                    Role::User => "user",
-                    Role::Assistant => "assistant",
-                },
-                content: &m.content,
-            })
-            .collect();
-        let body = AnthropicRequest {
-            model: &self.model,
-            max_tokens: request.max_tokens,
-            system: request.system.as_deref(),
-            messages,
-            temperature: request.temperature,
-            tools: None,
-            tool_choice: None,
-        };
+        let body = self.build_request(&request, None);
         let response: AnthropicResponse = self.post(&body).await?;
         let text = response
             .content
@@ -208,33 +189,7 @@ impl LlmProvider for AnthropicProvider {
         request: ChatRequest,
         schema: serde_json::Value,
     ) -> LlmResult<serde_json::Value> {
-        let tool = AnthropicTool {
-            name: "result".into(),
-            description: "Emit the structured result.".into(),
-            input_schema: schema,
-        };
-        let messages: Vec<AnthropicMsg<'_>> = request
-            .messages
-            .iter()
-            .map(|m| AnthropicMsg {
-                role: match m.role {
-                    Role::User => "user",
-                    Role::Assistant => "assistant",
-                },
-                content: &m.content,
-            })
-            .collect();
-        let body = AnthropicRequest {
-            model: &self.model,
-            max_tokens: request.max_tokens,
-            system: request.system.as_deref(),
-            messages,
-            temperature: request.temperature,
-            tools: Some(vec![tool]),
-            tool_choice: Some(AnthropicToolChoice::Tool {
-                name: "result".into(),
-            }),
-        };
+        let body = self.build_request(&request, Some(schema));
         let response: AnthropicResponse = self.post(&body).await?;
         for c in response.content {
             if let AnthropicContent::ToolUse { input, .. } = c {
@@ -248,6 +203,57 @@ impl LlmProvider for AnthropicProvider {
 }
 
 impl AnthropicProvider {
+    /// Build the `/v1/messages` body shared by `complete` and
+    /// `complete_structured_raw`. Passing a schema turns the call into the
+    /// forced-tool structured-output shape. Both paths go through here so the
+    /// temperature rule below can't apply to one and silently miss the other.
+    fn build_request<'a>(
+        &'a self,
+        request: &'a ChatRequest,
+        schema: Option<serde_json::Value>,
+    ) -> AnthropicRequest<'a> {
+        let messages: Vec<AnthropicMsg<'a>> = request
+            .messages
+            .iter()
+            .map(|m| AnthropicMsg {
+                role: match m.role {
+                    Role::User => "user",
+                    Role::Assistant => "assistant",
+                },
+                content: &m.content,
+            })
+            .collect();
+        let (tools, tool_choice) = match schema {
+            Some(input_schema) => (
+                Some(vec![AnthropicTool {
+                    name: "result".into(),
+                    description: "Emit the structured result.".into(),
+                    input_schema,
+                }]),
+                Some(AnthropicToolChoice::Tool {
+                    name: "result".into(),
+                }),
+            ),
+            None => (None, None),
+        };
+        // Newer models reject any caller-supplied `temperature` with a 400;
+        // omit the field so the API applies its own default.
+        let temperature = if model_rejects_temperature(&self.model) {
+            None
+        } else {
+            request.temperature
+        };
+        AnthropicRequest {
+            model: &self.model,
+            max_tokens: request.max_tokens,
+            system: request.system.as_deref(),
+            messages,
+            temperature,
+            tools,
+            tool_choice,
+        }
+    }
+
     async fn post<B: Serialize, R: DeserializeOwned>(&self, body: &B) -> LlmResult<R> {
         let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
         debug!(url, "POST anthropic");
@@ -289,9 +295,64 @@ impl AnthropicProvider {
     }
 }
 
+/// Models that reject any caller-supplied `temperature`.
+///
+/// Anthropic deprecated sampling parameters on the newer models: sending
+/// `temperature` to Claude 5 (Opus / Sonnet / Fable) or to Opus 4.7+ returns a
+/// 400 with `` `temperature` is deprecated for this model. `` Every structured
+/// call site — bootstrap, consolidation, lint, auto-improve — passes 0.1-0.2,
+/// so without this the whole LLM pipeline is unusable on those models while
+/// `llm-test` (which sends no temperature) still reports the model as healthy.
+/// Omitting the field lets the API apply its own default, the same escape
+/// hatch `openai.rs::model_requires_default_temperature` uses for gpt-5 /
+/// o-series.
+///
+/// Anything we can't parse as a modern `claude-<family>-<major>[-<minor>]` id
+/// keeps the caller's value: the legacy `claude-3-5-sonnet-…` ordering and the
+/// whole Claude 4.0-4.6 line still accept sampling parameters, and a gateway
+/// proxying a non-Claude model behind this wire format must not be silently
+/// stripped either.
+fn model_rejects_temperature(model: &str) -> bool {
+    match claude_family_version(model) {
+        Some((major, minor)) => major >= 5 || (major == 4 && minor >= 7),
+        None => false,
+    }
+}
+
+/// Parse the `<major>[-<minor>]` version following the family name of a modern
+/// Claude id (`claude-opus-5`, `claude-sonnet-4-6`, `claude-opus-5@20260115`,
+/// `anthropic.claude-opus-5-v1:0`). Returns `None` for the legacy
+/// family-last ordering (`claude-3-5-sonnet-20241022`) and for ids that carry
+/// no numeric version (`claude-opus-latest`).
+fn claude_family_version(model: &str) -> Option<(u32, u32)> {
+    let lower = model.to_ascii_lowercase();
+    // Bedrock/Vertex ids carry a vendor prefix and a snapshot suffix around
+    // the same `claude-<family>-<version>` core.
+    let rest = &lower[lower.find("claude-")? + "claude-".len()..];
+    let mut parts = rest.split(|c: char| !c.is_ascii_alphanumeric());
+    if !matches!(parts.next()?, "opus" | "sonnet" | "haiku" | "fable") {
+        return None;
+    }
+    let major = version_segment(parts.next()?)?;
+    let minor = parts.next().and_then(version_segment).unwrap_or(0);
+    Some((major, minor))
+}
+
+/// A version segment is one or two digits; a longer digit run is a date
+/// snapshot (`claude-opus-4-20250514`), not a minor version.
+fn version_segment(segment: &str) -> Option<u32> {
+    if segment.is_empty() || segment.len() > 2 || !segment.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    segment.parse().ok()
+}
+
 #[cfg(test)]
 mod tests {
     use secrecy::SecretString;
+    use serde_json::json;
+
+    use crate::types::ChatMessage;
 
     use super::*;
 
@@ -352,6 +413,83 @@ mod tests {
             beta_val.contains("oauth-2025-04-20"),
             "anthropic-beta must contain oauth-2025-04-20"
         );
+    }
+
+    fn chat_request() -> ChatRequest {
+        ChatRequest {
+            system: None,
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: "x".into(),
+            }],
+            max_tokens: 256,
+            temperature: Some(0.2),
+        }
+    }
+
+    /// Serialized `/v1/messages` body for `model`, with the caller's
+    /// temperature set to 0.2 — what bootstrap / consolidation actually send.
+    fn body_for(model: &str, schema: Option<serde_json::Value>) -> serde_json::Value {
+        let provider = AnthropicProvider::new(SecretString::from("sk-ant-test"), model).unwrap();
+        let request = chat_request();
+        serde_json::to_value(provider.build_request(&request, schema)).unwrap()
+    }
+
+    #[test]
+    fn build_request_omits_temperature_for_models_that_deprecated_it() {
+        // The structured path is the one that actually broke in the field:
+        // bootstrap sends temperature 0.2 and Anthropic answers 400
+        // "`temperature` is deprecated for this model".
+        for model in [
+            "claude-opus-5",
+            "claude-sonnet-5",
+            "claude-fable-5",
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+            "anthropic.claude-opus-5-v1:0",
+        ] {
+            let body = body_for(model, Some(json!({})));
+            assert!(
+                body.get("temperature").is_none(),
+                "temperature must be omitted for {model}"
+            );
+        }
+    }
+
+    #[test]
+    fn build_request_keeps_temperature_for_models_that_still_accept_it() {
+        // Determinism matters for consolidation output, so the models that
+        // still honour sampling params must keep the caller's 0.2.
+        for model in [
+            "claude-sonnet-4-6",
+            "claude-opus-4-6",
+            "claude-haiku-4-5-20251001",
+            "claude-opus-4-20250514",
+            "claude-3-5-sonnet-20241022",
+        ] {
+            let body = body_for(model, None);
+            let temp = body["temperature"]
+                .as_f64()
+                .unwrap_or_else(|| panic!("temperature must be forwarded for {model}, got {body}"));
+            assert!((temp - 0.2).abs() < 1e-6, "{model}: got {temp}");
+        }
+    }
+
+    #[test]
+    fn build_request_keeps_the_structured_tool_shape() {
+        // The temperature rule must not disturb the forced-tool wiring the
+        // structured path depends on.
+        let body = body_for("claude-opus-5", Some(json!({"type": "object"})));
+        assert_eq!(body["tools"][0]["name"], json!("result"));
+        assert_eq!(body["tools"][0]["input_schema"], json!({"type": "object"}));
+        assert_eq!(
+            body["tool_choice"],
+            json!({"type": "tool", "name": "result"})
+        );
+
+        let plain = body_for("claude-opus-5", None);
+        assert!(plain.get("tools").is_none());
+        assert!(plain.get("tool_choice").is_none());
     }
 
     #[test]

--- a/crates/ai-memory-llm/src/anthropic.rs
+++ b/crates/ai-memory-llm/src/anthropic.rs
@@ -236,8 +236,8 @@ impl AnthropicProvider {
             ),
             None => (None, None),
         };
-        // Newer models reject any caller-supplied `temperature` with a 400;
-        // omit the field so the API applies its own default.
+        // Newer models reject ai-memory's non-default `temperature` with a
+        // 400; omit the field so the API applies its own default.
         let temperature = if model_rejects_temperature(&self.model) {
             None
         } else {
@@ -295,14 +295,13 @@ impl AnthropicProvider {
     }
 }
 
-/// Models that reject any caller-supplied `temperature`.
+/// Models that reject ai-memory's non-default `temperature`.
 ///
 /// Anthropic deprecated sampling parameters on the newer models: sending
-/// `temperature` to Claude 5 (Opus / Sonnet / Fable) or to Opus 4.7+ returns a
+/// `temperature` to Claude 4.7+ or to Claude Mythos Preview returns a
 /// 400 with `` `temperature` is deprecated for this model. `` Every structured
 /// call site — bootstrap, consolidation, lint, auto-improve — passes 0.1-0.2,
-/// so without this the whole LLM pipeline is unusable on those models while
-/// `llm-test` (which sends no temperature) still reports the model as healthy.
+/// so without this the whole LLM pipeline is unusable on those models.
 /// Omitting the field lets the API apply its own default, the same escape
 /// hatch `openai.rs::model_requires_default_temperature` uses for gpt-5 /
 /// o-series.
@@ -313,10 +312,29 @@ impl AnthropicProvider {
 /// proxying a non-Claude model behind this wire format must not be silently
 /// stripped either.
 fn model_rejects_temperature(model: &str) -> bool {
+    if is_mythos_preview(model) {
+        return true;
+    }
     match claude_family_version(model) {
         Some((major, minor)) => major >= 5 || (major == 4 && minor >= 7),
         None => false,
     }
+}
+
+/// Match the dateless preview id, including vendor-prefixed variants.
+fn is_mythos_preview(model: &str) -> bool {
+    let lower = model.to_ascii_lowercase();
+    let Some(rest) = lower
+        .find("claude-")
+        .map(|start| &lower[start + "claude-".len()..])
+    else {
+        return false;
+    };
+    let mut parts = rest.split(|c: char| !c.is_ascii_alphanumeric());
+    matches!(
+        (parts.next(), parts.next()),
+        (Some("mythos"), Some("preview"))
+    )
 }
 
 /// Parse the `<major>[-<minor>]` version following the family name of a modern
@@ -330,7 +348,10 @@ fn claude_family_version(model: &str) -> Option<(u32, u32)> {
     // the same `claude-<family>-<version>` core.
     let rest = &lower[lower.find("claude-")? + "claude-".len()..];
     let mut parts = rest.split(|c: char| !c.is_ascii_alphanumeric());
-    if !matches!(parts.next()?, "opus" | "sonnet" | "haiku" | "fable") {
+    if !matches!(
+        parts.next()?,
+        "opus" | "sonnet" | "haiku" | "fable" | "mythos"
+    ) {
         return None;
     }
     let major = version_segment(parts.next()?)?;
@@ -444,6 +465,9 @@ mod tests {
             "claude-opus-5",
             "claude-sonnet-5",
             "claude-fable-5",
+            "claude-mythos-5",
+            "claude-mythos-preview",
+            "anthropic.claude-mythos-preview-v1:0",
             "claude-opus-4-7",
             "claude-opus-4-8",
             "anthropic.claude-opus-5-v1:0",

--- a/docs/install.md
+++ b/docs/install.md
@@ -1254,6 +1254,12 @@ Docker rather than placed in the wrapper's command line. The long-lived server
 container still needs the provider and token variables in its own environment,
 as in the example above.
 
+For both Anthropic providers, ai-memory omits `temperature` for Claude
+4.7 and later models and Claude Mythos Preview because those models reject
+non-default sampling parameters. `llm-test` deliberately starts with the same
+representative 0.2 value as bootstrap and consolidation, then exercises the
+provider's compatibility normalization before sending the request.
+
 > [!TIP]
 > **Pick a small, fast model.** ai-memory's LLM work — session
 > consolidation, lint, and explore — is summarisation/extraction, not hard


### PR DESCRIPTION
## What changed

`AnthropicProvider` no longer sends `temperature` to models that reject it.

**Before:** every LLM feature — `bootstrap`, consolidation, `lint`, auto-improve — fails against the newer Anthropic models:

```
Error: server returned 502 Bad Gateway:
{"error":"provider error 400: {... \"message\":\"`temperature` is deprecated for this model.\"}"}
```

**After:** the field is omitted for the affected models, so the API applies its own default. Every other model keeps the caller's value byte-for-byte.

No new flag, env var, or config key. The only behaviour change is the omitted request field on models that rejected it.

`complete` and `complete_structured_raw` each built their request body inline; both now go through a single `build_request`, so the rule cannot apply to one path and silently miss the other.

## Why

The affected models reject non-default sampling parameters, and every structured call site sets one:

- `crates/ai-memory-consolidate/src/bootstrap.rs:1208` — `temperature: Some(0.2)`
- `crates/ai-memory-consolidate/src/consolidator.rs:912,989` — `0.2`
- `crates/ai-memory-consolidate/src/lint.rs:337` — `0.1`
- `crates/ai-memory-consolidate/src/auto_improve.rs:481` — `0.1`

`crates/ai-memory-llm/src/anthropic.rs:182,232` forwarded the value verbatim, so the request 400s and the server surfaces it as a 502 — which reads like an upstream outage rather than a request-shape problem. `anthropic-oauth` shares `AnthropicProvider`, so it is affected identically.

Body captured against a local proxy (`AI_MEMORY_LLM_BASE_URL=http://127.0.0.1:49999`):

```
POST /v1/messages
{"model":"claude-sonnet-5","max_tokens":16000,"temperature":0.2,
 "tools":[{"name":"result","description":"Emit the structured result.", ...}],
 "tool_choice":{"type":"tool","name":"result"}}
```

The fix mirrors the precedent already in `openai.rs` (`model_requires_default_temperature`, added because gpt-5 / o-series reject any non-default temperature): omit the field and let the API default apply. `temperature` is already `#[serde(skip_serializing_if = "Option::is_none")]`, so `None` drops it from the body — no call site has to become model-aware.

Detection parses the `claude-<family>-<major>[-<minor>]` id with 4.7 as the cutoff and handles the explicit `claude-mythos-preview` id, including vendor-prefixed forms. That covers dated snapshots, `claude-mythos-5`, and vendor ids such as `anthropic.claude-opus-5-v1:0`. Anything unrecognized keeps the caller's value: the legacy `claude-3-5-sonnet-…` ordering and the 4.0-4.6 line still honour sampling parameters, and consolidation output quality depends on staying near 0.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `cargo deny check` passes (`advisories ok, bans ok, licenses ok, sources ok`)
- [x] Manual test: the 400 was originally captured by proxying `/v1/messages` to a local listener and reading the emitted body (quoted above) — that is where the `temperature: 0.2` in the structured call was confirmed. Verification of the fix itself is by unit test over the serialized request body rather than a second live call. Regression tests in `crates/ai-memory-llm/src/anthropic.rs`: omit `temperature` for `claude-opus-5` / `claude-sonnet-5` / `claude-fable-5` / `claude-mythos-5` / `claude-mythos-preview` / vendor-prefixed Mythos Preview / `claude-opus-4-7` / `claude-opus-4-8` / `anthropic.claude-opus-5-v1:0`; keep the caller's `0.2` for `claude-sonnet-4-6` / `claude-opus-4-6` / `claude-haiku-4-5-20251001` / `claude-opus-4-20250514` / `claude-3-5-sonnet-20241022`; forced-tool wiring (`tools` / `tool_choice`) unchanged by the refactor.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected
      any unintended identity before requesting merge. See
      [commit attribution guidance](https://github.com/akitaonrails/ai-memory/blob/main/CONTRIBUTING.md#commit-attribution).

## CHANGELOG (merge gate)

- [x] I added a `CHANGELOG.md` `[Unreleased]` entry under `### Fixed` with the final `(#377)` reference.
- [x] Any changed **default** (flag behaviour, config default, env var,
      response shape) is called out explicitly in "What changed" above.

## Notes for reviewers

Three things worth extra scrutiny:

1. **The cutoff.** Anthropic's current deprecation table says Claude 4.7 and later models plus Claude Mythos Preview reject non-default sampling parameters. Numeric Claude 5 families and the explicit Mythos Preview id omit; 4.0-4.6 and older keep. The 400 was observed directly on `claude-sonnet-5`; the boundary lives in `model_rejects_temperature`.
2. **Unparsed ids fall through to the old behaviour** rather than defaulting to omission. Deliberate: omitting `temperature` where it is still honoured would silently raise sampling temperature to the model default and make consolidation output less deterministic, so the safe direction is to keep forwarding unless we recognise the model.
3. **The `build_request` extraction is a refactor**, which AGENTS.md rule 4 discourages. My reasoning: without it the rule has to be written twice, in two functions that had already drifted apart. Happy to inline it in both paths instead if you prefer the smaller diff.

`llm-test` now starts with the representative `temperature: 0.2` used by bootstrap and consolidation. Provider normalization then removes it for affected Anthropic models, so the smoke test exercises the same compatibility path as production calls.