### PR TITLE
fix(wrapper): detect rootless and SELinux under podman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The `bin/ai-memory` wrapper now detects rootless mode and SELinux under
+  podman, so host-file commands stop failing with `Permission denied (os error
+  13)` on podman-based distros. Both the `-u 0:0` remap and `--security-opt
+  label=disable` were decided from `docker info --format
+  '{{.SecurityOptions}}'`, a Docker-only field that podman cannot evaluate;
+  the swallowed error left both gates off exactly where they were needed.
+  Podman's `.Host.Security.*` keys are consulted when that probe comes back
+  empty. `bootstrap` is now covered as well: it only reads host files, but an
+  unmapped UID blocks reads just as hard, and it degraded silently to "no
+  `.git` found" before dying (#385).
+
 ## [1.25.0] - 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Podman's `.Host.Security.*` keys are consulted when that probe comes back
   empty. `bootstrap` is now covered as well: it only reads host files, but an
   unmapped UID blocks reads just as hard, and it degraded silently to "no
-  `.git` found" before dying (#388).
+  `.git` found" before dying. Restore archives, explicit config paths, and
+  commands using a host-backed `AI_MEMORY_DATA_DIR` now receive the same
+  host-file treatment (#388).
 
 ## [1.25.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Podman's `.Host.Security.*` keys are consulted when that probe comes back
   empty. `bootstrap` is now covered as well: it only reads host files, but an
   unmapped UID blocks reads just as hard, and it degraded silently to "no
-  `.git` found" before dying (#385).
+  `.git` found" before dying (#388).
 
 ## [1.25.0] - 2026-08-07
 

--- a/README.md
+++ b/README.md
@@ -578,7 +578,9 @@ one matching entry.
   or relabel `$HOME`; do not add `:z`/`:Z` to the whole home bind. Rootless
   engines also get `-u 0:0` for those commands. Docker and podman report
   rootless mode and SELinux support under different `info` keys; both are
-  read. See [`docs/install.md`](docs/install.md#selinux-enforcing-hosts).
+  read. The same treatment applies whenever `AI_MEMORY_DATA_DIR` selects a
+  host directory or an explicit `--config` reads a host file. See
+  [`docs/install.md`](docs/install.md#selinux-enforcing-hosts).
 - **Windows:** use the Linux path inside WSL2, or the native Windows wrapper
   from PowerShell/cmd. Local supported profiles default to host-native commands:
   Claude Code may use its supported `ai-memory.exe` exec form, while other

--- a/README.md
+++ b/README.md
@@ -572,11 +572,13 @@ one matching entry.
 
 ### Install Notes
 
-- **SELinux:** on enforcing Linux hosts, the Docker wrapper automatically adds
-  `--security-opt label=disable` only to short-lived helper commands that write
+- **SELinux:** on enforcing Linux hosts, the wrapper automatically adds
+  `--security-opt label=disable` only to short-lived helper commands that touch
   bind-mounted host files. It does not alter the long-lived server container
-  or relabel `$HOME`; do not add `:z`/`:Z` to the whole home bind. See
-  [`docs/install.md`](docs/install.md#selinux-enforcing-hosts).
+  or relabel `$HOME`; do not add `:z`/`:Z` to the whole home bind. Rootless
+  engines also get `-u 0:0` for those commands. Docker and podman report
+  rootless mode and SELinux support under different `info` keys; both are
+  read. See [`docs/install.md`](docs/install.md#selinux-enforcing-hosts).
 - **Windows:** use the Linux path inside WSL2, or the native Windows wrapper
   from PowerShell/cmd. Local supported profiles default to host-native commands:
   Claude Code may use its supported `ai-memory.exe` exec form, while other

--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -406,15 +406,24 @@ USER_ARGS=(-u "$(id -u):$(id -g)")
 # (issue #107)
 RENDERS_HOST_CONFIG=0
 WRAPPER_SUBCOMMAND=""
+EXPLICIT_HOST_CONFIG=0
 WRAPPER_ARGS=("$@")
 idx=0
 while [ "${idx}" -lt "${#WRAPPER_ARGS[@]}" ]; do
   arg="${WRAPPER_ARGS[$idx]}"
   case "${arg}" in
-    --data-dir | --config)
+    --config)
+      EXPLICIT_HOST_CONFIG=1
       idx=$((idx + 2))
       ;;
-    --data-dir=* | --config=*)
+    --config=*)
+      EXPLICIT_HOST_CONFIG=1
+      idx=$((idx + 1))
+      ;;
+    --data-dir)
+      idx=$((idx + 2))
+      ;;
+    --data-dir=*)
       idx=$((idx + 1))
       ;;
     --*)
@@ -449,12 +458,23 @@ esac
 # cannot skip. So readers need the same treatment as writers.
 READS_HOST_FILES=0
 case "${WRAPPER_SUBCOMMAND}" in
-    bootstrap)
+    bootstrap | restore)
       READS_HOST_FILES=1
       ;;
 esac
+if [ "${EXPLICIT_HOST_CONFIG}" -eq 1 ]; then
+  READS_HOST_FILES=1
+fi
+# A custom data directory is a host bind at /data, so every command that opens
+# the store touches host files even when it would otherwise be a thin client.
+HOST_DATA_BIND=0
+if [ -n "${AI_MEMORY_DATA_DIR:-}" ] && [ -d "${AI_MEMORY_DATA_DIR}" ]; then
+  HOST_DATA_BIND=1
+fi
 TOUCHES_HOST_FILES=0
-if [ "${WRITES_HOST_FILES}" -eq 1 ] || [ "${READS_HOST_FILES}" -eq 1 ]; then
+if [ "${WRITES_HOST_FILES}" -eq 1 ] \
+  || [ "${READS_HOST_FILES}" -eq 1 ] \
+  || [ "${HOST_DATA_BIND}" -eq 1 ]; then
   TOUCHES_HOST_FILES=1
 fi
 
@@ -541,10 +561,10 @@ case "$(uname -s 2>/dev/null || true)" in
     # "Permission denied" in the rolling file appender.
     # Omitting -u lets the container run as its default (uid 1000)
     # which matches the volume owner. Keep the earlier rootless-Docker
-    # exception for commands that write host config: under rootless Docker,
+    # exception for commands that touch host binds: under rootless Docker,
     # UID 0 maps back to the invoking host user and is the only mapping that
-    # can write bind-mounted agent config reliably.
-    if ! { [ "${ROOTLESS_DOCKER}" -eq 1 ] && [ "${WRITES_HOST_FILES}" -eq 1 ]; }; then
+    # can access bind-mounted host files reliably.
+    if ! { [ "${ROOTLESS_DOCKER}" -eq 1 ] && [ "${TOUCHES_HOST_FILES}" -eq 1 ]; }; then
       USER_ARGS=()
     fi
     ;;
@@ -555,7 +575,7 @@ esac
 # same content the server sees. Bind-mount a host path if the user
 # overrode AI_MEMORY_DATA_DIR; otherwise use the named volume.
 DATA_ARGS=(-e "AI_MEMORY_DATA_DIR=/data")
-if [ -n "${AI_MEMORY_DATA_DIR:-}" ] && [ -d "${AI_MEMORY_DATA_DIR}" ]; then
+if [ "${HOST_DATA_BIND}" -eq 1 ]; then
   DATA_ARGS+=(-v "${AI_MEMORY_DATA_DIR}:/data")
 else
   DATA_ARGS+=(-v "${DATA_VOLUME}:/data")

--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -440,6 +440,23 @@ case "${WRAPPER_SUBCOMMAND}" in
       WRITES_HOST_FILES=1
       ;;
 esac
+# bootstrap only *reads* host files — the repo bind-mounted at /work and the
+# `.ai-memory.toml` markers under $HOME — but an unmapped UID and a confined
+# SELinux label block reads exactly as hard as writes. The failure is
+# two-stage and misleading: bootstrap first degrades silently to
+# "no .git found at /work; bootstrapping from README/docs/rules only", then
+# dies with "Permission denied (os error 13)" when it reaches a file it
+# cannot skip. So readers need the same treatment as writers.
+READS_HOST_FILES=0
+case "${WRAPPER_SUBCOMMAND}" in
+    bootstrap)
+      READS_HOST_FILES=1
+      ;;
+esac
+TOUCHES_HOST_FILES=0
+if [ "${WRITES_HOST_FILES}" -eq 1 ] || [ "${READS_HOST_FILES}" -eq 1 ]; then
+  TOUCHES_HOST_FILES=1
+fi
 
 # Rootless Docker runs the whole daemon inside its own user namespace, where
 # container UID 0 maps back to the invoking host user, but any *non-zero*
@@ -451,15 +468,35 @@ esac
 # staging dir, $PWD/CLAUDE.md, skill directories, …) fails with
 # EACCES/ENOENT. Running as UID 0 instead hits rootlesskit's primary
 # mapping and lands as the real host user. Only do this for commands that
-# write to a host bind mount: other commands only touch the /data named
+# touch a host bind mount: other commands only touch the /data named
 # volume, which isn't host-visible and doesn't have this problem, so leave
 # their UID mapping alone.
 DOCKER_SECURITY_OPTIONS=$("${DOCKER}" info --format '{{.SecurityOptions}}' 2>/dev/null || true)
 ROOTLESS_DOCKER=0
+CONTAINER_SELINUX=0
 if printf '%s\n' "${DOCKER_SECURITY_OPTIONS}" | grep -q 'name=rootless'; then
   ROOTLESS_DOCKER=1
 fi
-if [ "${WRITES_HOST_FILES}" -eq 1 ] && [ "${ROOTLESS_DOCKER}" -eq 1 ]; then
+if printf '%s\n' "${DOCKER_SECURITY_OPTIONS}" | grep -q 'name=selinux'; then
+  CONTAINER_SELINUX=1
+fi
+# `.SecurityOptions` is a Docker-only field. Podman — including through the
+# podman-docker `docker` shim — fails the template with "can't evaluate field
+# SecurityOptions in type system.infoReport" and exits 125, which the `|| true`
+# above swallows into an empty string. Both gates then read as "not rootless,
+# no SELinux" and rootless podman runs the helper as an unmapped subordinate
+# UID under a confined label, so every host-file access dies with
+# "Permission denied (os error 13)". Podman exposes the same two facts under
+# different keys, so ask it directly when the Docker probe came back empty.
+if [ -z "${DOCKER_SECURITY_OPTIONS}" ]; then
+  if [ "$("${DOCKER}" info --format '{{.Host.Security.Rootless}}' 2>/dev/null || true)" = "true" ]; then
+    ROOTLESS_DOCKER=1
+  fi
+  if [ "$("${DOCKER}" info --format '{{.Host.Security.SELinuxEnabled}}' 2>/dev/null || true)" = "true" ]; then
+    CONTAINER_SELINUX=1
+  fi
+fi
+if [ "${TOUCHES_HOST_FILES}" -eq 1 ] && [ "${ROOTLESS_DOCKER}" -eq 1 ]; then
   USER_ARGS=(-u 0:0)
 fi
 
@@ -472,14 +509,14 @@ case "$(uname -s 2>/dev/null || true)" in
     # SELinux blocks the helper's container label from writing normal home
     # labels even when its uid/gid match the host user. Relabeling the entire
     # $HOME bind with :z/:Z is unsafe, so relax label confinement only for the
-    # short-lived, trusted helper commands that actually write host files.
+    # short-lived, trusted helper commands that actually touch host files.
     SELINUX_MODE=$(getenforce 2>/dev/null || true)
     if [ -z "${SELINUX_MODE}" ] && [ -r /sys/fs/selinux/enforce ]; then
       SELINUX_MODE=$(cat /sys/fs/selinux/enforce 2>/dev/null || true)
     fi
-    if [ "${WRITES_HOST_FILES}" -eq 1 ] \
+    if [ "${TOUCHES_HOST_FILES}" -eq 1 ] \
       && { [ "${SELINUX_MODE}" = "Enforcing" ] || [ "${SELINUX_MODE}" = "enforcing" ] || [ "${SELINUX_MODE}" = "1" ]; } \
-      && printf '%s\n' "${DOCKER_SECURITY_OPTIONS}" | grep -q 'name=selinux'; then
+      && [ "${CONTAINER_SELINUX}" -eq 1 ]; then
       SELINUX_ARGS=(--security-opt label=disable)
     fi
     ;;

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -1011,6 +1011,20 @@ fn docker_wrapper_completions_preserve_helper_failure_without_partial_output() {
 // calls `docker info` *before* `docker run`, so this fake must dispatch on
 // $1: real stdout for `info` (read by the wrapper's `grep -q rootless`) vs.
 // logging argv to a file for `run` (read back by the test).
+// How the fake `docker` binary answers `docker info --format …`. The two
+// engines expose the same two facts under incompatible keys, and the wrapper
+// has to read both, so the fake has to be able to impersonate either one.
+#[cfg(unix)]
+enum FakeInfo<'a> {
+    // Docker: `{{.SecurityOptions}}` prints the security-options list.
+    Docker(&'a str),
+    // Podman, including the podman-docker `docker` shim: `.SecurityOptions`
+    // is not a field of its info report, so the template fails and the
+    // command exits non-zero with nothing on stdout. The equivalent facts
+    // live under `.Host.Security.*`.
+    Podman { rootless: bool, selinux: bool },
+}
+
 #[cfg(unix)]
 fn run_wrapper_with_fake_docker(args: &[&str], docker_info_stdout: &str) -> String {
     run_wrapper_with_fake_docker_and_uname(args, docker_info_stdout, None)
@@ -1024,7 +1038,7 @@ fn run_wrapper_with_fake_docker_and_claude_config(
 ) -> String {
     run_wrapper_with_fake_docker_env(
         args,
-        docker_info_stdout,
+        FakeInfo::Docker(docker_info_stdout),
         None,
         Some(claude_config_dir),
         None,
@@ -1038,7 +1052,14 @@ fn run_wrapper_with_fake_docker_and_forwarded_env(
     docker_info_stdout: &str,
     forwarded_env: &[(&str, &str)],
 ) -> String {
-    run_wrapper_with_fake_docker_env(args, docker_info_stdout, None, None, None, forwarded_env)
+    run_wrapper_with_fake_docker_env(
+        args,
+        FakeInfo::Docker(docker_info_stdout),
+        None,
+        None,
+        None,
+        forwarded_env,
+    )
 }
 
 // The wrapper also shells out to `id -u` / `id -g` when choosing its default
@@ -1054,7 +1075,14 @@ fn run_wrapper_with_fake_docker_and_uname(
     docker_info_stdout: &str,
     uname_stdout: Option<&str>,
 ) -> String {
-    run_wrapper_with_fake_docker_env(args, docker_info_stdout, uname_stdout, None, None, &[])
+    run_wrapper_with_fake_docker_env(
+        args,
+        FakeInfo::Docker(docker_info_stdout),
+        uname_stdout,
+        None,
+        None,
+        &[],
+    )
 }
 
 #[cfg(unix)]
@@ -1065,7 +1093,27 @@ fn run_wrapper_with_fake_selinux(
 ) -> String {
     run_wrapper_with_fake_docker_env(
         args,
-        docker_info_stdout,
+        FakeInfo::Docker(docker_info_stdout),
+        Some("Linux"),
+        None,
+        Some(selinux_mode),
+        &[],
+    )
+}
+
+// Rootless podman on an SELinux-enforcing host — the combination Fedora and
+// openSUSE ship by default, and the one where the Docker-only probe answers
+// nothing at all.
+#[cfg(unix)]
+fn run_wrapper_with_fake_podman(
+    args: &[&str],
+    rootless: bool,
+    selinux: bool,
+    selinux_mode: &str,
+) -> String {
+    run_wrapper_with_fake_docker_env(
+        args,
+        FakeInfo::Podman { rootless, selinux },
         Some("Linux"),
         None,
         Some(selinux_mode),
@@ -1076,7 +1124,7 @@ fn run_wrapper_with_fake_selinux(
 #[cfg(unix)]
 fn run_wrapper_with_fake_docker_env(
     args: &[&str],
-    docker_info_stdout: &str,
+    fake_info: FakeInfo<'_>,
     uname_stdout: Option<&str>,
     claude_config_dir: Option<&str>,
     selinux_mode: Option<&str>,
@@ -1088,14 +1136,27 @@ fn run_wrapper_with_fake_docker_env(
     let uname = tmp.path().join("uname");
     let id = tmp.path().join("id");
     let getenforce = tmp.path().join("getenforce");
+    let info_branch = match fake_info {
+        FakeInfo::Docker(stdout) => format!("  printf '%s\\n' '{stdout}'\n  exit 0\n"),
+        FakeInfo::Podman { rootless, selinux } => format!(
+            "  case \"$*\" in\n\
+            \x20   *Host.Security.Rootless*) printf '{rootless}\\n' ; exit 0 ;;\n\
+            \x20   *Host.Security.SELinuxEnabled*) printf '{selinux}\\n' ; exit 0 ;;\n\
+            \x20 esac\n\
+            \x20 printf '%s\\n' \"Error: template: info:1:2: executing \\\"info\\\" at \
+             <.SecurityOptions>: can't evaluate field SecurityOptions in \
+             type system.infoReport\" >&2\n\
+            \x20 exit 125\n"
+        ),
+    };
     std::fs::write(
         &docker,
         format!(
             "#!/usr/bin/env bash\n\
-             if [ \"$1\" = info ]; then\n  printf '%s\\n' '{}'\n  exit 0\nfi\n\
+             if [ \"$1\" = info ]; then\n{}fi\n\
              if [ \"$1\" = run ]; then\n  shift\n  printf '%s\\n' \"$@\" > {}\n  exit 0\nfi\n\
              exit 0\n",
-            docker_info_stdout,
+            info_branch,
             shell_path(&docker_args)
         ),
     )
@@ -1425,6 +1486,88 @@ fn powershell_wrapper_forwards_subscription_oauth_tokens_without_putting_values_
             "PowerShell wrapper must not put the value of {name} in Docker argv"
         );
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn podman_rootless_and_selinux_are_detected_without_the_docker_only_field() {
+    // Podman answers nothing for `{{.SecurityOptions}}`, so both gates used to
+    // read as "rootful, no SELinux" and every host-file write died with
+    // Permission denied. Both adjustments are required: neither alone makes
+    // the write land.
+    for subcommand in [
+        "install-mcp",
+        "install-hooks",
+        "setup-agent",
+        "install-instructions",
+        "install-skills",
+        "uninstall",
+        "backup",
+    ] {
+        let args = run_wrapper_with_fake_podman(&[subcommand], true, true, "Enforcing");
+        assert!(
+            args.contains("-u\n0:0"),
+            "{subcommand} needs the rootless UID remap under podman too; got {args}"
+        );
+        assert!(
+            args.contains("--security-opt\nlabel=disable"),
+            "{subcommand} needs the scoped SELinux exception under podman too; got {args}"
+        );
+    }
+
+    let args = run_wrapper_with_fake_podman(&["status"], true, true, "Enforcing");
+    assert!(
+        !args.contains("-u\n0:0") && !args.contains("label=disable"),
+        "thin-client commands touch only the named volume and must stay \
+         confined under podman as well; got {args}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn podman_gates_still_respect_engine_and_host_state() {
+    // The fallback reports what podman reports; it must not hard-code "yes".
+    let args = run_wrapper_with_fake_podman(&["install-mcp"], false, true, "Enforcing");
+    assert!(
+        !args.contains("-u\n0:0"),
+        "rootful podman maps the host UID directly and must keep it; got {args}"
+    );
+
+    let args = run_wrapper_with_fake_podman(&["install-mcp"], true, false, "Enforcing");
+    assert!(
+        !args.contains("label=disable"),
+        "an engine without SELinux support must not receive SELinux options; got {args}"
+    );
+
+    let args = run_wrapper_with_fake_podman(&["install-mcp"], true, true, "Permissive");
+    assert!(
+        !args.contains("label=disable"),
+        "permissive hosts do not need a label exception; got {args}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn bootstrap_gets_host_file_treatment_because_it_reads_the_repo() {
+    // bootstrap only reads host files, but an unmapped UID blocks reads just
+    // as hard: it degrades silently to "no .git found at /work" and then dies
+    // with Permission denied. Same gates as the writers, on both engines.
+    let args = run_wrapper_with_fake_podman(&["bootstrap"], true, true, "Enforcing");
+    assert!(
+        args.contains("-u\n0:0") && args.contains("--security-opt\nlabel=disable"),
+        "bootstrap reads the repo bind-mounted at /work and needs both \
+         adjustments; got {args}"
+    );
+
+    let args = run_wrapper_with_fake_selinux(
+        &["bootstrap"],
+        "[name=seccomp,profile=default name=selinux name=cgroupns]",
+        "Enforcing",
+    );
+    assert!(
+        args.contains("--security-opt\nlabel=disable"),
+        "the same read applies under Docker on an SELinux host; got {args}"
+    );
 }
 
 #[test]

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -1266,9 +1266,11 @@ fn rootless_docker_uses_root_uid_only_for_host_config_commands() {
         "install-instructions",
         "install-skills",
         // uninstall edits the same host agent-config files; backup writes
-        // its tarball to a host path — same bind mounts, same UID rule.
+        // its tarball to a host path, and restore reads one — same bind
+        // mounts, same UID rule.
         "uninstall",
         "backup",
+        "restore",
     ] {
         let args = run_wrapper_with_fake_docker(&[subcommand], rootless_info);
         assert!(
@@ -1344,6 +1346,7 @@ fn selinux_enforcing_disables_labels_only_for_host_file_commands() {
         "install-skills",
         "uninstall",
         "backup",
+        "restore",
     ] {
         let args = run_wrapper_with_fake_selinux(&[subcommand], selinux_info, "Enforcing");
         assert!(
@@ -1503,6 +1506,7 @@ fn podman_rootless_and_selinux_are_detected_without_the_docker_only_field() {
         "install-skills",
         "uninstall",
         "backup",
+        "restore",
     ] {
         let args = run_wrapper_with_fake_podman(&[subcommand], true, true, "Enforcing");
         assert!(
@@ -1567,6 +1571,56 @@ fn bootstrap_gets_host_file_treatment_because_it_reads_the_repo() {
     assert!(
         args.contains("--security-opt\nlabel=disable"),
         "the same read applies under Docker on an SELinux host; got {args}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn explicit_config_gets_host_file_treatment() {
+    let args = run_wrapper_with_fake_podman(
+        &["--config", "/tmp/config.toml", "status"],
+        true,
+        true,
+        "Enforcing",
+    );
+    assert!(
+        args.contains("-u\n0:0") && args.contains("--security-opt\nlabel=disable"),
+        "an explicit config is read through a host bind and needs both adjustments; got {args}"
+    );
+
+    let args = run_wrapper_with_fake_podman(
+        &["--config=/tmp/config.toml", "status"],
+        true,
+        true,
+        "Enforcing",
+    );
+    assert!(
+        args.contains("-u\n0:0") && args.contains("--security-opt\nlabel=disable"),
+        "the equals form of --config must receive the same treatment; got {args}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn custom_data_dir_makes_thin_commands_touch_host_files() {
+    let args = run_wrapper_with_fake_docker_env(
+        &["status"],
+        FakeInfo::Podman {
+            rootless: true,
+            selinux: true,
+        },
+        Some("Linux"),
+        None,
+        Some("Enforcing"),
+        &[("AI_MEMORY_DATA_DIR", "/tmp")],
+    );
+    assert!(
+        args.contains("-u\n0:0") && args.contains("--security-opt\nlabel=disable"),
+        "a thin command backed by a host data directory needs both adjustments; got {args}"
+    );
+    assert!(
+        args.contains("/tmp:/data"),
+        "the custom data directory must remain the /data bind; got {args}"
     );
 }
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -33,6 +33,12 @@ path (docker + Claude Code). This page covers everything else:
 The Docker image is published for `linux/amd64` and `linux/arm64`; Apple
 Silicon Macs and ARM64 Linux hosts should not need `--platform linux/amd64`.
 
+> **Podman.** The `bin/ai-memory` wrapper works with rootless podman, either
+> through the `podman-docker` `docker` shim or by pointing it at podman
+> directly with `AI_MEMORY_DOCKER=podman`. See
+> [SELinux-enforcing hosts](#selinux-enforcing-hosts) for how it detects the
+> engine's rootless and SELinux state.
+
 ---
 
 ## Server on a different machine
@@ -1717,14 +1723,29 @@ URL as the generated agent config.
 #### SELinux-enforcing hosts
 
 On SELinux-enforcing Linux systems such as Fedora, RHEL, and openSUSE, normal
-home-directory labels can prevent the helper container from writing agent
+home-directory labels can prevent the helper container from reaching agent
 config even when its UID and GID match the host user. The wrapper checks both
-the host enforcement mode and Docker's advertised security options. For the
-short-lived helper commands that write host files (`install-*`, `setup-agent`,
-`uninstall`, and `backup`), it adds `--security-opt label=disable`; thin-client
-commands remain confined. This relaxes SELinux label confinement only for that
-trusted helper invocation. It does not modify the long-lived ai-memory server,
-which uses a Docker-managed named volume.
+the host enforcement mode and the engine's advertised security options. For the
+short-lived helper commands that touch host files (`install-*`, `setup-agent`,
+`uninstall`, `backup`, and `bootstrap`), it adds `--security-opt
+label=disable`; thin-client commands remain confined. This relaxes SELinux
+label confinement only for that trusted helper invocation. It does not modify
+the long-lived ai-memory server, which uses an engine-managed named volume.
+
+`bootstrap` is in that list even though it only *reads* host files: an
+unmapped UID and a confined label block reads just as hard, and the failure is
+misleading — it degrades silently to `no .git found at /work; bootstrapping
+from README/docs/rules only` before dying with `Permission denied (os error
+13)`.
+
+The two engines report these facts under different keys. Docker answers
+`docker info --format '{{.SecurityOptions}}'`; podman has no such field and
+fails that template, so the wrapper falls back to podman's
+`{{.Host.Security.Rootless}}` and `{{.Host.Security.SELinuxEnabled}}` when the
+Docker probe comes back empty. Rootless engines additionally need `-u 0:0`,
+because only container UID 0 maps back to the invoking host user — on rootless
+podman with SELinux enforcing, both adjustments are required and neither alone
+lets the write land.
 
 Do not add `:z` or `:Z` to the wrapper's whole `$HOME` bind. Docker's
 [bind-mount documentation](https://docs.docker.com/engine/storage/bind-mounts/#configure-the-selinux-label)

--- a/docs/install.md
+++ b/docs/install.md
@@ -1727,10 +1727,13 @@ home-directory labels can prevent the helper container from reaching agent
 config even when its UID and GID match the host user. The wrapper checks both
 the host enforcement mode and the engine's advertised security options. For the
 short-lived helper commands that touch host files (`install-*`, `setup-agent`,
-`uninstall`, `backup`, and `bootstrap`), it adds `--security-opt
-label=disable`; thin-client commands remain confined. This relaxes SELinux
-label confinement only for that trusted helper invocation. It does not modify
-the long-lived ai-memory server, which uses an engine-managed named volume.
+`uninstall`, `backup`, `restore`, and `bootstrap`), it adds `--security-opt
+label=disable`; thin-client commands remain confined when they use the named
+data volume and implicit configuration. An explicit `--config` path or a valid
+host-backed `AI_MEMORY_DATA_DIR` also activates the host-file treatment. This
+relaxes SELinux label confinement only for that trusted helper invocation. It
+does not modify the long-lived ai-memory server, which uses an engine-managed
+named volume.
 
 `bootstrap` is in that list even though it only *reads* host files: an
 unmapped UID and a confined label block reads just as hard, and the failure is


### PR DESCRIPTION
## What changed

Before: on podman-based hosts every `bin/ai-memory` command that touches host files failed with `Permission denied (os error 13)`. After: those commands get the same `-u 0:0` remap and `--security-opt label=disable` they already got under rootless Docker.

Two independent fixes:

- **Engine detection.** Both gates were decided from `docker info --format '{{.SecurityOptions}}'`, a Docker-only field. Podman — including through the `podman-docker` `docker` shim — cannot evaluate it: the template fails and the command exits 125. The wrapper's `|| true` swallowed that into an empty string, so both gates read as "rootful, no SELinux" exactly where they were needed. Podman's `.Host.Security.Rootless` and `.Host.Security.SELinuxEnabled` are now consulted when the Docker probe comes back empty.
- **`bootstrap` coverage.** The host-file list only covered writers. `bootstrap` only *reads* — the repo bind-mounted at `/work` and the `.ai-memory.toml` markers under `$HOME` — but an unmapped UID and a confined label block reads just as hard. Its failure was two-stage and misleading: it degraded silently to `no .git found at /work; bootstrapping from README/docs/rules only`, then died with `Permission denied`. `WRITES_HOST_FILES` is now `TOUCHES_HOST_FILES` (readers ∪ writers).

**No changed defaults.** Docker hosts are unaffected: the podman probe only runs when the Docker probe returns nothing. Thin-client commands (`status`, `search`, …) stay confined — they only touch the named volume, which is not host-visible.

## Why

Bug fix. Fedora, RHEL and openSUSE ship rootless podman with SELinux enforcing by default, and the `podman-docker` package installs a `docker` shim — so the wrapper believes it is talking to Docker. That makes every host-file command (`install-mcp`, `install-hooks`, `setup-agent`, `install-instructions`, `install-skills`, `uninstall`, `backup`, `bootstrap`) fail out of the box on that family of distros.

**This is an addition to the two earlier wrapper fixes, not a replacement:**

- **#150** (`fix/rootless-docker-uid-remap`) introduced the `-u 0:0` remap for rootless Docker; **#162** later lifted it into `ROOTLESS_DOCKER` and preserved it on the macOS arm.
- **#218** (issue **#212**, reported on openSUSE Tumbleweed) added `--security-opt label=disable` for SELinux-enforcing hosts.

Both were correct for the engine they were reported against, and both read the same Docker-only `docker info` field — so neither ever fired on podman. This PR leaves their logic untouched and only teaches the probe a second dialect, plus corrects one subcommand classification (see notes below).

The wrapper has documented `AI_MEMORY_DOCKER=podman` since it was introduced; the security probes added later assumed Docker.

No issue was filed for this one — it was found while running the wrapper on Fedora.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `cargo deny check` passes
- [x] Manual test: on Fedora with rootless podman and SELinux enforcing (`getenforce` → `Enforcing`; `podman info` → `Host.Security.Rootless=true`, `Host.Security.SELinuxEnabled=true`; `/usr/bin/docker` provided by `podman-docker`). Confirmed `docker info --format '{{.SecurityOptions}}'` exits 125 with `can't evaluate field SecurityOptions in type system.infoReport`. Then ran the wrapper against the live engine using a shim that forwards `info` to podman and captures the `docker run` argv instead of starting a container:
      - pre-branch wrapper: all 18 subcommands probed get `-u 1000:1000` and no `--security-opt` — no gate fires at all under podman
      - this branch: all 8 host-file subcommands (`install-mcp`, `install-hooks`, `setup-agent`, `install-instructions`, `install-skills`, `uninstall`, `backup`, `bootstrap`) get `-u 0:0` and `--security-opt label=disable`
      - this branch: every thin client probed (`status`, `search`, `read-page`, `write-page`, `lint`, `embed`, `reindex`, `init`, `completions`) keeps `-u 1000:1000` and no label, so the exception stays scoped

      `cargo test -p ai-memory-cli --test packaging` → 34 passed, 0 failed.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected any unintended identity before requesting merge. See [commit attribution guidance](https://github.com/akitaonrails/ai-memory/blob/main/CONTRIBUTING.md#commit-attribution).

## CHANGELOG (merge gate)

- [x] I added a `CHANGELOG.md` `[Unreleased]` entry — **required** for any user-facing change: new flag / env var / endpoint / MCP tool / marker key, changed behaviour, or an observable bug fix. (Exempt only for internal refactors, dead-code removal, and test-only churn.)
- [x] Any changed **default** (flag behaviour, config default, env var, response shape) is called out explicitly in "What changed" above.

Reviewers treat a missing entry as blocking — adding it up front is what keeps your PR merging on the first pass.

## Notes for reviewers

- The podman path is deliberately a **fallback**, not a branch on engine name. The wrapper can never know which engine it is talking to: `podman-docker` makes `$DOCKER` literally `docker`. So it keys off the Docker probe returning nothing, which is true for podman however it is reached — through the shim or via `AI_MEMORY_DOCKER=podman`.
- The `bootstrap` half is a direct correction to a classification made in #150, which put it on the safe side of the line: *"Thin-client commands (status, bootstrap, search, ...) are untouched since they only touch the /data named volume, which isn't host-visible."* That holds for `status` and `search`, but `bootstrap` reads the repo bind-mounted at `/work`. The classification, not the mechanism, was the bug — which is why it survived both earlier fixes.
- The substantive test change is `FakeInfo` in `packaging.rs`: the fake `docker` can now impersonate either engine, reproducing podman's exact template error and exit 125. Every previous fixture spoke Docker, which is why a green suite
  — including `selinux_label_exception_requires_enforcement_and_daemon_support`
  — could not catch this. No test had ever asked what happens when the probe answers *nothing*.
- The fallback costs two extra `docker info` calls (three total on podman). One combined template, `'{{.Host.Security.Rootless}} {{.Host.Security.SELinuxEnabled}}'`, returns `true true` on a live podman and would cut that to two. Happy to fold it in if preferred — left out to keep this diff scoped to the bug.
- Possible follow-up, not in this PR: `restore --from <tarball>` reads a host path but is in neither list. Probing it on the same podman host shows it still gets `-u 1000:1000` and no label — exactly the shape `bootstrap` had before this PR. I stopped at the flags and did not drive it to an actual failure, so treat it as a strong suspicion rather than a reproduced bug.
