### PR TITLE
fix(store): make the FTS drift counters able to detect drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The `pages_fts_rows` and `observations_fts_rows` status counters now count
+  indexed documents instead of content-table rows. Both FTS tables use external
+  content, so `SELECT COUNT(*)` against them was answered from `pages` /
+  `observations` and the `fts: N/M` health pair could never diverge, no matter
+  how far the index had drifted.
+
 ## [1.26.0] - 2026-08-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   indexed documents instead of content-table rows. Both FTS tables use external
   content, so `SELECT COUNT(*)` against them was answered from `pages` /
   `observations` and the `fts: N/M` health pair could never diverge, no matter
-  how far the index had drifted.
+  how far the index had drifted (#392).
 
 ## [1.26.0] - 2026-08-12
 

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -5850,9 +5850,17 @@ impl ReaderPool {
 
             Ok(DerivedIndexStatus {
                 pages_rows: count(conn, "SELECT COUNT(*) FROM pages")?,
-                pages_fts_rows: count(conn, "SELECT COUNT(*) FROM pages_fts")?,
+                // `pages_fts` is an external-content FTS5 table, so
+                // `COUNT(*)` on it is answered from `pages` and can never
+                // diverge. The `_docsize` shadow table holds one row per
+                // indexed document, which is what makes this pair a drift
+                // check rather than a tautology. Same for `observations_fts`.
+                pages_fts_rows: count(conn, "SELECT COUNT(*) FROM pages_fts_docsize")?,
                 observations_rows: count(conn, "SELECT COUNT(*) FROM observations")?,
-                observations_fts_rows: count(conn, "SELECT COUNT(*) FROM observations_fts")?,
+                observations_fts_rows: count(
+                    conn,
+                    "SELECT COUNT(*) FROM observations_fts_docsize",
+                )?,
                 latest_pages_missing_embeddings: count(
                     conn,
                     "SELECT COUNT(*) \

--- a/crates/ai-memory-store/tests/fts_drift_status.rs
+++ b/crates/ai-memory-store/tests/fts_drift_status.rs
@@ -1,0 +1,78 @@
+//! `derived_index_status` must be able to report FTS drift.
+//!
+//! `pages_fts` and `observations_fts` are external-content FTS5 tables
+//! (`content='pages'` / `content='observations'`), so `SELECT COUNT(*)`
+//! against them is answered from the content table and can never diverge from
+//! it. Counting the `_docsize` shadow table is what turns the `fts: N/M`
+//! status pair into a drift check instead of a tautology.
+
+use ai_memory_core::{NewPage, PagePath, Tier};
+use ai_memory_store::Store;
+
+#[tokio::test]
+async fn page_fts_rows_report_index_drift() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let ws = store
+        .writer
+        .get_or_create_workspace("default".to_string())
+        .await
+        .unwrap();
+    let proj = store
+        .writer
+        .get_or_create_project(ws, "app".to_string(), None)
+        .await
+        .unwrap();
+    store
+        .writer
+        .upsert_page(NewPage {
+            workspace_id: ws,
+            project_id: proj,
+            path: PagePath::new("notes/one.md").unwrap(),
+            title: "one".into(),
+            body: "alpha zebra".into(),
+            tier: Tier::Semantic,
+            frontmatter_json: serde_json::json!({}),
+            pinned: false,
+            links: Vec::new(),
+            author_id: None,
+            expires_at: None,
+            entities: Vec::new(),
+        })
+        .await
+        .unwrap();
+
+    let before = store.reader.derived_index_status().await.unwrap();
+    assert_eq!(before.pages_rows, 1);
+    assert_eq!(
+        before.pages_fts_rows, 1,
+        "a freshly written page is indexed",
+    );
+
+    // Drop the page's entry from the FTS index while leaving the row in
+    // `pages`: exactly the drift this status pair exists to surface.
+    {
+        let conn = rusqlite::Connection::open(store.db_path()).unwrap();
+        conn.execute(
+            "INSERT INTO pages_fts(pages_fts, rowid, title, body, path_search) \
+             SELECT 'delete', rowid, title, body, path_search FROM pages",
+            [],
+        )
+        .unwrap();
+        let hits: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pages_fts WHERE pages_fts MATCH 'alpha'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(hits, 0, "the entry really left the index");
+    }
+
+    let after = store.reader.derived_index_status().await.unwrap();
+    assert_eq!(after.pages_rows, 1, "the source row is untouched");
+    assert_eq!(
+        after.pages_fts_rows, 0,
+        "the status pair must surface the drift, not mirror the content table",
+    );
+}

--- a/crates/ai-memory-store/tests/fts_drift_status.rs
+++ b/crates/ai-memory-store/tests/fts_drift_status.rs
@@ -6,7 +6,10 @@
 //! it. Counting the `_docsize` shadow table is what turns the `fts: N/M`
 //! status pair into a drift check instead of a tautology.
 
-use ai_memory_core::{NewPage, PagePath, Tier};
+use ai_memory_core::{
+    AgentKind, NewObservation, NewPage, NewSession, ObservationKind, PagePath, Sanitized,
+    Sanitizer, SessionId, Tier,
+};
 use ai_memory_store::Store;
 
 #[tokio::test]
@@ -73,6 +76,85 @@ async fn page_fts_rows_report_index_drift() {
     assert_eq!(after.pages_rows, 1, "the source row is untouched");
     assert_eq!(
         after.pages_fts_rows, 0,
+        "the status pair must surface the drift, not mirror the content table",
+    );
+}
+
+#[tokio::test]
+async fn observation_fts_rows_report_index_drift() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let ws = store
+        .writer
+        .get_or_create_workspace("default".to_string())
+        .await
+        .unwrap();
+    let proj = store
+        .writer
+        .get_or_create_project(ws, "app".to_string(), None)
+        .await
+        .unwrap();
+    let session_id = SessionId::new();
+    store
+        .writer
+        .begin_session(NewSession {
+            id: session_id,
+            workspace_id: ws,
+            project_id: proj,
+            agent_kind: AgentKind::Codex,
+            cwd: None,
+            actor_user: None,
+        })
+        .await
+        .unwrap();
+    store
+        .writer
+        .insert_observation(Sanitized::new(
+            NewObservation {
+                session_id,
+                workspace_id: ws,
+                project_id: proj,
+                kind: ObservationKind::UserPrompt,
+                extension: None,
+                source_event: None,
+                title: "prompt".into(),
+                body: "bravo zebra".into(),
+                importance: 5,
+            },
+            &Sanitizer::builtin(),
+        ))
+        .await
+        .unwrap();
+
+    let before = store.reader.derived_index_status().await.unwrap();
+    assert_eq!(before.observations_rows, 1);
+    assert_eq!(
+        before.observations_fts_rows, 1,
+        "a freshly written observation is indexed",
+    );
+
+    {
+        let conn = rusqlite::Connection::open(store.db_path()).unwrap();
+        conn.execute(
+            "INSERT INTO observations_fts(observations_fts, rowid, title, body) \
+             SELECT 'delete', rowid, title, body FROM observations",
+            [],
+        )
+        .unwrap();
+        let hits: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM observations_fts WHERE observations_fts MATCH 'bravo'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(hits, 0, "the entry really left the index");
+    }
+
+    let after = store.reader.derived_index_status().await.unwrap();
+    assert_eq!(after.observations_rows, 1, "the source row is untouched");
+    assert_eq!(
+        after.observations_fts_rows, 0,
         "the status pair must surface the drift, not mirror the content table",
     );
 }


### PR DESCRIPTION
## Problem

`DerivedIndexStatus` documents an invariant:

```rust
// crates/ai-memory-store/src/reader.rs:663
/// All page rows in the source table. `pages_fts_rows` should match this.
```

and `ai-memory status` prints the pair as a health signal
(`crates/ai-memory-cli/src/commands/status.rs:106-110`):

```
  fts:          pages 3269/3269; observations 106935/106935
```

Both counters are computed with `SELECT COUNT(*)` against the FTS tables
(`reader.rs:5853` and `reader.rs:5855`). Both `pages_fts` and
`observations_fts` are **external content** tables (`content='pages'` in
`V17__pages_fts_index_path.sql:32-38`, `content='observations'` in
`V12__fts_remove_diacritics.sql:49-53`), so `COUNT(*)` on them is answered from
the content table, not from the index.

The consequence is that the two ratios are structurally always `N/N`. They
cannot report drift, which is the only thing they exist to report.

## Proof, self-contained

Ten lines of SQLite, no ai-memory involved. One index entry is removed while the
content row stays, which is exactly the drift the counter is meant to catch:

```sql
CREATE TABLE pages(id INTEGER PRIMARY KEY, title TEXT, body TEXT);
CREATE VIRTUAL TABLE pages_fts USING fts5(title, body, content='pages',
    content_rowid='id', tokenize="unicode61 remove_diacritics 2 tokenchars '/_-'");
CREATE TRIGGER ai AFTER INSERT ON pages BEGIN
  INSERT INTO pages_fts(rowid,title,body) VALUES (new.id,new.title,new.body); END;
INSERT INTO pages(title,body) VALUES ('a','alpha zebra'),('b','beta zebra'),('c','gama zebra');

-- in sync
SELECT (SELECT COUNT(*) FROM pages_fts), (SELECT COUNT(*) FROM pages_fts_docsize);  -- 3 | 3

-- introduce real drift: drop one entry from the index, keep the row
INSERT INTO pages_fts(pages_fts,rowid,title,body)
  SELECT 'delete', id, title, body FROM pages WHERE title='a';

SELECT (SELECT COUNT(*) FROM pages_fts), (SELECT COUNT(*) FROM pages_fts_docsize);  -- 3 | 2
SELECT COUNT(*) FROM pages_fts WHERE pages_fts MATCH 'alpha';                       -- 0
```

`COUNT(*)` still reports 3 after the row became unsearchable. `docsize` reports
2, which is the actual number of indexed documents.

## Fix

Count the index side of the pair from the `_docsize` shadow table:

```diff
--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@
                 pages_rows: count(conn, "SELECT COUNT(*) FROM pages")?,
-                pages_fts_rows: count(conn, "SELECT COUNT(*) FROM pages_fts")?,
+                // `pages_fts` is an external-content FTS5 table, so
+                // `COUNT(*)` on it is answered from `pages` and can never
+                // diverge. The `_docsize` shadow table is the real count of
+                // indexed documents, which is what makes this pair a drift
+                // check rather than a tautology.
+                pages_fts_rows: count(conn, "SELECT COUNT(*) FROM pages_fts_docsize")?,
                 observations_rows: count(conn, "SELECT COUNT(*) FROM observations")?,
-                observations_fts_rows: count(conn, "SELECT COUNT(*) FROM observations_fts")?,
+                observations_fts_rows: count(conn, "SELECT COUNT(*) FROM observations_fts_docsize")?,
```

Also worth correcting while touching the area, though it can be dropped if you
prefer a narrower diff: `V01__init.sql:53` calls the table "contentless", but
`content='pages'` makes it external content. Contentless is `content=''`, a
different mode where `_docsize` may be absent.

## Honest caveats

- **Output does not change on a healthy store.** Both ratios keep printing
  `N/N`. The change is what happens when they are *not* equal: today that state
  is unrepresentable, after the change it is visible.
- **It depends on a shadow table.** `<name>_docsize` is part of the documented
  FTS5 on-disk structure and exists for every FTS5 table that does not set
  `columnsize=0`, which neither of these does. If you would rather not read
  shadow tables, the alternative is
  `INSERT INTO pages_fts(pages_fts, rank) VALUES('integrity-check', 1)`, which
  compares index against content properly but is a write-form statement and
  much more expensive, so it does not fit a status call.
- No behaviour, schema or migration change. Read-only, in the spirit of the
  comment already in that file about these checks reporting drift rather than
  repairing it.

## Test

New test next to the existing status assertions
(`crates/ai-memory-mcp/tests/admin_status_search.rs:117-118` asserts
`pages_rows` and `pages_fts_rows` are both 1):

```
fts_row_counts_detect_index_drift
  1. write one page, assert pages_rows == pages_fts_rows == 1
  2. remove that page's entry from the index with the FTS5 'delete' command,
     leaving the row in `pages`
  3. assert pages_rows == 1 and pages_fts_rows == 0
```

Step 3 fails before this change (both counters report 1) and passes after.

## Pre-submit checklist (run 2026-08-13 on branch `fix/fts-drift-counters` off v1.26.0)

- [x] new test fails before the change and passes after, verified in that order.
      Before: `assertion left == right failed: the status pair must surface the
      drift, not mirror the content table / left: 1 / right: 0`. After:
      `test page_fts_rows_report_index_drift ... ok`. Both runs used the
      project's own bundled SQLite, not a system one.
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` exit 0
- [x] `cargo test --workspace`: no new failures. One pre-existing failure on
      this machine, `powershell_wrapper_forwards_subscription_oauth_tokens_without_putting_values_in_argv`
      (`crates/ai-memory-cli/tests/packaging.rs:1474`), which was verified to
      fail identically on the pristine v1.26.0 tree with the change stashed.
      Everything else passes.
- [x] CHANGELOG entry under `[Unreleased]` / `### Fixed`
- [x] no store data, host paths or project names in the diff or the description
- [x] `cargo deny check`: `advisories ok, bans ok, licenses ok, sources ok`,
      exit 0. (cargo-deny 0.20.2 was installed locally to run this for real
      rather than reason about it.)

### Local environment notes, not part of the change

Two accommodations were needed to get a full-workspace run on this machine, and
neither affects what the tests exercise:

- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0` and `-j 2`. With the
  default debug profile, linking several test binaries in parallel exhausted
  memory (`link.exe` LNK1102) on a 16 GB machine.
- `TMP`/`TEMP` pointed outside the user profile. Six `ai-memory-cli` marker
  tests, including `marker::tests::find_marker_returns_none_without_one`, fail
  when a real `.ai-memory.toml` exists anywhere above the temp directory,
  because the walk-up finds it. They pass once the temp dir sits outside that
  tree. This is worth knowing for anyone running the suite on a machine that
  uses ai-memory, and it reproduces on the pristine tag too. Happy to file it
  separately if useful.
