### PR TITLE
feat(purge): strong per-session deletion (#387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `ai-memory purge-session` and `POST /admin/purge-session` for strong
+  per-session deletion, so an application that promises "forget this
+  conversation" can keep that promise. Removes the session, its observations
+  and both FTS indexes, handoffs it produced or accepted, queued consolidation
+  and auto-improvement claims, derived auto-improvement runs/proposals/events/
+  rejections, every version of its derived pages, and the wiki files — leaving
+  only a content-free tombstone. Root-only, `--confirm` required, full UUID
+  only, idempotent, and `409` while the session is still in flight unless
+  `--force`. Page provenance is now structural and sticky, so an LLM rewrite or
+  hand edit cannot launder a derived page out of the purge's reach. Managed
+  workstreams are explicitly out of scope: their `native_session_id` has no
+  foreign key to `sessions.id` and is never matched by coincidence (#387).
 - Added `[routing] mid_session` to choose how a mid-session event is attributed
   once the agent's cwd has moved. `follow-cwd` (default) keeps the historical
   per-event resolution; `sticky` keeps the session's project wherever the agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hand edit cannot launder a derived page out of the purge's reach. Managed
   workstreams are explicitly out of scope: their `native_session_id` has no
   foreign key to `sessions.id` and is never matched by coincidence (#387).
+- Hook ingest for a purged session is now refused as terminal with
+  `410 {"code":"session_purged","terminal":true}`, so an event spooled by a
+  client that was offline during the purge cannot resurrect it. The native
+  drainer treats that response as terminal — the entry is dropped without
+  spending a retry attempt — and `purge-session` additionally sweeps the local
+  `hook-spool` by exact session identity. Spools on other hosts cannot be
+  reached by the CLI; the server-side tombstone is what refuses them (#387).
+- Monthly log entries now record which session produced them, so
+  `purge-session` removes exactly that session's lines and leaves every other
+  session's intact. Entries written before this cannot be attributed to any
+  session: they are reported as a structured block rather than matched by text
+  search, and `--force` removes that month's log as the whole retention
+  unit (#387).
 - Added `[routing] mid_session` to choose how a mid-session event is attributed
   once the agent's cwd has moved. `follow-cwd` (default) keeps the historical
   per-event resolution; `sticky` keeps the session's project wherever the agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   spending a retry attempt — and `purge-session` additionally sweeps the local
   `hook-spool` by exact session identity. Spools on other hosts cannot be
   reached by the CLI; the server-side tombstone is what refuses them (#387).
+- `purge-session` now removes the purged pages from the wiki's git history
+  itself, not just from the working tree. Deleting a file and committing left
+  every prior version reachable — and `restore-page` would hand one back — so
+  the repository is rebuilt without those paths and the old object database is
+  physically destroyed. History is preserved, not squashed; a blob shared with
+  a surviving page is spared; directories emptied by the purge are dropped; and
+  the rebuild is verified against both the paths and the object database before
+  anything destructive happens, so a failed verification leaves the live
+  repository untouched. An interrupted swap is completed from a durable journal
+  at the next startup, before the wiki is opened for business (#387).
 - Monthly log entries now record which session produced them, so
   `purge-session` removes exactly that session's lines and leaves every other
   session's intact. Entries written before this cannot be attributed to any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3323 +1,708 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-### Added
-- Added `ai-memory purge-session` and `POST /admin/purge-session` for strong
-  per-session deletion, so an application that promises "forget this
-  conversation" can keep that promise. Removes the session, its observations
-  and both FTS indexes, handoffs it produced or accepted, queued consolidation
-  and auto-improvement claims, derived auto-improvement runs/proposals/events/
-  rejections, every version of its derived pages, and the wiki files — leaving
-  only a content-free tombstone. Root-only, `--confirm` required, full UUID
-  only, idempotent, and `409` while the session is still in flight unless
-  `--force`. Page provenance is now structural and sticky, so an LLM rewrite or
-  hand edit cannot launder a derived page out of the purge's reach. Managed
-  workstreams are explicitly out of scope: their `native_session_id` has no
-  foreign key to `sessions.id` and is never matched by coincidence (#387).
-- Hook ingest for a purged session is now refused as terminal with
-  `410 {"code":"session_purged","terminal":true}`, so an event spooled by a
-  client that was offline during the purge cannot resurrect it. The native
-  drainer treats that response as terminal — the entry is dropped without
-  spending a retry attempt — and `purge-session` additionally sweeps the local
-  `hook-spool` by exact session identity. Spools on other hosts cannot be
-  reached by the CLI; the server-side tombstone is what refuses them (#387).
-- `purge-session` now removes the purged pages from the wiki's git history
-  itself, not just from the working tree. Deleting a file and committing left
-  every prior version reachable — and `restore-page` would hand one back — so
-  the repository is rebuilt without those paths and the old object database is
-  physically destroyed. History is preserved, not squashed; a blob shared with
-  a surviving page is spared; directories emptied by the purge are dropped; and
-  the rebuild is verified against both the paths and the object database before
-  anything destructive happens, so a failed verification leaves the live
-  repository untouched. An interrupted swap is completed from a durable journal
-  at the next startup, before the wiki is opened for business (#387).
-- Monthly log entries now record which session produced them, so
-  `purge-session` removes exactly that session's lines and leaves every other
-  session's intact. Entries written before this cannot be attributed to any
-  session: they are reported as a structured block rather than matched by text
-  search, and `--force` removes that month's log as the whole retention
-  unit (#387).
-- Added `[routing] mid_session` to choose how a mid-session event is attributed
-  once the agent's cwd has moved. `follow-cwd` (default) keeps the historical
-  per-event resolution; `sticky` keeps the session's project wherever the agent
-  wanders, closing the cross-repo `cd` case that split one session's raw record
-  across two projects. Lifecycle hooks now tag each `project` override with its
-  provenance (`project_src=marker` or `project_src=repo-root`), so `sticky`
-  overrules a host-derived repo name while a `.ai-memory.toml` marker still
-  wins in both modes. Clients older than this release send no provenance and
-  keep their overrides authoritative (#394).
-- Added `[auth].secure_cookie` for HTTPS reverse-proxy deployments to mark
-  `/web` browser authentication cookies `Secure` while preserving plain-HTTP
-  loopback compatibility by default (#396).
-
-### Changed
-- Unauthenticated HTTP binds beyond loopback now fail closed before accepting
-  requests. Intentional insecure LAN use requires `--allow-insecure-no-auth`;
-  authenticated non-loopback HTTP remains available with its TLS warning
-  (#396).
-- `/api/v1` internal failures now return the fixed body
-  `{"error":"internal server error"}` instead of the source error chain, which
-  could expose data-directory paths and configuration to a browser. The
-  detailed cause is logged server-side (#396).
-- The `/web` browser authentication cookie is now `SameSite=Strict` rather than
-  `SameSite=Lax`, so it no longer rides top-level cross-site navigations into
-  the UI. Existing sessions stay valid (#396).
-
-### Fixed
-- Mid-session hook events that resolve to a different project than their
-  session — the ordinary result of an agent `cd`-ing into another checkout —
-  are recorded again instead of being dropped as a session-UUID collision.
-  Owner and agent still identify a session and a mismatch there remains
-  terminal; a `SessionEnd` naming a foreign scope is still dropped without
-  ending the session (#396).
-- Hook session UUIDs now reject cross-owner reuse atomically before ingest-key,
-  observation, summary, handoff, or end-state mutation; explicit root
-  `finalize-session --all-owners` recovery remains available (#396).
-- Newly created data directories, configuration files, SQLite databases,
-  managed-workstream segments, and downloaded backups now receive owner-only
-  Unix permissions before sensitive content is written, independent of the
-  ambient umask. Existing installations are left unchanged; Windows relies on
-  filesystem ACLs (#396).
-- Under the `repo-root` project strategy, mid-session events whose cwd sits
-  outside any git repository and any `.ai-memory.toml` marker (agent scratch
-  directories, `/tmp`, data folders) now inherit the session's project instead
-  of minting phantom basename projects (`scratchpad`, `data`, `tmp`, ...). The
-  host-side hook resolves the repository root itself and sends
-  `project=<root name>`, so a missing override already proves the cwd is
-  unresolvable; session-sticky attribution now accepts these events even
-  outside the session's cwd subtree, with the broad-anchor guards unchanged.
-  Deliberate rescopes keep working: git checkouts and markers arrive as
-  explicit overrides and never reach stickiness, and the default `basename`
-  strategy is untouched (#394).
-
-## [1.26.1] - 2026-08-14
-
-### Fixed
-- Forget-sweep decay now removes the authoritative Markdown file while
-  conditionally tombstoning the selected page, preventing reconciliation from
-  resurrecting evicted content. Aged cleanup recognizes rewritten heads,
-  deletes their complete `supersedes` ancestry, ignores lifetime access counts,
-  and preserves a newer page recreated at the same path. The corrected scoped
-  tombstone index is added by a new migration rather than rewriting history
-  (#391).
-- The `pages_fts_rows` and `observations_fts_rows` status counters now count
-  indexed documents instead of content-table rows. Both FTS tables use external
-  content, so `SELECT COUNT(*)` against them was answered from `pages` /
-  `observations` and the `fts: N/M` health pair could never diverge, no matter
-  how far the index had drifted (#392).
-
-## [1.26.0] - 2026-08-12
-
-### Added
-- Added MCP-only Swival CLI support. `install-mcp --client swival --apply`
-  merges ai-memory's native HTTP entry into the project-root
-  `.swival/mcp.json`, and `uninstall` removes only the matching ai-memory
-  entry while preserving sibling servers. Lifecycle capture and managed
-  workstreams remain unsupported because Swival's callback contract does not
-  expose a stable session identifier (#385).
-
-### Fixed
-- Lifecycle-only sessions containing only `SessionStart` / `SessionEnd` now
-  close without generating an empty session page, fallback handoff, or LLM
-  consolidation job. Startup handoff claims are bound to the native receiver
-  session when clients expose one; if that receiver exits without substantive
-  work, the same transaction that ends it returns the accepted handoff to the
-  open pool. Tool-bearing zero-prompt sessions remain substantive. Shipped
-  Claude Code, Codex, OpenCode, Command Code, Kiro, Antigravity, Devin, Cursor,
-  Gemini CLI, and Kimi Code delivery paths forward their available session ids
-  so an empty receiver cannot permanently consume real work (#386).
-- The `bin/ai-memory` wrapper now detects rootless mode and SELinux under
-  podman, so host-file commands stop failing with `Permission denied (os error
-  13)` on podman-based distros. Both the `-u 0:0` remap and `--security-opt
-  label=disable` were decided from `docker info --format
-  '{{.SecurityOptions}}'`, a Docker-only field that podman cannot evaluate;
-  the swallowed error left both gates off exactly where they were needed.
-  Podman's `.Host.Security.*` keys are consulted when that probe comes back
-  empty. `bootstrap` is now covered as well: it only reads host files, but an
-  unmapped UID blocks reads just as hard, and it degraded silently to "no
-  `.git` found" before dying. Restore archives, explicit config paths, and
-  commands using a host-backed `AI_MEMORY_DATA_DIR` now receive the same
-  host-file treatment (#388).
-
-## [1.25.0] - 2026-08-07
-
-### Added
-- Added version-aware Kiro CLI v3 managed workstreams. `ai-memory run kiro
-  --v3` reads the authenticated 2.16.2 nested `session.json` / `messages.jsonl`
-  store through a visible-event allowlist, persists the incompatible engine
-  flavor in its cursor, resumes with exact `--v3 --resume-id`, and joins bare
-  automatic selection alongside v2 without cross-resuming either store. Plain
-  returning Kiro launches recover the linked engine transparently; v3 wrapper
-  `--yolo` adds no flag because Kiro replaced `--trust-all-tools` with
-  `permissions.yaml`. A targeted compatibility path also handles Kiro 2.16.2
-  writing v3 sessions to default `~/.kiro` despite custom `KIRO_HOME`: only a
-  resume proven to live in that fallback drops the override for its child
-  process. The optional deterministic acceptance runner now covers fresh,
-  resume, and import round trips for both engines. The server automatic-harness
-  validator now accepts the Kiro candidate pool advertised by the client,
-  preventing bare `ai-memory run` from rejecting a discovered Kiro session
-  before launch (#356).
-- Added first-party Command Code MCP and stable lifecycle-hook support.
-  `install-mcp --client command-code` merges the documented user-scope HTTP
-  entry; `install-hooks --agent command-code` preserves existing settings and
-  registers only `SessionStart`, `PreToolUse`, `PostToolUse`, and `Stop` with
-  native session attribution, capture exclusions, and startup handoff
-  injection. `ai-memory run command-code` now adds v3 checkout-scoped
-  transcript discovery, exact `--session <uuid>` resume, automatic harness
-  selection, native `--yolo` translation, and a visible-event allowlist that
-  retains branch parent ids and summaries while excluding hidden reasoning,
-  images, custom/Mod records, and provider metadata. Deterministic acceptance
-  covers fresh, resume, and incremental-import round trips. Experimental unsandboxed Mods remain
-  excluded, and the turn-only Stop boundary is documented with the manual
-  finalizer workflow (#373).
-- `ai-memory finalize-session --session-id <uuid>` targets exactly one open
-  session instead of "the latest open one for this agent+scope". Agents with
-  no true SessionEnd hook (Kiro CLI, Codex, Antigravity CLI) rely on
-  `finalize-session` to synthesize the summary+handoff, and the
-  newest-first default breaks down with several concurrent sessions for the
-  same agent in one project — e.g. multiple terminal tabs each running Kiro
-  CLI against the same repo — where it can close out a still-active session
-  instead of the one that actually finished. Backed by a new optional
-  `session_id` filter on `GET /admin/open-sessions`, composed with (not
-  bypassing) the existing owner filter: a session id belonging to another
-  operator is still unreachable without `--all-owners`, same as the default
-  query ([#374]).
-
-### Fixed
-- Kimi Code 0.34.0 managed runs now discover checkout-local sessions from the
-  current `state.json` `cwd` field as well as the legacy `workDir` alias. The
-  parser rejects conflicting aliases and persisted ids that disagree with the
-  session directory, and deterministic acceptance now exercises the current
-  state schema (#382).
-- Prevented delayed post-tool and shutdown hook tails from redirecting the
-  shared active-project fallback after work moved to another project. Only
-  session starts, user prompts, and pre-tool events now advance shared or
-  identity-only fallbacks; other events refresh exact session mappings, and
-  dropped-subagent preflight no longer publishes scope (#372).
-- The Anthropic provider stopped sending `temperature` to Claude 4.7 and later
-  models, including the Claude 5 families, and to Claude Mythos Preview. Those
-  models reject non-default sampling parameters, which made `bootstrap`,
-  consolidation, `lint`, and auto-improvement fail with an upstream 400. Both
-  `anthropic` and `anthropic-oauth` now omit the field for affected models and
-  preserve it elsewhere. `llm-test` also sends a representative 0.2 value
-  before provider normalization, so it exercises the same compatibility path
-  as the real pipeline (#377).
-- Both wrappers (`bin/ai-memory` and `bin/ai-memory.ps1`) now forward
-  `ANTHROPIC_OAUTH_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN` to the helper
-  container. Their API-key counterparts were already in the passthrough list,
-  so subscription-token setups (`claude setup-token`,
-  `AI_MEMORY_LLM_PROVIDER=anthropic-oauth`) silently lost their credential at
-  the container boundary. The visible symptom is that the retry `status`
-  itself recommends — `llm-test --provider anthropic-oauth` — fails with a
-  missing-token error, because `llm-test` runs client-side in the helper
-  rather than on the server. The PowerShell wrapper also trims trailing path
-  separators as individual characters, so Windows invocations reach Docker
-  instead of failing during path normalization (#379).
-
-## [1.24.0] - 2026-08-04
-
-### Added
-- MCP-only clients are now visible in the operator's traffic picture.
-  Every MCP tool call is counted against its caller — the sanitized
-  `clientInfo.name` from the initialize handshake when the HTTP
-  transport runs stateful (`--http-stateful`) or over stdio, else the
-  `X-Memory-Actor-Agent` overlay an ingress proxy asserts, else
-  `unknown` — split into reads and writes and bucketed per UTC day in a
-  new `client_activity` table (V46). A new multi-user root-gated
-  `GET /admin/activity/by-client?since_days=N` reports the aggregate,
-  volume-descending with a name tiebreak (`0`/absent = whole history).
-  Counts buffer in memory and flush from one background task on a one-minute
-  interval, even when the server becomes quiet; failed batches remain bounded
-  in memory and retry once per interval. Process exit can still lose the
-  current interval. Each UTC day retains at most 128 distinct names and folds
-  additional names into `other`, preventing untrusted client names from
-  causing traffic-proportional row growth. Unknown future tools count as
-  writes, so an unclassified tool surfaces as suspicious growth instead of
-  hiding among reads. This complements
-  `/admin/sessions/by-agent`: hook-driven agents open sessions,
-  MCP-only clients (VS Code Copilot, Claude Desktop, scripts) never do,
-  and until now left no trace at all. (#366)
-- Added explicit Kiro CLI v2 managed-workstream launches through `ai-memory run
-  kiro` / `kiro-cli`, including native `--resume-id` reuse, `$KIRO_HOME`
-  discovery, v2 `--yolo` translation, read-only visible-event import, and
-  checkout-scoped UUID/metadata validation. Non-v2 engines pass through
-  without session injection. Kiro remains outside bare automatic selection
-  until a logged-in current-format acceptance run is available, and v3 managed
-  sessions remain unsupported (#356).
-- Added verified Kiro CLI lifecycle hooks for both incompatible engines. The
-  existing `kiro` / `kiro-cli` target keeps v2's camelCase hooks in agent
-  configs; the explicit `kiro-cli-v3` target atomically merges Kiro's
-  standalone `v1` registration under `$KIRO_HOME/hooks`. Both preserve
-  unrelated entries and project strategies, infer remote MCP connectivity,
-  inject startup handoffs, enforce capture exclusions for documented file-tool
-  payloads, and uninstall only proven ai-memory entries (#355).
-- Added `[consolidation] max_input_tokens` and `max_output_tokens`
-  (`AI_MEMORY_CONSOLIDATION__MAX_INPUT_TOKENS` /
-  `AI_MEMORY_CONSOLIDATION__MAX_OUTPUT_TOKENS`) for provider-specific context
-  limits. Input sizing now accounts for the rendered system/user messages,
-  bounded current-page or slot context, structured-output schema, and provider
-  envelope reserve instead of budgeting only the observation dump. Unsupported
-  minimums are rejected at startup (#369).
-
-### Fixed
-- Mixed-case and trailing-period usernames now use deterministic hashed
-  per-operator slot namespaces, preventing distinct identities from sharing one
-  physical directory on case-insensitive filesystems (#364).
-- Consolidation prompts no longer ignore system, schema, instructions, and
-  dynamic slot/current-page overhead when allocating observations. The
-  provider-neutral estimate is deliberately conservative and documents the
-  remaining tokenizer variance instead of claiming an exact token ceiling
-  (#369).
-- A failing LLM no longer costs a session its PreCompact/PostCompaction
-  checkpoint. Provider failures (context overflow, rate limit, outage) and
-  unmappable structured output now degrade to the rule-based checkpoint a
-  zero-LLM install writes, so configuring a provider can no longer be worse
-  than leaving it unset. The fallback keeps the `consolidate` admission event;
-  admission rejections, wiki/store failures, and unresolvable sessions still
-  fail closed (#369).
-- Native-session checkout matching now fails closed when either path cannot be
-  canonicalized, instead of treating two missing or inaccessible paths as the
-  same checkout during managed resume or adoption (#356).
-
-## [1.23.0] - 2026-08-03
-
-### Changed
-- Documented provider-neutral coexistence with structural code-intelligence
-  tools: use ai-memory for historical intent and continuity, use the current
-  checkout or structural provider for live symbols and impact analysis, verify
-  historical structural claims before acting, and keep source, builds, tests,
-  and observed runtime behavior authoritative. No provider coupling, automatic
-  querying, or persisted structural-evidence schema was added (#353).
-
-### Fixed
-- Antigravity CLI's generated native `PreToolUse` hook now returns the required
-  `{"decision":"allow"}` response on normal capture, malformed input, and
-  capture-policy drops. Local installs default to the native spool-based hook
-  command, whose generic `{}` response caused Antigravity to deny every tool
-  call even though the staged shell and PowerShell hooks already returned the
-  correct decision (#352).
-
-### Added
-- Kiro CLI is now supported as an MCP-only client through `install-mcp
-  --client kiro-cli` (alias `kiro`). The installer preserves existing
-  `$KIRO_HOME/settings/mcp.json` content, adds bearer headers when configured,
-  honors `$KIRO_HOME`, and appends a Bedrock schema flavor that removes only
-  unsupported root-level JSON Schema combinators. Non-loopback Kiro endpoints
-  must use HTTPS and are rejected before `--apply` writes an unusable config.
-  Kiro lifecycle hooks and managed workstreams remain deferred because its v2
-  and early-access v3 engines use incompatible hook and session formats
-  (#351).
-- Added `ai-memory continue`, which resumes the most recently launched managed
-  checkout from any directory. `run`'s bare mode already continues the current
-  checkout, but its workstream lookup is keyed by repository and worktree
-  fingerprints, so it requires a `cd` first. `continue` orders the client-local
-  checkout links by their `linked_at` stamp, revalidates the newest one's path
-  and resolved scope, and then delegates to the same bare-mode launch. Stale,
-  retargeted, scope-mismatched, or corrupt-ordering links are announced on
-  stderr and skipped rather than silently resuming a different project. It
-  accepts `--workspace`,
-  `--yolo`, and `--fresh`; native harness arguments and `--executable` remain
-  unavailable because bare mode does not know which harness it will pick.
-  Docker-wrapper installs route the command through the checksum-verified host
-  client so it can inspect local checkouts, session stores, and harnesses
-  (#350).
-- New `GET /admin/sessions/by-agent` endpoint reporting how many sessions
-  each agent CLI opened in one scope (`claude-code`, `cursor`, `codex`, …),
-  so a dashboard can answer "where is this project's memory coming from".
-  `sessions.agent_kind` already carried the answer but no read surface
-  exposed it — the existing `/admin/open-sessions` takes the agent as a
-  *filter* and returns neither the kind nor a total. Counts cover open and
-  ended sessions alike, take an optional `since_days` window (`0` or absent
-  = whole history), and order count-descending with an agent-name tiebreak
-  so equal counts do not reorder between calls. Like the other scoped admin
-  reads it reports the caller's own sessions plus unowned ones, with
-  `all_owners=true` as the recovery switch. Unknown scopes 404 rather than
-  being auto-created. No migration. (#349)
-
-## [1.22.0] - 2026-08-01
-
-### Added
-- Added `ai-memory show`, a project-first managed launcher that joins private
-  client-local checkout links with public server project metadata and a bounded
-  local scan, then launches an installed harness without changing the parent
-  process directory. It supports discovery-only `--json`, stages new projects
-  atomically with routing and Agent Skills, keeps remote-server filesystem paths
-  private, refreshes links after successful managed prepares and CLI
-  rename/move operations, and runs host-side through the Docker wrapper (#342).
-- Hook ingestion now recognizes Hermes Agent as a concrete session kind and
-  understands its documented shell-hook `tool_name` / `tool_input` envelope
-  for bounded tool-family titles and capture exclusions. Migration V44 expands
-  the session allowlist without losing session ownership, observation
-  watermarks, indexes, or scope-pairing triggers. This remains protocol support,
-  not a first-party Hermes installer, and session-start handoff acceptance stays
-  disabled because Hermes ignores that hook's stdout (#337).
-- Trusted-proxy identity now has a dedicated
-  `[auth].actor_proxy_bearer_token`, distinct from the root bearer. Proxy
-  requests must assert either a username or the complete OIDC issuer/subject
-  pair; missing, partial, duplicated, or comma-folded identity headers fail
-  closed. Proxied root access requires the configured OIDC issuer/subject pair;
-  a display username never grants root. Ordinary root and DB-user requests
-  continue to ignore raw actor headers, and leaving the proxy token unset
-  preserves existing behavior (#333).
-- Qualified identity keys now keep usernames separate from OIDC
-  `(issuer, subject)` pairs and drive active-project routing consistently for
-  hook and MCP requests. The stable OIDC pair outranks display usernames, so
-  same-subject users from different issuers cannot alias each other (#333).
-- The `/admin/*` route layer and the MCP `memory_forget_sweep` tool now ask
-  "does this deployment distinguish operators" instead of "do `users` rows
-  exist", so a trusted-proxy deployment — which never writes a `users` row —
-  gets root-only admin gating instead of waving every proxied caller through
-  the single-operator escape hatch (#333).
-- Optional `[slots] per_user` namespaced engine-written memory slots by the
-  authenticated operator. Session briefs and consolidation prompts now receive
-  shared slots plus that operator's own bounded namespace, while foreign slot
-  writes are refused. The feature defaults off, preserves existing shared
-  slots, and intentionally leaves exact wiki reads and searches project-wide
-  because it is an agent-context injection boundary rather than RBAC (#335).
-- Handoffs now belong to the operator that created them (migration V39). On a
-  server shared by several people the open-handoff lookup was scoped by
-  `(workspace, project, state)` alone, so the next session to start — whoever it
-  belonged to — consumed the pending baton, and delivery is destructive, so the
-  author simply lost it. `cwd` did not help: a handoff created through
-  `memory_handoff_begin` is always manual (`from_session_id = NULL`), and manual
-  handoffs bypass the cwd check and outrank automatic ones, so the deliberate
-  artefact was exactly the one that crossed operators. Ownership is now checked
-  before those rules, and the owner column holds the qualified
-  `IdentityKey::storage_key()` TEXT. `memory_handoff_begin` gains `shared: true`
-  to publish a baton to the whole project on purpose; `memory_handoff_accept`
-  gains `any_owner: true` for recovery. A NULL owner still means "shared", so
-  every stored row and every caller without an authenticated actor behaves
-  exactly as before (#334).
-- Sessions record their operator (migration V40), and the open-session lookup
-  behind `GET /admin/open-sessions` is scoped to the caller unless
-  `all_owners=true`. `finalize-session` drives off that lookup and acts
-  destructively on the result — ending the session, synthesising a page from its
-  observations and minting a handoff carrying its raw prompts — so picking "the
-  newest open session in the scope" could do all of that to a colleague's live
-  session. The new `--all-owners` flag exposes the server switch (#334).
-- New `GET /api/v1/workspaces/{workspace}/projects/{project}/handoffs` lists a
-  project's handoffs, filtered by `state` and scoped by owner, backed by new
-  non-partial indexes (migration V41) since every pre-existing handoffs index is
-  partial on `state = 'open'`. There was no handoff listing anywhere in the
-  system: readers only ever fetched the single pending one and consumed it, so a
-  mis-delivered baton could not be inspected or recovered. On a server that
-  authenticates, the prompt-derived fields (`summary`, `open_questions`,
-  `next_steps`) are served to a caller the server can name and to the root
-  operator, and are omitted with `redacted: true` for a caller it can place as
-  neither — unowned rows are shared, so such a caller matches every one of them,
-  and unlike the overview's single newest card this returns the project's whole
-  history. Cross-owner reads require the explicit root-only
-  `all_owners=true` recovery switch. The metadata is served either way,
-  which is what makes the listing useful; a server with no auth configured
-  serves the bodies too, since it already serves every page body
-  unauthenticated (#334).
-- New admission-chain operations `handoff_begin`, `handoff_accept` and
-  `handoff_cancel`. Handoffs live in their own table, so their lifecycle never
-  passed through `Wiki::write_page` and was invisible to admission webhooks —
-  leaving the operations that move prompt-derived text between operators
-  unauthorizable. Every path raising one of them asks and announces in the same
-  order: only the webhooks that can refuse (blocking + reject policy) are
-  awaited before the operation, and observers are dispatched fire-and-forget
-  after it, only if it happened — so `memory_handoff_accept`, whose routine
-  answer is `{"handoff": null}`, never announces an accept that found nothing,
-  and a mirror is never told about a baton the engine then abandoned. The
-  automatic SessionEnd handoff and the session-start claim run through the same
-  chain as their operator-triggered counterparts, forwarding the caller's
-  webhook skip-list under the same root-only rule as every other transport.
-  Neither can cost an operator anything beyond the operation the webhook
-  declined: SessionEnd still writes the summary page, runs the opt-in
-  consolidation and commits (a refusal skips the baton and is logged), and a
-  refused, timed-out or unreachable claim leaves the handoff open for the next
-  session (#334).
-- Pending auto-improve proposals record who staged them (V42
-  `staged_by_actor_user`, the qualified identity key, surfaced on the proposal
-  detail), and the one-pending-per-target rule is scoped per operator through
-  a NULL-collapsing unique index, so one operator's pending suggestion stops
-  blocking everybody else's for the same page while every unattributed caller
-  keeps the original one-per-page rule unchanged (#336).
-- Page reinforcement records each distinct authenticated operator (V43
-  `page_access`) beside the existing shared access counter. The opt-in
-  `[decay] breadth_weight` term (default `0.0`) lets the forget sweep retain
-  pages reinforced by several operators without changing existing scores at
-  the default or for pages with zero or one identified reader (#336).
-
-- `run` accepts `antigravity` (aliases `antigravity-cli`, `agy`) as a
-  managed harness, so an Antigravity session joins the same workstream as the
-  Claude Code or Codex sessions on the same checkout. `agy` accepts no
-  caller-chosen id for a new conversation, so a fresh launch injects no
-  selector and the id is linked by the hooks or discovered afterwards; a
-  linked resume passes `--conversation <id>`, and `--continue` / `-c` is
-  respected as an explicit user choice. `--yolo` maps to
-  `--dangerously-skip-permissions`, and the utility
-  subcommands (`models`, `plugin`, `update`, …) pass through without a selector.
-  Conversation discovery reads the per-conversation SQLite databases under
-  `~/.gemini/antigravity-cli/conversations/`: the id is the file name and the
-  workspace comes from two observed protobuf fields, so only conversations
-  opened on the current directory are offered and a database from another `agy`
-  version is skipped instead of failing the listing. Step payloads are
-  undocumented, unversioned protobuf, so conversation text is deliberately not
-  decoded — the visible-event ledger for this harness comes from lifecycle-hook
-  capture, and transcript export fails with a message saying so. Antigravity is
-  not part of the no-argument auto-detection pool. The native contract was
-  verified against Antigravity CLI v1.1.7 (#345).
-
-### Fixed
-- `run` on Windows now resolves npm-style harness installs through `PATHEXT`
-  and starts the resolved wrapper. This avoids accepting an extensionless Unix
-  shell shim such as `opencode` during availability checks and then failing to
-  launch it when the adjacent `opencode.cmd` is the Windows entry point. Unix
-  resolution remains unchanged (#343).
-- `memory_auto_improve` without a `session_id` now selects the newest
-  completed session that has no persisted auto-improvement run. Preflight-
-  skipped sessions therefore advance the implicit manual-review queue instead
-  of permanently starving older sessions; passing an explicit session ID still
-  permits a targeted rerun (#338).
-- Handoff and session ownership is stamped only where the deployment actually
-  distinguishes operators. A server with `[auth].bearer_token` +
-  `[auth].root_username`, no `users` rows and no proxy has one operator and two
-  transports: stamping that one name on every HTTP write while the stdio /
-  in-process transport carries no actor would make one person's handoffs and
-  sessions invisible to their own other transport on the same data directory.
-  With nobody to separate, the stamp is the pre-ownership `NULL` and both
-  transports agree. Reads are deliberately not gated the same way, so rows
-  stamped while a deployment did distinguish operators stay readable by that
-  operator afterwards (#334).
-- The automatic SessionEnd handoff, the session page and both consolidation
-  paths attribute to the operator recorded on the **session**, not to whoever
-  delivered the event — a spool drain, a shared hook token or an operator
-  finalizing a stuck session all carry a different identity. The atomic store
-  operation also rejects a handoff whose owner differs from its source session
-  (#334).
-- Briefings and both read-only overviews — workspace and project — scope
-  handoffs to the requesting actor instead of showing only unowned ones, and
-  `pending_handoff_count` applies the same filter as the fetch — otherwise a
-  briefing advertises a pending baton the same caller can never retrieve, and on
-  any server that stamps owners the overview's handoff card would go permanently
-  empty while the count beside it kept reporting the row. The read-only
-  `/api/v1` overview no longer surfaces handoffs that belong to a specific
-  operator, including the raw prompt text an automatic handoff is synthesised
-  from, to a browser the server cannot attribute (#334).
-- Retiring superseded automatic handoffs no longer crosses an operator
-  boundary. Both sweeps — the same-cwd expiry on a new SessionEnd handoff and
-  the post-claim cleanup after an accept — match on the acting handoff's
-  `owner_user`, so one person starting or ending a session in a directory
-  cannot expire another person's pending baton. A shared handoff (no owner) is
-  visible to everyone, so it is only ever superseded by another shared one; on
-  a single-operator or unauthenticated server every row is unowned and the
-  sweeps behave exactly as they did (#334).
-- `ops::accept_handoff` propagates whether the claim actually succeeded, so
-  `memory_handoff_accept` no longer returns the handoff body when the atomic
-  claim was lost — previously two agents could be handed the same baton. The
-  cross-operator escape hatches require admin authority: `any_owner` on
-  `memory_handoff_accept` and on `memory_handoff_cancel` (which previously had
-  no recovery path at all, so a handoff whose owner no longer matched any
-  reachable identity could not be discarded), and `--all-owners` on
-  `ai-memory finalize-session` (#334).
-- The `[auto_scope] per_actor` active-project map is keyed by the qualified
-  identity on both sides — the hook ingress that publishes and the MCP tools
-  that read — so an OIDC-proxied operator's writes and reads land on the same
-  slot instead of silently missing on every read (#334).
-- Owner predicates for pending and exact-id handoff reads now execute in SQL
-  before prompt-derived fields are loaded. Exact-id cancellation returns the
-  same result for absent, wrong-scope and foreign-owner ids, so it no longer
-  discloses another operator's handoff state before authorization. Accept and
-  cancel also recheck the expected workspace and project in the atomic state
-  update, closing a lifecycle race between the scoped read and destructive
-  write (#334).
-- Ownership writes reject malformed identity keys, and malformed non-null
-  session-owner keys already present in the database fail closed during hook
-  processing instead of being converted to the shared `NULL` bucket.
-  Named-user handoff history uses two indexed shared/owned ranges, so a large
-  volume of another operator's rows cannot turn a bounded listing into a
-  project-wide scan (#334).
-- Actor-scoped briefing, overview and handoff-history responses now use
-  `Cache-Control: private, no-store`, preventing a browser from reusing one
-  operator's prompt-derived response after credentials at the same URL change
-  to another operator (#334).
-- Automatic session-start handoff admission is capped at 750 ms, below the
-  shortest shipped client's one-second fetch timeout. A slow deciding webhook
-  leaves the baton open instead of approving and consuming it after the caller
-  has disconnected (#334).
-- A staged auto-improve proposal colliding with one already pending no longer
-  aborts its whole staging run (losing the run row, its sibling proposals and
-  the paid LLM review): the colliding proposal alone is skipped, and every
-  staging surface — `memory_auto_improve`, `/admin/auto-improve`, the
-  telemetry report, the curator, the CLI and the scheduler's log — names the
-  skipped target and the reason instead of silently returning N-1 proposals
-  (#336).
-
-## [1.21.0] - 2026-07-31
-
-### Added
-- Per-page TTL via a frontmatter `expires_at:` key (RFC3339, or a bare
-  `YYYY-MM-DD` meaning end of that day UTC), mirrored into a new
-  `pages.expires_at` column (V36) and settable through a new optional
-  `expires_at` parameter on `memory_write_page`. Expired pages are hidden
-  from `memory_query`/`memory_recent`/briefing/session-brief surfaces —
-  `memory_query` gains `include_expired: true` to still see them — while
-  exact-path reads still return the page, annotated `expired: true`,
-  because an explicit read is not a search. The forget sweep hard-deletes
-  them through the wiki layer, so the markdown file goes too, not just
-  the rows. An explicit TTL outranks `pinned` (a pin means "don't decay
-  this", not "keep it past the date its author set"); `memory_lint`
-  flags pinned+expiring pages so the combination is visible rather than
-  silent. (#309)
-- Zed editor as an MCP-only client. `install-mcp --client zed` renders,
-  and `--apply` idempotently merges, a native remote HTTP entry under the
-  top-level `context_servers` map in Zed's platform user `settings.json`,
-  with optional bearer headers. The JSONC-aware apply and uninstall paths
-  preserve user comments, trailing commas, unrelated settings, and sibling
-  servers while changing only the matching ai-memory entry. Zed does not
-  provide lifecycle hooks or managed-workstream continuity. (#321)
-- Entity-match retrieval as a fourth RRF stream (V38 `entities` +
-  `entity_page_links`). Consolidation emits up to 10 normalized technologies,
-  components, services, files, or domain nouns per page into frontmatter;
-  manually edited `entities` use the same index path, and reindex rebuilds the
-  derived tables from markdown. Project-scoped query tokens match exact names,
-  name prefixes, or word prefixes inside compound names and are weighted by
-  inverse entity frequency before RRF fusion and the existing authority and
-  optional LLM reranking stages. Empty entity indexes contribute no candidates
-  or score, and entity matching makes no LLM call. `explain: true` reports the
-  entity stream's rank, raw inverse-frequency weight, contribution, and matched
-  names. (#320)
-- Optional post-RRF reranking for project and explicit-scope
-  `memory_query`, off by default. Set `AI_MEMORY_RERANKER=llm` (requires
-  `AI_MEMORY_LLM_PROVIDER`) to over-fetch candidates, fuse scopes, and
-  make at most one structured-output call through any existing LLM
-  provider. The prompt JSON-encodes untrusted input and sends the query
-  (up to 1,000 bytes) plus at most 30 page titles (200 bytes each) and
-  snippets (600 bytes each) to that provider. The requested result limit
-  is preserved even above 30; only the first 30 candidates are judged.
-  A partial/duplicate/unknown id set, invalid score, timeout, provider error,
-  or four-call concurrency saturation preserves the pre-rerank order.
-  `global=true` and supplemental
-  global-preference hits keep their existing non-RRF ranking. With
-  `explain: true`, judged hits include `rerank_score`. Unknown reranker
-  values and `llm` without a provider fail at startup. (#319)
-- New MCP tool `memory_feedback` (17th tool) — the "finer-grained
-  reinforcement beyond access counts" P2 item. Record how useful a
-  recalled page actually was by exact path: `helpful` / `not_helpful`
-  step the page's new `pages.salience` column (V37, bounded to
-  `[0.25, 2.0]` in 0.25 steps), which now scales the retention formula's
-  time term for sweep-eligible episodic pages instead of a single global
-  `salience_default`; `stale` /
-  `wrong` floor the salience AND surface the page as a
-  `feedback_flagged` finding in the next `memory_lint` report. Signals
-  land in a new append-only `page_feedback` table with an optional
-  sanitized, bounded single-line reason, the resulting salience needed to
-  rebuild derived state, and a full audit-log entry. Nothing is ever
-  deleted by feedback. The exact path resolves to the current page version
-  in the feedback transaction, so rewriting a flagged page later retires
-  both its salience and its lint findings — there is no separate dismissal
-  state. Pages without feedback keep `salience = NULL`, which reads as
-  exactly the previous behaviour. Retrieved content cannot authorize a
-  feedback call; agents treat it as untrusted data. (#318)
-- `memory_query` gained an optional `explain: true` mode for project and
-  explicit-scope searches. Each compiled-page hit then includes its 1-based
-  FTS5, entity, vector, and graph ranks; raw BM25/cosine/entity values; matched
-  entity names; graph seed and link direction; per-stream RRF contributions;
-  fused score; and bounded authority multiplier. `streams_active` makes vector
-  degradation visible. Global
-  cross-project search reports its distinct FTS-only stream but does not attach
-  RRF details to `global_hits`. Explain provenance is computed only when
-  requested. (#317)
-- Per-project consolidation instructions: write a reserved
-  `_prompts/consolidation.md` wiki page (via `memory_write_page` or on
-  disk - no config key) and its body is appended to both single-page and
-  multi-page consolidation prompts as advisory preferences ("prefer
-  Portuguese titles", "skip CI noise", ...). The block is scrubbed
-  through the configured sanitizer, capped at 2,000 characters, JSON-encoded,
-  and injected into the LLM user message under an explicitly untrusted,
-  schema-subordinate system-prompt contract. `memory_consolidate` also gained
-  an optional `instructions` argument that overrides the page for one call;
-  TTL-expired standing pages are ignored. (#316)
-
-### Fixed
-- Zero-embedding startup and current retrieval descriptions now include the
-  entity-match stream, and release notes attribute per-page TTL to the release
-  where it shipped. (#329)
-- Retrieved `_rules/`, `gotchas/`, `procedures/`, and `decisions/` pages are now
-  described consistently across MCP and installed skill prompts as untrusted
-  historical evidence, removing contradictory language that elevated stored
-  prose into operating policy or constraints. (#325)
-- A project-scoped forget sweep now purges aged decay tombstones only from its
-  resolved workspace/project instead of deleting eligible derived rows across
-  every project. Entity-index rows orphaned by the scoped purge are removed in
-  the same transaction, and `hard_deleted` reports only the target scope. (#323)
-- Zero-LLM `memory_query` now keeps graph-neighbour expansion active instead
-  of falling back to FTS5 alone when no query embedding exists. Equal adjusted
-  hybrid and explicit multi-scope scores now use a deterministic path
-  tiebreak. (#317)
-
-## [1.20.2] - 2026-07-30
-
-### Fixed
-- Docker build contexts now exclude the gitignored operator deployment files,
-  preventing local server configuration and production environment secrets
-  from being sent to the Docker builder. A packaging regression test keeps the
-  exclusions as the final ignore rules so later negations cannot re-include
-  them. (#314)
-- Managed workstream heartbeats now bound each server request and condense an
-  outage into one short notice plus one recovery notice. Active launchers keep
-  the lease-safe 30-second retry cadence without printing the same timeout on
-  every attempt, and may renew their original run after a longer outage unless
-  another launcher has already claimed the workstream. (#311)
-
-## [1.20.1] - 2026-07-30
-
-### Fixed
-- Managed workstream packets, handoffs, project briefs, MCP routing prompts,
-  and all LLM maintenance prompts now identify stored project material as
-  untrusted historical data rather than executable instructions. This limits
-  persistent prompt injection through captured prompts, tool output, wiki
-  pages, commit messages, or another authenticated user's shared content.
-  (#302)
-- Docker wrapper installation and self-upgrade now use checksum-verified assets
-  from the latest GitHub Release instead of executing the mutable `main` branch.
-  The standalone hook installer and hook bundle use the same verified release
-  path and install only the expected hook members without extracting arbitrary
-  archive paths. Release jobs publish POSIX/Windows wrapper and hook assets with
-  SHA-256 companions, all GitHub Actions are commit-pinned, and default
-  workflow permissions are read-only outside the release publisher.
-  (#302)
-
-## [1.20.0] - 2026-07-30
-
-### Added
-- New `openai-compat` embedding provider for self-hosted engines
-  (Ollama, LM Studio, vLLM). Set
-  `AI_MEMORY_EMBEDDING_PROVIDER=openai-compat` together with explicit
-  `AI_MEMORY_EMBEDDING_BASE_URL`, `AI_MEMORY_EMBEDDING_MODEL`, and
-  `AI_MEMORY_EMBEDDING_DIM` — there is no safe default model or
-  dimensionality for a self-hosted engine, so each is required rather
-  than guessed. Unlike the other providers it is keyless: a bearer
-  token is sent only when `LLM_API_KEY` is present, for gateways that
-  want one. Embeddings are stored under their own
-  `provider="openai-compat"` identity, so switching an existing
-  `openai`+base-URL setup over changes the stored
-  `{provider, model, dim}` triple — run `ai-memory embed --force` to
-  re-embed. (#300)
-
-### Fixed
-- Antigravity CLI's `PreInvocation` hook now maps only its documented
-  `invocationNum = 0` call to ai-memory's synthetic `SessionStart`. Later model
-  invocations perform no capture or destructive handoff fetch, so a manual
-  handoff created while the conversation winds down remains open for the next
-  session. Native Windows hooks also emit Antigravity's required `injectSteps`
-  envelope instead of Claude Code's `hookSpecificOutput` shape. (#298)
-- Automatic handoff selection now prefers the newest cwd-eligible session over
-  a stale, more-specific ancestor. A new automatic handoff expires prior open
-  automatic handoffs from the exact cwd, and accepting the winner atomically
-  expires older eligible automatic handoffs. Manual and sibling-directory
-  handoffs remain open, preventing stale delivery and inflated pending counts.
-  (#293)
-- OpenAI-compatible providers now send each structured operation's JSON Schema
-  through `response_format=json_schema` by default, so local models cannot
-  replace consolidation JSON with prose or omit required fields. Explicit
-  structured-output capability rejections fall back to the tolerant parser;
-  other HTTP failures still propagate, and
-  `AI_MEMORY_LLM_COMPAT_STRICT=false` remains the compatibility opt-out. (#292)
-- Recognized Antigravity CLI's native file/edit and search tools, applied path
-  exclusions to its `TargetFile` operations, and captured bounded successful
-  edit content from `toolCall.args` when the hook omits an output field. Generic
-  MCP/resource tools remain fail-closed until their path schemas are proven,
-  while failed edits retain their error instead of attempted content. (#294)
-
-## [1.19.2] - 2026-07-28
-
-### Fixed
-- Source installation no longer fails when `cargo install --path` resolves
-  rmcp 1.8, whose `peer_info()` return type differs from rmcp 1.7. CI now checks
-  the unlocked source-install resolution separately from the workspace's
-  lock-aware gates, while the documented persistent Windows install uses
-  `--locked` for reproducibility. (#285)
-- Antigravity CLI hook installation and documentation now expose the existing
-  agent-aware manual finalizer:
-  `ai-memory finalize-session --agent antigravity-cli`. Antigravity's `Stop`
-  event ends one execution loop rather than the conversation, so it remains a
-  normal observation; the explicit command closes the latest scoped session
-  through the canonical SessionEnd path, producing its summary and automatic
-  handoff and queueing opt-in consolidation. The docs also clarify that
-  `memory_handoff_begin` deliberately creates a session-neutral, project-wide
-  manual handoff for every MCP client; attributed handoffs come from canonical
-  SessionEnd processing. (#284)
-
-## [1.19.1] - 2026-07-27
-
-### Changed
-- Wiki search now applies a bounded source-authority adjustment after FTS5,
-  graph, and optional vector candidate generation. Canonical rules, decisions,
-  procedures, gotchas, semantic/procedural tiers, `pinned` pages, and
-  `canonical` / `active` / `source-of-truth` tags win close relevance contests;
-  episodic sessions, `_lint/` output, investigations, and pages tagged
-  `superseded`, `historical`, `test-fixture`, or `do-not-answer-from` are
-  downgraded but remain searchable. Exact session-only queries still retrieve
-  their evidence, and the returned `rank` includes the bounded adjustment so
-  multi-scope merging preserves the same order. (#269)
-- Client CLI commands now resolve their `(workspace, project)` from the
-  nearest `.ai-memory.toml` marker, not just the lifecycle hooks. Previously
-  only the hook path read the marker, so a checkout declaring
-  `workspace = "acme"` had its captures land in `acme` while `run`,
-  `bootstrap`, `search`, `write-page` and every other scope-taking command
-  resolved into `default` — the same repository split across two scopes, with
-  `ai-memory run`'s managed workstream stranded on the wrong side. Each field
-  still prefers an explicit flag; when the marker decides one, the command
-  announces the resolved scope on stderr, naming which half the marker
-  decided. `AI_MEMORY_IGNORE_MARKER=1` restores the previous resolution for
-  one invocation (client commands only — the hooks keep reading the marker).
-  `embed --force` without `--project` still fans out across the workspace and
-  no longer needs a derivable project name. `ai-memory serve` is unchanged:
-  it has no caller cwd, and its `--workspace` / `--project` remain the baked
-  fallback for hook events without a usable one. (#259)
-- Marker discovery now stays inside its trust boundary when the caller's cwd
-  is outside `$HOME`: it walks no higher than the nearest checkout root, or
-  checks only cwd for a non-git directory. Workspace-only markers also keep
-  the hooks' documented `project = basename(cwd)` behavior for CLI commands,
-  including subdirectories and linked worktrees. (#259)
-
-### Fixed
-- Scheduled hollow-project cleanup now treats managed workstreams as project
-  data. Older projects whose only history is a managed workstream, including
-  those with a live run, are no longer cascade-deleted out from under the
-  workstream heartbeat or left with orphaned transcript segments. (#279)
-- Hybrid search now gives its FTS, vector, and graph streams the same bounded
-  candidate window used by authority-aware FTS search. Small result limits no
-  longer exclude a canonical page before post-fusion authority ranking can
-  promote it, and candidate-limit arithmetic is saturating throughout. (#277)
-- Forced workspace deletion now removes the immutable managed-workstream
-  segment directories whose database rows are removed by the workspace
-  cascade. Its admin report includes workstream/run counts and IDs, and raw
-  segment cleanup participates in the existing filesystem partial-failure
-  reporting instead of leaving transcript data orphaned. (#275)
-- Lossless `move-project` true moves now re-stamp managed workstreams into the
-  destination workspace in the same transaction as the project and its other
-  denormalized child rows. Previously the project moved while its managed
-  workstreams retained the source `workspace_id`, hiding portable history from
-  destination-scope lookup and violating the project/workspace pairing
-  invariant. The admin response now reports `workstreams_moved`. (#273)
-- SessionEnd recovery now commits the ended generation and automatic handoff in
-  one SQLite transaction, then lets an already-ended native replay converge the
-  remaining wiki commit, durable consolidation enqueue, and ingest-key
-  completion. An interruption after `ended_at` can no longer strand a missing
-  handoff or permanently pending spool key, and missing or scope/agent-
-  mismatched SessionEnd events no longer attempt consolidation recovery against
-  an unrelated session. (#271)
-- Bare `install-hooks --apply` re-runs, including the Docker wrapper's
-  post-upgrade refresh, now preserve an install's baked `repo-root` project
-  strategy for every supported hook integration. An explicit
-  `--project-strategy basename` still removes the install-wide default. (#267)
-- Installer `--apply` modes now write through symlinked agent configuration
-  files instead of atomically replacing the symlink itself. Symlink chains and
-  dangling final targets are preserved, while backups remain next to the
-  user-facing configuration path. (#264)
-- SessionEnd re-consolidation now converges by comparing the current
-  observation count with a persisted count stamped by the latest completed
-  end, instead of comparing independently generated wall-clock timestamps.
-  Clock skew could otherwise leave an old observation permanently "new" and
-  repeatedly rewrite the same session page, handoff, and opt-in LLM job with no
-  agent activity. Existing ended sessions are baselined during migration so an
-  upgrade does not enqueue historical catch-up work. (#268)
-- Capture exclusions now canonicalize an existing hook working directory
-  before matching paths, so filesystem aliases such as macOS `/var` versus
-  `/private/var` cannot turn an excluded file event into a spooled event.
-  Marker discovery tests likewise accept the canonical path they request.
-  (#265)
-- Opt-in SessionEnd LLM consolidation now runs from a durable, generation-
-  idempotent queue instead of inside the hook batch request. The hook commits
-  its deterministic session page and handoff, persists the provider job, and
-  returns without waiting for LLM latency; a single bounded worker recovers
-  queued or expired-lease work after restart and makes at most five provider
-  attempts with backoff. A stale SessionEnd redelivery also repairs the
-  enqueue when the original request was cancelled just after `ended_at`, so
-  the default hook drain timeout can no longer silently strand the heuristic
-  page as the final result. (#265)
-- `purge-project` no longer deletes a project out from under a running agent.
-  `workstreams` cascades from `projects` and `managed_runs` cascades from
-  `workstreams`, so purging a scope that still held a live managed run tore
-  out its lease row: the wrapper then failed every heartbeat with
-  `409 managed run lease is not active` and the session's transcript never
-  reached the ledger. The purge now refuses with a `409` naming the offending
-  workstreams unless `--force` is passed, and its report counts the
-  `workstreams` and `managed_runs` the cascade removes; their
-  `raw/workstreams/<id>/` directories are now removed server-side and included
-  in the same filesystem success/failure report instead of being orphaned.
-  Those counters previously showed `0 pages, 0 sessions, …` and made such a
-  scope look safe to delete. Liveness is the lease, not the row state: a
-  crashed wrapper leaves `state = 'active'` behind until the next
-  `ai-memory run` sweeps it, so only a lease that has not yet expired blocks
-  the purge. `move-project`'s
-  copy-purge merge surfaces the same conflict as a `409` naming how many
-  pages were already copied, instead of a `500`; its `--force` flag only
-  overrides the active-project guard and never destroys a live managed-run
-  lease. (#259)
-
-## [1.19.0] - 2026-07-25
-
-### Fixed
-- Claude Desktop's rendered Windows MCP instructions now distinguish the
-  unpackaged `%APPDATA%` config from the detected MSIX `LocalCache` config, and
-  contributor, managed-workstream, and CLI reference docs no longer omit
-  recently shipped harnesses or commands. (#256)
-- The opt-in managed-workstream real-harness acceptance runner now verifies
-  context delivery from the managed-run cursor/acknowledgement state and a new
-  persisted assistant event instead of requiring the model to quote a prior
-  sentinel. Large Claude Code hook packets can be file-backed, so acceptance no
-  longer passes or fails based on whether the model chooses to use `Read`.
-  The deterministic fake Grok leg covers the same assertion path. (#242)
-
-### Added
-- `install-mcp --client claude-code --session-aware` now registers an
-  ai-memory-owned stdio bridge that forwards Claude Code's
-  `CLAUDE_CODE_SESSION_ID` as `X-Memory-Actor-Session-Id` on every upstream
-  HTTP MCP request. This makes `[auto_scope] mode = "per_session"` effective
-  for concurrent Claude Code sessions against local or remote servers while
-  leaving the existing static HTTP registration as the default. The bridge
-  preserves bearer auth, stateless/stateful HTTP compatibility, and uninstall
-  ownership; both Docker wrappers forward the Claude session variable into
-  the helper container. (#244)
-- `GET /admin/open-sessions` lists open (not yet ended) sessions for one
-  workspace/project/agent, newest first (`all=true` returns every match).
-  `ai-memory finalize-session` now uses this endpoint instead of opening
-  the local SQLite index directly, so every CLI command is a thin HTTP
-  client of the running server; the command now requires a reachable
-  server and no longer works against an offline data directory. (#236)
-- Managed workstream support for Grok Build CLI: `ai-memory run grok` (alias
-  `grok-build`) creates fresh sessions with a wrapper-generated `--session-id`,
-  resumes linked sessions with `--resume`, maps wrapper `--yolo` onto Grok's
-  native `--yolo`/`--always-approve`, and delivers the bounded workstream
-  context packet through Grok's native `--rules` flag (system-prompt append,
-  acknowledged only after the child spawns). Transcript import reads
-  `$GROK_HOME/sessions/*/*/chat_history.jsonl` read-only with a
-  prefix-validated cursor and content-hash event ids so rewind-driven journal
-  rewrites cannot duplicate history; system prompts and encrypted reasoning
-  are excluded as loss annotations, as are the harness-injected `<user_info>`
-  and `<system-reminder>` blocks Grok stores inside `user` records (project
-  instructions, the skills catalogue, and connected MCP servers), which would
-  otherwise leak harness internals into the portable ledger and evict real
-  conversation from the startup packet budget. Discovery
-  matches checkouts through `summary.json`'s recorded `info.cwd` and honors
-  `GROK_HOME`. Grok stays out of the bare-mode automatic pool. Verified
-  against Grok Build CLI v0.2.111 ([#237]).
-
-### Changed
-- Single-page, batch, and bootstrap consolidation prompts now ask the model
-  to connect related wiki pages with path-based wikilinks and to mirror the
-  dominant natural language of the source material while preserving code,
-  identifiers, paths, commands, error strings, and JSON field names. (#238)
-- The M8 access-counter reinforcement now bumps a page's `access_count` and
-  `last_accessed_at` at most once per minute instead of on every search that
-  returns it. A first sighting still bumps immediately, and a continuously hot
-  page remains eligible once per window, while the cooldown map self-prunes to
-  the pages searched within the window. This reduces redundant single-writer
-  work under bursty or overlapping searches while intentionally making
-  `access_count` a coarser retention signal. (#239)
-
-### Fixed
-- Managed workstream packets now carry a versioned origin marker, and Claude
-  Code transcript import excludes a tool result only when its content begins
-  with that marker (or the legacy rendered packet header). This prevents a
-  large SessionStart packet that Claude persists and later reads from
-  `tool-results/` from re-entering the ledger and recursively consuming future
-  packet budgets, while ordinary tool results that merely mention the marker
-  remain visible. (#241)
-- Lifecycle `user-prompt` and `post-compaction` bodies are now truncated
-  UTF-8-safely at 16 KiB, while notification and tool excerpts remain capped at
-  2 KB. Native hook commands apply the event cap before local spooling or
-  transport, the server repeats it for direct and older clients, and the
-  sanitized observation boundary independently caps every durable body at
-  16 KiB so neither SQLite nor observation FTS can grow to the 10 MiB HTTP
-  transport limit. (#249)
-- `ai-memory run <harness>` now verifies an ai-memory-injected native resume
-  target still exists in that harness's read-only session store. A confirmed
-  orphan starts a fresh native session and repoints the same workstream instead
-  of retrying the dead id forever. The new wrapper-owned `--fresh` flag forces
-  the same per-workstream recovery without a resume attempt or adoption prompt;
-  explicit native resume/session/fork selectors remain authoritative and
-  cannot be combined with `--fresh`. (#240)
-- `install-mcp --client claude-desktop` now detects an MSIX-packaged
-  Claude Desktop on Windows and writes to its virtualized
-  `AppData\Local\Packages\Claude_<id>\LocalCache\Roaming\Claude\claude_desktop_config.json`
-  instead of the plain `%APPDATA%\Claude\` path. Previously this
-  silently wrote a config file the running app ignored, so the MCP
-  server never appeared after restart. The detector uses Windows'
-  resolved local and roaming app-data roots, prefers an existing config
-  when multiple package directories exist, and fails with an explicit
-  `--config-file` recovery instruction when the active package is
-  ambiguous. Unpackaged installs keep resolving to the plain path.
-  (#250)
-
-- The Docker wrappers (`bin/ai-memory`, `bin/ai-memory.ps1`) kept stdin
-  attached only on a real terminal, so every piped or redirected
-  invocation reached the container with a closed stdin. `ai-memory
-  write-page --body -` therefore stored a page with frontmatter and an
-  empty body while still reporting a successful write, and the same
-  applied to any other stdin reader (hooks fed by a pipe). The wrappers
-  now always pass `-i`, while `-t` is added only when stdin and stdout are
-  both terminals. `AI_MEMORY_NO_TTY=1` disables only TTY allocation and
-  no longer disconnects stdin. (#243)
-- Managed `SessionStart` delivery now includes a pending single-use
-  handoff before the portable workstream ledger and optional project
-  brief. Handoff and ledger acknowledgements are claimed together only
-  after the complete response has been assembled; a failed or racing
-  ledger claim cannot consume the handoff or suppress retry delivery.
-  (#235)
-
-## [1.18.0] - 2026-07-23
-
-### Added
-- The store writer only accepts `Sanitized<NewObservation>`: the privacy
-  strip is enforced by the type system at the persistence boundary, so an
-  unsanitized observation cannot reach disk by construction.
-- The session-review sampler now scores a non-empty `Stop` observation just
-  below `PreCompact` (88 vs 90) instead of the low `55` prior, so the opt-in
-  assistant/Stop excerpt (a late summary or correction) competes for a sampling
-  slot while keeping the `UserPrompt` base priority higher. An empty `Stop`
-  keeps its low prior. The reviewer still sees only the first 1500 characters
-  of any observation body, so a correction inside a long excerpt must fall in
-  that window ([#196]).
-- Opt-in assistant/Stop capture for Claude Code (#196). When BOTH the server
-  (`capture_assistant = true` / `AI_MEMORY_CAPTURE_ASSISTANT=true`) and the
-  client (`install-hooks --agent claude-code --capture-assistant`) opt in, a
-  Claude Code `Stop` event carries a sanitized, 2 KB-capped excerpt of the
-  assistant's final turn as the Stop body. The client sanitizes with the
-  built-in patterns and truncates before the excerpt ever touches the spool or
-  wire, splicing a versioned `_ai_memory_assistant` marker into the body and a
-  `capture_assistant=1` flag onto the event URL; the server re-scrubs with its
-  configured `[sanitize]` patterns and re-enforces the 2 KB cap at the
-  persistence boundary (never trusting the client's length). Off by default,
-  and any gate failure (server off, wrong agent/event, malformed or
-  future-versioned marker, empty excerpt) degrades to an empty Stop with the
-  same `202` response. Assistant text is privacy-sensitive — see `SECURITY.md`
-  for what it can contain and where it flows. Script-fallback installs cannot
-  sanitize the field and drop the whole Stop event instead; move to a native
-  install to capture it.
-- Managed workstreams now support Kimi Code through `ai-memory run kimi`;
-  `kimi-code` and `kimi-cli` are accepted aliases for the installed `kimi`
-  executable.
-  Returning runs resume the linked native session with `--session <id>`;
-  fresh sessions are discovered post-exit by exact checkout match through
-  `state.json`'s `workDir` (the session bucket name is a one-way hash and is
-  never parsed). The adapter reads `$KIMI_CODE_HOME/sessions` (default
-  `~/.kimi-code/sessions`) and imports only visible user/assistant/tool
-  messages and compaction summaries from `agents/main/wire.jsonl`, excluding
-  system prompts, hidden reasoning, hook-injected context (`hook_result` and
-  related origins), and subagent transcripts. Wrapper `--yolo` maps to Kimi
-  Code's `--yolo`, and kimi joins the automatic bare-run harness pool. The
-  deterministic and opt-in real-harness acceptance paths cover Kimi creation,
-  transcript import, cross-harness delivery, and returning native resume; the
-  native contract was live-verified against Kimi Code v0.29.0.
-
-### Fixed
-- Native hook spool retries now reuse a per-entry idempotency key, so a lost
-  batch response does not duplicate observations or completed session-end
-  effects. The server claims each key atomically with its observation, resumes
-  downstream wiki/handoff work when a prior delivery stopped incomplete, and
-  skips only events already marked complete. Overlapping deliveries of the same
-  key are serialized; keys are project-scoped and expire after the spool retry
-  horizon.
-- Managed-workstream overview and command-reference documentation now
-  consistently includes Kimi Code in the supported and automatic-selection
-  harness lists.
-- Windows PowerShell fallback hooks now force text output and silence
-  non-interactive progress records. This prevents nested PowerShell runners
-  such as Antigravity CLI from reporting serialized `CLIXML` progress on every
-  hook while preserving the hook's JSON stdout. Existing script-fallback
-  installs should rerun `install-hooks --agent <agent> --apply` after upgrading
-  ([#224]).
-- Kimi Code handoffs are now delivered through the `UserPromptSubmit` hook
-  instead of `SessionStart`. Kimi Code fires `SessionStart` but discards the
-  hook's stdout/result (verified against kimi-code v0.28.1,
-  `packages/agent-core/src/session/index.ts`), so the previous hook consumed
-  pending handoffs — legacy and managed — without ever showing them to the
-  model. `UserPromptSubmit` stdout is injected as a user message before the
-  turn. The native `ai-memory hook` path now also accepts the
-  `user-prompt-submit` event token alongside `user-prompt` for kimi handoff
-  delivery. Existing native hook commands pick up the correction when the
-  binary is upgraded; script-fallback installations must re-run
-  `ai-memory install-hooks --agent kimi-code --apply` to refresh their staged
-  scripts.
-- The `[briefing]` compiled project brief is now gated to once per session
-  for Kimi Code: it rides the first user prompt (kimi discards SessionStart
-  hook stdout, so session-start delivery is impossible) and later prompts
-  keep fetching the handoff without the briefing params, so the server no
-  longer recomposes the brief on every prompt. This also works for managed
-  handoffs, creates local markers only for opted-in repositories, and retains
-  at most 512 markers. Re-briefing after `/clear` is not supported in v1.
-- Kimi Code managed transcript cursors now validate the imported byte prefix
-  before resuming. When Kimi rewrites `wire.jsonl` in place, ai-memory safely
-  replays the journal with stable event IDs instead of seeking into a changed
-  record or skipping new events.
-- Kimi Code managed transcript extraction now imports native
-  `context.append_loop_event` assistant text, tool calls, and tool results.
-  Current Kimi journals store model output in those records rather than
-  re-appending it as a completed assistant message.
-- `ai-memory run kimi server ...` now passes through Kimi Code's deprecated
-  but still functional `server` utility command instead of treating it as an
-  interactive session launch.
-
-## [1.17.3] - 2026-07-22
-
-### Fixed
-- Corrected Docker-wrapper upgrade guidance: `ai-memory upgrade` no longer
-  claims a configured remote server is stale when it cannot inspect that
-  deployment, and the install guide now makes clear that refreshing Docker
-  script hooks does not convert them to native capture-policy commands.
-
-## [1.17.2] - 2026-07-22
-
-### Added
-- `ai-memory completions <shell>` prints a shell-completion script for bash,
-  zsh, fish, PowerShell, or elvish. The script is generated from the binary's
-  own command tree, so it always matches the installed version; install paths
-  per shell are documented in `docs/shell-completions.md`. The command reads no
-  config and needs no data directory, so it works before `ai-memory init`.
-
-### Changed
-- Documented Atlas Cloud through the existing `openai-compat` provider instead
-  of adding a redundant provider type, including the endpoint, model, and API
-  key mapping needed for deployment.
-- The native hook binary now drops any raw assistant-message field (Claude
-  Code's `last_assistant_message` on `Stop`) before it can reach the local
-  spool or the wire, and drains pre-existing spooled entries with the field
-  stripped too. The server applies the same strip defensively on `/hook` and
-  `/hook/batch` before building an envelope. This field was already never
-  persisted, so there is no behavior change; it closes a raw-text exposure in
-  the spool/wire. Optional assistant/Stop capture proposed in #196 remains
-  disabled. Upgrading the binary is sufficient for native Claude Code installs;
-  script-fallback installs (Docker wrapper, `AI_MEMORY_HOOK_PLATFORM=posix`)
-  still send the raw field to the server, which strips it immediately on
-  receipt. Closing the local-wire vector requires a native client on the agent
-  host and using it to reinstall hooks; running the installer through the
-  Docker wrapper only refreshes its scripts ([#196]).
-
-### Fixed
-- Removed the unused `syntect` dependency and its `plist`, `quick-xml`,
-  `bincode`, and `yaml-rust` transitive dependencies. This eliminates two
-  high-severity `quick-xml` denial-of-service advisories and makes the prior
-  temporary cargo-audit exceptions unnecessary; ai-memory's rendered Markdown
-  behavior is unchanged because the syntax-highlighting crate was never used.
-- The Docker wrapper now buffers generated shell completions before streaming
-  them to stdout. Piping `ai-memory completions <shell>` into a short-lived
-  consumer such as `head` no longer exposes Docker's own broken-pipe error or
-  non-zero exit after the native command completed successfully; real helper
-  container failures still propagate without printing a partial script.
-- The Linux Docker wrapper now detects an SELinux-enforcing host plus a
-  SELinux-enabled daemon and adds `--security-opt label=disable` only to
-  short-lived helper commands that write bind-mounted host files. This avoids
-  `Permission denied` during `install-*`, `setup-agent`, `uninstall`, and
-  `backup` without relabeling the user's home directory or changing the
-  long-lived server container ([#212]).
-- Windows `.ps1` fallback hook commands now use PowerShell `-EncodedCommand`
-  instead of embedding `$env:` setup inside a nested quoted command. This
-  prevents outer Windows hook runners such as Antigravity CLI from expanding
-  the setup before the inner PowerShell process receives it. Existing Windows
-  Docker-wrapper installs should rerun `install-hooks --agent <agent> --apply`
-  after upgrading ([#214]).
-- `install-mcp --client claude-code` and `uninstall` now honour
-  `CLAUDE_CONFIG_DIR`: MCP registrations go to
-  `$CLAUDE_CONFIG_DIR/.claude.json` when the variable is set (non-empty),
-  falling back to `~/.claude.json` otherwise. Uninstall checks both the active
-  relocated path and the home default so enabling the variable does not orphan
-  a prior default-path registration. The
-  dry-run output prints the resolved config path instead of a hardcoded path.
-- `install-hooks --agent claude-code` and `setup-agent` follow the same
-  resolution for the hooks settings file: `$CLAUDE_CONFIG_DIR/settings.json`
-  when set, else `~/.claude/settings.json`. Uninstall checks both locations;
-  rendered output and the chmod-600 warning show the resolved path.
-- `install-skills --scope global` (claude-code root) installs to
-  `$CLAUDE_CONFIG_DIR/skills` when the variable is set, else
-  `~/.claude/skills`. `uninstall` sweeps the relocated root alongside the
-  home default so installs that predate the env var are still removed.
-- The Docker CLI wrapper forwards `CLAUDE_CONFIG_DIR` into its helper
-  container for relocated Claude Code configs beneath the existing home bind.
-
-## [1.17.1] - 2026-07-20
-
-### Fixed
-- Managed launch failures now cancel their server lease immediately, and a new
-  launch waits briefly when the previous launcher is still finalizing. The
-  parent launcher also survives terminal interrupts long enough to finish or
-  cancel the run, preventing a normal quit-and-reopen from being blocked by the
-  90-second crash-recovery lease.
-- CLI startup diagnostics now show the configured server URL and use the real
-  host name in lease-owner messages, avoiding misleading `localhost` labels for
-  remote-server clients.
-
-## [1.17.0] - 2026-07-20
-
-### Added
-- `ai-memory run` without a harness now selects among checkout-local Claude
-  Code, Codex, OpenCode, Pi, and Crush sessions. Empty workstreams adopt the
-  newest session automatically; established workstreams prefer their most
-  recently linked available harness. A directory with no matching session
-  exits with explicit start commands instead of creating an empty workstream.
-- Managed workstreams now support Crush through its project-local read-only
-  SQLite transcript and supported `options.global_context_paths` configuration.
-  ai-memory never writes the original Crush config or session database; the
-  launched Crush process retains normal ownership of its native session writes.
-- Wrapper-owned `run --yolo` translates to each harness's native dangerous-mode
-  option for Claude Code, Codex, OpenCode, Pi, and Crush.
-- A managed-harness contribution protocol documents the native-session,
-  read-only import, context-delivery, migration, privacy, and acceptance-test
-  requirements for adding agents beyond the currently supported set.
-
-### Changed
-- The first interactive `ai-memory run` on an otherwise-empty workstream now
-  offers recent native sessions recorded for the same checkout, with the newest
-  as the default or an explicit fresh-session choice. Adoption is disabled for
-  `--new`, explicit selectors, scripted/noninteractive launches, and any
-  workstream already established by another harness, preventing obsolete local
-  sessions from contaminating later cross-harness switches.
-
-### Fixed
-- Managed utility invocations such as `ai-memory run codex --version` no longer
-  discover and import a different process's recently updated native session.
-  Passthrough commands also do not fetch or acknowledge managed startup context.
-- Managed runs now verify the host harness executable before opening a server
-  lease and report how to refresh a stale Docker wrapper. The wrapper path is
-  regression-tested to preserve a remote `AI_MEMORY_SERVER_URL`, auth, and the
-  host `PATH` without entering Docker, and now retains the `run` subcommand when
-  it hands control to the native ai-memory client.
-- Corrected stale project-move flags in the marker guide and documented the
-  distinction between a server-side project rename and a physical checkout or
-  native-session relocation.
-
-## [1.16.0] - 2026-07-20
-
-### Added
-- Optional managed cross-harness workstreams via `ai-memory run` for Claude
-  Code, Codex, OpenCode, Pi, and OMP. Direct harness launches retain the legacy
-  hook/handoff behavior. Managed launches transparently create or resume one
-  native session per harness, pass all harness argv through without a `--`
-  separator, inject unseen portable context at SessionStart, import visible
-  native transcript tails through read-only adapters, and record non-mutating
-  repository checkpoints. A lease prevents concurrent writers; deterministic
-  event ids, incremental cursors, immutable sanitized JSONL segments, and
-  batched idempotent imports make retry and crash recovery explicit. Hidden
-  reasoning and private provider records are excluded with loss annotations.
-  `ai-memory workstream-search` searches history older than the bounded startup
-  packet. The Linux/macOS Docker wrapper uses a checksum-verified cached native
-  client for `run` so host agent executables and transcript stores remain
-  accessible. A separate opt-in local acceptance runner validates real
-  cross-harness delivery and native resume without adding credentialed model
-  calls to CI. Generated OpenCode/Pi/OMP integrations reserve managed context
-  acknowledgement for their model-visible injection path; OpenCode caches the
-  packet per native session so auxiliary model requests cannot consume it
-  before the main coding turn. Pi/OMP native `--session-dir` overrides are
-  honored by the importer, as are native store environment overrides for all
-  five adapters. This includes complete atomic-write temp transcripts left by
-  a Pi-family process that exits before its final rename.
-
-### Changed
-- Configuring the hosted `anthropic` or `openai` provider without an explicit
-  model now selects the documented recommended defaults, `claude-haiku-4-5`
-  and `gpt-5.4-mini`, instead of the older `claude-sonnet-4-6` and
-  `gpt-4o-mini` fallbacks. Explicit `AI_MEMORY_LLM_MODEL` values are unchanged.
-### Fixed
-- User-facing help and current-reference documentation now match the shipped
-  agent integrations, multi-user activation boundary, MCP URL normalization,
-  Pi bridge, and `memory_consolidate` configuration requirements. Local
-  documentation links and anchors were also audited and repaired.
-- Reader APIs now derive absent page kinds consistently from canonical path
-  families. Session, concept, procedure, note, and slot pages no longer surface
-  as generic facts, while an explicit frontmatter `kind` still takes precedence
-  ([#198]).
-- Native lifecycle hooks now accept one leading UTF-8 BOM on JSON stdin, which
-  covers PowerShell pipelines on Windows. Other malformed payloads are dropped
-  before spool or network delivery with a bounded content-free stderr warning;
-  hooks still return `{}` and exit successfully ([#197]).
-
-## [1.15.0] - 2026-07-19
-
-### Added
-- Tool lifecycle capture now records safe metadata summaries for the closed
-  Claude Code, OpenCode, Pi, and Antigravity schemas: canonical family,
-  validated agent-provided call ID where available, and a PostToolUse outcome.
-  PreToolUse never stores tool inputs, commands, paths, or arbitrary tool
-  names; PostToolUse keeps its bounded response/error excerpt. Stop and
-  assistant-message capture remain disabled/deferred ([#190]).
-- Per-repository capture exclusions via `[capture] ignore_paths` in the nearest
-  `.ai-memory.toml` ([#194]). Supported native hooks and generated
-  OpenCode/OMP/Pi/OpenClaw integrations apply the policy before local spool or
-  network delivery; `ai-memory hook --check-capture` safely reports a bounded
-  local decision. Generated integrations resolve relative file-tool paths from
-  the event `cwd`, including nested working directories, rather than from the
-  marker directory. This changes no MCP tools and needs no database migration.
-- Kimi Code CLI is now a supported MCP + lifecycle-hook integration
-  (`--client kimi-code` / `--agent kimi-code`, alias `kimi`). `install-mcp`
-  merges an `mcpServers` entry into `~/.kimi-code/mcp.json` with a plain `url`
-  (Kimi Code treats `url` with no `transport` field as streamable HTTP) plus
-  optional bearer `headers`. `install-hooks` merges `[[hooks]]` entries into
-  `~/.kimi-code/config.toml`, preserving the provider/model settings the same
-  file holds, and covers 10 events: `SessionStart`, `SessionEnd`,
-  `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`
-  (Kimi Code reports tool failures separately from successful calls; the
-  entry reuses the post-tool-use capture path), `Stop`, `SubagentStart`,
-  `SubagentStop`, and `PreCompact`. Both paths honor `$KIMI_CODE_HOME`.
-  Handoff injection happens at `SessionStart` through hook stdout, which Kimi
-  Code appends to the model context; `setup-agent` and `uninstall` handle the
-  new agent like the other first-class integrations. The `install-mcp` entry
-  points at `/mcp?flavor=moonshot`: the Moonshot API validates tool parameter
-  schemas against a restricted dialect ("moonshot flavored json schema") that
-  rejects root-level `anyOf`/`oneOf`/`allOf` combinators — including the
-  `anyOf` on `memory_read_page` — and fails the whole session at `tools/list`.
-  Requests carrying that flavor receive flat tool schemas from the server;
-  every other client keeps receiving the upstream schemas unchanged.
-  `uninstall` matches the Kimi Code entry in either URL form, so removing an
-  install made before or after this change both work with the default
-  `--mcp-url`.
-- Grok Build CLI is now a first-class MCP client as well as a hook agent:
-  `install-mcp --client grok` renders and `--apply` merges a native HTTP
-  entry into `$GROK_HOME/config.toml` (default `~/.grok/config.toml`)
-  (`[mcp_servers.ai-memory]` with
-  `url` / `enabled` / `[mcp_servers.ai-memory.headers]` — not Codex's
-  `http_headers` key). `install-hooks --agent grok` reuses that entry to
-  infer server URL and bearer token; `uninstall` strips the MCP table;
-  `setup-agent --agent grok` prints the companion `install-mcp` tip.
-  Managed routing skills can target `.grok/skills` / `$GROK_HOME/skills`
-  (default `~/.grok/skills`) via
-  `install-skills --agent grok` and `memory_install_self_routing`
-  `target_hints`. Lifecycle capture was already present; handoff injection
-  remains unavailable because Grok ignores SessionStart stdout — recover
-  via MCP `memory_handoff_accept`.
-
-### Changed
-- Scheduled forget sweep and rule-based lint now persist their last successful
-  completion across restarts. Overdue or never-run jobs perform one bounded
-  startup catch-up, while not-due jobs wait only their remaining interval;
-  failures retry without advancing cadence. Embedding backfill remains opt-in
-  and does not gain startup catch-up behavior ([#192]).
-- `init`-generated token peppers no longer make operational `/admin/*` routes
-  root-only before the first user is created. Admin mode now switches
-  immediately and fail-closed from a store-backed user-row check; expired users
-  still count. Servers refuse startup when user rows exist but either the
-  non-empty `[auth].token_pepper` or static `[auth].bearer_token` is missing or
-  blank, preventing accidental anonymous admin reopening ([#191]).
-- `install-hooks --agent devin` now infers the server URL and bearer token from
-  `~/.devin/config.json` when flags and environment settings are absent, keeping
-  hooks aligned with an existing Devin MCP registration.
-- Grok routing guidance now treats Grok Build CLI as an AGENTS-based client and
-  directs its managed skills to `.grok/skills` or `$GROK_HOME/skills` (default
-  `~/.grok/skills`). The MCP self-routing payload and installed prompt surface
-  now guard those targets;
-  Grok (like Zero) still resumes handoffs through `memory_handoff_accept`
-  because it ignores SessionStart stdout.
-- One-shot client commands (`rename-project`, `status`, `write-page`, …) no
-  longer print the "cannot write log files … falling back" warning when the
-  log directory is unwritable — they still degrade to temp/stderr logging
-  silently. The warning was written for the long-running server (where an
-  operator should know persistent logs moved) but fired on every Docker
-  thin-client invocation too, where it read as a problem with the command
-  itself and its sandbox hint was misleading. `serve` still warns, with
-  clearer wording that names both the intended and the fallback location.
-
-## [1.14.0] - 2026-07-15
-
-### Added
-- New admin endpoint `POST /admin/merge-workspace {from, to, confirm}`: fold
-  every project of one workspace into another, then delete the emptied source
-  workspace — completing the workspace CRUD surface alongside rename/delete.
-  It is sugar over move-project: each source project runs the same validated
-  path, so a project that already exists in the destination merges by content
-  (copy-purge under `on_conflict`) while a fresh one is a lossless re-stamp.
-  Destructive, so `confirm=true` is required; `force` overrides the
-  live-session guard per project. It stops at the first failing project — the
-  moves already committed stand, and the failing project plus the source
-  workspace are left intact for the operator to resolve and re-run (moves are
-  idempotent) ([#187]).
-
-### Fixed
-- Hook query values are now percent-encoded with an RFC 3986 allow-list
-  (everything outside `A-Za-z0-9-_.~`) in both the native helper and the
-  POSIX `hooks/_lib.sh`, and the shell cwd extractor unescapes JSON `\\` /
-  `\/`. Previously a Windows cwd like `C:\dev\myproject` went into the query
-  string with raw backslashes, which broke the shell-script fallback outside
-  Git Bash. The reporter confirmed that native Windows handoff delivery was
-  already correct for well-formed JSON; their original failure came from a
-  PowerShell pipe adding a UTF-8 BOM. The session-start hook now also prints a
-  stderr warning when the handoff fetch fails (server unreachable, bad URL)
-  instead of being indistinguishable from "no pending handoff" — exit code
-  stays 0, hooks never break the agent. Malformed-payload/BOM diagnostics are
-  tracked separately in [#197] ([#188]).
-- `install-mcp --server-url` now appends the `/mcp` path when given a base
-  URL (the same value `install-hooks --server-url` takes), instead of
-  rendering a client config that points at the server root and 404s. The
-  suffix join is idempotent, so passing the full `…/mcp` endpoint still
-  works unchanged; only a URL deliberately pointing MCP at a path not
-  ending in `/mcp` (an exotic reverse-proxy rewrite) would notice
-  ([#185]).
-- Opening a store whose schema is *newer* than the running binary now fails
-  with an actionable error instead of refinery's raw "migration V… is missing
-  from the filesystem" wording. When an applied migration is absent from the
-  binary's compiled-in set (the data was migrated by a newer ai-memory build),
-  the store layer now returns `DataSchemaAhead`, which names the offending
-  migration, reports the highest schema version this build ships, and tells the
-  operator to run a build at least as new as the one that wrote the data. Every
-  other migration failure is unchanged ([#184]).
-- `memory_consolidate` now resolves its target `(workspace, project)` from
-  where the session's observations actually landed, rather than trusting the
-  `sessions` row. A session that adopts its scope marker mid-run keeps a
-  session row frozen on the pre-marker scope (`begin_session` uses
-  `ON CONFLICT DO NOTHING`), while each observation carries the correct
-  per-cwd scope — so a "hybrid" session used to consolidate into the wrong
-  project. Resolution now prefers the majority observation scope, then the
-  session row, then the server's startup IDs ([#186]).
-
-### Changed
-- `memory_consolidate` runs the blocking admission chain up front, before the
-  LLM, so a rejected scope/actor fails fast and identically in every mode
-  instead of only surfacing at write time — previously a single-page write
-  spent the LLM before the 403, and a multi-page / dry-run request ran the
-  full completion only for the client to time out before seeing the
-  rejection. Consequently `dry_run=true` is now a cheap plan: it runs the
-  admission preflight and reports the resolved page path without calling the
-  LLM (it no longer returns an LLM-generated body preview); a real
-  (non-dry) run still produces the page bodies ([#186]).
-
-## [1.13.0] - 2026-07-14
-
-### Fixed
-- `memory_consolidate` now attributes its consolidated page to the request's
-  authenticated identity (same derivation as `memory_write_page`) instead of
-  a hard-coded anonymous actor — so `last_modified_by` is populated and an
-  actor-gated admission webhook authorizes the write by user rather than
-  rejecting the empty actor. The automatic session-end / compaction
-  consolidation in the hook router is system-initiated and deliberately
-  stays anonymous ([#183]).
-
-### Changed
-- `audit-contamination` no longer flags an observation whose project differs
-  from its session's home project (the old `observation_session_drift` CHECK
-  B, including the `observations_drifted` summary count and the finding's
-  `session_id` field). With per-event cwd resolution, an agent that
-  legitimately `cd`s across repos in one session produces exactly that shape
-  — it is correct attribution, not contamination — so the check drowned
-  multi-repo instances in false positives. CHECK A (`session_wrong_bucket`,
-  anchored on the session's own cwd evidence) is unchanged and remains the
-  high-precision signal ([#182]).
-
-### Added
-- The `[recall] default_global` marker now broadens `memory_recent` too,
-  completing the pair started with `memory_query` in v1.12.0: an unscoped
-  `memory_recent` from an opted-in repo returns the most-recently-updated
-  pages across every project as `global_hits` (workspace + project
-  annotated). Explicit `workspace`/`project` arguments still scope exactly
-  as before, and the plain project-scoped response shape is unchanged
-  ([#181]).
-- New read-only admin endpoint `GET /admin/projects`: the authoritative
-  `(workspace, project)` inventory with page counts and last-updated
-  timestamps. Gives dashboards, exports, and backup/mirror tooling a
-  first-class list to reconcile against — a mirror directory whose project
-  no longer appears here is an orphan and can be pruned. Root-only in
-  multi-user mode, like every `/admin/*` route ([#180]).
-- `memory_delete_page` / admin `delete-page` now write one attributed
-  `audit_log` row pointing at the deleted page id, in the same transaction
-  as the delete — completing the "who deleted the gotcha page about X?"
-  trail that purge/rename attribution started. Idempotent no-op deletes
-  write nothing. The handoff lifecycle (insert / accept / cancel) is also
-  audited, scoped to the handoff's workspace/project with a NULL author by
-  design — handoffs are agent/session-keyed, not owned by a DB user
-  ([#179]).
-- Devin CLI is now a supported MCP + lifecycle-hook integration. `install-mcp
-  --client devin` writes Devin's `mcpServers` config, `install-hooks --agent
-  devin` writes Devin lifecycle hooks, `setup-agent --agent devin` emits
-  host-copyable hook snippets, and `uninstall` removes only ai-memory-owned
-  Devin entries. Devin hook capture covers `SessionStart`,
-  `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PostCompaction`, `Stop`,
-  and `SessionEnd`; `PostCompaction` is stored as a dedicated observation kind
-  and captures Devin's `summary` field. Devin does not expose subagent hook
-  events, so subagent capture is not installed for Devin ([#178]).
-- Managed Agent Skills can now target Devin: project installs use
-  `.devin/skills`; global installs use `%APPDATA%\devin\skills` on Windows and
-  `~/.devin/skills` elsewhere ([#178]).
-- The store migration set now admits `devin` as a persisted
-  `sessions.agent_kind`, preserving the same workspace/project invariants as
-  the other supported agents ([#178]).
-
-### Fixed
-- `install-mcp` and `install-hooks` now honor an explicit `--server-url` even
-  when it matches the compiled default. Previously that value was
-  indistinguishable from "flag omitted" and could be overridden by
-  `AI_MEMORY_SERVER_URL`, which could write config for the wrong local server
-  ([#178]).
-- Devin hook capture now derives `cwd` when the native payload omits it:
-  payload `cwd` still wins, followed by `DEVIN_PROJECT_DIR`, then the hook
-  process working directory. This keeps real Devin `SessionStart` /
-  `PostToolUse` fixtures routable without inventing a payload field.
-  Payloads without a `session_id` are bridged the same way: a per-host id is
-  minted at `SessionStart`, reused for later events, and cleared at
-  `SessionEnd`; set `AI_MEMORY_SESSION_ID` in the hook environment to pin an
-  externally managed run id. A payload-supplied id always wins ([#178]).
-
-## [1.12.0] - 2026-07-12
-
-### Added
-- New `.ai-memory.toml` marker section `[briefing] inject_on_session_start
-  = "true"` ([#176]): the session-start handoff fetch also returns a
-  compiled project brief — pinned / `_rules/` / `_slots/` pages with
-  bodies plus recently-updated page titles — injected as agent context so
-  a fresh session (or a Claude Code `/clear`, which re-fires SessionStart)
-  starts with the architecture instead of re-exploring the codebase.
-  `max_chars` caps the brief (default 4000 chars, clamped to 500–20000);
-  over-budget pages are truncated or listed by path. The brief is
-  recomposed on every opted-in session start (non-consumable, unlike the
-  handoff) and appended after any pending handoff. Off by default — it
-  costs tokens on every session start.
-- Generated OpenCode / OMP / OpenClaw TypeScript integrations now forward
-  the `[recall] default_global` marker flag (previously only the native
-  hook binary did) and the new `[briefing]` keys, accepting bare
-  (unquoted) TOML values for both.
-- New `.ai-memory.toml` marker option `[recall] default_global = "true"`
-  ([#177]): sessions in the marked tree make an *unscoped* `memory_query`
-  behave as `global=true`, so meta-repos that constantly need
-  sibling-project context stop passing `global=true` by hand. Strictly
-  opt-in and per-repo; explicit `workspace`/`project`/`scopes`/`global`
-  arguments always win. While active, unscoped queries return
-  cross-project `global_hits` (workspace+project annotated) instead of
-  project `hits` + `global_scope_hits`; `memory_recent` stays
-  project-scoped (documented follow-up).
-- `purge-project` and `rename-project` now write attributed rows to the
-  append-only `audit_log`, inside the same transaction as the operation
-  itself — so "which user wiped project X?" finally has an answer, and a
-  rolled-back rename (name collision) leaves no phantom trail. The
-  operator identity comes from the authenticated admin request and is
-  `NULL` for single-user/unauthenticated servers; internal sub-purges
-  (move-project's copy-purge step, the hook router's self-heal) are
-  deliberately not attributed as standalone purges ([#175]).
-
-## [1.11.4] - 2026-07-11
-
-### Fixed
-- Scheduled forget sweep, rule-based lint, and opt-in embedding backfill now
-  iterate every existing workspace/project scope instead of only the project
-  selected at server boot. Embedding backfill remains disabled by default, but
-  enabled schedules are now store-wide and can increase provider usage ([#173]).
-
-## [1.11.3] - 2026-07-11
-
-### Changed
-- Documented the community-maintained Hermes Agent plugin as a third-party
-  bridge rather than first-party ai-memory support, with compatibility and
-  secret-handling cautions ([#172]).
-- `/admin/delete-workspace` now runs `purge_workspace` admission before
-  destructive work, reports filesystem partial failures in `files_failed`, and
-  notifies non-blocking mirrors after durable deletion; `/admin/rename-workspace`
-  refreshes scope manifests after the SQLite rename.
-- OIDC CLI help and token-store test fixtures now use a neutral `ai-memory`
-  realm placeholder instead of the old project-specific `serpro` example, and
-  the unused LLM retry-exhaustion error variant was removed ([#171]).
-
-### Fixed
-- Admin scope mutations now invalidate both legacy and keyed active-project
-  state plus hook project caches: project moves retarget live active entries,
-  workspace deletes clear affected active/cache entries so deleted scopes are
-  not recreated by the next hook, and workspace rename manifest refresh
-  failures return success with an explicit warning after the committed SQLite
-  rename instead of a misleading 500.
-- `/hook/batch` now skips per-source rate-limited items and continues accepting
-  later unrelated sources, returns non-contiguous acknowledgements for new spool
-  drains, bounds limiter key bytes, keys by actor+session with deterministic
-  missing-session fallbacks, and avoids spending source tokens on globally
-  saturated events. `AI_MEMORY_HOOK_RATE_PER_SEC` and
-  `AI_MEMORY_HOOK_RATE_BURST` are now parsed through typed server config
-  instead of the hooks crate reading env directly ([#170]).
-- MCP tool calls over the stdio transport now fall back to an anonymous
-  synthetic request context when HTTP request parts are absent, while preserving
-  real streamable-HTTP auth/session parts when present ([#168]).
-- Copy-purge `/admin/move-project` now skips only the webhook named exactly
-  `contributors` while copying pages, avoiding redundant per-page contributor
-  enrichment on already-enriched frontmatter while preserving other
-  `write_page` webhooks and the terminal purge notification ([#167]).
-- `memory_read_page` by-path not-found errors now name the resolved
-  workspace/project scope, making stale or mis-scoped page paths easier to
-  diagnose from MCP clients ([#166]).
-
-## [1.11.2] - 2026-07-11
-
-### Fixed
-- `ai-memory install-instructions` and `ai-memory uninstall --only instructions`
-  now match only line-anchored routing markers, handle CRLF marker lines, and
-  repair one or more exact orphan-tail copies left by older refreshes when the
-  snippet body mentioned an end marker inline ([#161]).
-- Project creation now emits a warning when the same project name already
-  exists in another workspace, helping catch accidental cross-workspace
-  misroutes while preserving legal id-namespaced homonyms ([#160]).
-- `memory_query` now runs the raw-observation fallback for explicit `scopes`
-  requests when compiled wiki pages miss, so scoped cross-project searches can
-  still surface bounded raw session matches without falling back to the current
-  project ([#159]).
-- Upgraded `crossbeam-epoch` to the RUSTSEC-2026-0204 fixed release ([#162]).
-- Fixed the Docker wrapper on macOS with rootless Docker so host-config
-  commands (`install-mcp`, `install-hooks`, `install-instructions`, and
-  related setup/removal commands) keep the `-u 0:0` mapping needed to write
-  bind-mounted agent configuration as the invoking host user ([#162]).
-- Stabilized the Windows uninstall purge-preview regression test against
-  verbatim temp-path spelling ([#162]).
-
-## [1.11.1] - 2026-07-09
-
-### Fixed
-- The documented auto-improvement safety invariant "never rewrite pinned
-  pages" is now enforced in code, not just in the reviewer prompt: the
-  apply path — shared by manual approval and `require_approval = false`
-  auto-apply — refuses `update` proposals whose target page is pinned,
-  recording the proposal as a conflict with an explicit reason. Unpinning
-  the page is the explicit way to allow a rewrite ([#157]).
-
-### Added
-- Architectural-decision guidance ([#157]): the managed durable-pages
-  Agent Skill now teaches agents to record architectural decisions as
-  pinned wiki pages under `decisions/<slug>.md` with ADR structure
-  (Status / Context / Decision / Consequences, rejected alternatives
-  included) and to supersede with a new page instead of editing history.
-  `docs/usage.md` gains an ADR section clarifying that ai-memory never
-  touches repository files (a `docs/adr/` tree managed by hand or by an
-  external ADR MCP server is outside its write surface) and how the two
-  coexist.
-
-## [1.11.0] - 2026-07-09
-
-### Fixed
-- Mid-session events can no longer scatter observations into basename
-  "fragment" projects (`sources`, `desktop`, …). The hook router now uses
-  session-sticky attribution: when an event's session already exists, its
-  observations inherit the session's project instead of re-deriving one
-  from the event's cwd — closing the hole left between the v0.12.2
-  cwd-prefix guard (which keys on `repo_path`) and the #103 rule that
-  non-git parents never record one, which together left plain-directory
-  projects unprotected against every mid-session `cd subdir/`. Explicit
-  `.ai-memory.toml` overrides still win, and cwd derivation still decides
-  for session-creating events.
-- V27 data-repair migration re-runs the idempotent V19 repair on upgrade,
-  re-attributing the fragment observations that accumulated since V19 to
-  their sessions' projects and deleting the emptied fragment rows.
-  Reserved projects (`scratch`, `_global`) are exempt.
-
-### Added
-- The maintenance scheduler now sweeps "hollow" project rows — zero
-  pages, sessions, observations, and handoffs — once they are older than
-  seven days, shortly after startup and then daily. Nothing exists to
-  lose in a hollow row (probe/rename residue), so the sweep needs no
-  config; rows holding any data are never touched, and reserved projects
-  are exempt.
-
-## [1.10.1] - 2026-07-09
-
-### Fixed
-- Every CLI command panicked at startup on read-only filesystems
-  (sandboxes like ai-jail) when the log directory already existed but the
-  log *file* couldn't be created — the half of the failure the existing
-  tempdir fallback didn't cover, because it only triggered on directory-
-  creation errors and used the panicking appender constructor. File
-  logging now degrades instead of failing: `<data_dir>/logs` → the OS
-  temp dir → stderr-only, with a warning naming the exact path that
-  failed at each step (so sandbox users know what to `--rw-map`), and
-  commands keep working regardless ([#158]).
-
-## [1.10.0] - 2026-07-09
-
-### Added
-- Zero (Gitlawb/zero) is now a supported agent/client ([#156]).
-  `install-mcp --client zero` merges a native HTTP + bearer entry into
-  Zero's `~/.config/zero/config.json` (`mcp.servers` map), and
-  `install-hooks --agent zero --apply` merges exec-form lifecycle hooks
-  (the native `ai-memory hook` command with an args array — JSON payload
-  on stdin, no shell) into `~/.config/zero/hooks.json`, preserving
-  third-party hooks in the same file by id prefix. All six Zero events
-  are covered: `sessionStart`/`sessionEnd`, `beforeTool`/`afterTool`,
-  and `specialistStart`/`specialistStop` (mapped to ai-memory's subagent
-  events). Zero discards `sessionStart` hook stdout, so capture and
-  handoff creation work but handoff injection does not — recover
-  handoffs via the MCP `memory_handoff_accept` tool, same policy as
-  Grok. `uninstall` strips the hook entries and the MCP registration;
-  `setup-agent --agent zero` prints the config for docker-host flows.
-  Support tracks Zero's current formats — it is a fast-moving young
-  project and upstream churn will be fixed as reported.
-
-## [1.9.1] - 2026-07-08
-
-### Fixed
-- `memory_read_page`'s input schema now encodes the "exactly one of
-  `path` or `query`" contract as an `anyOf` whose branches demand the
-  key's presence *and* a non-null string, so MCP clients that null-fill
-  defaulted arguments (observed with OpenCode 1.17.x) are schema-blocked
-  from sending the neither-arg call instead of looping on a server
-  error. The runtime error for a bare call is now instructive — it names
-  both arguments and shows a concrete `{"path": "notes/topic.md"}`
-  example so a looping model can self-correct — and the tool/argument
-  descriptions state the MUST-pass-one rule up front ([#155]).
-
-## [1.9.0] - 2026-07-07
-
-### Added
-- Global preferences scope ([#154]): standing user/team context that
-  should apply to every project — technology choices, code style,
-  durable personal conventions — now has a dedicated home. Write with
-  `memory_write_page` + `scope: "global"`; the page lands in the
-  reserved `_global` project (default workspace, following the
-  `_meta.md`/`_pending/` reserved-name convention). Default-scoped
-  `memory_query` calls union that scope into every project as a new
-  `global_scope_hits` response field — one extra scoped search, not the
-  O(projects) `global=true` fan-out — while explicitly scoped queries
-  (`workspace`/`project`/`scopes`/`global=true`) are unchanged. The
-  scope participates by existence: no config, zero effect until the
-  first global write. Event capture never creates or attributes to it —
-  a directory or marker override named `_global` falls back to the
-  server-default project.
-
-### Fixed
-- A session that is resumed under the same id after an early `SessionEnd`
-  now re-consolidates when it ends again. The end-of-session guard used to
-  drop any `SessionEnd` for a session with `ended_at` set, so a resumed
-  session's page stayed frozen at the first end's content and the resumed
-  work lived only in raw observations. The guard now distinguishes a
-  duplicate/stale end (no observations newer than `ended_at` — still
-  dropped, which keeps `finalize-session` and late spool drains safe) from
-  a genuine re-end with new work behind it, which re-runs the full end
-  path: heuristic page rewrite, `ended_at` bump, auto-handoff refresh, and
-  the opt-in LLM consolidation ([#152]).
-- `bin/ai-memory` no longer fails `install-mcp`, `install-hooks`,
-  `setup-agent`, `install-instructions`, `install-skills`, `uninstall`,
-  and `backup` under rootless Docker. Rootless Docker maps container UID
-  0 back to the real
-  host user but routes any other UID (including the host UID the wrapper
-  always passed via `-u`) through an unrelated subordinate-UID range, so
-  every write to a bind-mounted host path (`~/.claude/settings.json`,
-  the hook staging dir, `$PWD/CLAUDE.md`, skill directories) failed with
-  `Permission denied` or a misleading "does not exist" error. The wrapper
-  now detects rootless Docker via `docker info --format
-  '{{.SecurityOptions}}'` and runs as `-u 0:0` for just the commands that
-  write host-side files; thin-client commands (`status`, `bootstrap`, …)
-  are unaffected since they only touch the `/data` named volume.
-
-## [1.8.0] - 2026-07-04
-
-### Added
-- OpenCode Zen/Go is now a first-class LLM provider:
-  `AI_MEMORY_LLM_PROVIDER=opencode` (alias `opencode-zen`) routes
-  consolidation through `https://opencode.ai/zen/go/v1` using the OpenAI
-  chat-completions wire format. Authenticate with `OPENCODE_API_KEY`
-  (key from `opencode.ai/auth`); the default model is `claude-sonnet-4-6`.
-  `ai-memory llm-test --provider opencode` exercises it end-to-end ([#147]).
-- `docker/docker-compose.yml` now loads provider credentials from a
-  gitignored `docker/.env` via `env_file` (optional — existing deployments
-  without that file keep working), replacing the commented-out inline
-  provider blocks ([#147]).
-
-### Fixed
-- Gemini structured output no longer fails with `400 INVALID_ARGUMENT …
-  "type" … Proto field is not repeating, cannot start list` when a schema
-  contains an optional field. `prepare_schema_for_gemini` now collapses
-  schemars' Draft-2020-12 `type` arrays (e.g. `["string", "null"]` for
-  `Option<T>`) into Gemini's single `type` + `nullable: true` form, so
-  consolidation / auto-improve work again with `gemini-2.5-pro` and other
-  Gemini models.
-- The detached drainer's `logs/hook-drain.log` now rotates once it exceeds
-  1 MiB (previous contents move to `hook-drain.log.old`), so an agent
-  pointed at a chronically unreachable server can no longer grow the log
-  without bound.
-- Windows hook-spool drain locks now treat native lock-violation responses as
-  expected lock contention, so overlapping background drains skip cleanly
-  instead of failing the single-flight guard.
-- Windows wiki checkpoints now fall back to the Git CLI for native libgit2
-  path-resolution failures when reopening freshly initialised repos, keeping
-  delete and purge operations usable under dot-prefixed temp or wrapper paths.
-
-### Changed
-- Post-audit cleanup, no behavior change: the `AI_MEMORY_HOOK_PLATFORM`
-  override is parsed in one place instead of three copies, the CLI
-  `AgentChoice` → domain `AgentKind` mapping is a single `kind()` method
-  instead of three per-command match blocks, the companion importer crate
-  is now gated in CI (fmt/clippy/test), and
-  `crates/ai-memory-store/src/auto_improve.rs` is fully documented (its
-  file-wide `missing_docs` allowance is gone). `AI_MEMORY_HOOKS_HOST_ROOT`
-  is now documented in `docs/install.md`.
-
-## [1.7.1] - 2026-07-02
-
-### Fixed
-- Acknowledged the new `quick-xml` RustSec advisories in CI for the existing
-  `syntect` transitive dependency bucket. `plist` still constrains `quick-xml`
-  below the fixed 0.41.x branch, and ai-memory does not parse untrusted XML in
-  this path; the ignores keep cargo-audit/cargo-deny focused on actionable
-  advisories until the upstream dependency chain can update.
-
-## [1.7.0] - 2026-07-02
-
-### Added
-- Added `ai-memory finalize-session`, a supported manual Codex finalization
-  flow. It defaults to the latest open Codex session in the current
-  workspace/project and posts a synthetic `session-end` hook so summaries,
-  handoffs, and auto-improvement eligibility use the canonical SessionEnd path.
-
-### Fixed
-- Native hook spool delivery no longer relies only on the cancellation-prone
-  `session-end` hook to start the detached drainer. `stop` and `pre-compact`
-  also request the background `hook-drain` helper after enqueue, and Unix builds
-  use a trusted `setsid` launcher when available before falling back to a
-  separate process group.
-- OpenCode generated plugins now close sessions from the official
-  `session.deleted` event and a deduped best-effort `dispose` fallback, so
-  OpenCode sessions can produce automatic session summaries and handoffs without
-  duplicate `session-end` emissions.
-
-## [1.6.0] - 2026-07-01
-
-### Fixed
-- Documented and regression-tested that `install-instructions` updates only the
-  ai-memory marker block, preserves unrelated CLAUDE.md / AGENTS.md content,
-  writes backups for existing files, and refuses unmanaged same-name skills
-  unless explicitly forced.
-- Claude Code WindowsNative hook installs now use Claude's exec form
-  (`command` executable plus `args` argv array) for the native `ai-memory.exe`
-  hook, avoiding shell/Git Bash/PowerShell command-string mangling. Set
-  `AI_MEMORY_HOOK_PLATFORM=windows-bash` before `install-hooks` as a fallback for
-  older Claude Code builds; exec form requires a real `.exe`, not `.cmd`/`.bat`
-  shims.
-- Native `session-end` hooks now enqueue and return quickly, then drain the hook
-  spool through a hidden detached `hook-drain` process guarded by a real
-  single-flight file lock. Background drains use the new bounded
-  `AI_MEMORY_HOOK_BACKGROUND_DRAIN_BUDGET_MINUTES` setting (default 5, max 60),
-  while `session-start` cleanup remains synchronous and uses one shared
-  `AI_MEMORY_HOOK_START_BUDGET_MINUTES` budget for lock wait plus cleanup drain.
-  This supersedes the previous inline `session-end` deferred-drain note and
-  `AI_MEMORY_HOOK_END_BUDGET_MINUTES` session-end flush budget.
-- Pi is now supported through a generated `~/.pi/agent/extensions/ai-memory.ts`
-  TypeScript extension that combines lifecycle capture with an HTTP MCP bridge;
-  `install-hooks --agent pi --apply` writes it, while `install-mcp --client pi`
-  prints bridge guidance instead of writing an ignored native `mcp.json`.
-- Generated OpenCode and OMP TypeScript lifecycle hooks now buffer capture
-  posts through a bounded best-effort queue instead of spawning one unbounded
-  fetch per event, reducing client-side request bursts while preserving direct
-  handoff fetches.
-- Corrected the Pi vs Oh My Pi / OMP install split: OMP remains supported via
-  `--client omp` / `--agent omp` (or `oh-my-pi`) and writes `.omp` config, while
-  real `pi` remains a separate install surface. Users who previously used `pi`
-  to mean OMP should switch to `omp` or `oh-my-pi`.
-
-## [1.5.0] - 2026-07-01
-
-### Added
-- Per-project `drop_subagent_captures` opt-in. A project sets
-  `drop_subagent_captures = "true"` in its `.ai-memory.toml`; the host-side hook
-  forwards it (as the `drop_subagent` query flag, alongside the existing
-  `workspace`/`project`/`project_strategy` marker fields) so the ingest router
-  **accepts but does not persist** that project's subagent-session captures,
-  keeping only top-level sessions. A multi-agent harness fans one goal out to
-  many subagent sessions, each firing lifecycle hooks; on a small shared
-  instance that flood can saturate ingest and bloat the store. Scoping the
-  opt-in to the project that asked for it avoids a server-global switch that
-  would shed subagent captures for every project on the instance. Captures are
-  accepted (HTTP 202 / counted in the `/hook/batch` ack) so clients do not retry
-  or spool them, but they are not stored. Detection combines a per-event marker
-  (`subagentType` for grok, `agent_type`/`agent_id` for Claude Code) with
-  stateful, bounded tracking of subagent session ids: the router seeds the set
-  from any marked event and from the newly registered
-  `SubagentStart`/`SubagentStop` lifecycle hooks (claude-code and grok), and
-  clears it on `SubagentStop`, so the unmarked tail of a subagent session (its
-  `user_prompt_submit`/`stop`/`session_end`, which carry no marker) is dropped
-  too — not just the marker-bearing tool-use events.
-
-### Fixed
-- Native Windows/Git Bash installs now normalize hook cwd, stored project
-  `repo_path`, and the home-directory guard consistently across slash styles,
-  including legacy rows persisted with backslashes. `AI_MEMORY_HOME` now feeds
-  the same home guard as `$HOME`, and Git-backed helpers preserve bare-repo
-  fallback semantics while limiting CLI git fallbacks to path/open failures.
-
-## [1.4.1] - 2026-06-28
-
-## [1.4.0] - 2026-06-26
-
-### Changed
-- `install-instructions` now refreshes a slim markered CLAUDE.md/AGENTS.md
-  snippet and installs or updates managed ai-memory Agent Skills by default,
-  with `--no-skills` for snippet-only refreshes and `--skills-*` flags for
-  scope, agent family, target root, and forced unmanaged replacement. Added
-  `install-skills` for refreshing those prompt-packaging skills directly, and
-  `memory_install_self_routing` now returns the slim block, managed skill
-  payloads, target hints, and overwrite guidance for agents that install
-  routing through MCP.
-
-### Added
-- The native `session-end` hook now emits a one-line stderr note when the spool
-  drain leaves events queued for a later boundary: it reports how many events
-  were flushed, how many remain queued, whether any events were dropped as
-  undeliverable, and names the knobs to bound the backlog
-  (`AI_MEMORY_HOOK_END_BUDGET_MINUTES`, `AI_MEMORY_HOOK_INCREMENTAL_THRESHOLD`),
-  turning an otherwise silent, scary cancelled-hook symptom into an actionable,
-  self-documenting message. A fully-drained session stays silent. (#130)
-- `ai-memory uninstall --only skills` now removes ai-memory-managed Agent Skill
-  files from the default project/global `.claude/skills` and `.agents/skills`
-  roots after marker validation; custom `--target-dir` skill roots remain a
-  manual cleanup path.
-
-### Changed
-- Agent-facing routing prompts and auto-scope docs now call out that static MCP
-  clients running parallel sessions need explicit scope arguments or a
-  session-aware bridge that forwards the real lifecycle-hook session id.
-
-### Fixed
-- Thin-client HTTP CLI commands (`status`, `search`, `read-page`, `write-page`,
-  `delete-page`, `backup`, `embed`, and related admin commands) now fall back to
-  a stored OIDC device-flow token from `auth.json` when `AI_MEMORY_AUTH_TOKEN` /
-  `[auth].bearer_token` is absent. This sends a bearer for external OIDC-aware
-  gateways/bridges; native ai-memory server auth still uses the static root
-  bearer or DB-user tokens, and `/admin/*` remains root-only unless a gateway
-  translates accepted OIDC auth into upstream auth that ai-memory accepts.
-  Static bearer tokens still take precedence.
-
-## [1.3.0] - 2026-06-24
-
-### Added
-- `install-hooks --project-strategy repo-root` bakes a default project strategy
-  into the generated hooks, so every session resolves its project from the main
-  git repo root (collapsing subdirectories and worktrees) without a per-repo
-  `.ai-memory.toml` marker — preventing a persistent `cd` into a subdirectory
-  from forking memory into a phantom project. A marker's own `project_strategy`
-  still takes precedence, and the default (`basename`) bakes nothing, so existing
-  installs are unchanged. Covers every delivery path: POSIX/PowerShell hook
-  scripts, the native `hook` command, and the OpenCode / OMP / OpenClaw
-  TypeScript integrations. (#128)
-
-## [1.2.2] - 2026-06-23
-
-### Fixed
-- Long-session consolidation now favors later same-session corrections when the
-  observation projection cap forces sampling, and both consolidation prompts now
-  instruct the model to treat the most recent/final state as authoritative when
-  observations contradict earlier drafts.
-
-## [1.2.1] - 2026-06-23
-
-### Fixed
-- Hook spool batch drains now scale the `/hook/batch` request timeout with the
-  number of events in the chunk, reducing false timeout retries after a slow
-  server has successfully committed the batch.
-- Hook spool filenames now include a per-process monotonic suffix so tight loops
-  or long-lived helper processes cannot overwrite events created in the same
-  millisecond.
-- Contamination audits now treat `%` and `_` in stored `repo_path` values as
-  literal path bytes, matching runtime cwd-prefix resolution.
-- Auto-improve telemetry rejection aggregates now exclude rejected maintenance
-  report proposals (`curator_report` and `auto_improve_report`) from learning
-  rejection signals.
-- Auto-improve eval stdout capping now reads only `MAX+1` bytes before failing
-  closed, avoiding a flaky oversized-output test path while preserving the cap.
-- Updated `quinn-proto` to clear the new RustSec memory-exhaustion advisory.
-
-## [1.2.0] - 2026-06-23
-
-### Added
-- Added the standalone optional `companions/ai-memory-importer` package for
-  dry-run-by-default OMC flat Markdown wiki imports through public HTTP APIs;
-  it is isolated from the root Cargo workspace and root `cargo test --workspace`.
-- Auto-improvement reviews can now stage bounded patch proposals for existing
-  `_rules/` and `procedures/` pages using append, add-section, and checked
-  replace-section edits, with base-body hashes guarding materialize-to-stage
-  races.
-- Auto-improvement patch proposals now honor a per-run edit budget, and final
-  `_rules/` / `procedures/` pages have configurable token budgets to prevent
-  reviewer runs from growing policy or procedure pages too aggressively.
-- Auto-improvement now keeps a scoped rejection buffer for human rejects,
-  approval conflicts/failures, and validator rejected candidates, then feeds a
-  bounded summary into future reviewer prompts to avoid repeated failed edits.
-- Auto-improvement can now run an optional operator-supplied executable eval gate
-  under `[auto_improve.eval]` after LLM validation and before staging/approval for
-  selected targets (default `_rules` and `procedures`). The gate is disabled by
-  default, receives proposal JSON on stdin, fails closed on command/timeout/JSON
-  errors or insufficient score delta, and records eval failures as rejected
-  candidates without running from hook paths.
-- Added read-only auto-improvement telemetry reporting via
-  `POST /admin/auto-improve/report` and `ai-memory auto-improve-report`, with
-  JSON and human CLI output for recent run counts, proposal outcomes, terminal
-  rates, and operational findings without staging pending proposals; optional
-  `--stage` / `stage: true` creates one pending audit report page for approval.
-- Added `docs/auto-improve-eval-gates.md` plus dependency-free Python and shell
-  scorer templates for `[auto_improve.eval]` proposal gates.
-- Hook spool drains now use `POST /hook/batch` when the server supports it,
-  grouping compatible queued lifecycle events into bounded batches to amortize
-  remote request latency. Older servers fall back to the existing per-event
-  `POST /hook` path.
-
-### Fixed
-- Auto-improvement eval gates now apply timeouts to the full child interaction,
-  cap stdout at 64 KiB, cap eval rejection evidence, and make direct root admin
-  requests inherit server eval defaults unless the request explicitly overrides
-  them.
-- Hook project routing now stores git repo paths using the incoming cwd's visible
-  path spelling, so macOS `/var` vs `/private/var` aliases and symlinked cwd
-  aliases still prefix-match later events into the same project.
-- Updated `git2` to the patched 0.21 line to clear new RustSec unsoundness
-  advisories in libgit2 bindings.
-- Native Claude Code hooks now capture array-shaped `tool_response` content and
-  recognize the native `user-prompt-submit` event token, restoring prompt text
-  and tool output bodies for native installs.
-- The headless hook spool now warns (instead of silently swallowing) when it
-  cannot persist a bumped retry-attempt count back to disk, matching the v1.1.3
-  enqueue-failure fix. A failed atomic rewrite previously lost the in-memory
-  attempt bump, so a poison spool entry never reached `MAX_ATTEMPTS` and kept
-  retrying on every drain boundary with no operator signal until the 7-day
-  age-out pruned it. The warning is sanitized and carries no path (a raw spool
-  path can be a Windows verbatim `\\?\…` path).
-
-## [1.1.3] - 2026-06-20
-
-### Fixed
-- Native Windows Claude Code hooks no longer silently drop every captured event.
-  On Windows, `install-hooks` canonicalizes the data dir, which yields a verbatim
-  extended-length path (`\\?\C:\…`), and that prefix was baked verbatim into the
-  generated `--data-dir` for each native hook command. At capture time the
-  hook-spool write under a `\\?\`-prefixed data dir never lands, and the failure
-  was swallowed (`let _ = enqueue(...)`), so every `UserPromptSubmit` /
-  `PreToolUse` / `PostToolUse` / `PreCompact` / `Stop` / `SessionEnd` event was
-  lost while each hook still exited 0 — only `SessionStart` (handoff retrieval)
-  kept working, masking the loss. The data dir is now de-verbatim'd both when
-  rendering the hook command (new installs emit a plain `--data-dir`) and when
-  the hook resolves its data dir at capture time (an already-installed hook
-  recovers on the next session without re-running `install-hooks`), and future
-  spool enqueue failures emit a sanitized stderr warning instead of staying fully
-  silent. (issue #116)
-- `bin/release` now handles changelog entries containing backslashes, so Windows
-  path examples cannot abort the release after the version files are updated.
-
-## [1.1.2] - 2026-06-19
-
-### Added
-- Documented a migration checklist for users replacing another memory tool:
-  export first, scrub secrets, curate legacy material into reviewed Markdown,
-  configure one client at a time, and remove stale hooks/plugins/MCP servers only
-  after ai-memory capture and retrieval are verified. (issue #115)
-
-### Fixed
-- Handoff selection no longer strands a detailed manual handoff behind a vague
-  auto one. A manual handoff (`memory_handoff_begin`) typically has no cwd while
-  the SessionEnd auto handoff carries the session cwd; the read filtered by exact
-  `cwd` equality, so the next session — whose SessionStart hook always sends a
-  cwd — silently skipped the cwd-less manual handoff and consumed the cwd-bearing
-  auto one instead, leaving the manual one open but unreachable (handoffs have no
-  list/search surface). Selection now prefers a manual handoff over an auto one
-  deterministically: `memory_handoff_begin` always stores a null
-  `from_session_id` and the SessionEnd auto handoff always a non-null one, so
-  manual handoffs are treated as project-wide (always candidates, whatever cwd
-  they carry) and an explicit baton beats the heuristic one regardless of whether
-  the model passed a cwd. Among manual handoffs the most recent wins. Auto
-  handoffs are scoped by a cwd path-boundary (a handoff left in `/repo` reaches a
-  session in `/repo/api`, never `/repo-other`), with the most specific cwd then
-  the most recent as tiebreaks — the cwd-specificity tiebreak applies only to
-  auto handoffs, never reordering manual ones. The path-boundary is computed in
-  Rust, not SQL `LIKE`, so `%`/`_` in a path cannot act as wildcards.
-  The stored cwd is normalized (trailing slash stripped) at insert time so
-  trailing-slash drift between agent payloads cannot break the match.
-  Cross-project isolation is unchanged: handoffs remain scoped by `workspace_id`
-  + `project_id`.
-
-## [1.1.1] - 2026-06-18
-
-### Fixed
-- Internal consolidation and auto-improvement prompts now use a deterministic,
-  budgeted observation projection that preserves high-signal anchors instead of
-  suffix-only observation windows. Manual handoff fields and item lists are
-  capped after sanitizer scrub with visible truncation markers so oversized
-  handoffs do not overwhelm the next agent context; raw observations remain
-  unchanged.
-- `project_strategy = "repo-root"` no longer falls back to `basename(cwd)` for
-  git worktrees whose directory lives outside the main repo tree when the server
-  runs in a container. The server resolves repo-root via libgit2 on the incoming
-  `cwd`, which fails when that host path is not visible inside the container, so
-  every such worktree became its own project. Lifecycle hooks and generated
-  TypeScript plugins now resolve the main repo root host-side — following the
-  worktree commondir pointer with `git rev-parse --git-common-dir` (or the same
-  Rust/libgit2 helper for native hooks) — and send it as an explicit `project`,
-  so linked worktrees collapse to one stable project regardless of where the
-  worktree directory lives or how the server is deployed. The hook-side git
-  probe is silent outside real work trees, preserving the existing basename
-  fallback there. (issue #110)
-- Unscoped MCP queries could resolve to the wrong project on a shared
-  install. The cwd-to-project resolver recorded the bare working directory
-  as a project's `repo_path` whenever the cwd was not inside a git repo
-  (which, under the default basename strategy, was always), so opening a
-  session in a broad ancestor such as `$HOME` created a row that
-  prefix-matched every project nested beneath it and captured their unscoped
-  lookups. A project's `repo_path` is now the git working-tree root, or unset
-  when the cwd is not inside a git repo, never the bare cwd; under the
-  default basename strategy it is recorded only when the cwd is the
-  repository root, never a subdirectory. A read-time guard additionally
-  refuses to prefix-match a stored `repo_path` equal to the operator's
-  `$HOME`, and `ai-memory serve` heals existing installs on startup by
-  clearing any `repo_path` that is not a real git working-tree root (such as
-  a legacy `~/projects` or `/work` catch-all), not only `$HOME` and the
-  filesystem root, while leaving paths it cannot see locally (a remote or
-  multi-user client path, or an unmounted drive) untouched. (issue #103)
-- macOS Docker quick-start now produces a working native-agent setup out of the
-  box (issue #107). Three independent breakages are fixed: (1) the macOS wrapper
-  baked the container-only `host.docker.internal` URL into the *host* agent
-  config, so MCP and every capture hook failed silently — `install-mcp`,
-  `install-hooks`, and `setup-agent` now render the host-reachable
-  `http://127.0.0.1:49374`, decoupled from the `host.docker.internal` URL the
-  wrapper still uses for its own in-container thin-client commands; (2) those
-  thin-client commands were rejected with `403 forbidden host` because the
-  server's loopback-only Host allowlist excluded `host.docker.internal` — the
-  Docker image now ships it in the default `AI_MEMORY_ALLOWED_HOSTS` (native
-  installs stay loopback-only; exposed deployments still override it); and (3)
-  `setup-agent`/`install-hooks` could not locate the hooks bundle that ships
-  beside the binary in the release tarball (the probe derived a bogus
-  `/private/hooks/…`), so the binary-sibling `hooks/` directory is now on the
-  discovery search path and `--source` is no longer required.
-- Wiki reindex and checkpoint restore now preserve page `tier` and `pinned`
-  metadata from frontmatter instead of forcing every reindexed page back to
-  semantic/unpinned. Wiki writes now serialize canonical tier/pinned metadata so
-  later watcher reconciliation remains idempotent for episodic and pinned pages.
-
-### Added
-- `GET /admin/audit-contamination` (and `ai-memory audit-contamination`) — a
-  read-only, SQL-only structural cross-project contamination audit. Flags
-  sessions whose `cwd` longest-prefix-resolves to a different project than the
-  one they landed in (the auto-scope-bleed signature, resolved with the same
-  prefix logic the runtime uses) and observations whose project disagrees with
-  their owning session (a regression tripwire that should stay empty on a
-  healthy DB). Optional `?workspace=&project=` scope; reports only, never
-  mutates, so it is safe to run on any cadence. Purely semantic mislandings
-  (no cwd/session anomaly) are out of scope by design.
-- Mid-session hook-spool drain: on `post-tool-use`, once the local spool backlog
-  crosses a threshold, the hook runs a tightly time-boxed (~250 ms) catch-up
-  drain so a heavy session keeps the backlog flat instead of waiting for the next
-  session boundary. Tunable via `AI_MEMORY_HOOK_INCREMENTAL_THRESHOLD`
-  (default 32 events).
-- Added [`docs/macos.md`](docs/macos.md) covering macOS install paths (prebuilt
-  release binary, source build, and the Docker wrapper) and the `posix` vs
-  `posix-native` hook platform split, with troubleshooting notes for macOS
-  wrapper and hook-discovery issues. Linked it from the README support matrix, the docs
-  table, and `docs/install.md`, and bundled it into the macOS release tarballs
-  alongside `docs/install.md` (mirroring how the Windows zip ships
-  `docs/windows.md`).
-
-### Fixed
-- Bounded heuristic session-page raw observation dumps and single-page
-  consolidation prompts so very large sessions cannot re-include unbounded
-  `## Raw observations` history (issue #102).
-- Hook spool no longer counts a server `429` (saturation / `hook queue full`)
-  against a spooled event's `MAX_ATTEMPTS` retry budget: transient backpressure
-  keeps the event queued without burning an attempt (`MAX_AGE_MS` still bounds
-  it), so a saturation burst no longer silently discards real observations.
-
-## [1.1.0] - 2026-06-16
-
-### Fixed
-- Auto-improvement scheduling now scans every known project each tick instead of
-  only the server's startup/default project. Scheduler ticks remain
-  non-overlapping; if reviewing all projects takes longer than the configured
-  interval, the next tick is delayed until the current tick finishes.
-
-## [1.0.11] - 2026-06-15
-
-### Added
-- Added a server-side auto-improvement scheduler. When an LLM provider is
-  configured, `[auto_improve.scheduler] enabled = true` reviews newly completed
-  sessions in the background, stages validated proposals for audit, and then
-  follows the normal auto-improvement approval policy.
-- Added persistent scheduler state and per-session scheduler claims so upgrades
-  from the v1.0.3-era schema do not process historical session backlog
-  automatically, and failed scheduled reviews do not retry forever. Manual
-  `ai-memory auto-improve --session-id <uuid>` and MCP `memory_auto_improve`
-  remain the catch-up path for older or failed scheduled sessions.
-
-### Changed
-- Clarified that scheduling and approval are separate: disable automatic review
-  with `[auto_improve.scheduler] enabled = false`; keep proposals pending with
-  `[auto_improve] require_approval = true`.
-
-## [1.0.10] - 2026-06-15
-
-### Changed
-- `ai-memory auto-improve --session-id <uuid>` and `POST /admin/auto-improve`
-  now record validated proposals in the pending-writes audit trail and approve
-  them immediately through the normal wiki write path. Set
-  `[auto_improve] require_approval = true` to keep proposals pending for manual
-  review. The MCP `memory_auto_improve` tool uses the same behavior.
-- Existing project wikis need no migration. Existing server configs that
-  contain the old `[auto_improve] mode = ...` key keep working; the key is now
-  ignored and can be removed when convenient.
-
-## [1.0.9] - 2026-06-15
-
-### Fixed
-- Clarified architecture and auto-improvement design docs so CLI/admin
-  auto-improvement is described with pending-writes storage and approval
-  boundaries.
-
-## [1.0.8] - 2026-06-15
-
-### Added
-- Added auto-improvement proposal storage: `ai-memory auto-improve` and
-  `POST /admin/auto-improve` store validated proposals in durable SQLite-backed
-  pending-write rows with non-indexed `_pending/auto-improve/` sidecars. The new
-  `ai-memory pending-writes list|show|diff|approve|reject` commands and
-  `/admin/pending-writes*` routes let operators review, apply, or reject stored
-  proposal bodies through the normal wiki mutation path.
-- Added first-release curator support: `ai-memory curator` and
-  `POST /admin/curator` run a rule-based, no-LLM, report-only maintenance
-  review for an existing workspace/project. Dry-run is the default and writes
-  nothing; `--stage` creates exactly one pending report proposal for approval
-  through the existing pending-writes queue, without editing pages, deleting
-  content, rewriting links, or changing slots.
-
-## [1.0.7] - 2026-06-15
-
-### Added
-- Added the initial auto-improvement reviewer: `ai-memory auto-improve
-  --session-id <uuid>` calls `POST /admin/auto-improve`, reads one completed
-  session, applies preflight noise filters, samples large sessions via the
-  consolidated session page plus high-signal observations, asks the configured
-  LLM for structured durable wiki edit proposals, and validates
-  path/evidence/confidence plus duplicate existing path/title constraints.
-  Thresholds remain configurable: confidence, input budget, proposal cap,
-  `auto_improve` attribution, and `_pending/auto-improve` proposal path.
-- Added MCP tool `memory_auto_improve` so agents can run learning review for the
-  latest completed session (or a named session) without shelling out. The
-  canonical MCP instructions and installed CLAUDE.md/AGENTS.md routing snippet
-  now teach agents to treat `_rules/`, `gotchas/`, `procedures/`, and
-  `decisions/` as actionable guidance for proactive retrieval.
-
-### Changed
-- Clarified upgrade guidance: Docker-wrapper users should run
-  `ai-memory upgrade` on each agent machine to refresh the wrapper, pulled
-  image, and staged hook scripts; native package/source installs should rerun
-  `install-hooks --apply` after binary upgrades; remote servers still need a
-  separate redeploy; and existing projects can refresh the managed routing block
-  to pick up new proactive retrieval and `memory_auto_improve` guidance.
-
-### Fixed
-- `auto-improve` now tolerates common malformed LLM proposal shapes found during
-  live testing: evidence arrays may contain bare quote strings instead of
-  `{ page, quote }` objects, a missing `operation` defaults to the only supported
-  `create_or_update` operation, markdown bodies can arrive as `body`,
-  `markdown`, or `content`, plural/folder-style kind names are normalized before
-  path validation, and proposals still missing required target data are rejected
-  by validation instead of turning the whole review into a 502 response.
-- Admin destructive ops (`/admin/purge-project`, `/admin/move-project`) now
-  propagate the authenticated actor (from the auth middleware's
-  `Extension<ActorContext>`) into the admission context, so a `scope-guard`
-  admission webhook can authorize them by user. They previously built the
-  context with an empty actor, which a per-user scope-guard ACL rejected with
-  `403 user '' not allowed to purge_project`, making purge/move unusable on any
-  instance running scope-guard. `rename-project` is unaffected (it runs no
-  admission chain).
-## [1.0.6] - 2026-06-14
-
-### Changed
-- Centralized workspace/project scope resolution in `ai_memory_store::ScopeResolver`
-  and shared explicit helpers, then migrated MCP, admin, and web API routes onto
-  the common no-create/create-on-write policies.
-- Centralized auth checks behind `AuthLevel::authorize(Capability::...)` so admin,
-  user-management, and admission-skip behavior share one permission framework.
-- Tightened wiki/SQLite consistency semantics: markdown remains the source of
-  truth, batch writes install files before committing the derived SQL index, and
-  runtime SQL failures roll installed files back best-effort.
-
-### Added
-- Regression tests for shared scope policies, capability authorization, and
-  wiki-file rollback when `write_page` / `apply_batch` store upserts fail.
-
-## [1.0.5] - 2026-06-14
-
-### Fixed
-- Multi-user admin authorization is now enforced at the shared `/admin/*`
-  router boundary, including user-management routes, so DB-user tokens can use
-  normal MCP/API read-write surfaces for attribution but cannot reach any admin
-  endpoint. Added regression coverage for every admin route plus DB-user write
-  attribution.
-
-## [1.0.4] - 2026-06-14
-### Added
-- `install-hooks --agent grok` (plus `setup-agent` / `uninstall` coverage) for
-  the xAI **Grok Build CLI**. Grok's `~/.grok/hooks/ai-memory.json` shares Claude
-  Code's JSON shape and seven-event vocabulary, with a Grok-specific hook bundle
-  and native `ai-memory hook --event … --agent grok` commands.
-  ai-memory entries merge into a dedicated `ai-memory.json`, leaving any
-  third-party `~/.grok/hooks/*.json` untouched. NOTE: Grok ignores hook stdout on
-  `SessionStart`, so capture works but handoff injection does not. Grok's
-  `session-start` therefore skips the handoff fetch entirely — the fetch is
-  destructive (it marks the handoff accepted server-side) and Grok would discard
-  the result, silently losing the handoff; recover a prior session's handoff via
-  the MCP `memory_handoff_accept` tool instead. Adds `AgentKind::Grok` (`grok`
-  wire tag), the `AgentKind::session_start_injects_handoff` gate, and migration
-  `V20` extending the `sessions.agent_kind` CHECK so Grok sessions persist on
-  upgraded servers (the antigravity/`V11` precedent).
-
-### Fixed
-- Actor-scoped MCP tool calls no longer fall through to a user's or process's
-  latest hook-published project when the request carries a session id that does
-  not match hook activity. This prevents HTTP-remote shared servers from reading
-  or writing another same-user project when the MCP transport session id differs
-  from the hook session id ([#97]).
-- `memory_handoff_begin` and `memory_handoff_accept` now accept an optional
-  `workspace` argument alongside `project`, resolving through the same
-  workspace+project path as `memory_write_page` (begin, create-if-missing) and
-  `memory_handoff_cancel` (accept, find-only). They previously took `project`
-  only, so a cross-workspace handoff was routed by the per-actor active-project
-  fallback and could be written to — or read from — the wrong project.
-  `memory_handoff_cancel` already carried `workspace`.
-- Workspace/project resolution now fails closed across the MCP and admin
-  surfaces. Explicit MCP project misses no longer fall back to the active/default
-  project, write-style MCP calls reject `workspace` without `project`, admin
-  read/search/embed/lint/sweep paths use no-create lookups, and `/admin/reorg`
-  only moves sessions and graveyards latest pages inside the target workspace.
-
-## [1.0.3] - 2026-06-13
-### Added
-- Native macOS release tarballs (`ai-memory-macos-aarch64.tar.gz` for
-  Apple Silicon and `ai-memory-macos-x86_64.tar.gz` for Intel) are now
-  published on every tag, alongside the existing Linux tarballs and the
-  Windows zip. The macOS `release-build` CI job also runs on every push,
-  so a macOS-only release regression is caught before the tag rather
-  than after. Install instructions added to `README.md` and
-  `docs/install.md` ([#94]).
-
-## [1.0.2] - 2026-06-12
-### Fixed
-- Session-page tool-call counts no longer double every entry. The
-  no-LLM synthesizer was counting both `PreToolUse` and `PostToolUse`
-  observations into the same bucket, so a single Bash call rendered
-  as `Bash: 2` and two real calls as `Bash: 4`. It now counts only
-  `PostToolUse` (the "completed call" event), matching the user-facing
-  meaning of the heading.
-
-## [1.0.1] - 2026-06-12
-### Added
-- `install-mcp --client vscode-copilot` renders (and `--apply` writes) a
-  workspace-scoped `.vscode/mcp.json` for VS Code GitHub Copilot's agent
-  mode. The renderer uses VS Code's MCP framework schema — top-level
-  `servers` key, `type: "http"`, `url`, and an inline `headers` map for
-  the bearer token — and includes a note that VS Code Copilot does not
-  yet expose lifecycle hooks, so ai-memory's automatic capture is not
-  active there (the MCP tools must be called explicitly from chat).
-  Aliases: `copilot`, `github-copilot`. `uninstall --only mcp` strips
-  the same entry idempotently.
-
-## [1.0.0] - 2026-06-12
-### Added
-- Native hook drain and handoff timings can now be raised with
-  `AI_MEMORY_HOOK_DRAIN_TIMEOUT_MINUTES`,
-  `AI_MEMORY_HOOK_HANDOFF_TIMEOUT_MINUTES`,
-  `AI_MEMORY_HOOK_START_BUDGET_MINUTES`, and
-  `AI_MEMORY_HOOK_END_BUDGET_MINUTES` for high-latency or large-backlog
-  instances. Defaults preserve the existing short hook behavior; invalid,
-  zero, or overly large values fall back or clamp safely.
-
-## [0.16.0] - 2026-06-11
-### Added
-- Native Claude Code hooks on macOS/Linux now use the direct
-  `ai-memory hook --event ...` command by default, matching native Windows.
-  Native hook commands spool events locally and can authenticate with a stored
-  per-developer OIDC device token instead of a shared static hook token.
-- `ai-memory auth login oidc-device --issuer <url> --client-id <id>` stores a
-  generic OIDC device-flow token for native hook authentication.
-
-### Fixed
-- `ai-memory uninstall --only hooks` now recognizes and removes native
-  `ai-memory hook ...` commands as well as legacy script commands.
-
-## [0.15.0] - 2026-06-11
-### Added
-- Wiki recovery checkpoints now have first-class operator commands:
-  `ai-memory checkpoints` lists recent wiki git commits and
-  `ai-memory restore-page --path <page.md> --from <rev>` restores one page
-  from a checkpoint, writes a new post-restore checkpoint, and reindexes the
-  restored page into SQLite. Startup also creates a one-time upgrade baseline
-  checkpoint for existing wiki trees that had no git commits yet.
-
-### Fixed
-- Release publication now limits the GitHub Release asset download step to
-  `ai-memory-*` artifacts, avoiding Docker Buildx side artifacts that can make
-  tag workflows fail after binaries and Docker images are already published.
-
-## [0.14.0] - 2026-06-11
-### Added
-- Tagged releases now publish a native Windows x86_64 zip artifact
-  (`ai-memory-windows-x86_64.zip`) with `ai-memory.exe`, hooks, default
-  config template, checksums, and Windows install docs, giving native
-  Windows agents a no-toolchain path to the fast direct-binary hook mode.
-
-## [0.13.0] - 2026-06-08
-### Added
-- New `ai-memory reindex` lifecycle command rebuilds the derived SQLite page
-  index from the on-disk wiki. It recreates workspace/project rows from
-  per-scope `_meta.md` manifests while preserving the UUIDs encoded in the
-  wiki tree, then reindexes page markdown into pages, links, and FTS. The
-  command refuses to run unless the SQLite store is clean; operators should
-  stop the server, back up data, move/remove `db/memory.sqlite`, run
-  `reindex`, and recompute embeddings separately with `embed` when needed.
-- Wiki startup now backfills per-workspace and per-project `_meta.md` manifests
-  containing the human workspace/project names (and `repo_path` for projects)
-  so the markdown tree is self-describing enough to rebuild the derived DB.
-
-### Fixed
-- Wiki reindexing now treats `log.md` / `log-YYYY-MM.md` as raw hook ledgers
-  only when their content opens with the hook log prefix, so ordinary markdown
-  pages with reserved-looking names are no longer silently dropped. `_meta.md`
-  manifests and direct watcher events also reject symlinks before reading.
-
-## [0.12.3] - 2026-06-07
-
-## [0.12.2] - 2026-06-07
-### Fixed
-- The hook router no longer auto-creates fragment "projects" for
-  subdirectory cwds. When a tool call's cwd sits inside an existing
-  project's `repo_path` tree (for example a `Read` of
-  `manga-plus/reader/src/main.rs` while the session is attributed to
-  `manga-plus`), the resolver now picks the existing parent project
-  instead of materialising a `src` or `reader` project for the
-  subdirectory name. The schema column `projects.repo_path` has
-  always been there for exactly this kind of cwd matching; the
-  resolver finally queries it. Sub-projects declared via
-  `.ai-memory.toml` still win because their longer `repo_path` ranks
-  ahead. New `find_project_by_cwd_prefix` reader helper covers the
-  query. Three regression tests in `ai-memory-hooks::router::tests`
-  pin the parent / sub-project / cold-start paths.
-- V19 data-repair migration re-attributes pre-existing orphan
-  observations and handoffs to their session's project, then deletes
-  the now-truly-empty fragment project rows that were left behind
-  by the bug above. The session is the source of truth — observations
-  belong to the session that emitted them and the FK enforces
-  session existence. The migration is idempotent (re-running on a
-  repaired DB is a no-op) and runs once per data directory at server
-  startup via the existing refinery chain. `scratch` is explicitly
-  preserved per CLAUDE.md invariant #15a (defensive cwd-less
-  default).
-
-## [0.12.1] - 2026-06-07
-### Fixed
-- `GET /favicon.ico` now lives at the absolute host root, outside
-  `--base-path` and outside the `/web` nest, so the browser's
-  automatic favicon fetch actually reaches it. The 0.12.0 build mounted
-  the route inside the web router and ended up serving the icon only
-  at `/web/favicon.ico` — invisible to the browser's auto-fetch (the
-  icon still appeared via the in-page `<link rel="icon">` tag, so the
-  user-visible behaviour stayed correct, but the dedicated route was
-  unreachable). The new mount is also exempt from bearer auth and the
-  host allowlist so a fresh tab gets the icon without an HTTP Basic
-  prompt; the embedded PNG is the same one any visitor to `/web`
-  already sees, so the info-leak surface is nil. Surfaced by the
-  post-merge audit live test ([#79]).
-
-## [0.12.0] - 2026-06-07
-### Added
-- New `ai-memory hook` subcommand emits one lifecycle event natively (reads
-  the JSON payload from stdin, POSTs to `/hook`, GETs `/handoff` on
-  `session-start`) without spawning a shell. On native Windows, Claude Code
-  now defaults to the native hook command — measured ~3.5-5× faster per
-  tool-call hook (~735 ms shell → ~150-205 ms native on an i7-6700HQ).
-  Opt back into the previous Git Bash + `.sh` path with
-  `AI_MEMORY_HOOK_PLATFORM=windows-bash`. See
-  [`docs/windows.md`](docs/windows.md#native-hook-command-claude-code-on-windows)
-  ([#84]).
-- New `GET /favicon.ico` route on the web UI serves the same logo bytes as
-  the header, so the browser tab carries an icon without an extra asset
-  embed ([#79]).
-- Thin-client CLI commands (`status`, `write-page`, `search`, `read-page`,
-  `embed`, `lint`, `backup`, …) now respect the server's base-path mount
-  via `AI_MEMORY_BASE_PATH` or the path component of `AI_MEMORY_SERVER_URL`
-  (URL path wins), so deployments hosted behind a reverse proxy under a
-  subpath stop 404'ing — including the container `HEALTHCHECK`
-  (`ai-memory status`). Empty / unset means root mount, byte-identical to
-  the prior behaviour ([#82]).
-
-### Changed
-- The embedded web UI ships a single transparent 768×768 PNG (~126 KB,
-  down from a 992 KB JPEG mislabelled as PNG) used for both the header
-  logo and the favicon. README branding stays on the existing
-  light/dark pair via `<picture>` ([#79]).
-
-### Fixed
-- `install-hooks --apply` (and `ai-memory upgrade`, which calls it) now
-  MERGES into per-event hook arrays instead of replacing them, so
-  third-party hooks registered under the same event (e.g. a context-mode
-  `SessionStart` guard) survive re-apply. ai-memory-owned entries are
-  still swapped for the fresh ones; re-runs stay idempotent. Resolves
-  #80 ([#83]).
-- FTS5 searches for filenames carrying ASCII punctuation no longer error
-  or silently miss. `current.md` (which used to surface
-  `fts5: syntax error near "."`) and `ui-refresh` (which silently returned
-  zero hits despite `follow-ups/ui-refresh-scroll-restoration.md` existing)
-  both work end-to-end. Punctuated tokens are now quoted as both
-  whole-form and split-form phrases, OR'd, to satisfy the asymmetry
-  between the content tokenizer (`tokenchars '/_-'` keeps them inside
-  tokens) and the path index (which pre-expands `/_-.` to spaces)
-  ([#81]).
-
-## [0.11.0] - 2026-06-05
-### Added
-- New `[auto_scope]` config block (`mode`, `session_ttl_secs`,
-  `max_entries`) selects how the hook-published "currently active project"
-  pointer is shared across concurrent MCP callers. The default `single` mode
-  preserves the historical process-wide slot. Opt-in `per_session` keys the
-  pointer by `session_id` to isolate concurrent agent runs of the same
-  operator; opt-in `per_actor` keys by `(user, session_id)` to isolate
-  across operators as well, pairing with multi-user mode where `user`
-  comes from the `users` row that owns the bearer token. `per_actor`
-  also keeps a user-only fallback slot so authenticated MCP requests
-  from clients that cannot forward a session id do not inherit another
-  user's latest project; same-user session isolation still requires a
-  client/bridge that sends `X-Memory-Actor-Session-Id` or
-  `Mcp-Session-Id` on MCP tool calls. Per-key entries carry an insertion
-  timestamp and are TTL-evicted (default 1 hour) and
-  capped (default 4096) so adversarial / runaway clients cannot grow the
-  map without bound. Both opt-in modes still publish to the single slot
-  in parallel, so any caller without actor context falls back gracefully
-  to the most recent project rather than an empty pointer. All MCP read
-  tools (`memory_query`, `memory_recent`, `memory_read_page`,
-  `memory_status`, `memory_briefing`, `memory_explore`, `memory_lint`,
-  `memory_forget_sweep`, `memory_handoff_*`) now thread the request's
-  `ActorContext` into scope resolution, so opt-in isolation takes effect
-  for the full read surface.
-
-### Fixed
-- Claude Code lifecycle hooks now emit structured JSON on stdout. Fire-and-
-  forget hooks return `{}`, and `SessionStart` wraps pending handoff text in
-  `hookSpecificOutput.additionalContext`, avoiding Claude Code's repeated
-  "Hook output does not start with {" debug spam while preserving handoff
-  injection.
-- `POST /admin/rename-project` now returns `404 Not Found` when the project row
-  has been deleted (typically by a concurrent `purge-project`) between the
-  handler's id lookup and the writer's `UPDATE`. The pre-fix path silently
-  responded `200 OK` with `pages: 0` for an operation that affected zero rows,
-  which contradicted the concurrent purge's also-`200 OK` destruction of the
-  same project and gave operators no signal that the rename had been undone.
-
-## [0.10.0] - 2026-06-04
-### Added
-- New `POST /admin/delete-page` HTTP endpoint deletes a single page with
-  explicit `(workspace, project)`. Like `purge-project`/`rename-project`, it
-  uses no-create lookup — a delete on a typo'd or wrong scope now returns
-  `404 workspace 'X' not found` instead of silently auto-creating the
-  container and returning misleading `deleted: true`.
-- New `ai-memory delete-page --path <P> --workspace <W> --project <P>` CLI
-  subcommand, a thin client of `/admin/delete-page`. Mirrors the
-  write-page/read-page CLI shape so terminal users get a complete
-  delete-single-page surface for the first time.
-- New `memory_handoff_cancel` MCP tool marks an exact open handoff id expired,
-  giving agents a safe way to discard a mistakenly-created pending handoff
-  before the next session consumes stale context.
-
-### Fixed
-- MCP tool descriptions and routing snippets now draw a sharper boundary
-  between read-only `memory_briefing` and session-ending
-  `memory_handoff_begin`, reducing accidental dangling handoffs when an agent
-  was only asked for project status.
-- Custom `--web-ui-dir` SPAs mounted at a non-root `--web-slug` now serve the
-  injected shell at the trailing-slash root too (for example `/web/`), matching
-  `/web` and deep client routes instead of returning a refresh-only 404.
-- OpenCode and OMP generated hooks now derive `project_strategy = "repo-root"`
-  project names from the host-visible `.ai-memory.toml` marker directory before
-  sending hook payloads, so dockerized servers no longer fall back to git
-  discovery inside paths they cannot see.
-- `memory_delete_page` (MCP) now accepts `workspace` alongside `project` and
-  routes scope through `effective_ids_for_read_args`, the same path the read
-  tools use. Previously a project name that lived in multiple workspaces
-  could silently route the delete to the wrong slot and return `deleted:
-  true` for a page that was never touched. Operators on shared (multi-
-  workspace) servers should explicitly pass `workspace + project` to make
-  the target unambiguous.
-
-## [0.9.0] - 2026-06-02
-### Added
-- `openai-compat` LLM providers can now opt into strict JSON Schema structured
-  output with `AI_MEMORY_LLM_COMPAT_STRICT=true`. Strict mode sends
-  `response_format=json_schema` first for compatible Ollama, vLLM, LM Studio,
-  llama.cpp, and gateway endpoints, while the tolerant JSON-object parser
-  remains the default and the fallback for strict raw-call failures ([#70]).
-- The read-only web browser now renders `[[wiki links]]` as clickable internal
-  links to the target page. Supports `[[path]]`, `[[path|label]]`,
-  `[[project:path]]`, and `[[workspace/project:path]]`, resolved against the
-  current page's project unless the target carries its own scope; bare targets
-  get a `.md` suffix. External schemes, path traversal, and links inside fenced
-  or inline code are left as literal text ([#68]).
-- `ai-memory serve --transport http` can host the entire HTTP surface under a
-  configurable subpath with `--base-path` / `AI_MEMORY_BASE_PATH`; `/mcp`,
-  `/hook`, `/admin/*`, `/api/v1`, and the web UI all move under that prefix.
-  The web UI mount can also be changed with `--web-slug`, and custom
-  `--web-ui-dir` SPAs receive injected `<base href>` plus
-  `ai-memory-base-path` metadata for same-origin API calls behind reverse
-  proxies ([#65]).
-- `ai-memory move-project` can move projects across workspaces via the admin
-  API. Fresh destinations use a lossless true move that keeps the same
-  `project_id`, sessions, observations, handoffs, embeddings, and page history;
-  existing same-named destination projects use copy-purge merge with explicit
-  `on_conflict` handling. Admission webhooks can subscribe to the new
-  `move_project` event and receive destination names in the context ([#60]).
-- Page FTS now indexes normalized page paths, so searches can find pages by
-  filename or slug even when the slug does not appear in the title/body ([#62]).
-- Admission webhooks can now observe, mutate, or reject engine write/delete/
-  purge operations, with authenticated actor context, loop-prevention skip
-  lists for trusted re-entry, and non-blocking observer webhooks for mirrors
-  and backups ([#55]).
-- New `memory_delete_page` MCP tool deletes a single page by exact path,
-  updates the SQLite index directly, and fires `op=delete` admission hooks
-  before removal ([#55]).
-
-### Fixed
-- Backups no longer dereference symlinks under `wiki/`, preventing a planted
-  wiki symlink from pulling arbitrary readable host-file contents into
-  `backup.tar.gz`.
-- `ai-memory restore` now validates tar entries before extraction and accepts
-  only regular files/directories under the expected backup paths
-  (`wiki/`, `db/memory.sqlite`, and `config.toml`), rejecting links, special
-  files, unsafe paths, and unexpected archive entries.
-- In multi-user mode (`[auth].token_pepper` configured), operational
-  `/admin/*` endpoints now require the root token; DB-user tokens receive
-  403 while single-user installs keep the historical permissive admin behavior.
-- LLM provider clients now cap provider response bodies before JSON, text, or
-  SSE parsing, and truncate error bodies from bounded buffers instead of
-  buffering arbitrary-size responses.
-- Non-blocking admission webhooks now have a process-level in-flight cap and
-  webhook timeouts are clamped to a safe maximum, preventing observer hooks
-  from growing unbounded background work during write bursts.
-- Hook cwd/project resolution caching is now bounded with LRU-style eviction,
-  preventing unbounded process-lifetime growth from streams of unique cwd
-  values.
-- `memory_write_page` tool description and routing prompts now steer agents
-  toward writing the page title as a `# H1` on the first line of `body` and
-  omitting the `title` argument. ai-memory already auto-derived the title from
-  `# H1` (or path stem) when `title` was missing — the change is documentation
-  only, but it eliminates a known source of MCP `JSON parsing` errors when the
-  LLM failed to escape quotes/colons in `title` ([#67]).
-- Custom `--web-ui-dir` frontends no longer serve raw `/index.html` without
-  base-path injection; direct index requests and SPA fallback routes now return
-  the injected shell, while static assets remain untouched ([#65]).
-- `move-project` true moves now run through a wiki mutation gate: normal
-  page writes/reindexes validate the `(workspace_id, project_id)` pair before
-  touching disk, while true moves hold the exclusive side across the directory
-  rename and DB re-stamp. Stale old-workspace writes now fail without creating
-  orphan files, and V18 aborts if existing split-brain rows are present ([#60]).
-- `move-project` copy-purge conflict detection now treats body, frontmatter,
-  title, tier, and pinned status as the page identity under `on_conflict=block`,
-  preventing metadata-only overwrites from slipping through ([#60]).
-- `memory_write_page` calls that specify `project` without `workspace` now
-  default to the active workspace published by hooks, and project-only reads use
-  the same active-workspace resolution so the write can be read back without an
-  explicit workspace ([#61]).
-- `memory_read_page` now accepts explicit `workspace` + `project` for sibling
-  projects and falls back to the stored DB body only when the markdown file is
-  missing, not when the disk source of truth is corrupt or unreadable ([#63]).
-- `openai-oauth` now speaks the current ChatGPT/Codex responses stream format
-  for bootstrap/consolidation requests and avoids sending the unsupported
-  `max_output_tokens` field on that endpoint ([#64]).
-- `ai-memory write-page` now resolves an omitted `--project` through the same
-  current-project heuristic as `read-page` and `search`, preventing writes from
-  landing in `scratch` while the read-back targets the cwd-derived project
-  ([#66]).
-
-## [0.8.1] - 2026-05-30
-
-### Fixed
-- **Consolidation no longer fails on long sessions** (~5,000+ observations or
-  multi-hour agent runs). Two bugs surfaced trying to consolidate a real
-  16-hour / 7,234-observation session:
-  - **Prompt confusion (regression from the v0.8 `slot_kind` work):** the
-    multi-page consolidator prompt listed `slot_kind` values
-    (`state` / `invariant`) immediately above the `tier` values
-    (`working` / `episodic` / `semantic` / `procedural`). The LLM read them
-    as one list and emitted `tier: "state"` in structured responses, which
-    deserialisation rejected. Prompt now leads with `tier` (with explicit
-    "EXACTLY ONE OF FOUR strings" emphasis), then `kind`, then `slot_kind`
-    under its own clearly-scoped section that states "completely unrelated
-    to tier" and "only for `_slots/*` paths."
-  - **No token budget on the observation dump:** `build_request` and
-    `build_batch_request_with_slots` dumped every observation into the
-    prompt buffer, which exceeded the provider's 200k-token context on long
-    sessions (the sabadell run produced a 235k-token request → 400 from
-    the provider). New `window_observations_to_budget` walks the slice
-    from most-recent backward, keeping each entry whose render cost fits
-    in a 400k-char budget (~100k tokens), leaving room for the system
-    prompt + schema + LLM output. When entries are skipped, a prepended
-    note tells the LLM the context is partial so its summary doesn't
-    pretend to cover the early session. Both `PreCompact` and
-    `memory_consolidate` triggers benefit from the fix — both were silently
-    failing into the `warn!()` catchall on sessions this long.
-  - 5 unit tests guard the windowing invariants (empty input, fits-under-
-    budget passthrough, most-recent-preserved, single-too-large-obs drops
-    everything, observation-boundary alignment). No schema change, no
-    config knob, backward-compatible for sessions that already fit.
-
-## [0.8.0] - 2026-05-30
-
-### Added
-- **Multi-user attribution (v0.8 Phase 1, rolling out across milestones
-  P1.1–P1.8).** ai-memory's data model stays single-tenant — every
-  authenticated request sees every page — but writes can now be
-  attributed to a named user. Five `ai-memory user` subcommands
-  (`add`, `list`, `expire`, `revive`, `rotate-token`) manage a `users`
-  table; the auth middleware resolves every request to one of four
-  tiers (Anonymous, Root, DB user, 401), injects an
-  `Extension<ActorContext>` + `Extension<AuthLevel>` for downstream
-  consumers, and gates the root-only admin user-management endpoints.
-  Tokens are 32 bytes of OS CSPRNG, stored only as
-  `SHA-256(token || ":" || token_pepper)` (per-server pepper from
-  `[auth].token_pepper`, auto-generated on `ai-memory init`); see
-  [`docs/users.md`](docs/users.md) for the SHA-256-not-argon2id
-  rationale, the four-rung auth ladder, and the backward-compat
-  migration for pre-v0.8 installs. New v0.8 fields on `[auth]`:
-  `root_username` / `root_email` / `root_name` (label for the bearer
-  token's writes) and `token_pepper`. Per-page `author_id` + web UI
-  surfacing lands in P1.6/P1.7; this milestone set ships P1.1
-  (`ActorContext` + `UserId` in core), P1.2 (table + writer/reader
-  ops + V14 migration), P1.3 (auth middleware), P1.4 (root-gated
-  `POST/GET /admin/users` + `…/expire|revive|rotate-token`), and P1.5
-  (CLI subcommands). **No behaviour change for existing single-user
-  installs**: without `[auth].token_pepper` the multi-user lookup
-  stays dormant, user-management endpoints 503 with a clear
-  `multi-user not enabled` message pointing at `ai-memory init`,
-  and the existing `bearer_token`-only flow keeps authenticating
-  exactly as before.
-- **`memory_query { global: true }` — cross-project global search** that
-  reaches every project in every workspace in one call, with each hit
-  annotated by its workspace + project so the agent can tell where it
-  came from. Use when the agent doesn't know which project holds a
-  cross-cutting note (shared infra/ops, a sibling app). Mutually
-  exclusive with `scopes`/`project`/`workspace`. Routing snippet +
-  `MEMORY_INSTRUCTIONS` now teach both broadening modes (`scopes` for
-  named siblings, `global=true` for unknown locations) and explicitly
-  warn that `memory_query` returns snippets — use `memory_read_page`
-  for full bodies. The prompt-surface contradiction the original PR
-  shipped ("there is no global 'search everything' mode" right after
-  the bullet advertising `global=true`) was caught in the post-merge
-  audit and rewritten; the prompt regression test now refuses any
-  variant of that legacy phrasing
-  ([#56], thanks @djalmajr).
-- **Cross-project wiki links + dependency graph.** Wikilinks gain an
-  explicit scope qualifier: `[[project:path.md]]` for a sibling project
-  in the same workspace, `[[workspace/project:path.md]]` for another
-  workspace. Bare links are unchanged (resolve within the source's own
-  project). `links.to_workspace` / `links.to_project` join the primary
-  key so the same `to_path` can land in two different projects without
-  colliding. `memory_lint` now reports dangling cross-project refs
-  (typo'd project vs missing/renamed target page), `memory_briefing`
-  exposes `cross_project_dependents` / `cross_project_dependencies`
-  per project, and `GET /api/v1/graph` returns the resolved cross-
-  project edges for a graph view. Migration V13 rebuilds the `links`
-  table preserving existing rows as `(to_workspace=NULL,
-  to_project=NULL)` — same "local" semantics as before
-  ([#57], thanks @djalmajr).
-
-### Changed
-- **FTS5 queries OR-join bare multi-word inputs** instead of the
-  pre-existing AND default. A natural-language query like
-  `"have we discussed cross project search strategy"` previously
-  required every word to co-occur in one page — near-zero recall for
-  multi-word queries, which the caller silently mistook for "never
-  recorded". OR + BM25 ranking (callers already `ORDER BY rank`) keeps
-  the best-matching pages at the top of the list, so the user-visible
-  top-N is still AND-ish; OR just adds a relevant tail instead of
-  returning nothing. Explicit FTS5 syntax (`OR`/`AND`/`NOT`/`NEAR`,
-  quoted phrases, parens) is detected and preserved verbatim so the
-  exact-match escape hatch stays available. 5 new unit tests guard the
-  preservation contract (post-merge audit). Migration V12 rebuilds the
-  FTS tables with `unicode61 remove_diacritics 2` so accent-free
-  Portuguese queries (`"descricao da sessao"`) match accented stored
-  text (`"descrição da sessão"`); contentless FTS — source rows
-  untouched ([#58], thanks @djalmajr).
-- **MCP write tools now honour the session's project (and create
-  named projects on demand).** Three correctness fixes on
-  `memory_write_page` / `memory_lint` / `memory_forget_sweep`:
-  - A `memory_write_page { project: "X" }` for a project name that
-    doesn't exist used to silently fall through to the session's
-    active project (find-only resolution); writes meant for a fresh
-    project polluted the current one. A new `write_target_ids`
-    helper uses **get-or-create** for an explicit project name, so
-    a named write always lands where the agent asked.
-  - `memory_lint` + `memory_forget_sweep` previously always targeted
-    the server's baked `--project` regardless of the session, so a
-    cross-project lint or retention sweep could never reach the
-    project the user was actually working in. Both now resolve
-    through the same find-only `effective_ids_for_read_args` path
-    the read tools use, with the hook-published active project as
-    the fallback.
-  - Both `lint` / `sweep` and the new `write_page` add explicit
-    `workspace` + `project` args (defaulted to current session,
-    documented with the v0.5.2 "**Omit unless the user explicitly
-    names a *different* project.**" tail). 2 regression tests cover
-    "Bug B" (explicit-project write must create + land) and
-    "Bug C" (sweep must evaluate the named project, not the baked
-    default) ([#59], thanks @djalmajr).
-
-## [0.7.1] - 2026-05-29
-
-### Fixed
-- **`install-hooks --agent codex` no longer panics with `index not found`**
-  when `~/.codex/config.toml` carries an `[mcp_servers]` table that has other
-  MCP servers (context7, node_repl, …) but no `ai-memory` entry — a
-  perfectly valid setup since ai-memory can integrate via hooks alone.
-  `infer_codex_mcp_config` used `toml_edit`'s panicking `Index` impl with
-  bare `[]` chains; it now walks the table via `.get()` and returns `None`
-  on any missing key. Mirrors the safe pattern the JSON variant has used
-  all along. Adds 4 regression tests covering missing-entry,
-  missing-table, empty-doc, and bare-entry inputs
-  ([#53], thanks @Otavio-Machado-Santos).
-- **`install-hooks --agent claude-code` no longer silently stages 0 scripts
-  and points `settings.json` at an empty directory.** On macOS — and any
-  install where the binary lives outside the repo and the system package
-  paths (`/usr/local/share`, `/usr/share`) are absent — `resolve_hooks_dir`
-  fell through to the data-local candidate, which was *also* the staging
-  destination. The wipe-then-copy flow inside `stage_hook_scripts_in` then
-  deleted the very scripts it was about to read, leaving 0 copied; the
-  caller proceeded to rewrite `settings.json` anyway, disabling capture
-  with no error. The function now (a) canonicalizes source and destination
-  paths, skips the wipe + copy when they match and verifies in-place,
-  preserving any scripts a prior `setup-agent` run extracted there, and
-  (b) bails with an actionable error pointing at `--hooks-dir` or
-  `ai-memory setup-agent` whenever zero scripts are present in either
-  branch. Adds 3 regression tests
-  ([#52], thanks @Otavio-Machado-Santos).
-- **macOS thin-client wrapper no longer crashes with "Permission denied" in
-  the log file appender.** The `bin/ai-memory` wrapper passed
-  `-u $(id -u):$(id -g)` to the one-shot helper container, which on macOS
-  collides with the data volume owner (uid 1000 inside the container vs
-  uid 501/502 on the host). The wrapper now skips `-u` on Darwin so the
-  container runs as its default uid 1000 — Docker Desktop's file-sharing
-  layer handles host ownership transparently — while Linux and other
-  Unix systems continue to receive `-u`. Same change also hardens the
-  `${TTY_ARGS[@]}` / `${NETWORK_ARGS[@]}` / `${ENV_ARGS[@]}` /
-  `${USER_ARGS[@]}` expansions for `set -u` compatibility on macOS's
-  default bash 3.2 ([#51], thanks @abnersajr; supersedes [#50]).
-
-## [0.7.0] - 2026-05-29
-
-### Added
-- **`memory_read_page` MCP tool** (`read-only`) for fetching the FULL body of a
-  wiki page — pass `path` for a direct lookup or `query` to fetch the top FTS5
-  hit's full body. Complements `memory_query`'s 24-word snippets when an agent
-  needs to read an entire decision page end-to-end. Also exposed as
-  `GET /admin/read-page?workspace=…&project=…&path=…` (admin HTTP) and the new
-  `ai-memory read-page` CLI subcommand (thin HTTP client). All three surfaces
-  scope to the current project by default and route user-supplied paths through
-  `PagePath::new`, so traversal attempts (`../etc/passwd`) are rejected with
-  400. ARCHITECTURE.md's MCP-tool table grows from 12 to 13 rows ([#49]).
-- `_slots/*.md` pages can now declare `slot_kind: state` or
-  `slot_kind: invariant` frontmatter. `state` remains the default for existing
-  slots; `invariant` marks high-resistance project context or preferences that
-  consolidation should not rewrite unless observations directly contradict the
-  existing slot content ([#47], closes [#14]).
-
-### Fixed
-- **Windows PowerShell hooks no longer hang or stall the agent.** The shared
-  `hooks/lib/ai-memory-hook.ps1` read stdin via `[Console]::In.ReadToEnd()`,
-  which blocks indefinitely when the agent does not close the stdin pipe
-  (observed on Claude Code `PreCompact`); because the `Invoke-WebRequest`
-  timeout only starts after the read returns, a stuck read meant the hook
-  never POSTed anything. Stdin is now read asynchronously, guarded by
-  `[Console]::IsInputRedirected` with a 2s cap, so the hook can never freeze.
-  HTTP timeouts were also raised from 1s to 3s (POST) / 2s (handoff GET) to
-  tolerate remote servers over higher-latency links. The full raw payload is
-  still forwarded (parity with `_lib.sh`), so observation title/body stay
-  intact. Affects every agent still on the PowerShell hook runner
-  (Codex, Cursor, Gemini CLI, Antigravity, OpenCode on Windows) ([#48]).
-- Page upserts now treat frontmatter/title/tier/pinned changes as real page
-  updates instead of short-circuiting solely on unchanged body text, keeping
-  the SQLite index consistent with markdown frontmatter-only edits ([#47]).
-
-## [0.6.1] - 2026-05-28
-
-### Added
-- `Cache-Control: private, max-age=N` headers on all `/api/v1` read endpoints
-  (lists/search/recent/briefing/overview: 30–60s; single-page reads: 300s).
-  Errors stay uncached. A polling SPA no longer hits the DB on every request.
-- **ETag + conditional GET** on the single-page read endpoint
-  (`GET /api/v1/workspaces/{ws}/projects/{p}/pages/{*path}`): the response
-  carries `ETag: "<sha256>"` over the markdown body, and a follow-up request
-  with matching `If-None-Match` returns `304 Not Modified` with no body.
-- **`--cors-allow-origin`** flag (repeatable) and
-  `AI_MEMORY_CORS_ALLOW_ORIGINS=a,b,c` env var. When set, a `CorsLayer` is
-  attached **only to `/api/v1`** (`/mcp`, `/hook`, `/admin`, and `/web` are
-  intentionally untouched) so a separately-hosted SPA can call the API. Each
-  origin must include a scheme; `*` is rejected at startup (CORS spec forbids
-  credentials + wildcard). Empty list = same-origin only, unchanged behaviour.
-
-## [0.6.0] - 2026-05-28
-
-### Added
-- Read-only **`/api/v1`** JSON surface for third-party frontends: workspaces,
-  projects, pages (list + read with frontmatter, body, resolved links, and
-  back-links), recent, briefing, search (GET single/global + POST multi-scope
-  capped at 25 scopes), and workspace/project `overview` aggregates (handoff +
-  briefing + memory-health drill-down). Mounted before the bearer +
-  host-allowlist middleware so existing auth applies automatically. Read-only
-  by construction — zero writer calls in the handlers ([#7]).
-- **`--web-ui-dir`** flag on `ai-memory serve` to host any static SPA at
-  `/web` (same origin as the API, behind the same auth), with `index.html`
-  SPA fallback via `tower-http::ServeDir`. Validates the directory exists
-  and contains `index.html` before binding. When the flag is absent, the
-  built-in server-side `/web` browser stays the default ([#7]).
-- MCP read tools (`memory_query`, `memory_recent`, `memory_status`,
-  `memory_briefing`, `memory_explore`) accept optional `workspace` +
-  `scopes` args for explicit multi-project queries; existing single-`project`
-  behaviour is unchanged and remains the default ([#7]).
-- New reader queries powering the API: per-page outgoing links + incoming
-  back-links, workspace-aggregated briefing, memory-health (stale /
-  duplicate / orphan) counts and drill-down lists, workspace summaries
-  with last-update timestamps ([#7]).
-
-### Fixed
-- Antigravity `pre-tool-use` hook now emits the documented
-  `{"decision":"allow"}` JSON contract instead of an empty `{}`, while
-  keeping the `ai_memory_post_hook` call fully suppressed
-  (`>/dev/null 2>&1 || true`) so the `queued` body never bleeds into the
-  hook's stdout. Identical logic for `.sh` and `.ps1`; other hook scripts
-  remain silent and unchanged ([#44], thanks @ArtroxGabriel).
-
-### Docs
-- New **[`docs/frontend-api.md`](docs/frontend-api.md)** integration guide
-  for `/api/v1`: auth flow, response schemas (`PageHit`, `BriefingSnapshot`,
-  `HealthDetail`, `PageLinks`, …), error model, limits/pagination,
-  custom-UI hosting, a worked `fetch`/`curl` example, and pointers to the
-  canonical source-of-truth files.
-
-## [0.5.2] - 2026-05-28
-### Added
-- `ai-memory status` / `status --json` now includes passive process-scoped LLM
-  and embedding provider health based on the last real provider call, without
-  active probing or token spend ([#46]).
-
-### Changed
-- Agent-facing prompts (`MEMORY_INSTRUCTIONS`, the `CLAUDE.md`/`AGENTS.md`
-  routing snippet, and the per-tool `project`/`cwd` arg docstrings) now lead
-  with a clear "default to the current project — do not pass `project` or
-  `cwd` args unless the user names a *different* project" rule, plus a
-  reminder that the SessionStart auto-fetched handoff block already covers the
-  current project. Reduces cross-agent friction where a fresh agent surfaced
-  the wrong project's handoff because the LLM over-eagerly passed scoping
-  args. Doc-only, no behaviour change.
-
-### Fixed
-- Claude Code hook installs on native Windows now render Git Bash-compatible
-  `bash -c` commands that keep the POSIX `.sh` hook scripts and convert
-  drive-letter paths to Git Bash paths, matching Claude Code's actual hook
-  runner instead of emitting PowerShell commands ([#45]).
-- `ai-memory llm-test --provider anthropic-oauth` now parses and maps to the
-  Anthropic OAuth provider instead of being rejected by clap ([#43]).
-
-## [0.5.1] - 2026-05-27
-### Changed
-- Docker release publishing now builds Linux x86_64 and aarch64 artifacts once,
-  reuses those artifacts for Docker images, and smoke-tests both amd64 and arm64
-  images after assembling the multi-arch manifest.
-- The AUR `ai-memory-bin` package now supports aarch64 using the prebuilt Linux
-  aarch64 release artifact.
-- Docker source builds now use the vendored Tailwind CSS artifact, avoiding
-  cross-architecture Tailwind CLI cache collisions during multi-arch releases.
-
-## [0.5.0] - 2026-05-27
-### Fixed
-- Docker release images now publish both `linux/amd64` and `linux/arm64`
-  manifests, so Apple Silicon and ARM64 Linux hosts can pull the image without
-  forcing x86 emulation ([#41]).
-
-## [0.4.0] - 2026-05-27
-### Added
-- `anthropic-oauth` LLM provider: use a Claude Pro/Max subscription via
-  `claude setup-token` instead of an API key. In-Rust, reuses the existing
-  Anthropic Messages client (incl. structured output). **Unofficial and
-  against Anthropic's usage policies — use at your own risk** (docs warn
-  prominently).
-- Opt-in `AI_MEMORY_CONSOLIDATE_ON_SESSION_END`: when set and an LLM provider
-  is configured, SessionEnd additionally runs LLM consolidation on top of the
-  always-written rule-based summary page (non-fatal on failure) ([#40]).
-
-### Changed
-- Docs recommend a small/fast model (Haiku/mini class) for the OAuth /
-  subscription LLM backends — consolidation/lint/explore is summarisation, not
-  hard reasoning, and small models are far easier on subscription rate limits.
-- Aligned every prompt surface + doc with actual SessionEnd behavior: it always
-  writes a rule-based summary page + handoff; LLM consolidation runs on
-  PreCompact, on demand via `memory_consolidate`, and at session end only
-  behind the new opt-in flag ([#40]).
-
-### Fixed
-- Windows own-write detection: `inode_of` now returns the real NTFS file index
-  (was always `0`, which collapsed the watcher's own-write set) ([#37]).
-- `ai-memory upgrade` no longer fails with `invalid value 'lib' for --agent` —
-  the hook-refresh loop skips the shared `lib/` helper dir ([#38]).
-- Native packaging CI now supports non-root runners whose `systemd-tmpfiles`
-  lacks `--dry-run`, while still operating only inside a temporary alternate
-  root.
-
-## [0.3.2] - 2026-05-27
-### Fixed
-- AUR release publishing now runs with `HOME=/home/aurbuild` and an explicit
-  `GIT_SSH_COMMAND`, so the workflow uses the configured AUR deploy key.
-
-## [0.3.1] - 2026-05-27
-### Changed
-- Reissued the release after the initial AUR publish failure. This release was
-  superseded by 0.3.2 for the AUR SSH home fix.
-
-## [0.3.0] - 2026-05-27
-### Added
-- Arch Linux native packaging assets: source and prebuilt AUR package
-  definitions, system/user systemd units, sysusers/tmpfiles entries, native
-  config/env templates, CI-safe alternate-root packaging checks, and a manual
-  disposable-distrobox integration harness for validating real service startup
-  before publishing.
-- Tag-triggered release automation now validates that `vX.Y.Z` matches
-  `Cargo.toml`, publishes a native Linux release tarball, keeps Docker image
-  publishing behind Docker Hub secrets, and optionally publishes both AUR
-  package bases when `AUR_SSH_PRIVATE_KEY` is configured.
-- `memory_write_page` MCP tool for explicit durable annotations, so agents can
-  write permanent wiki knowledge without abusing single-use handoffs.
-- `openai-oauth` LLM provider for ChatGPT/Codex accounts, including
-  `ai-memory auth login|logout|status` device-flow commands and token storage
-  in `<data_dir>/auth.json`.
-- `copilot` LLM provider for GitHub Copilot Chat accounts. It stores a GitHub
-  token via `ai-memory auth login copilot`, exchanges it for a short-lived
-  Copilot API token, and sends Copilot Chat requests with `vscode-chat`
-  integration headers.
-
-### Fixed
-- `install-mcp`, `install-hooks`, and `setup-agent` now honor configured
-  `AI_MEMORY_SERVER_URL` defaults; `install-hooks` also reuses an existing
-  ai-memory MCP entry when present, preventing remote MCP setups from
-  regenerating loopback-only lifecycle hooks during installs/upgrades.
-- Filesystem watcher now reindexes a project when backends report only a
-  parent-directory event, improving external editor capture on macOS/FSEvents.
-- OpenAI strict structured-output schema normalization now strips generated
-  `$ref` annotation siblings and rewrites generated enum `oneOf` schemas to
-  `anyOf`, unblocking `memory_consolidate multi_page=true` on OpenAI models.
-- OpenAI-compatible embedding calls now truncate oversized page bodies, surface
-  provider errors returned in HTTP 200 bodies, retry bounded HTTP 429 responses,
-  and may reuse `LLM_API_KEY` when a custom embedding base URL is configured.
-- `ai-memory embed --force` without `--project` now re-embeds every project in
-  the workspace and purges stale/superseded embedding rows in the same scope.
-- Windows hook `cwd` values sent to a Linux server now resolve projects by the
-  final path component instead of treating the full backslash path as the
-  project name.
-
-## [0.2.0] - 2026-05-26
-### Added
-- `ai-memory bootstrap` now prunes collected sources before POSTing to the
-  server and supports `--chunk-input-tokens` to process large repositories via
-  sequential LLM calls instead of one oversized prompt.
-- Opt-in extension event metadata for `/hook`: custom integrations can
-  pass `extension=<namespace>` (and optionally `source_event=<name>`) to
-  preserve a validated third-party source event while storage keeps the
-  canonical `ObservationKind` closed. Unknown events without an extension
-  still collapse to `other` with no source-event metadata.
-- `.ai-memory.toml` marker file lets a directory tree declare its
-  `workspace` (required) and `project` (optional) without depending on
-  `basename($cwd)`. Lifecycle hook scripts walk up from `cwd` to find
-  the closest marker and forward `cwd` plus the declared names as
-  query params on `POST /hook` and `GET /handoff`. Markers can also set
-  `project_strategy = "repo-root"` to derive project identity from the
-  main git repository root, so linked worktrees share one project. Server
-  accepts the new params as optional overrides;
-  absent marker means the previous behaviour (`workspace = "default"`,
-  `project = basename(cwd)`) — fully backward compatible. See
-  [`docs/marker-file.md`](docs/marker-file.md).
-- Oh My Pi / OMP is now a first-class integration: `install-mcp --client pi`
-  and `--client omp` write native `~/.omp/agent/mcp.json` config, while
-  `install-hooks --agent omp` and `--agent pi` write the TypeScript extension
-  used for lifecycle capture and handoff injection.
-- Graph-aware retrieval: `memory_query` now combines FTS5, wikilink-neighbor
-  expansion, optional vector RRF, and bounded raw-observation fallback.
-- Observation FTS indexing and unresolved-link diagnostics surfaced through
-  admin/CLI status paths.
-- `_slots/` wiki pages are automatically pinned and surfaced in briefing /
-  explore snapshots.
-- Server-side scheduled maintenance for forget sweep and lint, with optional
-  embedding backfill scheduling.
-- Experimental native Windows support: PowerShell Docker wrapper,
-  `ai-memory.cmd`, `.ps1` lifecycle hooks in parity with `.sh` hooks, Windows
-  Tailwind hash/download support, and [`docs/windows.md`](docs/windows.md).
-- Google Gemini LLM provider via `AI_MEMORY_LLM_PROVIDER=gemini`, with
-  `gemini-2.5-flash` as the default hosted Google model and `GEMINI_API_KEY`
-  / `GOOGLE_API_KEY` support.
-- Google Gemini embeddings via `AI_MEMORY_EMBEDDING_PROVIDER=google` or
-  `gemini`, with `gemini-embedding-001` as the default embedding model and
-  `GEMINI_API_KEY` / `GOOGLE_API_KEY` support.
-- Antigravity CLI (`agy`) support for MCP config (`serverUrl`) and lifecycle
-  capture through its `PreInvocation`, `PreToolUse`, `PostToolUse`, and `Stop`
-  hook events.
-- README support matrix for operating systems, agent integrations, LLM
-  providers, and embedding providers.
-- `ai-memory uninstall` — removes ai-memory's hooks, MCP registration, and
-  CLAUDE.md/AGENTS.md instruction block across all detected agents (dry-run by
-  default; `--apply` to execute, with timestamped backups). `--purge-data`
-  wipes wiki/db/raw via the reset guard. `--only hooks|mcp|instructions` to
-  narrow. MCP matching is endpoint-based by default; pass `--mcp-url` when the
-  server was installed with a custom endpoint and `--mcp-name` only to narrow
-  removal to one matching entry. Docker/volume teardown is printed as a hint,
-  not executed.
-
-### Changed
-- Same-body page upserts are now true no-ops, avoiding periodic watcher
-  reconcile writes, FTS churn, and misleading recent-page timestamps.
-- Graph-neighbor expansion for hybrid search now batches all seed pages into
-  one SQL query instead of issuing incoming/outgoing lookups per seed.
-- Embedding backfill stores embeddings in chunks instead of one writer
-  command and SQLite transaction per page.
-- Hook ingestion now bounds in-flight processing and returns HTTP 429 when
-  saturated instead of spawning unbounded background tasks.
-- Documented the vector backend policy and the measured criteria required
-  before adding `sqlite-vec`.
-- Clarified Gemini CLI support docs: MCP registration, lifecycle hooks,
-  SessionStart handoff injection, and SessionEnd capture are now called out
-  consistently across README and install guides.
-- Added OpenClaw lifecycle support via a generated native plugin package and
-  updated Cursor / Claude Desktop / OpenClaw support docs against current
-  upstream MCP and hook documentation.
-- Docker images now bundle both POSIX and PowerShell hook scripts.
-- `ai-memory uninstall --purge-data` now previews the `wiki/`/`db/`/`raw/`
-  wipe in dry-run (mirroring `reset`) and refuses **up front** if an
-  `ai-memory` process is alive (all-or-nothing) instead of removing the
-  wiring and then skipping the purge. The data wipe is now shared with
-  `reset` via a single internal helper.
-- `ai-memory uninstall` only deletes generated plugin/extension files after
-  re-validating their ai-memory-generated content, and never treats a matching
-  filename or MCP server name alone as proof of ownership.
-
-### Fixed
-- `serve` now warns and starts when stored embedding rows were created with a
-  different `(provider, model, dim)` than the current config. Hybrid search
-  ignores stale rows until `ai-memory embed --force` or scheduled backfill
-  re-embeds them, avoiding the previous startup deadlock.
-- Session capture now persists every documented agent kind (`cursor`,
-  `gemini-cli`, `claude-desktop`, `openclaw`, `omp` / `pi`) instead of
-  failing the `sessions.agent_kind` database CHECK for agents added after
-  the initial schema.
-- `memory_handoff_begin` and `memory_handoff_accept` now resolve the active
-  project the same way the briefing/search tools do, so MCP handoffs land in
-  the project currently reported by hooks instead of the server's baked
-  default project.
-- Natural-language `memory_query` text containing bare colons, such as
-  `pick: handoff`, no longer trips FTS5 column syntax errors while explicit
-  FTS operators like `quick OR slow` remain supported.
-- Marker-file routing now reaches the generated OpenCode and OMP
-  TypeScript hook integrations, not only the POSIX/PowerShell script
-  hooks. POSIX helpers also preserve the outer hook `cwd` when nested
-  tool payloads contain their own `cwd`, and encode `+` correctly in
-  marker-derived query parameters.
-- `backup --to` now streams the tarball to disk instead of buffering the full
-  archive in CLI memory.
-- Hyphenated FTS5 queries such as `ai-memory` are normalized safely instead of
-  being parsed as column operators.
-- Gemini 2.5 Flash requests disable default dynamic thinking so hidden thought
-  tokens do not consume `maxOutputTokens` and truncate strict JSON responses.
-- `install-mcp --client claude-code` now prints the direct-edit JSON path as
-  `~/.claude.json`, matching the `--apply` path and `claude mcp add` behavior.
-- Hook routing now evicts a stale project-cache entry and retries once when a
-  live server sees a cached project deleted underneath it, such as after
-  `purge-project`, so capture resumes without restarting the server.
-- Session-start handoff hooks now include `cwd` even without a marker file, so
-  default `project = basename(cwd)` projects receive pending handoffs without
-  requiring `.ai-memory.toml`.
-- `ai-memory uninstall` now removes only ai-memory commands from mixed nested
-  hook entries, preserves third-party commands in the same matcher, and removes
-  legacy Codex inline-table MCP entries.
-- Generated POSIX hook commands now shell-quote script paths and env values
-  with metacharacters, fixing custom hook directories containing spaces and
-  preventing shell-active token/URL fragments.
-- OpenClaw's generated plugin now forwards marker-file routing params just like
-  the OpenCode and OMP generated integrations.
-- The Linux/macOS Docker wrapper now lets thin-client commands such as
-  `status` and `bootstrap` reach the local quick-start server bound on the
-  host's `127.0.0.1:49374`.
-
-## [0.1.3] - 2026-05-24
-
-### Added
-- `ai-memory lint --no-llm` (and `memory_lint` `no_llm` arg) to run only the
-  rule-based lint pass while leaving the LLM enabled for `memory_explore` /
-  `memory_consolidate` ([#4]).
-
-### Fixed
-- `memory_lint` LLM contradiction pass silently never contributed: the
-  `LintFinding` struct expected `severity`/`message` but the prompt asked for
-  `summary`/`detail`. The prompt is now aligned to the canonical shape and the
-  struct tolerates both (defaults `severity`, aliases `summary`→`message`,
-  captures optional `detail`) ([#4]).
-- Reasoning models (MiniMax M2.7, DeepSeek, Qwen, Kimi) that emit
-  `<think>…</think>` / `<analysis>…</analysis>` blocks before the JSON broke
-  structured-output parsing (`key must be a string at line 1 column 2`). The
-  openai-compat provider now strips reasoning blocks and surrounding markdown
-  fences before extracting the JSON object, so lint / consolidate / bootstrap
-  work with reasoning models ([#5]).
-- openai-compat base URLs with non-`v1` version segments (e.g. Z.AI's `/v4`)
-  or a full endpoint path no longer produce `…/v1/v1/…` 404s
-  ([#6], thanks @lucasliet).
-
-## [0.1.2] - 2026-05-24
-
-### Changed
-- HTTP transport now defaults to **stateless** mode (`json_response`, no
-  `Mcp-Session-Id` required), so stateless MCP clients (OpenCode
-  `type: "remote"`, `curl`) work without an `mcp-remote` stdio shim
-  ([#3]). New `serve --transport http --http-stateful` flag restores the
-  previous session+SSE behaviour for clients that need it.
-
-## [0.1.1] - 2026-05-24
-
-### Added
-- Wiki-structure migration framework: `wiki_migrations` SQL table (V06),
-  `WikiMigration` trait, migration registry, and `run_pending` runner
-  invoked at server startup before the watcher starts.
-- MCP read tools (`memory_query`, `memory_recent`, `memory_status`,
-  `memory_briefing`, `memory_explore`) accept an optional `project`
-  argument to target a specific project on a shared server.
-
-### Fixed
-- OpenCode hook events (`tool.execute.*`, `session.*`) were rejected with
-  "missing session_id" because OpenCode sends `sessionID` (capital `ID`)
-  and the extractor only matched `sessionId`. All spellings are now
-  accepted ([#1]).
-- MCP read tools were locked to the server's static `--project` (default
-  `scratch`), so on a shared HTTP server they returned empty memory even
-  while hooks populated the correct per-cwd project. The hook router now
-  publishes the active project to a shared pointer that the read tools
-  use as their default; an explicit `project` argument overrides it ([#2]).
-
-## [0.1.0] - 2026-05-23
-
-### Added
-- Per-project UUID-namespaced wiki layout: pages live at
-  `<wiki_root>/<workspace_id>/<project_id>/<page-path>`. Rename is now
-  a single column update; purge is `remove_dir_all` on the project dir.
-- CLI becomes a thin HTTP client: `bootstrap`, `status`, `search`,
-  `reorg`, `lint`, `forget-sweep`, `embed`, `commit`, `backup`,
-  `write-page` all delegate to the running server via `/admin/*` routes.
-  The server is the sole writer of wiki + SQLite.
-- `purge-project` command with cascade-delete indexes and per-project
-  isolation guard (refuses to delete files claimed by sibling projects).
-- `rename-project` command: column-only rename, no file moves.
-- `memory_install_self_routing` MCP tool: installs the agent-routing
-  snippet into CLAUDE.md / AGENTS.md / `.cursorrules` in one call.
-- Read-only HTTP wiki browser (`/web`) with project tree, page view,
-  and full-text search.
-- Bearer token auth (`AI_MEMORY_AUTH_TOKEN` / `generate-auth-token`),
-  Host-header allowlist, and 10 MB body cap for the HTTP server.
-- `backup` / `restore` commands using `.tar.gz` archives with live-process
-  guard (refuses to run if another `ai-memory` is active on the same data dir).
-- Per-cwd project routing in hooks: observations route to the project
-  matching the agent's working directory, not the server default.
-- `opencode` / `openclaw` aliases for the OpenCode MCP client.
-- Dockerised CLI wrapper (`bin/ai-memory`) with auto-restart for the
-  local container and nudge for remote upgrades.
-- `bootstrap` serialises parallel runs to prevent duplicate project creation
-  and handles the case where the CWD has no git repo.
-- Monthly log-md rotation to keep `log.md` from growing unbounded.
-- `memory_consolidate` PreCompact checkpointing falls back to rule-based
-  summarisation when no LLM is configured.
-- `docs/lifecycle-ops.md`: safety matrix for state-touching commands
-  (reset, restore, purge-project, rename-project).
-- `docs/wiki-migrations.md`: when and how to write a wiki migration.
-
-### Changed
-- `bin/ai-memory` forwards `AI_MEMORY_SERVER_URL` and no longer creates
-  `-w` mount-conflict directories.
-- `bootstrap` resolves the repo root via `libgit2`, removing the
-  `git` binary dependency.
-- Admin routes consolidated: dry-run support, correct status codes,
-  deduplicated handlers.
-- Host-header allowlist sourced from `Config.allowed_hosts`; logged at
-  startup so operators can verify the effective list.
-
-### Fixed
-- `AI_MEMORY_HOST_CWD` handling and dry-run no-project side effects.
-- Web page view: strip leading H1 from body to prevent title duplication.
-- `install-mcp` Codex config key was `bearer_token`, not
-  `http_headers` / `headers`.
-- Consolidator used server startup default project instead of the
-  session's actual project.
-
-[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.26.1...HEAD
-[1.26.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.26.1
-[1.26.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.26.0
-[1.25.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.25.0
-[1.24.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.24.0
-[1.23.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.23.0
-[1.22.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.22.0
-[1.21.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.21.0
-[1.20.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.20.2
-[1.20.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.20.1
-[1.20.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.20.0
-[1.19.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.19.2
-[1.19.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.19.1
-[1.19.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.19.0
-[1.18.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.18.0
-[1.17.3]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.3
-[1.17.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.2
-[1.17.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.1
-[1.17.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.0
-[1.16.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.16.0
-[1.15.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.15.0
-[1.14.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.14.0
-[1.13.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.13.0
-[1.12.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.12.0
-[1.11.4]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.11.4
-[1.11.3]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.11.3
-[1.11.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.11.2
-[1.11.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.11.1
-[1.11.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.11.0
-[1.10.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.10.1
-[1.10.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.10.0
-[1.9.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.9.1
-[1.9.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.9.0
-[1.8.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.8.0
-[1.7.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.7.1
-[1.7.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.7.0
-[1.6.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.6.0
-[1.5.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.5.0
-[1.4.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.4.1
-[1.4.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.4.0
-[1.3.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.3.0
-[1.2.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.2.2
-[1.2.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.2.1
-[1.2.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.2.0
-[1.1.3]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.1.3
-[1.1.2]: https://github.com/akitaonrails/ai-memory/compare/v1.1.1...v1.1.2
-[1.1.1]: https://github.com/akitaonrails/ai-memory/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.1.0
-[1.0.11]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.11
-[1.0.10]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.10
-[1.0.9]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.9
-[1.0.8]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.8
-[1.0.7]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.7
-[1.0.6]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.6
-[1.0.5]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.5
-[1.0.4]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.4
-[1.0.3]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.3
-[1.0.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.2
-[1.0.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.1
-[1.0.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.0
-[0.16.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.16.0
-[0.15.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.15.0
-[0.14.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.14.0
-[0.13.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.13.0
-[0.12.3]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.12.3
-[0.12.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.12.2
-[0.12.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.12.1
-[0.12.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.12.0
-[0.11.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.11.0
-[0.10.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.10.0
-[0.9.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.9.0
-[0.8.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.8.1
-[0.8.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.8.0
-[0.7.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.7.1
-[0.7.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.7.0
-[0.6.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.6.1
-[0.6.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.6.0
-[0.5.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.5.2
-[0.5.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.5.0
-[0.4.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.4.0
-[0.3.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.3.2
-[0.3.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.3.1
-[0.3.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.3.0
-[0.2.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.2.0
-[0.1.3]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.1.3
-[0.1.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.1.2
-[0.1.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.1.1
-[0.1.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.1.0
+# Lifecycle operations
+
+Reference for the destructive / state-touching ai-memory commands.
+Read this before running anything that mutates wiki + db, especially
+on a homelab box where mistakes are harder to undo.
+
+## TL;DR - safety matrix
+
+| Command | Safe with server **running**? | Wipes data? | Reversible? | Notes |
+|---|---|---|---|---|
+| `purge-project --confirm` | ✅ yes | the one project's data | no | Deletes the UUID-namespaced wiki root and raw workstream segments; sibling projects remain untouched. Refuses with `409` while a managed workstream under the project holds a live run lease — `--force` overrides. |
+| `purge-session --session-id --confirm` | ✅ yes | one session and everything derived from it | no | Removes the session, its observations and both FTS indexes, its handoffs, queued consolidation, auto-improvement runs/proposals/events/rejections, every version of its derived pages, and the wiki files. Leaves only a content-free tombstone. Refuses with `409` while the session is open or has work in flight — `--force` overrides. |
+| `rename-project --from --to` | ✅ yes | no | yes (rename back) | Column-only update on `projects.name`. The on-disk dir is keyed by `project_id` (UUID), so the rename never moves a file. |
+| `/admin/rename-workspace` | ✅ yes | no | yes (rename back) | Column-only update on `workspaces.name`; refreshes `_meta.md` scope manifests and checkpoints the wiki tree. |
+| `/admin/delete-workspace` | ✅ yes | the workspace and every child project | no | Runs `purge_workspace` admission first, deletes SQLite rows in one cascade, removes the UUID-keyed workspace directory and managed-workstream raw segments, reports filesystem partial failures, and dispatches mirror notification after durable work. |
+| `move-project --confirm` | ✅ yes | source only in the merge case (a `Reject`-policy `purge_project` webhook can still abort the source teardown leaving everything intact) | no | Fresh destination → lossless **true move** (re-stamp `workspace_id`, keep `project_id`, rename the dir): sessions/observations/handoffs + history all survive. Destination with a same-named project → **copy+purge merge**: only latest pages migrate. |
+| `backup --output-path` | ✅ yes | no | n/a | Streams a gzipped tarball from the server's online `sqlite3 .backup` plus the wiki tree. Safe alongside the live writer. |
+| `checkpoints` | ✅ yes | no | n/a | Lists recent wiki git checkpoints. Read-only. |
+| `restore-page --path --from` | ✅ yes | overwrites one markdown page version | yes (restore another checkpoint) | Restores one page from wiki git history, reindexes it into SQLite, and writes a post-restore checkpoint. Does not restore DB-only state. |
+| `restore --from <tarball>` | ❌ **stop the server first** | overwrites the data dir | no (without prior backup) | Refuses if any sibling `ai-memory` process is alive (sysinfo guard). |
+| `reset --confirm` | ❌ **stop the server first** | yes, all data | no | Refuses if any sibling `ai-memory` process is alive (sysinfo guard). |
+| `reindex` | ❌ **stop the server first** | no wiki wipe; requires a clean DB | only with prior DB backup | Rebuilds pages/links/FTS from `wiki/` using `_meta.md` manifests. Refuses if SQLite already has rows so stale DB-only state cannot survive silently. |
+
+State-touching commands route through the HTTP admin API except `reset`,
+`restore`, and `reindex`, which are direct-disk lifecycle operations that
+fundamentally cannot run while another process holds the SQLite WAL writer. See
+[CLAUDE.md §16](../CLAUDE.md) for the invariant.
+
+## What "project isolation" means here
+
+Every project's data lives under an isolated, UUID-keyed root on disk:
+
+```
+<wiki_root>/
+├── .git/
+├── <workspace_id>/
+│   ├── _meta.md                 # workspace name for rebuilds
+│   └── <project_id>/
+│       ├── concepts/
+│       ├── decisions/
+│       ├── gotchas/
+│       ├── sessions/
+│       ├── _rules/
+│       ├── _meta.md             # project name + repo_path for rebuilds
+│       ├── log-YYYY-MM.md      # rolling event log, one file per month
+│       └── bootstrap.md
+└── <other_workspace_id>/
+    └── <other_project_id>/
+        └── ...
+```
+
+The mutable **project name** (the human-readable `distrobox-gaming`
+or `.config` you see in `/web/`) never appears in any disk path; the
+stable **project_id UUID** does. SQLite's `projects.name` column maps
+name → id. Two projects can have the exact same `pages.path` (e.g.
+both have `decisions/0001.md`) without colliding on disk - the
+namespaced layout guarantees structural isolation.
+
+The git history is rooted at `<wiki_root>` (one repo, all projects
+as subtrees). A `git log` from inside the wiki dir shows changes
+across every project; per-project diffs are also possible via
+`git log -- <workspace_id>/<project_id>/`.
+
+Each workspace directory also carries `<workspace_id>/_meta.md`, and each
+project directory carries `<workspace_id>/<project_id>/_meta.md`. Those small
+frontmatter-only manifests store human names (plus `repo_path` for projects),
+so a clean SQLite DB can be rebuilt from the UUID-keyed wiki tree alone.
+
+## Command-by-command
+
+### `purge-project`
+
+```bash
+ai-memory purge-project --workspace default --project my-project --confirm
+```
+
+What happens, in order:
+
+1. Server looks up `(workspace_id, project_id)` by name. Returns 404
+   if either is missing.
+2. Refuses with 409 when a managed workstream under the project still
+   holds a **live** run lease (`managed_runs.state = 'active'` AND
+   `lease_expires_at` in the future). `workstreams` cascades out of
+   `projects` and `managed_runs` cascades out of `workstreams`, so
+   purging would delete a running agent's lease row: its heartbeat
+   would then fail with `409 managed run lease is not active` for the
+   rest of the session and the transcript would never reach the ledger.
+   A lapsed lease (crashed wrapper) does **not** block the purge.
+   `--force` purges anyway.
+3. Counts rows that will cascade (`pages`, `sessions`,
+   `observations`, `handoffs`, `page_embeddings`, plus `workstreams`
+   and `managed_runs`).
+4. Single `DELETE FROM projects WHERE id = ?` - the V01 + V05
+   `ON DELETE CASCADE` foreign keys propagate to every dependent
+   table in one transaction.
+5. Best-effort filesystem cleanup removes both the UUID-namespaced wiki root
+   and every `<data_dir>/raw/workstreams/<workstream_id>/` segment directory.
+6. Returns a summary: `{label, pages_deleted, sessions_deleted, …,
+   workstreams_deleted, managed_runs_deleted, workstream_ids,
+   files_deleted: [<project_root>, <raw_workstream_dir>, ...],
+   files_failed: [...]}`.
+
+`workstream_ids` remains in the report for auditability. Each corresponding
+raw segment directory is removed on the server and appears in
+`files_deleted`; a failed removal appears in `files_failed` alongside wiki
+cleanup failures.
+
+Failure modes:
+
+- **Workspace or project name not found** → 404, no mutation.
+- **Confirmation flag omitted** → 400, no mutation.
+- **Live managed run, no `--force`** → 409 naming the workstreams, no
+   mutation. Finish or cancel the session, or re-run with `--force`
+   (the running agent then stops being able to save its history).
+- **`remove_dir_all` partial failure** (e.g. permissions) → DB
+   rows are already gone but `files_failed` is populated. Re-run
+   the command with the same args is idempotent; the second call
+   returns 404 (project already deleted).
+
+Why this is safe with the server running:
+
+- The DB cascade is one transaction; the writer actor serialises
+  it against any other writes.
+- The on-disk delete touches only the project's UUID-keyed subdir,
+  which no other project shares files with. No race with the
+  watcher even mid-write - at worst the watcher emits delete
+  events for files we just removed, which it ignores (no DB row
+  to reindex).
+
+### `purge-session`
+
+```bash
+ai-memory purge-session \
+    --workspace default --project acme-api \
+    --session-id 11111111-1111-4111-8111-111111111111 \
+    --confirm
+```
+
+Strong deletion of **one** session, for when an application has promised
+"forget this conversation" and has to be able to keep that promise. Where
+`purge-project` is too broad and `delete-page` removes only one wiki path, this
+removes a session across every layer ai-memory administers.
+
+**What it removes**
+
+- the `sessions` row, its `observations`, and both external-content FTS indexes
+- handoffs the session produced *or* accepted (both links are `ON DELETE SET
+  NULL`, so the rows are deleted explicitly rather than orphaned)
+- queued SessionEnd consolidation jobs and auto-improvement scheduler claims
+- auto-improvement runs, proposals, proposal events, and rejections derived
+  from it, including their reasons, summaries, and evidence
+- every version of each derived page — the heuristic `sessions/<uuid>.md`, its
+  LLM rewrites, and multi-page consolidation output — plus the wiki files
+- entities left with no remaining page links
+
+**How targets are chosen.** Only by identity: the session UUID, a foreign key,
+or the deterministic `sessions/<uuid>.md` path. Never by searching page text —
+a deletion that guessed would both miss content and remove innocent pages. Page
+provenance is structural (`pages.source_session_id`) and sticky: a rewrite that
+declares no provenance inherits the superseded version's, so an LLM rewrite or
+a hand edit cannot launder a page out of the purge's reach.
+
+**Safety rules**
+
+- Root-only, like every `/admin/*` route once the first user exists.
+- `--confirm` is mandatory.
+- The full UUID is required. A prefix of a real session id is refused with
+  `422`, because this operation is irreversible and must never guess.
+- A session id that exists in a *different* project reads exactly like "no such
+  session" (`404`), so the response cannot be used to probe another project.
+- Idempotent: a second call returns `already_purged` with the original
+  tombstone and zero counts, and does not fail on the absence of what the first
+  call removed.
+- Refuses with `409` while the session is open, a consolidation is queued or
+  running, or an auto-improvement claim is outstanding. `--force` overrides.
+
+**Git history.** Removing the file and committing would leave every earlier
+version reachable, and `restore-page` would hand one back. So the wiki
+repository is rebuilt without those paths and the old object database is
+physically destroyed — the content is gone from the ODB itself, not merely
+unreferenced. Properties worth knowing:
+
+- **History is preserved, not squashed.** Every commit is carried over minus
+  the purged paths; unrelated pages keep their full version history.
+- **Shared blobs are spared.** git stores one object for identical content, so
+  a blob a surviving page also uses is never destroyed.
+- **Verification precedes destruction.** The rebuilt repository is checked
+  against both the purged paths and the object database *before* the swap; a
+  failed check leaves the live repository exactly as it was.
+- **Interrupted swaps converge.** A durable journal is written across the swap
+  and resolved at the next startup, before the wiki is opened for business. If
+  the rebuilt repository was lost mid-swap, the old one is restored and the
+  server refuses to start until the purge is re-run — it will not quietly serve
+  content it claimed to have deleted.
+- **No residue.** No quarantine copy, `.bak`, old pack, or swap directory
+  remains in the data dir.
+
+If the history rebuild fails, the receipt carries a loud
+`GIT HISTORY NOT PURGED` warning: the rows are already gone, but earlier page
+versions remain recoverable until you re-run the command.
+
+**The database files.** Deleting rows is not enough to make the bytes go away,
+and each of these was found by searching the data directory for a purged canary
+rather than by querying for it:
+
+- **FTS5 index segments.** An FTS5 delete is *logical*: it writes a delete
+  marker and leaves the original terms in the existing segments. `MATCH`
+  correctly returns nothing while the purged text stays readable in
+  `pages_fts_data` / `observations_fts_data`. The indexes are rebuilt from
+  their content tables.
+- **The write-ahead log.** Until a checkpoint runs, the deleted rows remain
+  readable in `memory.sqlite-wal`, beside the database and ready to be copied
+  into the next backup.
+- **Freed pages.** `secure_delete` zeroes content as the delete proceeds, and a
+  vacuum reclaims pages freed by earlier writes.
+
+If any of these cannot complete, the purge logs a warning rather than failing:
+the rows are genuinely deleted, and refusing the whole operation over an
+incomplete vacuum would leave you worse off.
+
+**Restore and reindex.** A snapshot taken before a purge contains everything
+that purge removed. `restore` therefore reads the tombstone ledger *before* the
+overwrite destroys it, reapplies it to the restored state, and **fails closed**
+if any purged session survives — a restore that cannot prove the ledger holds
+is not a safe restoration. Restoring into a fresh directory has no ledger of its
+own, so pass `--tombstones-from <path>` pointing at the directory that holds the
+current one. `reindex` drops pages the ledger covers by their deterministic
+`sessions/<uuid>.md` identity, because markdown rebuilt from disk cannot carry
+the relational provenance a purge relies on.
+
+**The tombstone.** The only permitted residue: scope, session UUID, purge time,
+schema version, and an audit-log id. No title, path, body, or count — a
+tombstone that quoted the session would defeat the deletion it records. It is
+what stops a late spooled event from a client that was offline during the purge
+from recreating the session.
+
+**`backup_cutoff`.** The receipt reports the purge instant. Snapshots taken
+before it still contain the purged content and should be invalidated by
+whatever rotates your backups; ai-memory does not operate that system.
+
+**Out of scope.** Managed workstreams are not touched. Their
+`native_session_id` columns are free text with no foreign key to `sessions.id`,
+so matching a purge against them by coincidence of value would delete unrelated
+history. That needs the composite `(workstream_id, agent_kind,
+native_session_id)` identity and a separate API. Histories kept by Claude Code,
+Codex, OpenCode, or any other harness are likewise outside ai-memory's control.
+
+### `rename-project`
+
+```bash
+ai-memory rename-project --workspace default --from old-name --to new-name
+```
+
+What happens:
+
+1. Look up `(workspace_id, project_id)` by current name. 404 on
+   miss.
+2. Validate the new name: non-empty, no `/`, no leading/trailing
+   whitespace. 422 on bad input.
+3. `UPDATE projects SET name = ? WHERE id = ?`. UNIQUE-violation on
+   the `(workspace_id, name)` index → 422 with "name taken".
+4. Return `{workspace, from, to, pages}`.
+
+Zero files move on disk because the disk path is keyed by
+`project_id`, not name. The web UI URL `/web/w/<ws>/<proj-name>/…`
+just resolves to the same `project_id` after the column update.
+This command also does not rename a source checkout or rewrite any native agent
+session locator. See [managed workstream rename
+behavior](managed-workstreams.md#project-and-directory-renames) before
+physically renaming a checkout that has native sessions.
+After a successful CLI rename, the client also rekeys its local `show` checkout
+link. A direct `/admin/rename-project` request cannot update other machines'
+client registries; the next successful managed `run` from a checkout refreshes
+its link.
+
+Failure modes:
+
+- **`to` name already exists in this workspace** → 422.
+- **`to` invalid (empty, slash, whitespace)** → 422.
+- **Source `from` not found** → 404.
+
+### `/admin/rename-workspace`
+
+Renames a workspace by updating `workspaces.name`; on-disk paths remain keyed by
+`workspace_id`, so no page files move. After the SQLite rename, the handler
+refreshes `_meta.md` scope manifests with `Wiki::backfill_scope_manifests()` and
+returns `manifests_refreshed` plus a post-rename checkpoint when the wiki tree
+changed.
+
+If manifest refresh fails after the SQLite rename has committed, the rename
+still returns `200 OK` with `manifests_refreshed: 0` and a `manifest_warning`
+string instead of reporting a misleading 500. The DB rename is authoritative at
+that point; operators can rerun a manifest refresh or restore from the emitted
+checkpoint if they need to repair `_meta.md` drift.
+
+Failure modes:
+
+- **Source `from` not found** → 404.
+- **`to` name already exists or is invalid** → 422.
+- **Manifest refresh failed after commit** → 200 with `manifest_warning` and
+  committed DB rename.
+
+### `/admin/delete-workspace`
+
+Deletes a workspace row and all child projects/pages/sessions/managed
+workstreams through the `workspace_id` cascade. The route is guarded by
+`force: true` for non-empty workspaces and follows the destructive-operation
+ordering used by project purges:
+
+1. Look up the workspace without creating missing scopes.
+2. Run blocking `op=purge_workspace` admission. A reject-policy webhook aborts
+   before DB rows or files are removed.
+3. Take a pre-delete checkpoint if the wiki tree is dirty.
+4. Delete the workspace in one writer-actor transaction.
+5. Remove `<wiki_root>/<workspace_id>` and every affected
+   `<data_dir>/raw/workstreams/<workstream_id>` directory from disk. The
+   response reports `workstreams_deleted`, `managed_runs_deleted`, and the
+   cleaned `workstream_ids` alongside the filesystem results.
+6. Dispatch non-blocking `purge_workspace` mirror notifications after durable
+   work. If the DB delete committed but disk removal failed, the response
+   includes `files_failed` and webhook `ctx.partial_failure: true`.
+7. Take a post-delete checkpoint if the wiki tree changed.
+
+Failure modes:
+
+- **Workspace not found** → 404, no mutation.
+- **Non-empty workspace without `force: true`** → 409, no mutation.
+- **Reject-policy `purge_workspace` webhook fails** → 500, no DB/disk mutation.
+- **Filesystem removal fails after SQL commit** → 200 with `files_failed`
+  populated and `partial_failure: true` on async mirror notifications; manual
+  cleanup of the reported path is required.
+
+### `move-project`
+
+```bash
+ai-memory move-project --from-workspace default --project my-project \
+  --to-workspace other-workspace --confirm
+```
+
+Moves a project into a **different** workspace. Unlike `rename-project`
+(a same-workspace column update), this crosses the workspace boundary.
+The destination decides which of two strategies runs — reported as
+`moved_via` in the response:
+
+**1. Fresh destination → `"true-move"` (lossless, the common case).**
+When the destination workspace has **no** same-named project, the move is
+a low-level re-stamp:
+
+1. Resolve the source `(from_workspace, project)`. 404 on miss.
+2. Reject `from_workspace == to_workspace` (use `rename-project`) → 422.
+3. Get-or-create the destination **workspace** row (not a new project).
+4. Take the wiki's exclusive mutation gate and run `op=move_project` admission
+   webhooks with source names in `ctx.workspace` / `ctx.project` and
+   destination names in `ctx.destination_workspace` /
+   `ctx.destination_project`. A reject-policy webhook aborts before files or DB
+   rows move.
+5. While still holding that gate, check that the destination dir is still
+   absent, then `fs::rename` the project dir
+   `<wiki>/<from_ws>/<proj>` → `<wiki>/<to_ws>/<proj>` (atomic within one
+   wiki root).
+6. Re-stamp `workspace_id` across every domain table for the project in
+   **one transaction**, keeping the same `project_id`
+   (`projects`, `pages`, `sessions`, `observations`, `handoffs`, `audit_log`,
+   auto-improvement state, SessionEnd consolidation jobs, and managed
+   `workstreams`). Native workstream sessions, runs, and events remain attached
+   through `workstream_id`; `page_embeddings` and `links` remain attached
+   through `page_id`, so none of those rows need a direct re-stamp.
+
+After a successful CLI true move, or a completed copy-purge move, the client
+rekeys its local `show` checkout link. Existing destination links win during a
+merge. Direct admin API callers leave client-local registries untouched; a
+later successful managed `run` repairs the relevant link.
+
+Ordering is **rename-FIRST, SQL-commit-LAST**, so the **DB is never ahead of
+disk**: a rename failure touches nothing; a crash between the two steps leaves
+at most an orphan dir at the destination with the DB still wholly at the source
+(recoverable), never a DB row pointing at a missing file. A SQL failure renames
+the dir back, so the move is all-or-nothing unless the filesystem also refuses
+the rollback, in which case the error names the manual repair. In-process page
+writes/reindexes take the shared side of the same mutation gate and validate the
+`(workspace_id, project_id)` pair before touching disk, so stale source writes
+fail without creating orphan files after the move.
+
+This is O(1) (one transaction + one rename), re-embeds nothing, and
+**preserves everything** — sessions, observations, handoffs and the full
+supersession history all travel with the project.
+
+**Live-session guard.** The server refuses (409) to move the project the
+hook router has published as the *active* project (a live session's next
+observation would carry a now-stale `workspace_id`). Pass `--force` /
+`force: true` to override — still safe: the move republishes the active
+pointer, and the wiki pair validator plus `(workspace_id, project_id)` insert
+trigger (V18) reject stale writes cleanly, so the router re-resolves instead of
+corrupting or creating old-workspace files.
+
+**2. Destination already has a same-named project → `"copy-purge"`
+(merge).** Two distinct `project_id`s can't be re-stamped into one (it
+would collide on `UNIQUE (workspace_id, name)`), so the source's latest
+pages are copied into the existing destination project via
+`Wiki::write_page` (sanitization, link re-resolution, FTS, and — on
+deploy — the admission/git-mirror webhooks all fire), source embeddings
+are carried over verbatim, and only then is the source purged
+(`merged_into_existing: true`, `source_purged: true`).
+
+`--force` overrides only the hook router's active-project guard. It never
+deletes a live managed-workstream lease during this destructive path; finish
+or cancel that run before retrying. A true move keeps the same project and
+lease ids, so it does not need this additional guard.
+
+Copy-before-purge means any copy failure aborts **before** the purge,
+leaving the source intact. An unreadable source file is skipped and also
+blocks the purge (`source_purged: false`) so a fixed re-run is safe
+(re-running is idempotent — copied pages just supersede). A **live managed
+run** under the source blocks the purge leg the same way: the move returns
+409 saying how many pages were already copied, and the source stays intact
+until the session ends and the move is re-run.
+
+**Same-path conflicts (`on_conflict`).** When a source page's path already
+exists in the destination with a different body, frontmatter, title, tier, or
+pinned bit, the policy decides (identical pages are always a no-op supersession
+at the same path):
+
+- **`block`** (default) — abort the whole move with 409, listing the
+  conflicting paths; the source is left intact. The safe default for a
+  destructive op: nothing is overwritten or split silently. The operator
+  resolves the conflicts or re-runs with an explicit policy.
+- **`overwrite`** — the source page supersedes the destination page at the
+  same path (the destination's prior version becomes history).
+- **`duplicate`** — keep both: the source page lands at
+  `<stem>-from-<src_workspace_slug>.md`, then `-2`, `-3`, … on
+  further collisions. The `-from-` literal is the `DEDUP_FROM_TOKEN`
+  constant in `crates/ai-memory-mcp/src/admin.rs`; if you ever
+  change one, change the other. Wikilinks pointing at the original
+  path are not rewritten, so the lossless `true-move` path remains
+  the way to preserve paths and links.
+
+Every conflict (overwrite/duplicate) is listed in the response `conflicts`
+array (`path` → `moved_to`). Set the policy via `--on-conflict` on the CLI
+or `"on_conflict": "block" | "overwrite" | "duplicate"` in the JSON body
+for direct `/admin/move-project` callers.
+
+**What does NOT migrate (merge case only):** in the `copy-purge` path the
+source's `sessions`, `observations`, and `handoffs` (the raw episodic
+capture log) are dropped by the purge, and the moved pages start a fresh
+supersession chain (the real page history lives in the wiki's git
+mirror). The `true-move` path has no such loss.
+
+> **Operational caveat — moving the project the current session writes
+> to.** Lifecycle hooks stamp a bounded observation on every supported tool-lifecycle event into the
+> session's project. If you move that very project mid-session, the next
+> hook re-creates the source (`scratch`-style) under the old workspace.
+> Before moving a live project, point the repo's `.ai-memory.toml` at the
+> **destination** workspace first, so new hook events already land there
+> and the move is a clean no-contention operation.
+
+Failure modes:
+
+- **Missing `--confirm`** → 400.
+- **`from_workspace == to_workspace`** → 422 (use `rename-project`).
+- **Source project not found** → 404.
+- **Destination workspace directory already exists** (true-move only)
+  → 409 with `WikiError::DestinationExists` body — the destination
+  has on-disk content for the same `(workspace, project)` UUID pair
+  without a corresponding DB row; refuse and let the operator
+  reconcile manually.
+- **Block-policy same-path conflict** (copy-purge merge only) → 409
+  with `{"error": "...", "conflicts": [paths...]}` listing every
+  conflicting path. Re-run with `on_conflict=overwrite` or
+  `on_conflict=duplicate` to proceed.
+- **True-move admission or SQL re-stamp failure** → 500 and no
+  committed move. If a rare rollback double-fault happens after the
+  directory moved but before SQL committed, the error includes the
+  exact manual repair.
+
+### `checkpoints`
+
+```bash
+ai-memory checkpoints
+```
+
+Lists recent wiki git commits, newest first. The short OID is enough for
+`restore-page`, but the JSON output includes the full OID:
+
+```bash
+ai-memory checkpoints --json
+```
+
+What it is for:
+
+- Finding the checkpoint just before a bad page write, delete, purge, move, or
+  restore.
+- Inspecting wiki history without shelling into the server's `wiki/.git` repo.
+
+Startup creates a one-time `upgrade baseline: existing wiki tree before recovery
+checkpoints` commit for existing data dirs whose wiki repo has zero commits.
+Fresh empty installs still have no commit until there is content to save.
+
+### `restore-page`
+
+```bash
+ai-memory restore-page --workspace default --project my-project \
+  --path notes/foo.md --from <checkpoint>
+```
+
+What happens:
+
+1. Server resolves `(workspace, project)` without auto-creating anything.
+2. Server validates the page path.
+3. Server checkpoints the current wiki tree first (`pre-restore-page ...`) when
+   there are uncommitted changes.
+4. Server reads the exact markdown blob for that project/page from git at
+   `--from`, parses it, writes it back to the live wiki tree, and upserts a new
+   latest page row in SQLite so search, links, and `/web` agree with disk.
+5. Server writes a post-restore checkpoint (`restore-page ...`) when the live
+   tree changed.
+
+Failure modes:
+
+- **Workspace or project name not found** → 404, no mutation.
+- **Invalid page path** → 422, no mutation.
+- **Checkpoint or file not found** → 500 with the git/libgit2 error; any
+  pre-restore checkpoint remains as an audit breadcrumb.
+- **Historical markdown is malformed or non-UTF-8** → 500, live file is not
+  replaced.
+
+What it does not recover:
+
+- Sessions, observations, handoffs, users, audit rows, access counters, and
+  embeddings. Those live only in SQLite and require a full `backup` / `restore`
+  if you need to roll them back.
+
+### `backup`
+
+```bash
+ai-memory backup --output-path /tmp/ai-memory-backup.tar.gz
+```
+
+What happens on the server:
+
+1. SQLite online-backup API copies the live WAL DB to a temp file -
+   guaranteed consistent snapshot without stopping the writer.
+2. Server tar-gzips the snapshot + the wiki tree + `config.toml`.
+3. Response body IS the gzipped tarball
+   (`Content-Type: application/gzip`).
+
+CLI writes the response body to `--output-path`. For a homelab user
+this is the standard "snapshot before doing something dangerous"
+move - `ai-memory backup` first, then proceed.
+
+Restoring a backup follows the inverse:
+
+```bash
+# Stop the server first.
+docker compose -f ~/deploy/ai-memory/docker-compose.yml down
+# Restore (sysinfo refuses if the container is still running).
+ai-memory restore --from /tmp/ai-memory-backup.tar.gz --data-dir /var/opt/docker/utils/ai-memory/data --confirm
+# Start back up.
+docker compose -f ~/deploy/ai-memory/docker-compose.yml up -d
+```
+
+The `--data-dir` flag points the CLI at the host-side path of the
+docker volume (since `restore` runs directly on disk, not via the
+HTTP admin API).
+
+### `restore`
+
+```bash
+ai-memory restore --from <tarball> --data-dir <path> --confirm
+```
+
+Direct-disk operation. Refuses if any other `ai-memory` process is
+alive (uses `sysinfo` to scan the process table).
+
+Order of operations:
+
+1. Check the data dir is empty (or the user passed `--force`).
+2. Extract the tarball into the data dir.
+3. Restore the SQLite snapshot in place.
+4. Print a one-line summary.
+
+Failure modes:
+
+- **Server still running** → exits with "another ai-memory process is
+  alive (pid X); stop it before restoring" - same wording as `reset`.
+- **`--confirm` omitted** → exits with usage hint.
+- **Data dir not empty + no `--force`** → exits with "data dir not
+  empty; pass `--force` to overwrite".
+
+### `reset`
+
+```bash
+ai-memory reset --confirm
+```
+
+Direct-disk operation. Refuses if any sibling `ai-memory` process is
+alive. Removes the contents of `wiki/`, `db/`, and `raw/` under the
+configured data dir. `config.toml` is preserved.
+
+Identical sysinfo guard to `restore`. The use case is "wipe and start
+over" - typically when changing major version with a breaking
+migration, or when bootstrapping a new install on top of an old
+data dir.
+
+For a docker deploy where the data lives in a host-path bind mount,
+you can also just `rm -rf <host-path>/*` after stopping the
+container - but `ai-memory reset` is the cross-platform path that
+works whether the data dir is local, bind-mounted, or in a named
+volume.
+
+### `reindex`
+
+```bash
+ai-memory reindex --data-dir <path>
+```
+
+Direct-disk lifecycle operation. Refuses if any sibling `ai-memory` process is
+alive, and also refuses if SQLite already contains rows. `reindex` is a
+rebuild-from-files path, not an in-place dirty-index repair.
+
+Use it when the markdown wiki is intact but you intentionally want a fresh
+SQLite migration lineage:
+
+1. Stop the server or container.
+2. Take a backup of the current data directory.
+3. Move or remove `<data-dir>/db/memory.sqlite` and its WAL/SHM siblings.
+4. Run `ai-memory reindex --data-dir <data-dir>`.
+5. Run `ai-memory embed` after restart if you need embeddings rebuilt.
+
+What is rebuilt:
+
+- Workspaces and projects from `_meta.md`, preserving the UUIDs encoded in the
+  wiki directory names.
+- Latest page rows, page links, and FTS from markdown files.
+
+What is not rebuilt:
+
+- Sessions, observations, handoffs, users/tokens, audit rows, access counters,
+  and embeddings. Those are DB-only state; keep a backup if you need them.
+
+## Operator workflows
+
+### "Fresh start" (wipe everything)
+
+For a docker / bind-mount deploy where data lives on the host:
+
+```bash
+ssh homelab
+cd ~/deploy/ai-memory
+docker compose down
+sudo rm -rf /var/opt/docker/utils/ai-memory/data/*
+docker compose up -d
+```
+
+Or via the CLI from any machine (slower but portable):
+
+```bash
+docker stop ai-memory   # so sysinfo guard passes
+ai-memory reset --confirm   # against the same data dir
+docker start ai-memory
+```
+
+### "Snapshot before risky op"
+
+```bash
+ai-memory backup --output-path "/tmp/ai-memory-$(date +%Y%m%d-%H%M).tar.gz"
+# … do the risky thing …
+# … oh no something broke …
+docker compose down
+ai-memory restore --from /tmp/ai-memory-2026-05-23-1530.tar.gz --confirm
+docker compose up -d
+```
+
+### "Drop one experimental project, keep everything else"
+
+```bash
+ai-memory purge-project --project experimental --confirm
+# Sibling projects (ai-memory, distrobox-gaming, …) untouched.
+```
+
+### "Rename a project after moving its directory"
+
+```bash
+ai-memory rename-project --from old --to new
+# Future sessions in /path/to/new will append to the same project
+# (the hook router stamps by basename(cwd) = "new"); past
+# observations stay under that project too because the project_id
+# is stable.
+```
+
+## Why this matters: the flat-wiki incident
+
+Before the per-project disk layout (commits up to `e7b9a17`), the
+wiki was flat: `wiki/<page-path>` regardless of project. Two
+projects with the same `pages.path` shared one file on disk. The
+`purge-project` handler then iterated and deleted those files,
+clobbering pages owned by the sibling project. The DB rows for the
+sibling survived (FK is scoped by `project_id`), but every `/web/`
+click returned 404 because the on-disk file was gone.
+
+The shipped band-aid was a `path_still_referenced` check before each
+delete. The proper fix landed in `e7b9a17`: per-project disk roots
+make path-collision structurally impossible. Both the band-aid and
+the underlying class of bug are gone. Lifecycle ops are now safe
+by construction.
+
+This is also why `rename-project` is free: the disk path is keyed
+by surrogate `project_id`, not the mutable name. Rename touches one
+column; nothing moves.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,708 +1,3343 @@
-# Lifecycle operations
-
-Reference for the destructive / state-touching ai-memory commands.
-Read this before running anything that mutates wiki + db, especially
-on a homelab box where mistakes are harder to undo.
-
-## TL;DR - safety matrix
-
-| Command | Safe with server **running**? | Wipes data? | Reversible? | Notes |
-|---|---|---|---|---|
-| `purge-project --confirm` | ✅ yes | the one project's data | no | Deletes the UUID-namespaced wiki root and raw workstream segments; sibling projects remain untouched. Refuses with `409` while a managed workstream under the project holds a live run lease — `--force` overrides. |
-| `purge-session --session-id --confirm` | ✅ yes | one session and everything derived from it | no | Removes the session, its observations and both FTS indexes, its handoffs, queued consolidation, auto-improvement runs/proposals/events/rejections, every version of its derived pages, and the wiki files. Leaves only a content-free tombstone. Refuses with `409` while the session is open or has work in flight — `--force` overrides. |
-| `rename-project --from --to` | ✅ yes | no | yes (rename back) | Column-only update on `projects.name`. The on-disk dir is keyed by `project_id` (UUID), so the rename never moves a file. |
-| `/admin/rename-workspace` | ✅ yes | no | yes (rename back) | Column-only update on `workspaces.name`; refreshes `_meta.md` scope manifests and checkpoints the wiki tree. |
-| `/admin/delete-workspace` | ✅ yes | the workspace and every child project | no | Runs `purge_workspace` admission first, deletes SQLite rows in one cascade, removes the UUID-keyed workspace directory and managed-workstream raw segments, reports filesystem partial failures, and dispatches mirror notification after durable work. |
-| `move-project --confirm` | ✅ yes | source only in the merge case (a `Reject`-policy `purge_project` webhook can still abort the source teardown leaving everything intact) | no | Fresh destination → lossless **true move** (re-stamp `workspace_id`, keep `project_id`, rename the dir): sessions/observations/handoffs + history all survive. Destination with a same-named project → **copy+purge merge**: only latest pages migrate. |
-| `backup --output-path` | ✅ yes | no | n/a | Streams a gzipped tarball from the server's online `sqlite3 .backup` plus the wiki tree. Safe alongside the live writer. |
-| `checkpoints` | ✅ yes | no | n/a | Lists recent wiki git checkpoints. Read-only. |
-| `restore-page --path --from` | ✅ yes | overwrites one markdown page version | yes (restore another checkpoint) | Restores one page from wiki git history, reindexes it into SQLite, and writes a post-restore checkpoint. Does not restore DB-only state. |
-| `restore --from <tarball>` | ❌ **stop the server first** | overwrites the data dir | no (without prior backup) | Refuses if any sibling `ai-memory` process is alive (sysinfo guard). |
-| `reset --confirm` | ❌ **stop the server first** | yes, all data | no | Refuses if any sibling `ai-memory` process is alive (sysinfo guard). |
-| `reindex` | ❌ **stop the server first** | no wiki wipe; requires a clean DB | only with prior DB backup | Rebuilds pages/links/FTS from `wiki/` using `_meta.md` manifests. Refuses if SQLite already has rows so stale DB-only state cannot survive silently. |
-
-State-touching commands route through the HTTP admin API except `reset`,
-`restore`, and `reindex`, which are direct-disk lifecycle operations that
-fundamentally cannot run while another process holds the SQLite WAL writer. See
-[CLAUDE.md §16](../CLAUDE.md) for the invariant.
-
-## What "project isolation" means here
-
-Every project's data lives under an isolated, UUID-keyed root on disk:
-
-```
-<wiki_root>/
-├── .git/
-├── <workspace_id>/
-│   ├── _meta.md                 # workspace name for rebuilds
-│   └── <project_id>/
-│       ├── concepts/
-│       ├── decisions/
-│       ├── gotchas/
-│       ├── sessions/
-│       ├── _rules/
-│       ├── _meta.md             # project name + repo_path for rebuilds
-│       ├── log-YYYY-MM.md      # rolling event log, one file per month
-│       └── bootstrap.md
-└── <other_workspace_id>/
-    └── <other_project_id>/
-        └── ...
-```
-
-The mutable **project name** (the human-readable `distrobox-gaming`
-or `.config` you see in `/web/`) never appears in any disk path; the
-stable **project_id UUID** does. SQLite's `projects.name` column maps
-name → id. Two projects can have the exact same `pages.path` (e.g.
-both have `decisions/0001.md`) without colliding on disk - the
-namespaced layout guarantees structural isolation.
-
-The git history is rooted at `<wiki_root>` (one repo, all projects
-as subtrees). A `git log` from inside the wiki dir shows changes
-across every project; per-project diffs are also possible via
-`git log -- <workspace_id>/<project_id>/`.
-
-Each workspace directory also carries `<workspace_id>/_meta.md`, and each
-project directory carries `<workspace_id>/<project_id>/_meta.md`. Those small
-frontmatter-only manifests store human names (plus `repo_path` for projects),
-so a clean SQLite DB can be rebuilt from the UUID-keyed wiki tree alone.
-
-## Command-by-command
-
-### `purge-project`
-
-```bash
-ai-memory purge-project --workspace default --project my-project --confirm
-```
-
-What happens, in order:
-
-1. Server looks up `(workspace_id, project_id)` by name. Returns 404
-   if either is missing.
-2. Refuses with 409 when a managed workstream under the project still
-   holds a **live** run lease (`managed_runs.state = 'active'` AND
-   `lease_expires_at` in the future). `workstreams` cascades out of
-   `projects` and `managed_runs` cascades out of `workstreams`, so
-   purging would delete a running agent's lease row: its heartbeat
-   would then fail with `409 managed run lease is not active` for the
-   rest of the session and the transcript would never reach the ledger.
-   A lapsed lease (crashed wrapper) does **not** block the purge.
-   `--force` purges anyway.
-3. Counts rows that will cascade (`pages`, `sessions`,
-   `observations`, `handoffs`, `page_embeddings`, plus `workstreams`
-   and `managed_runs`).
-4. Single `DELETE FROM projects WHERE id = ?` - the V01 + V05
-   `ON DELETE CASCADE` foreign keys propagate to every dependent
-   table in one transaction.
-5. Best-effort filesystem cleanup removes both the UUID-namespaced wiki root
-   and every `<data_dir>/raw/workstreams/<workstream_id>/` segment directory.
-6. Returns a summary: `{label, pages_deleted, sessions_deleted, …,
-   workstreams_deleted, managed_runs_deleted, workstream_ids,
-   files_deleted: [<project_root>, <raw_workstream_dir>, ...],
-   files_failed: [...]}`.
-
-`workstream_ids` remains in the report for auditability. Each corresponding
-raw segment directory is removed on the server and appears in
-`files_deleted`; a failed removal appears in `files_failed` alongside wiki
-cleanup failures.
-
-Failure modes:
-
-- **Workspace or project name not found** → 404, no mutation.
-- **Confirmation flag omitted** → 400, no mutation.
-- **Live managed run, no `--force`** → 409 naming the workstreams, no
-   mutation. Finish or cancel the session, or re-run with `--force`
-   (the running agent then stops being able to save its history).
-- **`remove_dir_all` partial failure** (e.g. permissions) → DB
-   rows are already gone but `files_failed` is populated. Re-run
-   the command with the same args is idempotent; the second call
-   returns 404 (project already deleted).
-
-Why this is safe with the server running:
-
-- The DB cascade is one transaction; the writer actor serialises
-  it against any other writes.
-- The on-disk delete touches only the project's UUID-keyed subdir,
-  which no other project shares files with. No race with the
-  watcher even mid-write - at worst the watcher emits delete
-  events for files we just removed, which it ignores (no DB row
-  to reindex).
-
-### `purge-session`
-
-```bash
-ai-memory purge-session \
-    --workspace default --project acme-api \
-    --session-id 11111111-1111-4111-8111-111111111111 \
-    --confirm
-```
-
-Strong deletion of **one** session, for when an application has promised
-"forget this conversation" and has to be able to keep that promise. Where
-`purge-project` is too broad and `delete-page` removes only one wiki path, this
-removes a session across every layer ai-memory administers.
-
-**What it removes**
-
-- the `sessions` row, its `observations`, and both external-content FTS indexes
-- handoffs the session produced *or* accepted (both links are `ON DELETE SET
-  NULL`, so the rows are deleted explicitly rather than orphaned)
-- queued SessionEnd consolidation jobs and auto-improvement scheduler claims
-- auto-improvement runs, proposals, proposal events, and rejections derived
-  from it, including their reasons, summaries, and evidence
-- every version of each derived page — the heuristic `sessions/<uuid>.md`, its
-  LLM rewrites, and multi-page consolidation output — plus the wiki files
-- entities left with no remaining page links
-
-**How targets are chosen.** Only by identity: the session UUID, a foreign key,
-or the deterministic `sessions/<uuid>.md` path. Never by searching page text —
-a deletion that guessed would both miss content and remove innocent pages. Page
-provenance is structural (`pages.source_session_id`) and sticky: a rewrite that
-declares no provenance inherits the superseded version's, so an LLM rewrite or
-a hand edit cannot launder a page out of the purge's reach.
-
-**Safety rules**
-
-- Root-only, like every `/admin/*` route once the first user exists.
-- `--confirm` is mandatory.
-- The full UUID is required. A prefix of a real session id is refused with
-  `422`, because this operation is irreversible and must never guess.
-- A session id that exists in a *different* project reads exactly like "no such
-  session" (`404`), so the response cannot be used to probe another project.
-- Idempotent: a second call returns `already_purged` with the original
-  tombstone and zero counts, and does not fail on the absence of what the first
-  call removed.
-- Refuses with `409` while the session is open, a consolidation is queued or
-  running, or an auto-improvement claim is outstanding. `--force` overrides.
-
-**Git history.** Removing the file and committing would leave every earlier
-version reachable, and `restore-page` would hand one back. So the wiki
-repository is rebuilt without those paths and the old object database is
-physically destroyed — the content is gone from the ODB itself, not merely
-unreferenced. Properties worth knowing:
-
-- **History is preserved, not squashed.** Every commit is carried over minus
-  the purged paths; unrelated pages keep their full version history.
-- **Shared blobs are spared.** git stores one object for identical content, so
-  a blob a surviving page also uses is never destroyed.
-- **Verification precedes destruction.** The rebuilt repository is checked
-  against both the purged paths and the object database *before* the swap; a
-  failed check leaves the live repository exactly as it was.
-- **Interrupted swaps converge.** A durable journal is written across the swap
-  and resolved at the next startup, before the wiki is opened for business. If
-  the rebuilt repository was lost mid-swap, the old one is restored and the
-  server refuses to start until the purge is re-run — it will not quietly serve
-  content it claimed to have deleted.
-- **No residue.** No quarantine copy, `.bak`, old pack, or swap directory
-  remains in the data dir.
-
-If the history rebuild fails, the receipt carries a loud
-`GIT HISTORY NOT PURGED` warning: the rows are already gone, but earlier page
-versions remain recoverable until you re-run the command.
-
-**The database files.** Deleting rows is not enough to make the bytes go away,
-and each of these was found by searching the data directory for a purged canary
-rather than by querying for it:
-
-- **FTS5 index segments.** An FTS5 delete is *logical*: it writes a delete
-  marker and leaves the original terms in the existing segments. `MATCH`
-  correctly returns nothing while the purged text stays readable in
-  `pages_fts_data` / `observations_fts_data`. The indexes are rebuilt from
-  their content tables.
-- **The write-ahead log.** Until a checkpoint runs, the deleted rows remain
-  readable in `memory.sqlite-wal`, beside the database and ready to be copied
-  into the next backup.
-- **Freed pages.** `secure_delete` zeroes content as the delete proceeds, and a
-  vacuum reclaims pages freed by earlier writes.
-
-If any of these cannot complete, the purge logs a warning rather than failing:
-the rows are genuinely deleted, and refusing the whole operation over an
-incomplete vacuum would leave you worse off.
-
-**Restore and reindex.** A snapshot taken before a purge contains everything
-that purge removed. `restore` therefore reads the tombstone ledger *before* the
-overwrite destroys it, reapplies it to the restored state, and **fails closed**
-if any purged session survives — a restore that cannot prove the ledger holds
-is not a safe restoration. Restoring into a fresh directory has no ledger of its
-own, so pass `--tombstones-from <path>` pointing at the directory that holds the
-current one. `reindex` drops pages the ledger covers by their deterministic
-`sessions/<uuid>.md` identity, because markdown rebuilt from disk cannot carry
-the relational provenance a purge relies on.
-
-**The tombstone.** The only permitted residue: scope, session UUID, purge time,
-schema version, and an audit-log id. No title, path, body, or count — a
-tombstone that quoted the session would defeat the deletion it records. It is
-what stops a late spooled event from a client that was offline during the purge
-from recreating the session.
-
-**`backup_cutoff`.** The receipt reports the purge instant. Snapshots taken
-before it still contain the purged content and should be invalidated by
-whatever rotates your backups; ai-memory does not operate that system.
-
-**Out of scope.** Managed workstreams are not touched. Their
-`native_session_id` columns are free text with no foreign key to `sessions.id`,
-so matching a purge against them by coincidence of value would delete unrelated
-history. That needs the composite `(workstream_id, agent_kind,
-native_session_id)` identity and a separate API. Histories kept by Claude Code,
-Codex, OpenCode, or any other harness are likewise outside ai-memory's control.
-
-### `rename-project`
-
-```bash
-ai-memory rename-project --workspace default --from old-name --to new-name
-```
-
-What happens:
-
-1. Look up `(workspace_id, project_id)` by current name. 404 on
-   miss.
-2. Validate the new name: non-empty, no `/`, no leading/trailing
-   whitespace. 422 on bad input.
-3. `UPDATE projects SET name = ? WHERE id = ?`. UNIQUE-violation on
-   the `(workspace_id, name)` index → 422 with "name taken".
-4. Return `{workspace, from, to, pages}`.
-
-Zero files move on disk because the disk path is keyed by
-`project_id`, not name. The web UI URL `/web/w/<ws>/<proj-name>/…`
-just resolves to the same `project_id` after the column update.
-This command also does not rename a source checkout or rewrite any native agent
-session locator. See [managed workstream rename
-behavior](managed-workstreams.md#project-and-directory-renames) before
-physically renaming a checkout that has native sessions.
-After a successful CLI rename, the client also rekeys its local `show` checkout
-link. A direct `/admin/rename-project` request cannot update other machines'
-client registries; the next successful managed `run` from a checkout refreshes
-its link.
-
-Failure modes:
-
-- **`to` name already exists in this workspace** → 422.
-- **`to` invalid (empty, slash, whitespace)** → 422.
-- **Source `from` not found** → 404.
-
-### `/admin/rename-workspace`
-
-Renames a workspace by updating `workspaces.name`; on-disk paths remain keyed by
-`workspace_id`, so no page files move. After the SQLite rename, the handler
-refreshes `_meta.md` scope manifests with `Wiki::backfill_scope_manifests()` and
-returns `manifests_refreshed` plus a post-rename checkpoint when the wiki tree
-changed.
-
-If manifest refresh fails after the SQLite rename has committed, the rename
-still returns `200 OK` with `manifests_refreshed: 0` and a `manifest_warning`
-string instead of reporting a misleading 500. The DB rename is authoritative at
-that point; operators can rerun a manifest refresh or restore from the emitted
-checkpoint if they need to repair `_meta.md` drift.
-
-Failure modes:
-
-- **Source `from` not found** → 404.
-- **`to` name already exists or is invalid** → 422.
-- **Manifest refresh failed after commit** → 200 with `manifest_warning` and
-  committed DB rename.
-
-### `/admin/delete-workspace`
-
-Deletes a workspace row and all child projects/pages/sessions/managed
-workstreams through the `workspace_id` cascade. The route is guarded by
-`force: true` for non-empty workspaces and follows the destructive-operation
-ordering used by project purges:
-
-1. Look up the workspace without creating missing scopes.
-2. Run blocking `op=purge_workspace` admission. A reject-policy webhook aborts
-   before DB rows or files are removed.
-3. Take a pre-delete checkpoint if the wiki tree is dirty.
-4. Delete the workspace in one writer-actor transaction.
-5. Remove `<wiki_root>/<workspace_id>` and every affected
-   `<data_dir>/raw/workstreams/<workstream_id>` directory from disk. The
-   response reports `workstreams_deleted`, `managed_runs_deleted`, and the
-   cleaned `workstream_ids` alongside the filesystem results.
-6. Dispatch non-blocking `purge_workspace` mirror notifications after durable
-   work. If the DB delete committed but disk removal failed, the response
-   includes `files_failed` and webhook `ctx.partial_failure: true`.
-7. Take a post-delete checkpoint if the wiki tree changed.
-
-Failure modes:
-
-- **Workspace not found** → 404, no mutation.
-- **Non-empty workspace without `force: true`** → 409, no mutation.
-- **Reject-policy `purge_workspace` webhook fails** → 500, no DB/disk mutation.
-- **Filesystem removal fails after SQL commit** → 200 with `files_failed`
-  populated and `partial_failure: true` on async mirror notifications; manual
-  cleanup of the reported path is required.
-
-### `move-project`
-
-```bash
-ai-memory move-project --from-workspace default --project my-project \
-  --to-workspace other-workspace --confirm
-```
-
-Moves a project into a **different** workspace. Unlike `rename-project`
-(a same-workspace column update), this crosses the workspace boundary.
-The destination decides which of two strategies runs — reported as
-`moved_via` in the response:
-
-**1. Fresh destination → `"true-move"` (lossless, the common case).**
-When the destination workspace has **no** same-named project, the move is
-a low-level re-stamp:
-
-1. Resolve the source `(from_workspace, project)`. 404 on miss.
-2. Reject `from_workspace == to_workspace` (use `rename-project`) → 422.
-3. Get-or-create the destination **workspace** row (not a new project).
-4. Take the wiki's exclusive mutation gate and run `op=move_project` admission
-   webhooks with source names in `ctx.workspace` / `ctx.project` and
-   destination names in `ctx.destination_workspace` /
-   `ctx.destination_project`. A reject-policy webhook aborts before files or DB
-   rows move.
-5. While still holding that gate, check that the destination dir is still
-   absent, then `fs::rename` the project dir
-   `<wiki>/<from_ws>/<proj>` → `<wiki>/<to_ws>/<proj>` (atomic within one
-   wiki root).
-6. Re-stamp `workspace_id` across every domain table for the project in
-   **one transaction**, keeping the same `project_id`
-   (`projects`, `pages`, `sessions`, `observations`, `handoffs`, `audit_log`,
-   auto-improvement state, SessionEnd consolidation jobs, and managed
-   `workstreams`). Native workstream sessions, runs, and events remain attached
-   through `workstream_id`; `page_embeddings` and `links` remain attached
-   through `page_id`, so none of those rows need a direct re-stamp.
-
-After a successful CLI true move, or a completed copy-purge move, the client
-rekeys its local `show` checkout link. Existing destination links win during a
-merge. Direct admin API callers leave client-local registries untouched; a
-later successful managed `run` repairs the relevant link.
-
-Ordering is **rename-FIRST, SQL-commit-LAST**, so the **DB is never ahead of
-disk**: a rename failure touches nothing; a crash between the two steps leaves
-at most an orphan dir at the destination with the DB still wholly at the source
-(recoverable), never a DB row pointing at a missing file. A SQL failure renames
-the dir back, so the move is all-or-nothing unless the filesystem also refuses
-the rollback, in which case the error names the manual repair. In-process page
-writes/reindexes take the shared side of the same mutation gate and validate the
-`(workspace_id, project_id)` pair before touching disk, so stale source writes
-fail without creating orphan files after the move.
-
-This is O(1) (one transaction + one rename), re-embeds nothing, and
-**preserves everything** — sessions, observations, handoffs and the full
-supersession history all travel with the project.
-
-**Live-session guard.** The server refuses (409) to move the project the
-hook router has published as the *active* project (a live session's next
-observation would carry a now-stale `workspace_id`). Pass `--force` /
-`force: true` to override — still safe: the move republishes the active
-pointer, and the wiki pair validator plus `(workspace_id, project_id)` insert
-trigger (V18) reject stale writes cleanly, so the router re-resolves instead of
-corrupting or creating old-workspace files.
-
-**2. Destination already has a same-named project → `"copy-purge"`
-(merge).** Two distinct `project_id`s can't be re-stamped into one (it
-would collide on `UNIQUE (workspace_id, name)`), so the source's latest
-pages are copied into the existing destination project via
-`Wiki::write_page` (sanitization, link re-resolution, FTS, and — on
-deploy — the admission/git-mirror webhooks all fire), source embeddings
-are carried over verbatim, and only then is the source purged
-(`merged_into_existing: true`, `source_purged: true`).
-
-`--force` overrides only the hook router's active-project guard. It never
-deletes a live managed-workstream lease during this destructive path; finish
-or cancel that run before retrying. A true move keeps the same project and
-lease ids, so it does not need this additional guard.
-
-Copy-before-purge means any copy failure aborts **before** the purge,
-leaving the source intact. An unreadable source file is skipped and also
-blocks the purge (`source_purged: false`) so a fixed re-run is safe
-(re-running is idempotent — copied pages just supersede). A **live managed
-run** under the source blocks the purge leg the same way: the move returns
-409 saying how many pages were already copied, and the source stays intact
-until the session ends and the move is re-run.
-
-**Same-path conflicts (`on_conflict`).** When a source page's path already
-exists in the destination with a different body, frontmatter, title, tier, or
-pinned bit, the policy decides (identical pages are always a no-op supersession
-at the same path):
-
-- **`block`** (default) — abort the whole move with 409, listing the
-  conflicting paths; the source is left intact. The safe default for a
-  destructive op: nothing is overwritten or split silently. The operator
-  resolves the conflicts or re-runs with an explicit policy.
-- **`overwrite`** — the source page supersedes the destination page at the
-  same path (the destination's prior version becomes history).
-- **`duplicate`** — keep both: the source page lands at
-  `<stem>-from-<src_workspace_slug>.md`, then `-2`, `-3`, … on
-  further collisions. The `-from-` literal is the `DEDUP_FROM_TOKEN`
-  constant in `crates/ai-memory-mcp/src/admin.rs`; if you ever
-  change one, change the other. Wikilinks pointing at the original
-  path are not rewritten, so the lossless `true-move` path remains
-  the way to preserve paths and links.
-
-Every conflict (overwrite/duplicate) is listed in the response `conflicts`
-array (`path` → `moved_to`). Set the policy via `--on-conflict` on the CLI
-or `"on_conflict": "block" | "overwrite" | "duplicate"` in the JSON body
-for direct `/admin/move-project` callers.
-
-**What does NOT migrate (merge case only):** in the `copy-purge` path the
-source's `sessions`, `observations`, and `handoffs` (the raw episodic
-capture log) are dropped by the purge, and the moved pages start a fresh
-supersession chain (the real page history lives in the wiki's git
-mirror). The `true-move` path has no such loss.
-
-> **Operational caveat — moving the project the current session writes
-> to.** Lifecycle hooks stamp a bounded observation on every supported tool-lifecycle event into the
-> session's project. If you move that very project mid-session, the next
-> hook re-creates the source (`scratch`-style) under the old workspace.
-> Before moving a live project, point the repo's `.ai-memory.toml` at the
-> **destination** workspace first, so new hook events already land there
-> and the move is a clean no-contention operation.
-
-Failure modes:
-
-- **Missing `--confirm`** → 400.
-- **`from_workspace == to_workspace`** → 422 (use `rename-project`).
-- **Source project not found** → 404.
-- **Destination workspace directory already exists** (true-move only)
-  → 409 with `WikiError::DestinationExists` body — the destination
-  has on-disk content for the same `(workspace, project)` UUID pair
-  without a corresponding DB row; refuse and let the operator
-  reconcile manually.
-- **Block-policy same-path conflict** (copy-purge merge only) → 409
-  with `{"error": "...", "conflicts": [paths...]}` listing every
-  conflicting path. Re-run with `on_conflict=overwrite` or
-  `on_conflict=duplicate` to proceed.
-- **True-move admission or SQL re-stamp failure** → 500 and no
-  committed move. If a rare rollback double-fault happens after the
-  directory moved but before SQL committed, the error includes the
-  exact manual repair.
-
-### `checkpoints`
-
-```bash
-ai-memory checkpoints
-```
-
-Lists recent wiki git commits, newest first. The short OID is enough for
-`restore-page`, but the JSON output includes the full OID:
-
-```bash
-ai-memory checkpoints --json
-```
-
-What it is for:
-
-- Finding the checkpoint just before a bad page write, delete, purge, move, or
-  restore.
-- Inspecting wiki history without shelling into the server's `wiki/.git` repo.
-
-Startup creates a one-time `upgrade baseline: existing wiki tree before recovery
-checkpoints` commit for existing data dirs whose wiki repo has zero commits.
-Fresh empty installs still have no commit until there is content to save.
-
-### `restore-page`
-
-```bash
-ai-memory restore-page --workspace default --project my-project \
-  --path notes/foo.md --from <checkpoint>
-```
-
-What happens:
-
-1. Server resolves `(workspace, project)` without auto-creating anything.
-2. Server validates the page path.
-3. Server checkpoints the current wiki tree first (`pre-restore-page ...`) when
-   there are uncommitted changes.
-4. Server reads the exact markdown blob for that project/page from git at
-   `--from`, parses it, writes it back to the live wiki tree, and upserts a new
-   latest page row in SQLite so search, links, and `/web` agree with disk.
-5. Server writes a post-restore checkpoint (`restore-page ...`) when the live
-   tree changed.
-
-Failure modes:
-
-- **Workspace or project name not found** → 404, no mutation.
-- **Invalid page path** → 422, no mutation.
-- **Checkpoint or file not found** → 500 with the git/libgit2 error; any
-  pre-restore checkpoint remains as an audit breadcrumb.
-- **Historical markdown is malformed or non-UTF-8** → 500, live file is not
-  replaced.
-
-What it does not recover:
-
-- Sessions, observations, handoffs, users, audit rows, access counters, and
-  embeddings. Those live only in SQLite and require a full `backup` / `restore`
-  if you need to roll them back.
-
-### `backup`
-
-```bash
-ai-memory backup --output-path /tmp/ai-memory-backup.tar.gz
-```
-
-What happens on the server:
-
-1. SQLite online-backup API copies the live WAL DB to a temp file -
-   guaranteed consistent snapshot without stopping the writer.
-2. Server tar-gzips the snapshot + the wiki tree + `config.toml`.
-3. Response body IS the gzipped tarball
-   (`Content-Type: application/gzip`).
-
-CLI writes the response body to `--output-path`. For a homelab user
-this is the standard "snapshot before doing something dangerous"
-move - `ai-memory backup` first, then proceed.
-
-Restoring a backup follows the inverse:
-
-```bash
-# Stop the server first.
-docker compose -f ~/deploy/ai-memory/docker-compose.yml down
-# Restore (sysinfo refuses if the container is still running).
-ai-memory restore --from /tmp/ai-memory-backup.tar.gz --data-dir /var/opt/docker/utils/ai-memory/data --confirm
-# Start back up.
-docker compose -f ~/deploy/ai-memory/docker-compose.yml up -d
-```
-
-The `--data-dir` flag points the CLI at the host-side path of the
-docker volume (since `restore` runs directly on disk, not via the
-HTTP admin API).
-
-### `restore`
-
-```bash
-ai-memory restore --from <tarball> --data-dir <path> --confirm
-```
-
-Direct-disk operation. Refuses if any other `ai-memory` process is
-alive (uses `sysinfo` to scan the process table).
-
-Order of operations:
-
-1. Check the data dir is empty (or the user passed `--force`).
-2. Extract the tarball into the data dir.
-3. Restore the SQLite snapshot in place.
-4. Print a one-line summary.
-
-Failure modes:
-
-- **Server still running** → exits with "another ai-memory process is
-  alive (pid X); stop it before restoring" - same wording as `reset`.
-- **`--confirm` omitted** → exits with usage hint.
-- **Data dir not empty + no `--force`** → exits with "data dir not
-  empty; pass `--force` to overwrite".
-
-### `reset`
-
-```bash
-ai-memory reset --confirm
-```
-
-Direct-disk operation. Refuses if any sibling `ai-memory` process is
-alive. Removes the contents of `wiki/`, `db/`, and `raw/` under the
-configured data dir. `config.toml` is preserved.
-
-Identical sysinfo guard to `restore`. The use case is "wipe and start
-over" - typically when changing major version with a breaking
-migration, or when bootstrapping a new install on top of an old
-data dir.
-
-For a docker deploy where the data lives in a host-path bind mount,
-you can also just `rm -rf <host-path>/*` after stopping the
-container - but `ai-memory reset` is the cross-platform path that
-works whether the data dir is local, bind-mounted, or in a named
-volume.
-
-### `reindex`
-
-```bash
-ai-memory reindex --data-dir <path>
-```
-
-Direct-disk lifecycle operation. Refuses if any sibling `ai-memory` process is
-alive, and also refuses if SQLite already contains rows. `reindex` is a
-rebuild-from-files path, not an in-place dirty-index repair.
-
-Use it when the markdown wiki is intact but you intentionally want a fresh
-SQLite migration lineage:
-
-1. Stop the server or container.
-2. Take a backup of the current data directory.
-3. Move or remove `<data-dir>/db/memory.sqlite` and its WAL/SHM siblings.
-4. Run `ai-memory reindex --data-dir <data-dir>`.
-5. Run `ai-memory embed` after restart if you need embeddings rebuilt.
-
-What is rebuilt:
-
-- Workspaces and projects from `_meta.md`, preserving the UUIDs encoded in the
-  wiki directory names.
-- Latest page rows, page links, and FTS from markdown files.
-
-What is not rebuilt:
-
-- Sessions, observations, handoffs, users/tokens, audit rows, access counters,
-  and embeddings. Those are DB-only state; keep a backup if you need them.
-
-## Operator workflows
-
-### "Fresh start" (wipe everything)
-
-For a docker / bind-mount deploy where data lives on the host:
-
-```bash
-ssh homelab
-cd ~/deploy/ai-memory
-docker compose down
-sudo rm -rf /var/opt/docker/utils/ai-memory/data/*
-docker compose up -d
-```
-
-Or via the CLI from any machine (slower but portable):
-
-```bash
-docker stop ai-memory   # so sysinfo guard passes
-ai-memory reset --confirm   # against the same data dir
-docker start ai-memory
-```
-
-### "Snapshot before risky op"
-
-```bash
-ai-memory backup --output-path "/tmp/ai-memory-$(date +%Y%m%d-%H%M).tar.gz"
-# … do the risky thing …
-# … oh no something broke …
-docker compose down
-ai-memory restore --from /tmp/ai-memory-2026-05-23-1530.tar.gz --confirm
-docker compose up -d
-```
-
-### "Drop one experimental project, keep everything else"
-
-```bash
-ai-memory purge-project --project experimental --confirm
-# Sibling projects (ai-memory, distrobox-gaming, …) untouched.
-```
-
-### "Rename a project after moving its directory"
-
-```bash
-ai-memory rename-project --from old --to new
-# Future sessions in /path/to/new will append to the same project
-# (the hook router stamps by basename(cwd) = "new"); past
-# observations stay under that project too because the project_id
-# is stable.
-```
-
-## Why this matters: the flat-wiki incident
-
-Before the per-project disk layout (commits up to `e7b9a17`), the
-wiki was flat: `wiki/<page-path>` regardless of project. Two
-projects with the same `pages.path` shared one file on disk. The
-`purge-project` handler then iterated and deleted those files,
-clobbering pages owned by the sibling project. The DB rows for the
-sibling survived (FK is scoped by `project_id`), but every `/web/`
-click returned 404 because the on-disk file was gone.
-
-The shipped band-aid was a `path_still_referenced` check before each
-delete. The proper fix landed in `e7b9a17`: per-project disk roots
-make path-collision structurally impossible. Both the band-aid and
-the underlying class of bug are gone. Lifecycle ops are now safe
-by construction.
-
-This is also why `rename-project` is free: the disk path is keyed
-by surrogate `project_id`, not the mutable name. Rename touches one
-column; nothing moves.
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Added `ai-memory purge-session` and `POST /admin/purge-session` for strong
+  per-session deletion, so an application that promises "forget this
+  conversation" can keep that promise. Removes the session, its observations
+  and both FTS indexes, handoffs it produced or accepted, queued consolidation
+  and auto-improvement claims, derived auto-improvement runs/proposals/events/
+  rejections, every version of its derived pages, and the wiki files — leaving
+  only a content-free tombstone. Root-only, `--confirm` required, full UUID
+  only, idempotent, and `409` while the session is still in flight unless
+  `--force`. Page provenance is now structural and sticky, so an LLM rewrite or
+  hand edit cannot launder a derived page out of the purge's reach. Managed
+  workstreams are explicitly out of scope: their `native_session_id` has no
+  foreign key to `sessions.id` and is never matched by coincidence (#387).
+- `restore` now carries the session tombstone ledger across the overwrite and
+  reapplies it before the restored state is available, so a snapshot taken
+  before a `purge-session` can no longer silently resurrect what that purge
+  removed. It fails closed if any purged session survives the reapplication.
+  `--tombstones-from <path>` supplies the governing ledger when restoring into
+  a fresh directory, which has none of its own. `reindex` likewise drops pages
+  the ledger covers, since markdown rebuilt from disk cannot carry the
+  relational provenance a purge relies on (#387).
+- `purge-session` now removes the purged bytes from the database FILES, not
+  just from the tables. FTS5 deletes are logical — they write a delete marker
+  and leave the original terms in the index segments — so the indexes are
+  rebuilt from their content tables; the write-ahead log is checkpointed, since
+  deleted rows stay readable in `memory.sqlite-wal` until then and would be
+  copied into the next backup; and freed pages are zeroed and reclaimed. Every
+  query reported the content gone while it was still legible on disk (#387).
+- `purge-session` also scrubs the purged session's lines from every historical
+  version of the shared monthly log, and redacts commit messages that carried
+  its prompt text. Removing the log's path from history would have destroyed
+  other sessions' entries, so its versions are rewritten line-wise instead
+  (#387).
+- Hook ingest for a purged session is now refused as terminal with
+  `410 {"code":"session_purged","terminal":true}`, so an event spooled by a
+  client that was offline during the purge cannot resurrect it. The native
+  drainer treats that response as terminal — the entry is dropped without
+  spending a retry attempt — and `purge-session` additionally sweeps the local
+  `hook-spool` by exact session identity. Spools on other hosts cannot be
+  reached by the CLI; the server-side tombstone is what refuses them (#387).
+- `purge-session` now removes the purged pages from the wiki's git history
+  itself, not just from the working tree. Deleting a file and committing left
+  every prior version reachable — and `restore-page` would hand one back — so
+  the repository is rebuilt without those paths and the old object database is
+  physically destroyed. History is preserved, not squashed; a blob shared with
+  a surviving page is spared; directories emptied by the purge are dropped; and
+  the rebuild is verified against both the paths and the object database before
+  anything destructive happens, so a failed verification leaves the live
+  repository untouched. An interrupted swap is completed from a durable journal
+  at the next startup, before the wiki is opened for business (#387).
+- Monthly log entries now record which session produced them, so
+  `purge-session` removes exactly that session's lines and leaves every other
+  session's intact. Entries written before this cannot be attributed to any
+  session: they are reported as a structured block rather than matched by text
+  search, and `--force` removes that month's log as the whole retention
+  unit (#387).
+- Added `[routing] mid_session` to choose how a mid-session event is attributed
+  once the agent's cwd has moved. `follow-cwd` (default) keeps the historical
+  per-event resolution; `sticky` keeps the session's project wherever the agent
+  wanders, closing the cross-repo `cd` case that split one session's raw record
+  across two projects. Lifecycle hooks now tag each `project` override with its
+  provenance (`project_src=marker` or `project_src=repo-root`), so `sticky`
+  overrules a host-derived repo name while a `.ai-memory.toml` marker still
+  wins in both modes. Clients older than this release send no provenance and
+  keep their overrides authoritative (#394).
+- Added `[auth].secure_cookie` for HTTPS reverse-proxy deployments to mark
+  `/web` browser authentication cookies `Secure` while preserving plain-HTTP
+  loopback compatibility by default (#396).
+
+### Changed
+- Unauthenticated HTTP binds beyond loopback now fail closed before accepting
+  requests. Intentional insecure LAN use requires `--allow-insecure-no-auth`;
+  authenticated non-loopback HTTP remains available with its TLS warning
+  (#396).
+- `/api/v1` internal failures now return the fixed body
+  `{"error":"internal server error"}` instead of the source error chain, which
+  could expose data-directory paths and configuration to a browser. The
+  detailed cause is logged server-side (#396).
+- The `/web` browser authentication cookie is now `SameSite=Strict` rather than
+  `SameSite=Lax`, so it no longer rides top-level cross-site navigations into
+  the UI. Existing sessions stay valid (#396).
+
+### Fixed
+- Mid-session hook events that resolve to a different project than their
+  session — the ordinary result of an agent `cd`-ing into another checkout —
+  are recorded again instead of being dropped as a session-UUID collision.
+  Owner and agent still identify a session and a mismatch there remains
+  terminal; a `SessionEnd` naming a foreign scope is still dropped without
+  ending the session (#396).
+- Hook session UUIDs now reject cross-owner reuse atomically before ingest-key,
+  observation, summary, handoff, or end-state mutation; explicit root
+  `finalize-session --all-owners` recovery remains available (#396).
+- Newly created data directories, configuration files, SQLite databases,
+  managed-workstream segments, and downloaded backups now receive owner-only
+  Unix permissions before sensitive content is written, independent of the
+  ambient umask. Existing installations are left unchanged; Windows relies on
+  filesystem ACLs (#396).
+- Under the `repo-root` project strategy, mid-session events whose cwd sits
+  outside any git repository and any `.ai-memory.toml` marker (agent scratch
+  directories, `/tmp`, data folders) now inherit the session's project instead
+  of minting phantom basename projects (`scratchpad`, `data`, `tmp`, ...). The
+  host-side hook resolves the repository root itself and sends
+  `project=<root name>`, so a missing override already proves the cwd is
+  unresolvable; session-sticky attribution now accepts these events even
+  outside the session's cwd subtree, with the broad-anchor guards unchanged.
+  Deliberate rescopes keep working: git checkouts and markers arrive as
+  explicit overrides and never reach stickiness, and the default `basename`
+  strategy is untouched (#394).
+
+## [1.26.1] - 2026-08-14
+
+### Fixed
+- Forget-sweep decay now removes the authoritative Markdown file while
+  conditionally tombstoning the selected page, preventing reconciliation from
+  resurrecting evicted content. Aged cleanup recognizes rewritten heads,
+  deletes their complete `supersedes` ancestry, ignores lifetime access counts,
+  and preserves a newer page recreated at the same path. The corrected scoped
+  tombstone index is added by a new migration rather than rewriting history
+  (#391).
+- The `pages_fts_rows` and `observations_fts_rows` status counters now count
+  indexed documents instead of content-table rows. Both FTS tables use external
+  content, so `SELECT COUNT(*)` against them was answered from `pages` /
+  `observations` and the `fts: N/M` health pair could never diverge, no matter
+  how far the index had drifted (#392).
+
+## [1.26.0] - 2026-08-12
+
+### Added
+- Added MCP-only Swival CLI support. `install-mcp --client swival --apply`
+  merges ai-memory's native HTTP entry into the project-root
+  `.swival/mcp.json`, and `uninstall` removes only the matching ai-memory
+  entry while preserving sibling servers. Lifecycle capture and managed
+  workstreams remain unsupported because Swival's callback contract does not
+  expose a stable session identifier (#385).
+
+### Fixed
+- Lifecycle-only sessions containing only `SessionStart` / `SessionEnd` now
+  close without generating an empty session page, fallback handoff, or LLM
+  consolidation job. Startup handoff claims are bound to the native receiver
+  session when clients expose one; if that receiver exits without substantive
+  work, the same transaction that ends it returns the accepted handoff to the
+  open pool. Tool-bearing zero-prompt sessions remain substantive. Shipped
+  Claude Code, Codex, OpenCode, Command Code, Kiro, Antigravity, Devin, Cursor,
+  Gemini CLI, and Kimi Code delivery paths forward their available session ids
+  so an empty receiver cannot permanently consume real work (#386).
+- The `bin/ai-memory` wrapper now detects rootless mode and SELinux under
+  podman, so host-file commands stop failing with `Permission denied (os error
+  13)` on podman-based distros. Both the `-u 0:0` remap and `--security-opt
+  label=disable` were decided from `docker info --format
+  '{{.SecurityOptions}}'`, a Docker-only field that podman cannot evaluate;
+  the swallowed error left both gates off exactly where they were needed.
+  Podman's `.Host.Security.*` keys are consulted when that probe comes back
+  empty. `bootstrap` is now covered as well: it only reads host files, but an
+  unmapped UID blocks reads just as hard, and it degraded silently to "no
+  `.git` found" before dying. Restore archives, explicit config paths, and
+  commands using a host-backed `AI_MEMORY_DATA_DIR` now receive the same
+  host-file treatment (#388).
+
+## [1.25.0] - 2026-08-07
+
+### Added
+- Added version-aware Kiro CLI v3 managed workstreams. `ai-memory run kiro
+  --v3` reads the authenticated 2.16.2 nested `session.json` / `messages.jsonl`
+  store through a visible-event allowlist, persists the incompatible engine
+  flavor in its cursor, resumes with exact `--v3 --resume-id`, and joins bare
+  automatic selection alongside v2 without cross-resuming either store. Plain
+  returning Kiro launches recover the linked engine transparently; v3 wrapper
+  `--yolo` adds no flag because Kiro replaced `--trust-all-tools` with
+  `permissions.yaml`. A targeted compatibility path also handles Kiro 2.16.2
+  writing v3 sessions to default `~/.kiro` despite custom `KIRO_HOME`: only a
+  resume proven to live in that fallback drops the override for its child
+  process. The optional deterministic acceptance runner now covers fresh,
+  resume, and import round trips for both engines. The server automatic-harness
+  validator now accepts the Kiro candidate pool advertised by the client,
+  preventing bare `ai-memory run` from rejecting a discovered Kiro session
+  before launch (#356).
+- Added first-party Command Code MCP and stable lifecycle-hook support.
+  `install-mcp --client command-code` merges the documented user-scope HTTP
+  entry; `install-hooks --agent command-code` preserves existing settings and
+  registers only `SessionStart`, `PreToolUse`, `PostToolUse`, and `Stop` with
+  native session attribution, capture exclusions, and startup handoff
+  injection. `ai-memory run command-code` now adds v3 checkout-scoped
+  transcript discovery, exact `--session <uuid>` resume, automatic harness
+  selection, native `--yolo` translation, and a visible-event allowlist that
+  retains branch parent ids and summaries while excluding hidden reasoning,
+  images, custom/Mod records, and provider metadata. Deterministic acceptance
+  covers fresh, resume, and incremental-import round trips. Experimental unsandboxed Mods remain
+  excluded, and the turn-only Stop boundary is documented with the manual
+  finalizer workflow (#373).
+- `ai-memory finalize-session --session-id <uuid>` targets exactly one open
+  session instead of "the latest open one for this agent+scope". Agents with
+  no true SessionEnd hook (Kiro CLI, Codex, Antigravity CLI) rely on
+  `finalize-session` to synthesize the summary+handoff, and the
+  newest-first default breaks down with several concurrent sessions for the
+  same agent in one project — e.g. multiple terminal tabs each running Kiro
+  CLI against the same repo — where it can close out a still-active session
+  instead of the one that actually finished. Backed by a new optional
+  `session_id` filter on `GET /admin/open-sessions`, composed with (not
+  bypassing) the existing owner filter: a session id belonging to another
+  operator is still unreachable without `--all-owners`, same as the default
+  query ([#374]).
+
+### Fixed
+- Kimi Code 0.34.0 managed runs now discover checkout-local sessions from the
+  current `state.json` `cwd` field as well as the legacy `workDir` alias. The
+  parser rejects conflicting aliases and persisted ids that disagree with the
+  session directory, and deterministic acceptance now exercises the current
+  state schema (#382).
+- Prevented delayed post-tool and shutdown hook tails from redirecting the
+  shared active-project fallback after work moved to another project. Only
+  session starts, user prompts, and pre-tool events now advance shared or
+  identity-only fallbacks; other events refresh exact session mappings, and
+  dropped-subagent preflight no longer publishes scope (#372).
+- The Anthropic provider stopped sending `temperature` to Claude 4.7 and later
+  models, including the Claude 5 families, and to Claude Mythos Preview. Those
+  models reject non-default sampling parameters, which made `bootstrap`,
+  consolidation, `lint`, and auto-improvement fail with an upstream 400. Both
+  `anthropic` and `anthropic-oauth` now omit the field for affected models and
+  preserve it elsewhere. `llm-test` also sends a representative 0.2 value
+  before provider normalization, so it exercises the same compatibility path
+  as the real pipeline (#377).
+- Both wrappers (`bin/ai-memory` and `bin/ai-memory.ps1`) now forward
+  `ANTHROPIC_OAUTH_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN` to the helper
+  container. Their API-key counterparts were already in the passthrough list,
+  so subscription-token setups (`claude setup-token`,
+  `AI_MEMORY_LLM_PROVIDER=anthropic-oauth`) silently lost their credential at
+  the container boundary. The visible symptom is that the retry `status`
+  itself recommends — `llm-test --provider anthropic-oauth` — fails with a
+  missing-token error, because `llm-test` runs client-side in the helper
+  rather than on the server. The PowerShell wrapper also trims trailing path
+  separators as individual characters, so Windows invocations reach Docker
+  instead of failing during path normalization (#379).
+
+## [1.24.0] - 2026-08-04
+
+### Added
+- MCP-only clients are now visible in the operator's traffic picture.
+  Every MCP tool call is counted against its caller — the sanitized
+  `clientInfo.name` from the initialize handshake when the HTTP
+  transport runs stateful (`--http-stateful`) or over stdio, else the
+  `X-Memory-Actor-Agent` overlay an ingress proxy asserts, else
+  `unknown` — split into reads and writes and bucketed per UTC day in a
+  new `client_activity` table (V46). A new multi-user root-gated
+  `GET /admin/activity/by-client?since_days=N` reports the aggregate,
+  volume-descending with a name tiebreak (`0`/absent = whole history).
+  Counts buffer in memory and flush from one background task on a one-minute
+  interval, even when the server becomes quiet; failed batches remain bounded
+  in memory and retry once per interval. Process exit can still lose the
+  current interval. Each UTC day retains at most 128 distinct names and folds
+  additional names into `other`, preventing untrusted client names from
+  causing traffic-proportional row growth. Unknown future tools count as
+  writes, so an unclassified tool surfaces as suspicious growth instead of
+  hiding among reads. This complements
+  `/admin/sessions/by-agent`: hook-driven agents open sessions,
+  MCP-only clients (VS Code Copilot, Claude Desktop, scripts) never do,
+  and until now left no trace at all. (#366)
+- Added explicit Kiro CLI v2 managed-workstream launches through `ai-memory run
+  kiro` / `kiro-cli`, including native `--resume-id` reuse, `$KIRO_HOME`
+  discovery, v2 `--yolo` translation, read-only visible-event import, and
+  checkout-scoped UUID/metadata validation. Non-v2 engines pass through
+  without session injection. Kiro remains outside bare automatic selection
+  until a logged-in current-format acceptance run is available, and v3 managed
+  sessions remain unsupported (#356).
+- Added verified Kiro CLI lifecycle hooks for both incompatible engines. The
+  existing `kiro` / `kiro-cli` target keeps v2's camelCase hooks in agent
+  configs; the explicit `kiro-cli-v3` target atomically merges Kiro's
+  standalone `v1` registration under `$KIRO_HOME/hooks`. Both preserve
+  unrelated entries and project strategies, infer remote MCP connectivity,
+  inject startup handoffs, enforce capture exclusions for documented file-tool
+  payloads, and uninstall only proven ai-memory entries (#355).
+- Added `[consolidation] max_input_tokens` and `max_output_tokens`
+  (`AI_MEMORY_CONSOLIDATION__MAX_INPUT_TOKENS` /
+  `AI_MEMORY_CONSOLIDATION__MAX_OUTPUT_TOKENS`) for provider-specific context
+  limits. Input sizing now accounts for the rendered system/user messages,
+  bounded current-page or slot context, structured-output schema, and provider
+  envelope reserve instead of budgeting only the observation dump. Unsupported
+  minimums are rejected at startup (#369).
+
+### Fixed
+- Mixed-case and trailing-period usernames now use deterministic hashed
+  per-operator slot namespaces, preventing distinct identities from sharing one
+  physical directory on case-insensitive filesystems (#364).
+- Consolidation prompts no longer ignore system, schema, instructions, and
+  dynamic slot/current-page overhead when allocating observations. The
+  provider-neutral estimate is deliberately conservative and documents the
+  remaining tokenizer variance instead of claiming an exact token ceiling
+  (#369).
+- A failing LLM no longer costs a session its PreCompact/PostCompaction
+  checkpoint. Provider failures (context overflow, rate limit, outage) and
+  unmappable structured output now degrade to the rule-based checkpoint a
+  zero-LLM install writes, so configuring a provider can no longer be worse
+  than leaving it unset. The fallback keeps the `consolidate` admission event;
+  admission rejections, wiki/store failures, and unresolvable sessions still
+  fail closed (#369).
+- Native-session checkout matching now fails closed when either path cannot be
+  canonicalized, instead of treating two missing or inaccessible paths as the
+  same checkout during managed resume or adoption (#356).
+
+## [1.23.0] - 2026-08-03
+
+### Changed
+- Documented provider-neutral coexistence with structural code-intelligence
+  tools: use ai-memory for historical intent and continuity, use the current
+  checkout or structural provider for live symbols and impact analysis, verify
+  historical structural claims before acting, and keep source, builds, tests,
+  and observed runtime behavior authoritative. No provider coupling, automatic
+  querying, or persisted structural-evidence schema was added (#353).
+
+### Fixed
+- Antigravity CLI's generated native `PreToolUse` hook now returns the required
+  `{"decision":"allow"}` response on normal capture, malformed input, and
+  capture-policy drops. Local installs default to the native spool-based hook
+  command, whose generic `{}` response caused Antigravity to deny every tool
+  call even though the staged shell and PowerShell hooks already returned the
+  correct decision (#352).
+
+### Added
+- Kiro CLI is now supported as an MCP-only client through `install-mcp
+  --client kiro-cli` (alias `kiro`). The installer preserves existing
+  `$KIRO_HOME/settings/mcp.json` content, adds bearer headers when configured,
+  honors `$KIRO_HOME`, and appends a Bedrock schema flavor that removes only
+  unsupported root-level JSON Schema combinators. Non-loopback Kiro endpoints
+  must use HTTPS and are rejected before `--apply` writes an unusable config.
+  Kiro lifecycle hooks and managed workstreams remain deferred because its v2
+  and early-access v3 engines use incompatible hook and session formats
+  (#351).
+- Added `ai-memory continue`, which resumes the most recently launched managed
+  checkout from any directory. `run`'s bare mode already continues the current
+  checkout, but its workstream lookup is keyed by repository and worktree
+  fingerprints, so it requires a `cd` first. `continue` orders the client-local
+  checkout links by their `linked_at` stamp, revalidates the newest one's path
+  and resolved scope, and then delegates to the same bare-mode launch. Stale,
+  retargeted, scope-mismatched, or corrupt-ordering links are announced on
+  stderr and skipped rather than silently resuming a different project. It
+  accepts `--workspace`,
+  `--yolo`, and `--fresh`; native harness arguments and `--executable` remain
+  unavailable because bare mode does not know which harness it will pick.
+  Docker-wrapper installs route the command through the checksum-verified host
+  client so it can inspect local checkouts, session stores, and harnesses
+  (#350).
+- New `GET /admin/sessions/by-agent` endpoint reporting how many sessions
+  each agent CLI opened in one scope (`claude-code`, `cursor`, `codex`, …),
+  so a dashboard can answer "where is this project's memory coming from".
+  `sessions.agent_kind` already carried the answer but no read surface
+  exposed it — the existing `/admin/open-sessions` takes the agent as a
+  *filter* and returns neither the kind nor a total. Counts cover open and
+  ended sessions alike, take an optional `since_days` window (`0` or absent
+  = whole history), and order count-descending with an agent-name tiebreak
+  so equal counts do not reorder between calls. Like the other scoped admin
+  reads it reports the caller's own sessions plus unowned ones, with
+  `all_owners=true` as the recovery switch. Unknown scopes 404 rather than
+  being auto-created. No migration. (#349)
+
+## [1.22.0] - 2026-08-01
+
+### Added
+- Added `ai-memory show`, a project-first managed launcher that joins private
+  client-local checkout links with public server project metadata and a bounded
+  local scan, then launches an installed harness without changing the parent
+  process directory. It supports discovery-only `--json`, stages new projects
+  atomically with routing and Agent Skills, keeps remote-server filesystem paths
+  private, refreshes links after successful managed prepares and CLI
+  rename/move operations, and runs host-side through the Docker wrapper (#342).
+- Hook ingestion now recognizes Hermes Agent as a concrete session kind and
+  understands its documented shell-hook `tool_name` / `tool_input` envelope
+  for bounded tool-family titles and capture exclusions. Migration V44 expands
+  the session allowlist without losing session ownership, observation
+  watermarks, indexes, or scope-pairing triggers. This remains protocol support,
+  not a first-party Hermes installer, and session-start handoff acceptance stays
+  disabled because Hermes ignores that hook's stdout (#337).
+- Trusted-proxy identity now has a dedicated
+  `[auth].actor_proxy_bearer_token`, distinct from the root bearer. Proxy
+  requests must assert either a username or the complete OIDC issuer/subject
+  pair; missing, partial, duplicated, or comma-folded identity headers fail
+  closed. Proxied root access requires the configured OIDC issuer/subject pair;
+  a display username never grants root. Ordinary root and DB-user requests
+  continue to ignore raw actor headers, and leaving the proxy token unset
+  preserves existing behavior (#333).
+- Qualified identity keys now keep usernames separate from OIDC
+  `(issuer, subject)` pairs and drive active-project routing consistently for
+  hook and MCP requests. The stable OIDC pair outranks display usernames, so
+  same-subject users from different issuers cannot alias each other (#333).
+- The `/admin/*` route layer and the MCP `memory_forget_sweep` tool now ask
+  "does this deployment distinguish operators" instead of "do `users` rows
+  exist", so a trusted-proxy deployment — which never writes a `users` row —
+  gets root-only admin gating instead of waving every proxied caller through
+  the single-operator escape hatch (#333).
+- Optional `[slots] per_user` namespaced engine-written memory slots by the
+  authenticated operator. Session briefs and consolidation prompts now receive
+  shared slots plus that operator's own bounded namespace, while foreign slot
+  writes are refused. The feature defaults off, preserves existing shared
+  slots, and intentionally leaves exact wiki reads and searches project-wide
+  because it is an agent-context injection boundary rather than RBAC (#335).
+- Handoffs now belong to the operator that created them (migration V39). On a
+  server shared by several people the open-handoff lookup was scoped by
+  `(workspace, project, state)` alone, so the next session to start — whoever it
+  belonged to — consumed the pending baton, and delivery is destructive, so the
+  author simply lost it. `cwd` did not help: a handoff created through
+  `memory_handoff_begin` is always manual (`from_session_id = NULL`), and manual
+  handoffs bypass the cwd check and outrank automatic ones, so the deliberate
+  artefact was exactly the one that crossed operators. Ownership is now checked
+  before those rules, and the owner column holds the qualified
+  `IdentityKey::storage_key()` TEXT. `memory_handoff_begin` gains `shared: true`
+  to publish a baton to the whole project on purpose; `memory_handoff_accept`
+  gains `any_owner: true` for recovery. A NULL owner still means "shared", so
+  every stored row and every caller without an authenticated actor behaves
+  exactly as before (#334).
+- Sessions record their operator (migration V40), and the open-session lookup
+  behind `GET /admin/open-sessions` is scoped to the caller unless
+  `all_owners=true`. `finalize-session` drives off that lookup and acts
+  destructively on the result — ending the session, synthesising a page from its
+  observations and minting a handoff carrying its raw prompts — so picking "the
+  newest open session in the scope" could do all of that to a colleague's live
+  session. The new `--all-owners` flag exposes the server switch (#334).
+- New `GET /api/v1/workspaces/{workspace}/projects/{project}/handoffs` lists a
+  project's handoffs, filtered by `state` and scoped by owner, backed by new
+  non-partial indexes (migration V41) since every pre-existing handoffs index is
+  partial on `state = 'open'`. There was no handoff listing anywhere in the
+  system: readers only ever fetched the single pending one and consumed it, so a
+  mis-delivered baton could not be inspected or recovered. On a server that
+  authenticates, the prompt-derived fields (`summary`, `open_questions`,
+  `next_steps`) are served to a caller the server can name and to the root
+  operator, and are omitted with `redacted: true` for a caller it can place as
+  neither — unowned rows are shared, so such a caller matches every one of them,
+  and unlike the overview's single newest card this returns the project's whole
+  history. Cross-owner reads require the explicit root-only
+  `all_owners=true` recovery switch. The metadata is served either way,
+  which is what makes the listing useful; a server with no auth configured
+  serves the bodies too, since it already serves every page body
+  unauthenticated (#334).
+- New admission-chain operations `handoff_begin`, `handoff_accept` and
+  `handoff_cancel`. Handoffs live in their own table, so their lifecycle never
+  passed through `Wiki::write_page` and was invisible to admission webhooks —
+  leaving the operations that move prompt-derived text between operators
+  unauthorizable. Every path raising one of them asks and announces in the same
+  order: only the webhooks that can refuse (blocking + reject policy) are
+  awaited before the operation, and observers are dispatched fire-and-forget
+  after it, only if it happened — so `memory_handoff_accept`, whose routine
+  answer is `{"handoff": null}`, never announces an accept that found nothing,
+  and a mirror is never told about a baton the engine then abandoned. The
+  automatic SessionEnd handoff and the session-start claim run through the same
+  chain as their operator-triggered counterparts, forwarding the caller's
+  webhook skip-list under the same root-only rule as every other transport.
+  Neither can cost an operator anything beyond the operation the webhook
+  declined: SessionEnd still writes the summary page, runs the opt-in
+  consolidation and commits (a refusal skips the baton and is logged), and a
+  refused, timed-out or unreachable claim leaves the handoff open for the next
+  session (#334).
+- Pending auto-improve proposals record who staged them (V42
+  `staged_by_actor_user`, the qualified identity key, surfaced on the proposal
+  detail), and the one-pending-per-target rule is scoped per operator through
+  a NULL-collapsing unique index, so one operator's pending suggestion stops
+  blocking everybody else's for the same page while every unattributed caller
+  keeps the original one-per-page rule unchanged (#336).
+- Page reinforcement records each distinct authenticated operator (V43
+  `page_access`) beside the existing shared access counter. The opt-in
+  `[decay] breadth_weight` term (default `0.0`) lets the forget sweep retain
+  pages reinforced by several operators without changing existing scores at
+  the default or for pages with zero or one identified reader (#336).
+
+- `run` accepts `antigravity` (aliases `antigravity-cli`, `agy`) as a
+  managed harness, so an Antigravity session joins the same workstream as the
+  Claude Code or Codex sessions on the same checkout. `agy` accepts no
+  caller-chosen id for a new conversation, so a fresh launch injects no
+  selector and the id is linked by the hooks or discovered afterwards; a
+  linked resume passes `--conversation <id>`, and `--continue` / `-c` is
+  respected as an explicit user choice. `--yolo` maps to
+  `--dangerously-skip-permissions`, and the utility
+  subcommands (`models`, `plugin`, `update`, …) pass through without a selector.
+  Conversation discovery reads the per-conversation SQLite databases under
+  `~/.gemini/antigravity-cli/conversations/`: the id is the file name and the
+  workspace comes from two observed protobuf fields, so only conversations
+  opened on the current directory are offered and a database from another `agy`
+  version is skipped instead of failing the listing. Step payloads are
+  undocumented, unversioned protobuf, so conversation text is deliberately not
+  decoded — the visible-event ledger for this harness comes from lifecycle-hook
+  capture, and transcript export fails with a message saying so. Antigravity is
+  not part of the no-argument auto-detection pool. The native contract was
+  verified against Antigravity CLI v1.1.7 (#345).
+
+### Fixed
+- `run` on Windows now resolves npm-style harness installs through `PATHEXT`
+  and starts the resolved wrapper. This avoids accepting an extensionless Unix
+  shell shim such as `opencode` during availability checks and then failing to
+  launch it when the adjacent `opencode.cmd` is the Windows entry point. Unix
+  resolution remains unchanged (#343).
+- `memory_auto_improve` without a `session_id` now selects the newest
+  completed session that has no persisted auto-improvement run. Preflight-
+  skipped sessions therefore advance the implicit manual-review queue instead
+  of permanently starving older sessions; passing an explicit session ID still
+  permits a targeted rerun (#338).
+- Handoff and session ownership is stamped only where the deployment actually
+  distinguishes operators. A server with `[auth].bearer_token` +
+  `[auth].root_username`, no `users` rows and no proxy has one operator and two
+  transports: stamping that one name on every HTTP write while the stdio /
+  in-process transport carries no actor would make one person's handoffs and
+  sessions invisible to their own other transport on the same data directory.
+  With nobody to separate, the stamp is the pre-ownership `NULL` and both
+  transports agree. Reads are deliberately not gated the same way, so rows
+  stamped while a deployment did distinguish operators stay readable by that
+  operator afterwards (#334).
+- The automatic SessionEnd handoff, the session page and both consolidation
+  paths attribute to the operator recorded on the **session**, not to whoever
+  delivered the event — a spool drain, a shared hook token or an operator
+  finalizing a stuck session all carry a different identity. The atomic store
+  operation also rejects a handoff whose owner differs from its source session
+  (#334).
+- Briefings and both read-only overviews — workspace and project — scope
+  handoffs to the requesting actor instead of showing only unowned ones, and
+  `pending_handoff_count` applies the same filter as the fetch — otherwise a
+  briefing advertises a pending baton the same caller can never retrieve, and on
+  any server that stamps owners the overview's handoff card would go permanently
+  empty while the count beside it kept reporting the row. The read-only
+  `/api/v1` overview no longer surfaces handoffs that belong to a specific
+  operator, including the raw prompt text an automatic handoff is synthesised
+  from, to a browser the server cannot attribute (#334).
+- Retiring superseded automatic handoffs no longer crosses an operator
+  boundary. Both sweeps — the same-cwd expiry on a new SessionEnd handoff and
+  the post-claim cleanup after an accept — match on the acting handoff's
+  `owner_user`, so one person starting or ending a session in a directory
+  cannot expire another person's pending baton. A shared handoff (no owner) is
+  visible to everyone, so it is only ever superseded by another shared one; on
+  a single-operator or unauthenticated server every row is unowned and the
+  sweeps behave exactly as they did (#334).
+- `ops::accept_handoff` propagates whether the claim actually succeeded, so
+  `memory_handoff_accept` no longer returns the handoff body when the atomic
+  claim was lost — previously two agents could be handed the same baton. The
+  cross-operator escape hatches require admin authority: `any_owner` on
+  `memory_handoff_accept` and on `memory_handoff_cancel` (which previously had
+  no recovery path at all, so a handoff whose owner no longer matched any
+  reachable identity could not be discarded), and `--all-owners` on
+  `ai-memory finalize-session` (#334).
+- The `[auto_scope] per_actor` active-project map is keyed by the qualified
+  identity on both sides — the hook ingress that publishes and the MCP tools
+  that read — so an OIDC-proxied operator's writes and reads land on the same
+  slot instead of silently missing on every read (#334).
+- Owner predicates for pending and exact-id handoff reads now execute in SQL
+  before prompt-derived fields are loaded. Exact-id cancellation returns the
+  same result for absent, wrong-scope and foreign-owner ids, so it no longer
+  discloses another operator's handoff state before authorization. Accept and
+  cancel also recheck the expected workspace and project in the atomic state
+  update, closing a lifecycle race between the scoped read and destructive
+  write (#334).
+- Ownership writes reject malformed identity keys, and malformed non-null
+  session-owner keys already present in the database fail closed during hook
+  processing instead of being converted to the shared `NULL` bucket.
+  Named-user handoff history uses two indexed shared/owned ranges, so a large
+  volume of another operator's rows cannot turn a bounded listing into a
+  project-wide scan (#334).
+- Actor-scoped briefing, overview and handoff-history responses now use
+  `Cache-Control: private, no-store`, preventing a browser from reusing one
+  operator's prompt-derived response after credentials at the same URL change
+  to another operator (#334).
+- Automatic session-start handoff admission is capped at 750 ms, below the
+  shortest shipped client's one-second fetch timeout. A slow deciding webhook
+  leaves the baton open instead of approving and consuming it after the caller
+  has disconnected (#334).
+- A staged auto-improve proposal colliding with one already pending no longer
+  aborts its whole staging run (losing the run row, its sibling proposals and
+  the paid LLM review): the colliding proposal alone is skipped, and every
+  staging surface — `memory_auto_improve`, `/admin/auto-improve`, the
+  telemetry report, the curator, the CLI and the scheduler's log — names the
+  skipped target and the reason instead of silently returning N-1 proposals
+  (#336).
+
+## [1.21.0] - 2026-07-31
+
+### Added
+- Per-page TTL via a frontmatter `expires_at:` key (RFC3339, or a bare
+  `YYYY-MM-DD` meaning end of that day UTC), mirrored into a new
+  `pages.expires_at` column (V36) and settable through a new optional
+  `expires_at` parameter on `memory_write_page`. Expired pages are hidden
+  from `memory_query`/`memory_recent`/briefing/session-brief surfaces —
+  `memory_query` gains `include_expired: true` to still see them — while
+  exact-path reads still return the page, annotated `expired: true`,
+  because an explicit read is not a search. The forget sweep hard-deletes
+  them through the wiki layer, so the markdown file goes too, not just
+  the rows. An explicit TTL outranks `pinned` (a pin means "don't decay
+  this", not "keep it past the date its author set"); `memory_lint`
+  flags pinned+expiring pages so the combination is visible rather than
+  silent. (#309)
+- Zed editor as an MCP-only client. `install-mcp --client zed` renders,
+  and `--apply` idempotently merges, a native remote HTTP entry under the
+  top-level `context_servers` map in Zed's platform user `settings.json`,
+  with optional bearer headers. The JSONC-aware apply and uninstall paths
+  preserve user comments, trailing commas, unrelated settings, and sibling
+  servers while changing only the matching ai-memory entry. Zed does not
+  provide lifecycle hooks or managed-workstream continuity. (#321)
+- Entity-match retrieval as a fourth RRF stream (V38 `entities` +
+  `entity_page_links`). Consolidation emits up to 10 normalized technologies,
+  components, services, files, or domain nouns per page into frontmatter;
+  manually edited `entities` use the same index path, and reindex rebuilds the
+  derived tables from markdown. Project-scoped query tokens match exact names,
+  name prefixes, or word prefixes inside compound names and are weighted by
+  inverse entity frequency before RRF fusion and the existing authority and
+  optional LLM reranking stages. Empty entity indexes contribute no candidates
+  or score, and entity matching makes no LLM call. `explain: true` reports the
+  entity stream's rank, raw inverse-frequency weight, contribution, and matched
+  names. (#320)
+- Optional post-RRF reranking for project and explicit-scope
+  `memory_query`, off by default. Set `AI_MEMORY_RERANKER=llm` (requires
+  `AI_MEMORY_LLM_PROVIDER`) to over-fetch candidates, fuse scopes, and
+  make at most one structured-output call through any existing LLM
+  provider. The prompt JSON-encodes untrusted input and sends the query
+  (up to 1,000 bytes) plus at most 30 page titles (200 bytes each) and
+  snippets (600 bytes each) to that provider. The requested result limit
+  is preserved even above 30; only the first 30 candidates are judged.
+  A partial/duplicate/unknown id set, invalid score, timeout, provider error,
+  or four-call concurrency saturation preserves the pre-rerank order.
+  `global=true` and supplemental
+  global-preference hits keep their existing non-RRF ranking. With
+  `explain: true`, judged hits include `rerank_score`. Unknown reranker
+  values and `llm` without a provider fail at startup. (#319)
+- New MCP tool `memory_feedback` (17th tool) — the "finer-grained
+  reinforcement beyond access counts" P2 item. Record how useful a
+  recalled page actually was by exact path: `helpful` / `not_helpful`
+  step the page's new `pages.salience` column (V37, bounded to
+  `[0.25, 2.0]` in 0.25 steps), which now scales the retention formula's
+  time term for sweep-eligible episodic pages instead of a single global
+  `salience_default`; `stale` /
+  `wrong` floor the salience AND surface the page as a
+  `feedback_flagged` finding in the next `memory_lint` report. Signals
+  land in a new append-only `page_feedback` table with an optional
+  sanitized, bounded single-line reason, the resulting salience needed to
+  rebuild derived state, and a full audit-log entry. Nothing is ever
+  deleted by feedback. The exact path resolves to the current page version
+  in the feedback transaction, so rewriting a flagged page later retires
+  both its salience and its lint findings — there is no separate dismissal
+  state. Pages without feedback keep `salience = NULL`, which reads as
+  exactly the previous behaviour. Retrieved content cannot authorize a
+  feedback call; agents treat it as untrusted data. (#318)
+- `memory_query` gained an optional `explain: true` mode for project and
+  explicit-scope searches. Each compiled-page hit then includes its 1-based
+  FTS5, entity, vector, and graph ranks; raw BM25/cosine/entity values; matched
+  entity names; graph seed and link direction; per-stream RRF contributions;
+  fused score; and bounded authority multiplier. `streams_active` makes vector
+  degradation visible. Global
+  cross-project search reports its distinct FTS-only stream but does not attach
+  RRF details to `global_hits`. Explain provenance is computed only when
+  requested. (#317)
+- Per-project consolidation instructions: write a reserved
+  `_prompts/consolidation.md` wiki page (via `memory_write_page` or on
+  disk - no config key) and its body is appended to both single-page and
+  multi-page consolidation prompts as advisory preferences ("prefer
+  Portuguese titles", "skip CI noise", ...). The block is scrubbed
+  through the configured sanitizer, capped at 2,000 characters, JSON-encoded,
+  and injected into the LLM user message under an explicitly untrusted,
+  schema-subordinate system-prompt contract. `memory_consolidate` also gained
+  an optional `instructions` argument that overrides the page for one call;
+  TTL-expired standing pages are ignored. (#316)
+
+### Fixed
+- Zero-embedding startup and current retrieval descriptions now include the
+  entity-match stream, and release notes attribute per-page TTL to the release
+  where it shipped. (#329)
+- Retrieved `_rules/`, `gotchas/`, `procedures/`, and `decisions/` pages are now
+  described consistently across MCP and installed skill prompts as untrusted
+  historical evidence, removing contradictory language that elevated stored
+  prose into operating policy or constraints. (#325)
+- A project-scoped forget sweep now purges aged decay tombstones only from its
+  resolved workspace/project instead of deleting eligible derived rows across
+  every project. Entity-index rows orphaned by the scoped purge are removed in
+  the same transaction, and `hard_deleted` reports only the target scope. (#323)
+- Zero-LLM `memory_query` now keeps graph-neighbour expansion active instead
+  of falling back to FTS5 alone when no query embedding exists. Equal adjusted
+  hybrid and explicit multi-scope scores now use a deterministic path
+  tiebreak. (#317)
+
+## [1.20.2] - 2026-07-30
+
+### Fixed
+- Docker build contexts now exclude the gitignored operator deployment files,
+  preventing local server configuration and production environment secrets
+  from being sent to the Docker builder. A packaging regression test keeps the
+  exclusions as the final ignore rules so later negations cannot re-include
+  them. (#314)
+- Managed workstream heartbeats now bound each server request and condense an
+  outage into one short notice plus one recovery notice. Active launchers keep
+  the lease-safe 30-second retry cadence without printing the same timeout on
+  every attempt, and may renew their original run after a longer outage unless
+  another launcher has already claimed the workstream. (#311)
+
+## [1.20.1] - 2026-07-30
+
+### Fixed
+- Managed workstream packets, handoffs, project briefs, MCP routing prompts,
+  and all LLM maintenance prompts now identify stored project material as
+  untrusted historical data rather than executable instructions. This limits
+  persistent prompt injection through captured prompts, tool output, wiki
+  pages, commit messages, or another authenticated user's shared content.
+  (#302)
+- Docker wrapper installation and self-upgrade now use checksum-verified assets
+  from the latest GitHub Release instead of executing the mutable `main` branch.
+  The standalone hook installer and hook bundle use the same verified release
+  path and install only the expected hook members without extracting arbitrary
+  archive paths. Release jobs publish POSIX/Windows wrapper and hook assets with
+  SHA-256 companions, all GitHub Actions are commit-pinned, and default
+  workflow permissions are read-only outside the release publisher.
+  (#302)
+
+## [1.20.0] - 2026-07-30
+
+### Added
+- New `openai-compat` embedding provider for self-hosted engines
+  (Ollama, LM Studio, vLLM). Set
+  `AI_MEMORY_EMBEDDING_PROVIDER=openai-compat` together with explicit
+  `AI_MEMORY_EMBEDDING_BASE_URL`, `AI_MEMORY_EMBEDDING_MODEL`, and
+  `AI_MEMORY_EMBEDDING_DIM` — there is no safe default model or
+  dimensionality for a self-hosted engine, so each is required rather
+  than guessed. Unlike the other providers it is keyless: a bearer
+  token is sent only when `LLM_API_KEY` is present, for gateways that
+  want one. Embeddings are stored under their own
+  `provider="openai-compat"` identity, so switching an existing
+  `openai`+base-URL setup over changes the stored
+  `{provider, model, dim}` triple — run `ai-memory embed --force` to
+  re-embed. (#300)
+
+### Fixed
+- Antigravity CLI's `PreInvocation` hook now maps only its documented
+  `invocationNum = 0` call to ai-memory's synthetic `SessionStart`. Later model
+  invocations perform no capture or destructive handoff fetch, so a manual
+  handoff created while the conversation winds down remains open for the next
+  session. Native Windows hooks also emit Antigravity's required `injectSteps`
+  envelope instead of Claude Code's `hookSpecificOutput` shape. (#298)
+- Automatic handoff selection now prefers the newest cwd-eligible session over
+  a stale, more-specific ancestor. A new automatic handoff expires prior open
+  automatic handoffs from the exact cwd, and accepting the winner atomically
+  expires older eligible automatic handoffs. Manual and sibling-directory
+  handoffs remain open, preventing stale delivery and inflated pending counts.
+  (#293)
+- OpenAI-compatible providers now send each structured operation's JSON Schema
+  through `response_format=json_schema` by default, so local models cannot
+  replace consolidation JSON with prose or omit required fields. Explicit
+  structured-output capability rejections fall back to the tolerant parser;
+  other HTTP failures still propagate, and
+  `AI_MEMORY_LLM_COMPAT_STRICT=false` remains the compatibility opt-out. (#292)
+- Recognized Antigravity CLI's native file/edit and search tools, applied path
+  exclusions to its `TargetFile` operations, and captured bounded successful
+  edit content from `toolCall.args` when the hook omits an output field. Generic
+  MCP/resource tools remain fail-closed until their path schemas are proven,
+  while failed edits retain their error instead of attempted content. (#294)
+
+## [1.19.2] - 2026-07-28
+
+### Fixed
+- Source installation no longer fails when `cargo install --path` resolves
+  rmcp 1.8, whose `peer_info()` return type differs from rmcp 1.7. CI now checks
+  the unlocked source-install resolution separately from the workspace's
+  lock-aware gates, while the documented persistent Windows install uses
+  `--locked` for reproducibility. (#285)
+- Antigravity CLI hook installation and documentation now expose the existing
+  agent-aware manual finalizer:
+  `ai-memory finalize-session --agent antigravity-cli`. Antigravity's `Stop`
+  event ends one execution loop rather than the conversation, so it remains a
+  normal observation; the explicit command closes the latest scoped session
+  through the canonical SessionEnd path, producing its summary and automatic
+  handoff and queueing opt-in consolidation. The docs also clarify that
+  `memory_handoff_begin` deliberately creates a session-neutral, project-wide
+  manual handoff for every MCP client; attributed handoffs come from canonical
+  SessionEnd processing. (#284)
+
+## [1.19.1] - 2026-07-27
+
+### Changed
+- Wiki search now applies a bounded source-authority adjustment after FTS5,
+  graph, and optional vector candidate generation. Canonical rules, decisions,
+  procedures, gotchas, semantic/procedural tiers, `pinned` pages, and
+  `canonical` / `active` / `source-of-truth` tags win close relevance contests;
+  episodic sessions, `_lint/` output, investigations, and pages tagged
+  `superseded`, `historical`, `test-fixture`, or `do-not-answer-from` are
+  downgraded but remain searchable. Exact session-only queries still retrieve
+  their evidence, and the returned `rank` includes the bounded adjustment so
+  multi-scope merging preserves the same order. (#269)
+- Client CLI commands now resolve their `(workspace, project)` from the
+  nearest `.ai-memory.toml` marker, not just the lifecycle hooks. Previously
+  only the hook path read the marker, so a checkout declaring
+  `workspace = "acme"` had its captures land in `acme` while `run`,
+  `bootstrap`, `search`, `write-page` and every other scope-taking command
+  resolved into `default` — the same repository split across two scopes, with
+  `ai-memory run`'s managed workstream stranded on the wrong side. Each field
+  still prefers an explicit flag; when the marker decides one, the command
+  announces the resolved scope on stderr, naming which half the marker
+  decided. `AI_MEMORY_IGNORE_MARKER=1` restores the previous resolution for
+  one invocation (client commands only — the hooks keep reading the marker).
+  `embed --force` without `--project` still fans out across the workspace and
+  no longer needs a derivable project name. `ai-memory serve` is unchanged:
+  it has no caller cwd, and its `--workspace` / `--project` remain the baked
+  fallback for hook events without a usable one. (#259)
+- Marker discovery now stays inside its trust boundary when the caller's cwd
+  is outside `$HOME`: it walks no higher than the nearest checkout root, or
+  checks only cwd for a non-git directory. Workspace-only markers also keep
+  the hooks' documented `project = basename(cwd)` behavior for CLI commands,
+  including subdirectories and linked worktrees. (#259)
+
+### Fixed
+- Scheduled hollow-project cleanup now treats managed workstreams as project
+  data. Older projects whose only history is a managed workstream, including
+  those with a live run, are no longer cascade-deleted out from under the
+  workstream heartbeat or left with orphaned transcript segments. (#279)
+- Hybrid search now gives its FTS, vector, and graph streams the same bounded
+  candidate window used by authority-aware FTS search. Small result limits no
+  longer exclude a canonical page before post-fusion authority ranking can
+  promote it, and candidate-limit arithmetic is saturating throughout. (#277)
+- Forced workspace deletion now removes the immutable managed-workstream
+  segment directories whose database rows are removed by the workspace
+  cascade. Its admin report includes workstream/run counts and IDs, and raw
+  segment cleanup participates in the existing filesystem partial-failure
+  reporting instead of leaving transcript data orphaned. (#275)
+- Lossless `move-project` true moves now re-stamp managed workstreams into the
+  destination workspace in the same transaction as the project and its other
+  denormalized child rows. Previously the project moved while its managed
+  workstreams retained the source `workspace_id`, hiding portable history from
+  destination-scope lookup and violating the project/workspace pairing
+  invariant. The admin response now reports `workstreams_moved`. (#273)
+- SessionEnd recovery now commits the ended generation and automatic handoff in
+  one SQLite transaction, then lets an already-ended native replay converge the
+  remaining wiki commit, durable consolidation enqueue, and ingest-key
+  completion. An interruption after `ended_at` can no longer strand a missing
+  handoff or permanently pending spool key, and missing or scope/agent-
+  mismatched SessionEnd events no longer attempt consolidation recovery against
+  an unrelated session. (#271)
+- Bare `install-hooks --apply` re-runs, including the Docker wrapper's
+  post-upgrade refresh, now preserve an install's baked `repo-root` project
+  strategy for every supported hook integration. An explicit
+  `--project-strategy basename` still removes the install-wide default. (#267)
+- Installer `--apply` modes now write through symlinked agent configuration
+  files instead of atomically replacing the symlink itself. Symlink chains and
+  dangling final targets are preserved, while backups remain next to the
+  user-facing configuration path. (#264)
+- SessionEnd re-consolidation now converges by comparing the current
+  observation count with a persisted count stamped by the latest completed
+  end, instead of comparing independently generated wall-clock timestamps.
+  Clock skew could otherwise leave an old observation permanently "new" and
+  repeatedly rewrite the same session page, handoff, and opt-in LLM job with no
+  agent activity. Existing ended sessions are baselined during migration so an
+  upgrade does not enqueue historical catch-up work. (#268)
+- Capture exclusions now canonicalize an existing hook working directory
+  before matching paths, so filesystem aliases such as macOS `/var` versus
+  `/private/var` cannot turn an excluded file event into a spooled event.
+  Marker discovery tests likewise accept the canonical path they request.
+  (#265)
+- Opt-in SessionEnd LLM consolidation now runs from a durable, generation-
+  idempotent queue instead of inside the hook batch request. The hook commits
+  its deterministic session page and handoff, persists the provider job, and
+  returns without waiting for LLM latency; a single bounded worker recovers
+  queued or expired-lease work after restart and makes at most five provider
+  attempts with backoff. A stale SessionEnd redelivery also repairs the
+  enqueue when the original request was cancelled just after `ended_at`, so
+  the default hook drain timeout can no longer silently strand the heuristic
+  page as the final result. (#265)
+- `purge-project` no longer deletes a project out from under a running agent.
+  `workstreams` cascades from `projects` and `managed_runs` cascades from
+  `workstreams`, so purging a scope that still held a live managed run tore
+  out its lease row: the wrapper then failed every heartbeat with
+  `409 managed run lease is not active` and the session's transcript never
+  reached the ledger. The purge now refuses with a `409` naming the offending
+  workstreams unless `--force` is passed, and its report counts the
+  `workstreams` and `managed_runs` the cascade removes; their
+  `raw/workstreams/<id>/` directories are now removed server-side and included
+  in the same filesystem success/failure report instead of being orphaned.
+  Those counters previously showed `0 pages, 0 sessions, …` and made such a
+  scope look safe to delete. Liveness is the lease, not the row state: a
+  crashed wrapper leaves `state = 'active'` behind until the next
+  `ai-memory run` sweeps it, so only a lease that has not yet expired blocks
+  the purge. `move-project`'s
+  copy-purge merge surfaces the same conflict as a `409` naming how many
+  pages were already copied, instead of a `500`; its `--force` flag only
+  overrides the active-project guard and never destroys a live managed-run
+  lease. (#259)
+
+## [1.19.0] - 2026-07-25
+
+### Fixed
+- Claude Desktop's rendered Windows MCP instructions now distinguish the
+  unpackaged `%APPDATA%` config from the detected MSIX `LocalCache` config, and
+  contributor, managed-workstream, and CLI reference docs no longer omit
+  recently shipped harnesses or commands. (#256)
+- The opt-in managed-workstream real-harness acceptance runner now verifies
+  context delivery from the managed-run cursor/acknowledgement state and a new
+  persisted assistant event instead of requiring the model to quote a prior
+  sentinel. Large Claude Code hook packets can be file-backed, so acceptance no
+  longer passes or fails based on whether the model chooses to use `Read`.
+  The deterministic fake Grok leg covers the same assertion path. (#242)
+
+### Added
+- `install-mcp --client claude-code --session-aware` now registers an
+  ai-memory-owned stdio bridge that forwards Claude Code's
+  `CLAUDE_CODE_SESSION_ID` as `X-Memory-Actor-Session-Id` on every upstream
+  HTTP MCP request. This makes `[auto_scope] mode = "per_session"` effective
+  for concurrent Claude Code sessions against local or remote servers while
+  leaving the existing static HTTP registration as the default. The bridge
+  preserves bearer auth, stateless/stateful HTTP compatibility, and uninstall
+  ownership; both Docker wrappers forward the Claude session variable into
+  the helper container. (#244)
+- `GET /admin/open-sessions` lists open (not yet ended) sessions for one
+  workspace/project/agent, newest first (`all=true` returns every match).
+  `ai-memory finalize-session` now uses this endpoint instead of opening
+  the local SQLite index directly, so every CLI command is a thin HTTP
+  client of the running server; the command now requires a reachable
+  server and no longer works against an offline data directory. (#236)
+- Managed workstream support for Grok Build CLI: `ai-memory run grok` (alias
+  `grok-build`) creates fresh sessions with a wrapper-generated `--session-id`,
+  resumes linked sessions with `--resume`, maps wrapper `--yolo` onto Grok's
+  native `--yolo`/`--always-approve`, and delivers the bounded workstream
+  context packet through Grok's native `--rules` flag (system-prompt append,
+  acknowledged only after the child spawns). Transcript import reads
+  `$GROK_HOME/sessions/*/*/chat_history.jsonl` read-only with a
+  prefix-validated cursor and content-hash event ids so rewind-driven journal
+  rewrites cannot duplicate history; system prompts and encrypted reasoning
+  are excluded as loss annotations, as are the harness-injected `<user_info>`
+  and `<system-reminder>` blocks Grok stores inside `user` records (project
+  instructions, the skills catalogue, and connected MCP servers), which would
+  otherwise leak harness internals into the portable ledger and evict real
+  conversation from the startup packet budget. Discovery
+  matches checkouts through `summary.json`'s recorded `info.cwd` and honors
+  `GROK_HOME`. Grok stays out of the bare-mode automatic pool. Verified
+  against Grok Build CLI v0.2.111 ([#237]).
+
+### Changed
+- Single-page, batch, and bootstrap consolidation prompts now ask the model
+  to connect related wiki pages with path-based wikilinks and to mirror the
+  dominant natural language of the source material while preserving code,
+  identifiers, paths, commands, error strings, and JSON field names. (#238)
+- The M8 access-counter reinforcement now bumps a page's `access_count` and
+  `last_accessed_at` at most once per minute instead of on every search that
+  returns it. A first sighting still bumps immediately, and a continuously hot
+  page remains eligible once per window, while the cooldown map self-prunes to
+  the pages searched within the window. This reduces redundant single-writer
+  work under bursty or overlapping searches while intentionally making
+  `access_count` a coarser retention signal. (#239)
+
+### Fixed
+- Managed workstream packets now carry a versioned origin marker, and Claude
+  Code transcript import excludes a tool result only when its content begins
+  with that marker (or the legacy rendered packet header). This prevents a
+  large SessionStart packet that Claude persists and later reads from
+  `tool-results/` from re-entering the ledger and recursively consuming future
+  packet budgets, while ordinary tool results that merely mention the marker
+  remain visible. (#241)
+- Lifecycle `user-prompt` and `post-compaction` bodies are now truncated
+  UTF-8-safely at 16 KiB, while notification and tool excerpts remain capped at
+  2 KB. Native hook commands apply the event cap before local spooling or
+  transport, the server repeats it for direct and older clients, and the
+  sanitized observation boundary independently caps every durable body at
+  16 KiB so neither SQLite nor observation FTS can grow to the 10 MiB HTTP
+  transport limit. (#249)
+- `ai-memory run <harness>` now verifies an ai-memory-injected native resume
+  target still exists in that harness's read-only session store. A confirmed
+  orphan starts a fresh native session and repoints the same workstream instead
+  of retrying the dead id forever. The new wrapper-owned `--fresh` flag forces
+  the same per-workstream recovery without a resume attempt or adoption prompt;
+  explicit native resume/session/fork selectors remain authoritative and
+  cannot be combined with `--fresh`. (#240)
+- `install-mcp --client claude-desktop` now detects an MSIX-packaged
+  Claude Desktop on Windows and writes to its virtualized
+  `AppData\Local\Packages\Claude_<id>\LocalCache\Roaming\Claude\claude_desktop_config.json`
+  instead of the plain `%APPDATA%\Claude\` path. Previously this
+  silently wrote a config file the running app ignored, so the MCP
+  server never appeared after restart. The detector uses Windows'
+  resolved local and roaming app-data roots, prefers an existing config
+  when multiple package directories exist, and fails with an explicit
+  `--config-file` recovery instruction when the active package is
+  ambiguous. Unpackaged installs keep resolving to the plain path.
+  (#250)
+
+- The Docker wrappers (`bin/ai-memory`, `bin/ai-memory.ps1`) kept stdin
+  attached only on a real terminal, so every piped or redirected
+  invocation reached the container with a closed stdin. `ai-memory
+  write-page --body -` therefore stored a page with frontmatter and an
+  empty body while still reporting a successful write, and the same
+  applied to any other stdin reader (hooks fed by a pipe). The wrappers
+  now always pass `-i`, while `-t` is added only when stdin and stdout are
+  both terminals. `AI_MEMORY_NO_TTY=1` disables only TTY allocation and
+  no longer disconnects stdin. (#243)
+- Managed `SessionStart` delivery now includes a pending single-use
+  handoff before the portable workstream ledger and optional project
+  brief. Handoff and ledger acknowledgements are claimed together only
+  after the complete response has been assembled; a failed or racing
+  ledger claim cannot consume the handoff or suppress retry delivery.
+  (#235)
+
+## [1.18.0] - 2026-07-23
+
+### Added
+- The store writer only accepts `Sanitized<NewObservation>`: the privacy
+  strip is enforced by the type system at the persistence boundary, so an
+  unsanitized observation cannot reach disk by construction.
+- The session-review sampler now scores a non-empty `Stop` observation just
+  below `PreCompact` (88 vs 90) instead of the low `55` prior, so the opt-in
+  assistant/Stop excerpt (a late summary or correction) competes for a sampling
+  slot while keeping the `UserPrompt` base priority higher. An empty `Stop`
+  keeps its low prior. The reviewer still sees only the first 1500 characters
+  of any observation body, so a correction inside a long excerpt must fall in
+  that window ([#196]).
+- Opt-in assistant/Stop capture for Claude Code (#196). When BOTH the server
+  (`capture_assistant = true` / `AI_MEMORY_CAPTURE_ASSISTANT=true`) and the
+  client (`install-hooks --agent claude-code --capture-assistant`) opt in, a
+  Claude Code `Stop` event carries a sanitized, 2 KB-capped excerpt of the
+  assistant's final turn as the Stop body. The client sanitizes with the
+  built-in patterns and truncates before the excerpt ever touches the spool or
+  wire, splicing a versioned `_ai_memory_assistant` marker into the body and a
+  `capture_assistant=1` flag onto the event URL; the server re-scrubs with its
+  configured `[sanitize]` patterns and re-enforces the 2 KB cap at the
+  persistence boundary (never trusting the client's length). Off by default,
+  and any gate failure (server off, wrong agent/event, malformed or
+  future-versioned marker, empty excerpt) degrades to an empty Stop with the
+  same `202` response. Assistant text is privacy-sensitive — see `SECURITY.md`
+  for what it can contain and where it flows. Script-fallback installs cannot
+  sanitize the field and drop the whole Stop event instead; move to a native
+  install to capture it.
+- Managed workstreams now support Kimi Code through `ai-memory run kimi`;
+  `kimi-code` and `kimi-cli` are accepted aliases for the installed `kimi`
+  executable.
+  Returning runs resume the linked native session with `--session <id>`;
+  fresh sessions are discovered post-exit by exact checkout match through
+  `state.json`'s `workDir` (the session bucket name is a one-way hash and is
+  never parsed). The adapter reads `$KIMI_CODE_HOME/sessions` (default
+  `~/.kimi-code/sessions`) and imports only visible user/assistant/tool
+  messages and compaction summaries from `agents/main/wire.jsonl`, excluding
+  system prompts, hidden reasoning, hook-injected context (`hook_result` and
+  related origins), and subagent transcripts. Wrapper `--yolo` maps to Kimi
+  Code's `--yolo`, and kimi joins the automatic bare-run harness pool. The
+  deterministic and opt-in real-harness acceptance paths cover Kimi creation,
+  transcript import, cross-harness delivery, and returning native resume; the
+  native contract was live-verified against Kimi Code v0.29.0.
+
+### Fixed
+- Native hook spool retries now reuse a per-entry idempotency key, so a lost
+  batch response does not duplicate observations or completed session-end
+  effects. The server claims each key atomically with its observation, resumes
+  downstream wiki/handoff work when a prior delivery stopped incomplete, and
+  skips only events already marked complete. Overlapping deliveries of the same
+  key are serialized; keys are project-scoped and expire after the spool retry
+  horizon.
+- Managed-workstream overview and command-reference documentation now
+  consistently includes Kimi Code in the supported and automatic-selection
+  harness lists.
+- Windows PowerShell fallback hooks now force text output and silence
+  non-interactive progress records. This prevents nested PowerShell runners
+  such as Antigravity CLI from reporting serialized `CLIXML` progress on every
+  hook while preserving the hook's JSON stdout. Existing script-fallback
+  installs should rerun `install-hooks --agent <agent> --apply` after upgrading
+  ([#224]).
+- Kimi Code handoffs are now delivered through the `UserPromptSubmit` hook
+  instead of `SessionStart`. Kimi Code fires `SessionStart` but discards the
+  hook's stdout/result (verified against kimi-code v0.28.1,
+  `packages/agent-core/src/session/index.ts`), so the previous hook consumed
+  pending handoffs — legacy and managed — without ever showing them to the
+  model. `UserPromptSubmit` stdout is injected as a user message before the
+  turn. The native `ai-memory hook` path now also accepts the
+  `user-prompt-submit` event token alongside `user-prompt` for kimi handoff
+  delivery. Existing native hook commands pick up the correction when the
+  binary is upgraded; script-fallback installations must re-run
+  `ai-memory install-hooks --agent kimi-code --apply` to refresh their staged
+  scripts.
+- The `[briefing]` compiled project brief is now gated to once per session
+  for Kimi Code: it rides the first user prompt (kimi discards SessionStart
+  hook stdout, so session-start delivery is impossible) and later prompts
+  keep fetching the handoff without the briefing params, so the server no
+  longer recomposes the brief on every prompt. This also works for managed
+  handoffs, creates local markers only for opted-in repositories, and retains
+  at most 512 markers. Re-briefing after `/clear` is not supported in v1.
+- Kimi Code managed transcript cursors now validate the imported byte prefix
+  before resuming. When Kimi rewrites `wire.jsonl` in place, ai-memory safely
+  replays the journal with stable event IDs instead of seeking into a changed
+  record or skipping new events.
+- Kimi Code managed transcript extraction now imports native
+  `context.append_loop_event` assistant text, tool calls, and tool results.
+  Current Kimi journals store model output in those records rather than
+  re-appending it as a completed assistant message.
+- `ai-memory run kimi server ...` now passes through Kimi Code's deprecated
+  but still functional `server` utility command instead of treating it as an
+  interactive session launch.
+
+## [1.17.3] - 2026-07-22
+
+### Fixed
+- Corrected Docker-wrapper upgrade guidance: `ai-memory upgrade` no longer
+  claims a configured remote server is stale when it cannot inspect that
+  deployment, and the install guide now makes clear that refreshing Docker
+  script hooks does not convert them to native capture-policy commands.
+
+## [1.17.2] - 2026-07-22
+
+### Added
+- `ai-memory completions <shell>` prints a shell-completion script for bash,
+  zsh, fish, PowerShell, or elvish. The script is generated from the binary's
+  own command tree, so it always matches the installed version; install paths
+  per shell are documented in `docs/shell-completions.md`. The command reads no
+  config and needs no data directory, so it works before `ai-memory init`.
+
+### Changed
+- Documented Atlas Cloud through the existing `openai-compat` provider instead
+  of adding a redundant provider type, including the endpoint, model, and API
+  key mapping needed for deployment.
+- The native hook binary now drops any raw assistant-message field (Claude
+  Code's `last_assistant_message` on `Stop`) before it can reach the local
+  spool or the wire, and drains pre-existing spooled entries with the field
+  stripped too. The server applies the same strip defensively on `/hook` and
+  `/hook/batch` before building an envelope. This field was already never
+  persisted, so there is no behavior change; it closes a raw-text exposure in
+  the spool/wire. Optional assistant/Stop capture proposed in #196 remains
+  disabled. Upgrading the binary is sufficient for native Claude Code installs;
+  script-fallback installs (Docker wrapper, `AI_MEMORY_HOOK_PLATFORM=posix`)
+  still send the raw field to the server, which strips it immediately on
+  receipt. Closing the local-wire vector requires a native client on the agent
+  host and using it to reinstall hooks; running the installer through the
+  Docker wrapper only refreshes its scripts ([#196]).
+
+### Fixed
+- Removed the unused `syntect` dependency and its `plist`, `quick-xml`,
+  `bincode`, and `yaml-rust` transitive dependencies. This eliminates two
+  high-severity `quick-xml` denial-of-service advisories and makes the prior
+  temporary cargo-audit exceptions unnecessary; ai-memory's rendered Markdown
+  behavior is unchanged because the syntax-highlighting crate was never used.
+- The Docker wrapper now buffers generated shell completions before streaming
+  them to stdout. Piping `ai-memory completions <shell>` into a short-lived
+  consumer such as `head` no longer exposes Docker's own broken-pipe error or
+  non-zero exit after the native command completed successfully; real helper
+  container failures still propagate without printing a partial script.
+- The Linux Docker wrapper now detects an SELinux-enforcing host plus a
+  SELinux-enabled daemon and adds `--security-opt label=disable` only to
+  short-lived helper commands that write bind-mounted host files. This avoids
+  `Permission denied` during `install-*`, `setup-agent`, `uninstall`, and
+  `backup` without relabeling the user's home directory or changing the
+  long-lived server container ([#212]).
+- Windows `.ps1` fallback hook commands now use PowerShell `-EncodedCommand`
+  instead of embedding `$env:` setup inside a nested quoted command. This
+  prevents outer Windows hook runners such as Antigravity CLI from expanding
+  the setup before the inner PowerShell process receives it. Existing Windows
+  Docker-wrapper installs should rerun `install-hooks --agent <agent> --apply`
+  after upgrading ([#214]).
+- `install-mcp --client claude-code` and `uninstall` now honour
+  `CLAUDE_CONFIG_DIR`: MCP registrations go to
+  `$CLAUDE_CONFIG_DIR/.claude.json` when the variable is set (non-empty),
+  falling back to `~/.claude.json` otherwise. Uninstall checks both the active
+  relocated path and the home default so enabling the variable does not orphan
+  a prior default-path registration. The
+  dry-run output prints the resolved config path instead of a hardcoded path.
+- `install-hooks --agent claude-code` and `setup-agent` follow the same
+  resolution for the hooks settings file: `$CLAUDE_CONFIG_DIR/settings.json`
+  when set, else `~/.claude/settings.json`. Uninstall checks both locations;
+  rendered output and the chmod-600 warning show the resolved path.
+- `install-skills --scope global` (claude-code root) installs to
+  `$CLAUDE_CONFIG_DIR/skills` when the variable is set, else
+  `~/.claude/skills`. `uninstall` sweeps the relocated root alongside the
+  home default so installs that predate the env var are still removed.
+- The Docker CLI wrapper forwards `CLAUDE_CONFIG_DIR` into its helper
+  container for relocated Claude Code configs beneath the existing home bind.
+
+## [1.17.1] - 2026-07-20
+
+### Fixed
+- Managed launch failures now cancel their server lease immediately, and a new
+  launch waits briefly when the previous launcher is still finalizing. The
+  parent launcher also survives terminal interrupts long enough to finish or
+  cancel the run, preventing a normal quit-and-reopen from being blocked by the
+  90-second crash-recovery lease.
+- CLI startup diagnostics now show the configured server URL and use the real
+  host name in lease-owner messages, avoiding misleading `localhost` labels for
+  remote-server clients.
+
+## [1.17.0] - 2026-07-20
+
+### Added
+- `ai-memory run` without a harness now selects among checkout-local Claude
+  Code, Codex, OpenCode, Pi, and Crush sessions. Empty workstreams adopt the
+  newest session automatically; established workstreams prefer their most
+  recently linked available harness. A directory with no matching session
+  exits with explicit start commands instead of creating an empty workstream.
+- Managed workstreams now support Crush through its project-local read-only
+  SQLite transcript and supported `options.global_context_paths` configuration.
+  ai-memory never writes the original Crush config or session database; the
+  launched Crush process retains normal ownership of its native session writes.
+- Wrapper-owned `run --yolo` translates to each harness's native dangerous-mode
+  option for Claude Code, Codex, OpenCode, Pi, and Crush.
+- A managed-harness contribution protocol documents the native-session,
+  read-only import, context-delivery, migration, privacy, and acceptance-test
+  requirements for adding agents beyond the currently supported set.
+
+### Changed
+- The first interactive `ai-memory run` on an otherwise-empty workstream now
+  offers recent native sessions recorded for the same checkout, with the newest
+  as the default or an explicit fresh-session choice. Adoption is disabled for
+  `--new`, explicit selectors, scripted/noninteractive launches, and any
+  workstream already established by another harness, preventing obsolete local
+  sessions from contaminating later cross-harness switches.
+
+### Fixed
+- Managed utility invocations such as `ai-memory run codex --version` no longer
+  discover and import a different process's recently updated native session.
+  Passthrough commands also do not fetch or acknowledge managed startup context.
+- Managed runs now verify the host harness executable before opening a server
+  lease and report how to refresh a stale Docker wrapper. The wrapper path is
+  regression-tested to preserve a remote `AI_MEMORY_SERVER_URL`, auth, and the
+  host `PATH` without entering Docker, and now retains the `run` subcommand when
+  it hands control to the native ai-memory client.
+- Corrected stale project-move flags in the marker guide and documented the
+  distinction between a server-side project rename and a physical checkout or
+  native-session relocation.
+
+## [1.16.0] - 2026-07-20
+
+### Added
+- Optional managed cross-harness workstreams via `ai-memory run` for Claude
+  Code, Codex, OpenCode, Pi, and OMP. Direct harness launches retain the legacy
+  hook/handoff behavior. Managed launches transparently create or resume one
+  native session per harness, pass all harness argv through without a `--`
+  separator, inject unseen portable context at SessionStart, import visible
+  native transcript tails through read-only adapters, and record non-mutating
+  repository checkpoints. A lease prevents concurrent writers; deterministic
+  event ids, incremental cursors, immutable sanitized JSONL segments, and
+  batched idempotent imports make retry and crash recovery explicit. Hidden
+  reasoning and private provider records are excluded with loss annotations.
+  `ai-memory workstream-search` searches history older than the bounded startup
+  packet. The Linux/macOS Docker wrapper uses a checksum-verified cached native
+  client for `run` so host agent executables and transcript stores remain
+  accessible. A separate opt-in local acceptance runner validates real
+  cross-harness delivery and native resume without adding credentialed model
+  calls to CI. Generated OpenCode/Pi/OMP integrations reserve managed context
+  acknowledgement for their model-visible injection path; OpenCode caches the
+  packet per native session so auxiliary model requests cannot consume it
+  before the main coding turn. Pi/OMP native `--session-dir` overrides are
+  honored by the importer, as are native store environment overrides for all
+  five adapters. This includes complete atomic-write temp transcripts left by
+  a Pi-family process that exits before its final rename.
+
+### Changed
+- Configuring the hosted `anthropic` or `openai` provider without an explicit
+  model now selects the documented recommended defaults, `claude-haiku-4-5`
+  and `gpt-5.4-mini`, instead of the older `claude-sonnet-4-6` and
+  `gpt-4o-mini` fallbacks. Explicit `AI_MEMORY_LLM_MODEL` values are unchanged.
+### Fixed
+- User-facing help and current-reference documentation now match the shipped
+  agent integrations, multi-user activation boundary, MCP URL normalization,
+  Pi bridge, and `memory_consolidate` configuration requirements. Local
+  documentation links and anchors were also audited and repaired.
+- Reader APIs now derive absent page kinds consistently from canonical path
+  families. Session, concept, procedure, note, and slot pages no longer surface
+  as generic facts, while an explicit frontmatter `kind` still takes precedence
+  ([#198]).
+- Native lifecycle hooks now accept one leading UTF-8 BOM on JSON stdin, which
+  covers PowerShell pipelines on Windows. Other malformed payloads are dropped
+  before spool or network delivery with a bounded content-free stderr warning;
+  hooks still return `{}` and exit successfully ([#197]).
+
+## [1.15.0] - 2026-07-19
+
+### Added
+- Tool lifecycle capture now records safe metadata summaries for the closed
+  Claude Code, OpenCode, Pi, and Antigravity schemas: canonical family,
+  validated agent-provided call ID where available, and a PostToolUse outcome.
+  PreToolUse never stores tool inputs, commands, paths, or arbitrary tool
+  names; PostToolUse keeps its bounded response/error excerpt. Stop and
+  assistant-message capture remain disabled/deferred ([#190]).
+- Per-repository capture exclusions via `[capture] ignore_paths` in the nearest
+  `.ai-memory.toml` ([#194]). Supported native hooks and generated
+  OpenCode/OMP/Pi/OpenClaw integrations apply the policy before local spool or
+  network delivery; `ai-memory hook --check-capture` safely reports a bounded
+  local decision. Generated integrations resolve relative file-tool paths from
+  the event `cwd`, including nested working directories, rather than from the
+  marker directory. This changes no MCP tools and needs no database migration.
+- Kimi Code CLI is now a supported MCP + lifecycle-hook integration
+  (`--client kimi-code` / `--agent kimi-code`, alias `kimi`). `install-mcp`
+  merges an `mcpServers` entry into `~/.kimi-code/mcp.json` with a plain `url`
+  (Kimi Code treats `url` with no `transport` field as streamable HTTP) plus
+  optional bearer `headers`. `install-hooks` merges `[[hooks]]` entries into
+  `~/.kimi-code/config.toml`, preserving the provider/model settings the same
+  file holds, and covers 10 events: `SessionStart`, `SessionEnd`,
+  `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`
+  (Kimi Code reports tool failures separately from successful calls; the
+  entry reuses the post-tool-use capture path), `Stop`, `SubagentStart`,
+  `SubagentStop`, and `PreCompact`. Both paths honor `$KIMI_CODE_HOME`.
+  Handoff injection happens at `SessionStart` through hook stdout, which Kimi
+  Code appends to the model context; `setup-agent` and `uninstall` handle the
+  new agent like the other first-class integrations. The `install-mcp` entry
+  points at `/mcp?flavor=moonshot`: the Moonshot API validates tool parameter
+  schemas against a restricted dialect ("moonshot flavored json schema") that
+  rejects root-level `anyOf`/`oneOf`/`allOf` combinators — including the
+  `anyOf` on `memory_read_page` — and fails the whole session at `tools/list`.
+  Requests carrying that flavor receive flat tool schemas from the server;
+  every other client keeps receiving the upstream schemas unchanged.
+  `uninstall` matches the Kimi Code entry in either URL form, so removing an
+  install made before or after this change both work with the default
+  `--mcp-url`.
+- Grok Build CLI is now a first-class MCP client as well as a hook agent:
+  `install-mcp --client grok` renders and `--apply` merges a native HTTP
+  entry into `$GROK_HOME/config.toml` (default `~/.grok/config.toml`)
+  (`[mcp_servers.ai-memory]` with
+  `url` / `enabled` / `[mcp_servers.ai-memory.headers]` — not Codex's
+  `http_headers` key). `install-hooks --agent grok` reuses that entry to
+  infer server URL and bearer token; `uninstall` strips the MCP table;
+  `setup-agent --agent grok` prints the companion `install-mcp` tip.
+  Managed routing skills can target `.grok/skills` / `$GROK_HOME/skills`
+  (default `~/.grok/skills`) via
+  `install-skills --agent grok` and `memory_install_self_routing`
+  `target_hints`. Lifecycle capture was already present; handoff injection
+  remains unavailable because Grok ignores SessionStart stdout — recover
+  via MCP `memory_handoff_accept`.
+
+### Changed
+- Scheduled forget sweep and rule-based lint now persist their last successful
+  completion across restarts. Overdue or never-run jobs perform one bounded
+  startup catch-up, while not-due jobs wait only their remaining interval;
+  failures retry without advancing cadence. Embedding backfill remains opt-in
+  and does not gain startup catch-up behavior ([#192]).
+- `init`-generated token peppers no longer make operational `/admin/*` routes
+  root-only before the first user is created. Admin mode now switches
+  immediately and fail-closed from a store-backed user-row check; expired users
+  still count. Servers refuse startup when user rows exist but either the
+  non-empty `[auth].token_pepper` or static `[auth].bearer_token` is missing or
+  blank, preventing accidental anonymous admin reopening ([#191]).
+- `install-hooks --agent devin` now infers the server URL and bearer token from
+  `~/.devin/config.json` when flags and environment settings are absent, keeping
+  hooks aligned with an existing Devin MCP registration.
+- Grok routing guidance now treats Grok Build CLI as an AGENTS-based client and
+  directs its managed skills to `.grok/skills` or `$GROK_HOME/skills` (default
+  `~/.grok/skills`). The MCP self-routing payload and installed prompt surface
+  now guard those targets;
+  Grok (like Zero) still resumes handoffs through `memory_handoff_accept`
+  because it ignores SessionStart stdout.
+- One-shot client commands (`rename-project`, `status`, `write-page`, …) no
+  longer print the "cannot write log files … falling back" warning when the
+  log directory is unwritable — they still degrade to temp/stderr logging
+  silently. The warning was written for the long-running server (where an
+  operator should know persistent logs moved) but fired on every Docker
+  thin-client invocation too, where it read as a problem with the command
+  itself and its sandbox hint was misleading. `serve` still warns, with
+  clearer wording that names both the intended and the fallback location.
+
+## [1.14.0] - 2026-07-15
+
+### Added
+- New admin endpoint `POST /admin/merge-workspace {from, to, confirm}`: fold
+  every project of one workspace into another, then delete the emptied source
+  workspace — completing the workspace CRUD surface alongside rename/delete.
+  It is sugar over move-project: each source project runs the same validated
+  path, so a project that already exists in the destination merges by content
+  (copy-purge under `on_conflict`) while a fresh one is a lossless re-stamp.
+  Destructive, so `confirm=true` is required; `force` overrides the
+  live-session guard per project. It stops at the first failing project — the
+  moves already committed stand, and the failing project plus the source
+  workspace are left intact for the operator to resolve and re-run (moves are
+  idempotent) ([#187]).
+
+### Fixed
+- Hook query values are now percent-encoded with an RFC 3986 allow-list
+  (everything outside `A-Za-z0-9-_.~`) in both the native helper and the
+  POSIX `hooks/_lib.sh`, and the shell cwd extractor unescapes JSON `\\` /
+  `\/`. Previously a Windows cwd like `C:\dev\myproject` went into the query
+  string with raw backslashes, which broke the shell-script fallback outside
+  Git Bash. The reporter confirmed that native Windows handoff delivery was
+  already correct for well-formed JSON; their original failure came from a
+  PowerShell pipe adding a UTF-8 BOM. The session-start hook now also prints a
+  stderr warning when the handoff fetch fails (server unreachable, bad URL)
+  instead of being indistinguishable from "no pending handoff" — exit code
+  stays 0, hooks never break the agent. Malformed-payload/BOM diagnostics are
+  tracked separately in [#197] ([#188]).
+- `install-mcp --server-url` now appends the `/mcp` path when given a base
+  URL (the same value `install-hooks --server-url` takes), instead of
+  rendering a client config that points at the server root and 404s. The
+  suffix join is idempotent, so passing the full `…/mcp` endpoint still
+  works unchanged; only a URL deliberately pointing MCP at a path not
+  ending in `/mcp` (an exotic reverse-proxy rewrite) would notice
+  ([#185]).
+- Opening a store whose schema is *newer* than the running binary now fails
+  with an actionable error instead of refinery's raw "migration V… is missing
+  from the filesystem" wording. When an applied migration is absent from the
+  binary's compiled-in set (the data was migrated by a newer ai-memory build),
+  the store layer now returns `DataSchemaAhead`, which names the offending
+  migration, reports the highest schema version this build ships, and tells the
+  operator to run a build at least as new as the one that wrote the data. Every
+  other migration failure is unchanged ([#184]).
+- `memory_consolidate` now resolves its target `(workspace, project)` from
+  where the session's observations actually landed, rather than trusting the
+  `sessions` row. A session that adopts its scope marker mid-run keeps a
+  session row frozen on the pre-marker scope (`begin_session` uses
+  `ON CONFLICT DO NOTHING`), while each observation carries the correct
+  per-cwd scope — so a "hybrid" session used to consolidate into the wrong
+  project. Resolution now prefers the majority observation scope, then the
+  session row, then the server's startup IDs ([#186]).
+
+### Changed
+- `memory_consolidate` runs the blocking admission chain up front, before the
+  LLM, so a rejected scope/actor fails fast and identically in every mode
+  instead of only surfacing at write time — previously a single-page write
+  spent the LLM before the 403, and a multi-page / dry-run request ran the
+  full completion only for the client to time out before seeing the
+  rejection. Consequently `dry_run=true` is now a cheap plan: it runs the
+  admission preflight and reports the resolved page path without calling the
+  LLM (it no longer returns an LLM-generated body preview); a real
+  (non-dry) run still produces the page bodies ([#186]).
+
+## [1.13.0] - 2026-07-14
+
+### Fixed
+- `memory_consolidate` now attributes its consolidated page to the request's
+  authenticated identity (same derivation as `memory_write_page`) instead of
+  a hard-coded anonymous actor — so `last_modified_by` is populated and an
+  actor-gated admission webhook authorizes the write by user rather than
+  rejecting the empty actor. The automatic session-end / compaction
+  consolidation in the hook router is system-initiated and deliberately
+  stays anonymous ([#183]).
+
+### Changed
+- `audit-contamination` no longer flags an observation whose project differs
+  from its session's home project (the old `observation_session_drift` CHECK
+  B, including the `observations_drifted` summary count and the finding's
+  `session_id` field). With per-event cwd resolution, an agent that
+  legitimately `cd`s across repos in one session produces exactly that shape
+  — it is correct attribution, not contamination — so the check drowned
+  multi-repo instances in false positives. CHECK A (`session_wrong_bucket`,
+  anchored on the session's own cwd evidence) is unchanged and remains the
+  high-precision signal ([#182]).
+
+### Added
+- The `[recall] default_global` marker now broadens `memory_recent` too,
+  completing the pair started with `memory_query` in v1.12.0: an unscoped
+  `memory_recent` from an opted-in repo returns the most-recently-updated
+  pages across every project as `global_hits` (workspace + project
+  annotated). Explicit `workspace`/`project` arguments still scope exactly
+  as before, and the plain project-scoped response shape is unchanged
+  ([#181]).
+- New read-only admin endpoint `GET /admin/projects`: the authoritative
+  `(workspace, project)` inventory with page counts and last-updated
+  timestamps. Gives dashboards, exports, and backup/mirror tooling a
+  first-class list to reconcile against — a mirror directory whose project
+  no longer appears here is an orphan and can be pruned. Root-only in
+  multi-user mode, like every `/admin/*` route ([#180]).
+- `memory_delete_page` / admin `delete-page` now write one attributed
+  `audit_log` row pointing at the deleted page id, in the same transaction
+  as the delete — completing the "who deleted the gotcha page about X?"
+  trail that purge/rename attribution started. Idempotent no-op deletes
+  write nothing. The handoff lifecycle (insert / accept / cancel) is also
+  audited, scoped to the handoff's workspace/project with a NULL author by
+  design — handoffs are agent/session-keyed, not owned by a DB user
+  ([#179]).
+- Devin CLI is now a supported MCP + lifecycle-hook integration. `install-mcp
+  --client devin` writes Devin's `mcpServers` config, `install-hooks --agent
+  devin` writes Devin lifecycle hooks, `setup-agent --agent devin` emits
+  host-copyable hook snippets, and `uninstall` removes only ai-memory-owned
+  Devin entries. Devin hook capture covers `SessionStart`,
+  `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PostCompaction`, `Stop`,
+  and `SessionEnd`; `PostCompaction` is stored as a dedicated observation kind
+  and captures Devin's `summary` field. Devin does not expose subagent hook
+  events, so subagent capture is not installed for Devin ([#178]).
+- Managed Agent Skills can now target Devin: project installs use
+  `.devin/skills`; global installs use `%APPDATA%\devin\skills` on Windows and
+  `~/.devin/skills` elsewhere ([#178]).
+- The store migration set now admits `devin` as a persisted
+  `sessions.agent_kind`, preserving the same workspace/project invariants as
+  the other supported agents ([#178]).
+
+### Fixed
+- `install-mcp` and `install-hooks` now honor an explicit `--server-url` even
+  when it matches the compiled default. Previously that value was
+  indistinguishable from "flag omitted" and could be overridden by
+  `AI_MEMORY_SERVER_URL`, which could write config for the wrong local server
+  ([#178]).
+- Devin hook capture now derives `cwd` when the native payload omits it:
+  payload `cwd` still wins, followed by `DEVIN_PROJECT_DIR`, then the hook
+  process working directory. This keeps real Devin `SessionStart` /
+  `PostToolUse` fixtures routable without inventing a payload field.
+  Payloads without a `session_id` are bridged the same way: a per-host id is
+  minted at `SessionStart`, reused for later events, and cleared at
+  `SessionEnd`; set `AI_MEMORY_SESSION_ID` in the hook environment to pin an
+  externally managed run id. A payload-supplied id always wins ([#178]).
+
+## [1.12.0] - 2026-07-12
+
+### Added
+- New `.ai-memory.toml` marker section `[briefing] inject_on_session_start
+  = "true"` ([#176]): the session-start handoff fetch also returns a
+  compiled project brief — pinned / `_rules/` / `_slots/` pages with
+  bodies plus recently-updated page titles — injected as agent context so
+  a fresh session (or a Claude Code `/clear`, which re-fires SessionStart)
+  starts with the architecture instead of re-exploring the codebase.
+  `max_chars` caps the brief (default 4000 chars, clamped to 500–20000);
+  over-budget pages are truncated or listed by path. The brief is
+  recomposed on every opted-in session start (non-consumable, unlike the
+  handoff) and appended after any pending handoff. Off by default — it
+  costs tokens on every session start.
+- Generated OpenCode / OMP / OpenClaw TypeScript integrations now forward
+  the `[recall] default_global` marker flag (previously only the native
+  hook binary did) and the new `[briefing]` keys, accepting bare
+  (unquoted) TOML values for both.
+- New `.ai-memory.toml` marker option `[recall] default_global = "true"`
+  ([#177]): sessions in the marked tree make an *unscoped* `memory_query`
+  behave as `global=true`, so meta-repos that constantly need
+  sibling-project context stop passing `global=true` by hand. Strictly
+  opt-in and per-repo; explicit `workspace`/`project`/`scopes`/`global`
+  arguments always win. While active, unscoped queries return
+  cross-project `global_hits` (workspace+project annotated) instead of
+  project `hits` + `global_scope_hits`; `memory_recent` stays
+  project-scoped (documented follow-up).
+- `purge-project` and `rename-project` now write attributed rows to the
+  append-only `audit_log`, inside the same transaction as the operation
+  itself — so "which user wiped project X?" finally has an answer, and a
+  rolled-back rename (name collision) leaves no phantom trail. The
+  operator identity comes from the authenticated admin request and is
+  `NULL` for single-user/unauthenticated servers; internal sub-purges
+  (move-project's copy-purge step, the hook router's self-heal) are
+  deliberately not attributed as standalone purges ([#175]).
+
+## [1.11.4] - 2026-07-11
+
+### Fixed
+- Scheduled forget sweep, rule-based lint, and opt-in embedding backfill now
+  iterate every existing workspace/project scope instead of only the project
+  selected at server boot. Embedding backfill remains disabled by default, but
+  enabled schedules are now store-wide and can increase provider usage ([#173]).
+
+## [1.11.3] - 2026-07-11
+
+### Changed
+- Documented the community-maintained Hermes Agent plugin as a third-party
+  bridge rather than first-party ai-memory support, with compatibility and
+  secret-handling cautions ([#172]).
+- `/admin/delete-workspace` now runs `purge_workspace` admission before
+  destructive work, reports filesystem partial failures in `files_failed`, and
+  notifies non-blocking mirrors after durable deletion; `/admin/rename-workspace`
+  refreshes scope manifests after the SQLite rename.
+- OIDC CLI help and token-store test fixtures now use a neutral `ai-memory`
+  realm placeholder instead of the old project-specific `serpro` example, and
+  the unused LLM retry-exhaustion error variant was removed ([#171]).
+
+### Fixed
+- Admin scope mutations now invalidate both legacy and keyed active-project
+  state plus hook project caches: project moves retarget live active entries,
+  workspace deletes clear affected active/cache entries so deleted scopes are
+  not recreated by the next hook, and workspace rename manifest refresh
+  failures return success with an explicit warning after the committed SQLite
+  rename instead of a misleading 500.
+- `/hook/batch` now skips per-source rate-limited items and continues accepting
+  later unrelated sources, returns non-contiguous acknowledgements for new spool
+  drains, bounds limiter key bytes, keys by actor+session with deterministic
+  missing-session fallbacks, and avoids spending source tokens on globally
+  saturated events. `AI_MEMORY_HOOK_RATE_PER_SEC` and
+  `AI_MEMORY_HOOK_RATE_BURST` are now parsed through typed server config
+  instead of the hooks crate reading env directly ([#170]).
+- MCP tool calls over the stdio transport now fall back to an anonymous
+  synthetic request context when HTTP request parts are absent, while preserving
+  real streamable-HTTP auth/session parts when present ([#168]).
+- Copy-purge `/admin/move-project` now skips only the webhook named exactly
+  `contributors` while copying pages, avoiding redundant per-page contributor
+  enrichment on already-enriched frontmatter while preserving other
+  `write_page` webhooks and the terminal purge notification ([#167]).
+- `memory_read_page` by-path not-found errors now name the resolved
+  workspace/project scope, making stale or mis-scoped page paths easier to
+  diagnose from MCP clients ([#166]).
+
+## [1.11.2] - 2026-07-11
+
+### Fixed
+- `ai-memory install-instructions` and `ai-memory uninstall --only instructions`
+  now match only line-anchored routing markers, handle CRLF marker lines, and
+  repair one or more exact orphan-tail copies left by older refreshes when the
+  snippet body mentioned an end marker inline ([#161]).
+- Project creation now emits a warning when the same project name already
+  exists in another workspace, helping catch accidental cross-workspace
+  misroutes while preserving legal id-namespaced homonyms ([#160]).
+- `memory_query` now runs the raw-observation fallback for explicit `scopes`
+  requests when compiled wiki pages miss, so scoped cross-project searches can
+  still surface bounded raw session matches without falling back to the current
+  project ([#159]).
+- Upgraded `crossbeam-epoch` to the RUSTSEC-2026-0204 fixed release ([#162]).
+- Fixed the Docker wrapper on macOS with rootless Docker so host-config
+  commands (`install-mcp`, `install-hooks`, `install-instructions`, and
+  related setup/removal commands) keep the `-u 0:0` mapping needed to write
+  bind-mounted agent configuration as the invoking host user ([#162]).
+- Stabilized the Windows uninstall purge-preview regression test against
+  verbatim temp-path spelling ([#162]).
+
+## [1.11.1] - 2026-07-09
+
+### Fixed
+- The documented auto-improvement safety invariant "never rewrite pinned
+  pages" is now enforced in code, not just in the reviewer prompt: the
+  apply path — shared by manual approval and `require_approval = false`
+  auto-apply — refuses `update` proposals whose target page is pinned,
+  recording the proposal as a conflict with an explicit reason. Unpinning
+  the page is the explicit way to allow a rewrite ([#157]).
+
+### Added
+- Architectural-decision guidance ([#157]): the managed durable-pages
+  Agent Skill now teaches agents to record architectural decisions as
+  pinned wiki pages under `decisions/<slug>.md` with ADR structure
+  (Status / Context / Decision / Consequences, rejected alternatives
+  included) and to supersede with a new page instead of editing history.
+  `docs/usage.md` gains an ADR section clarifying that ai-memory never
+  touches repository files (a `docs/adr/` tree managed by hand or by an
+  external ADR MCP server is outside its write surface) and how the two
+  coexist.
+
+## [1.11.0] - 2026-07-09
+
+### Fixed
+- Mid-session events can no longer scatter observations into basename
+  "fragment" projects (`sources`, `desktop`, …). The hook router now uses
+  session-sticky attribution: when an event's session already exists, its
+  observations inherit the session's project instead of re-deriving one
+  from the event's cwd — closing the hole left between the v0.12.2
+  cwd-prefix guard (which keys on `repo_path`) and the #103 rule that
+  non-git parents never record one, which together left plain-directory
+  projects unprotected against every mid-session `cd subdir/`. Explicit
+  `.ai-memory.toml` overrides still win, and cwd derivation still decides
+  for session-creating events.
+- V27 data-repair migration re-runs the idempotent V19 repair on upgrade,
+  re-attributing the fragment observations that accumulated since V19 to
+  their sessions' projects and deleting the emptied fragment rows.
+  Reserved projects (`scratch`, `_global`) are exempt.
+
+### Added
+- The maintenance scheduler now sweeps "hollow" project rows — zero
+  pages, sessions, observations, and handoffs — once they are older than
+  seven days, shortly after startup and then daily. Nothing exists to
+  lose in a hollow row (probe/rename residue), so the sweep needs no
+  config; rows holding any data are never touched, and reserved projects
+  are exempt.
+
+## [1.10.1] - 2026-07-09
+
+### Fixed
+- Every CLI command panicked at startup on read-only filesystems
+  (sandboxes like ai-jail) when the log directory already existed but the
+  log *file* couldn't be created — the half of the failure the existing
+  tempdir fallback didn't cover, because it only triggered on directory-
+  creation errors and used the panicking appender constructor. File
+  logging now degrades instead of failing: `<data_dir>/logs` → the OS
+  temp dir → stderr-only, with a warning naming the exact path that
+  failed at each step (so sandbox users know what to `--rw-map`), and
+  commands keep working regardless ([#158]).
+
+## [1.10.0] - 2026-07-09
+
+### Added
+- Zero (Gitlawb/zero) is now a supported agent/client ([#156]).
+  `install-mcp --client zero` merges a native HTTP + bearer entry into
+  Zero's `~/.config/zero/config.json` (`mcp.servers` map), and
+  `install-hooks --agent zero --apply` merges exec-form lifecycle hooks
+  (the native `ai-memory hook` command with an args array — JSON payload
+  on stdin, no shell) into `~/.config/zero/hooks.json`, preserving
+  third-party hooks in the same file by id prefix. All six Zero events
+  are covered: `sessionStart`/`sessionEnd`, `beforeTool`/`afterTool`,
+  and `specialistStart`/`specialistStop` (mapped to ai-memory's subagent
+  events). Zero discards `sessionStart` hook stdout, so capture and
+  handoff creation work but handoff injection does not — recover
+  handoffs via the MCP `memory_handoff_accept` tool, same policy as
+  Grok. `uninstall` strips the hook entries and the MCP registration;
+  `setup-agent --agent zero` prints the config for docker-host flows.
+  Support tracks Zero's current formats — it is a fast-moving young
+  project and upstream churn will be fixed as reported.
+
+## [1.9.1] - 2026-07-08
+
+### Fixed
+- `memory_read_page`'s input schema now encodes the "exactly one of
+  `path` or `query`" contract as an `anyOf` whose branches demand the
+  key's presence *and* a non-null string, so MCP clients that null-fill
+  defaulted arguments (observed with OpenCode 1.17.x) are schema-blocked
+  from sending the neither-arg call instead of looping on a server
+  error. The runtime error for a bare call is now instructive — it names
+  both arguments and shows a concrete `{"path": "notes/topic.md"}`
+  example so a looping model can self-correct — and the tool/argument
+  descriptions state the MUST-pass-one rule up front ([#155]).
+
+## [1.9.0] - 2026-07-07
+
+### Added
+- Global preferences scope ([#154]): standing user/team context that
+  should apply to every project — technology choices, code style,
+  durable personal conventions — now has a dedicated home. Write with
+  `memory_write_page` + `scope: "global"`; the page lands in the
+  reserved `_global` project (default workspace, following the
+  `_meta.md`/`_pending/` reserved-name convention). Default-scoped
+  `memory_query` calls union that scope into every project as a new
+  `global_scope_hits` response field — one extra scoped search, not the
+  O(projects) `global=true` fan-out — while explicitly scoped queries
+  (`workspace`/`project`/`scopes`/`global=true`) are unchanged. The
+  scope participates by existence: no config, zero effect until the
+  first global write. Event capture never creates or attributes to it —
+  a directory or marker override named `_global` falls back to the
+  server-default project.
+
+### Fixed
+- A session that is resumed under the same id after an early `SessionEnd`
+  now re-consolidates when it ends again. The end-of-session guard used to
+  drop any `SessionEnd` for a session with `ended_at` set, so a resumed
+  session's page stayed frozen at the first end's content and the resumed
+  work lived only in raw observations. The guard now distinguishes a
+  duplicate/stale end (no observations newer than `ended_at` — still
+  dropped, which keeps `finalize-session` and late spool drains safe) from
+  a genuine re-end with new work behind it, which re-runs the full end
+  path: heuristic page rewrite, `ended_at` bump, auto-handoff refresh, and
+  the opt-in LLM consolidation ([#152]).
+- `bin/ai-memory` no longer fails `install-mcp`, `install-hooks`,
+  `setup-agent`, `install-instructions`, `install-skills`, `uninstall`,
+  and `backup` under rootless Docker. Rootless Docker maps container UID
+  0 back to the real
+  host user but routes any other UID (including the host UID the wrapper
+  always passed via `-u`) through an unrelated subordinate-UID range, so
+  every write to a bind-mounted host path (`~/.claude/settings.json`,
+  the hook staging dir, `$PWD/CLAUDE.md`, skill directories) failed with
+  `Permission denied` or a misleading "does not exist" error. The wrapper
+  now detects rootless Docker via `docker info --format
+  '{{.SecurityOptions}}'` and runs as `-u 0:0` for just the commands that
+  write host-side files; thin-client commands (`status`, `bootstrap`, …)
+  are unaffected since they only touch the `/data` named volume.
+
+## [1.8.0] - 2026-07-04
+
+### Added
+- OpenCode Zen/Go is now a first-class LLM provider:
+  `AI_MEMORY_LLM_PROVIDER=opencode` (alias `opencode-zen`) routes
+  consolidation through `https://opencode.ai/zen/go/v1` using the OpenAI
+  chat-completions wire format. Authenticate with `OPENCODE_API_KEY`
+  (key from `opencode.ai/auth`); the default model is `claude-sonnet-4-6`.
+  `ai-memory llm-test --provider opencode` exercises it end-to-end ([#147]).
+- `docker/docker-compose.yml` now loads provider credentials from a
+  gitignored `docker/.env` via `env_file` (optional — existing deployments
+  without that file keep working), replacing the commented-out inline
+  provider blocks ([#147]).
+
+### Fixed
+- Gemini structured output no longer fails with `400 INVALID_ARGUMENT …
+  "type" … Proto field is not repeating, cannot start list` when a schema
+  contains an optional field. `prepare_schema_for_gemini` now collapses
+  schemars' Draft-2020-12 `type` arrays (e.g. `["string", "null"]` for
+  `Option<T>`) into Gemini's single `type` + `nullable: true` form, so
+  consolidation / auto-improve work again with `gemini-2.5-pro` and other
+  Gemini models.
+- The detached drainer's `logs/hook-drain.log` now rotates once it exceeds
+  1 MiB (previous contents move to `hook-drain.log.old`), so an agent
+  pointed at a chronically unreachable server can no longer grow the log
+  without bound.
+- Windows hook-spool drain locks now treat native lock-violation responses as
+  expected lock contention, so overlapping background drains skip cleanly
+  instead of failing the single-flight guard.
+- Windows wiki checkpoints now fall back to the Git CLI for native libgit2
+  path-resolution failures when reopening freshly initialised repos, keeping
+  delete and purge operations usable under dot-prefixed temp or wrapper paths.
+
+### Changed
+- Post-audit cleanup, no behavior change: the `AI_MEMORY_HOOK_PLATFORM`
+  override is parsed in one place instead of three copies, the CLI
+  `AgentChoice` → domain `AgentKind` mapping is a single `kind()` method
+  instead of three per-command match blocks, the companion importer crate
+  is now gated in CI (fmt/clippy/test), and
+  `crates/ai-memory-store/src/auto_improve.rs` is fully documented (its
+  file-wide `missing_docs` allowance is gone). `AI_MEMORY_HOOKS_HOST_ROOT`
+  is now documented in `docs/install.md`.
+
+## [1.7.1] - 2026-07-02
+
+### Fixed
+- Acknowledged the new `quick-xml` RustSec advisories in CI for the existing
+  `syntect` transitive dependency bucket. `plist` still constrains `quick-xml`
+  below the fixed 0.41.x branch, and ai-memory does not parse untrusted XML in
+  this path; the ignores keep cargo-audit/cargo-deny focused on actionable
+  advisories until the upstream dependency chain can update.
+
+## [1.7.0] - 2026-07-02
+
+### Added
+- Added `ai-memory finalize-session`, a supported manual Codex finalization
+  flow. It defaults to the latest open Codex session in the current
+  workspace/project and posts a synthetic `session-end` hook so summaries,
+  handoffs, and auto-improvement eligibility use the canonical SessionEnd path.
+
+### Fixed
+- Native hook spool delivery no longer relies only on the cancellation-prone
+  `session-end` hook to start the detached drainer. `stop` and `pre-compact`
+  also request the background `hook-drain` helper after enqueue, and Unix builds
+  use a trusted `setsid` launcher when available before falling back to a
+  separate process group.
+- OpenCode generated plugins now close sessions from the official
+  `session.deleted` event and a deduped best-effort `dispose` fallback, so
+  OpenCode sessions can produce automatic session summaries and handoffs without
+  duplicate `session-end` emissions.
+
+## [1.6.0] - 2026-07-01
+
+### Fixed
+- Documented and regression-tested that `install-instructions` updates only the
+  ai-memory marker block, preserves unrelated CLAUDE.md / AGENTS.md content,
+  writes backups for existing files, and refuses unmanaged same-name skills
+  unless explicitly forced.
+- Claude Code WindowsNative hook installs now use Claude's exec form
+  (`command` executable plus `args` argv array) for the native `ai-memory.exe`
+  hook, avoiding shell/Git Bash/PowerShell command-string mangling. Set
+  `AI_MEMORY_HOOK_PLATFORM=windows-bash` before `install-hooks` as a fallback for
+  older Claude Code builds; exec form requires a real `.exe`, not `.cmd`/`.bat`
+  shims.
+- Native `session-end` hooks now enqueue and return quickly, then drain the hook
+  spool through a hidden detached `hook-drain` process guarded by a real
+  single-flight file lock. Background drains use the new bounded
+  `AI_MEMORY_HOOK_BACKGROUND_DRAIN_BUDGET_MINUTES` setting (default 5, max 60),
+  while `session-start` cleanup remains synchronous and uses one shared
+  `AI_MEMORY_HOOK_START_BUDGET_MINUTES` budget for lock wait plus cleanup drain.
+  This supersedes the previous inline `session-end` deferred-drain note and
+  `AI_MEMORY_HOOK_END_BUDGET_MINUTES` session-end flush budget.
+- Pi is now supported through a generated `~/.pi/agent/extensions/ai-memory.ts`
+  TypeScript extension that combines lifecycle capture with an HTTP MCP bridge;
+  `install-hooks --agent pi --apply` writes it, while `install-mcp --client pi`
+  prints bridge guidance instead of writing an ignored native `mcp.json`.
+- Generated OpenCode and OMP TypeScript lifecycle hooks now buffer capture
+  posts through a bounded best-effort queue instead of spawning one unbounded
+  fetch per event, reducing client-side request bursts while preserving direct
+  handoff fetches.
+- Corrected the Pi vs Oh My Pi / OMP install split: OMP remains supported via
+  `--client omp` / `--agent omp` (or `oh-my-pi`) and writes `.omp` config, while
+  real `pi` remains a separate install surface. Users who previously used `pi`
+  to mean OMP should switch to `omp` or `oh-my-pi`.
+
+## [1.5.0] - 2026-07-01
+
+### Added
+- Per-project `drop_subagent_captures` opt-in. A project sets
+  `drop_subagent_captures = "true"` in its `.ai-memory.toml`; the host-side hook
+  forwards it (as the `drop_subagent` query flag, alongside the existing
+  `workspace`/`project`/`project_strategy` marker fields) so the ingest router
+  **accepts but does not persist** that project's subagent-session captures,
+  keeping only top-level sessions. A multi-agent harness fans one goal out to
+  many subagent sessions, each firing lifecycle hooks; on a small shared
+  instance that flood can saturate ingest and bloat the store. Scoping the
+  opt-in to the project that asked for it avoids a server-global switch that
+  would shed subagent captures for every project on the instance. Captures are
+  accepted (HTTP 202 / counted in the `/hook/batch` ack) so clients do not retry
+  or spool them, but they are not stored. Detection combines a per-event marker
+  (`subagentType` for grok, `agent_type`/`agent_id` for Claude Code) with
+  stateful, bounded tracking of subagent session ids: the router seeds the set
+  from any marked event and from the newly registered
+  `SubagentStart`/`SubagentStop` lifecycle hooks (claude-code and grok), and
+  clears it on `SubagentStop`, so the unmarked tail of a subagent session (its
+  `user_prompt_submit`/`stop`/`session_end`, which carry no marker) is dropped
+  too — not just the marker-bearing tool-use events.
+
+### Fixed
+- Native Windows/Git Bash installs now normalize hook cwd, stored project
+  `repo_path`, and the home-directory guard consistently across slash styles,
+  including legacy rows persisted with backslashes. `AI_MEMORY_HOME` now feeds
+  the same home guard as `$HOME`, and Git-backed helpers preserve bare-repo
+  fallback semantics while limiting CLI git fallbacks to path/open failures.
+
+## [1.4.1] - 2026-06-28
+
+## [1.4.0] - 2026-06-26
+
+### Changed
+- `install-instructions` now refreshes a slim markered CLAUDE.md/AGENTS.md
+  snippet and installs or updates managed ai-memory Agent Skills by default,
+  with `--no-skills` for snippet-only refreshes and `--skills-*` flags for
+  scope, agent family, target root, and forced unmanaged replacement. Added
+  `install-skills` for refreshing those prompt-packaging skills directly, and
+  `memory_install_self_routing` now returns the slim block, managed skill
+  payloads, target hints, and overwrite guidance for agents that install
+  routing through MCP.
+
+### Added
+- The native `session-end` hook now emits a one-line stderr note when the spool
+  drain leaves events queued for a later boundary: it reports how many events
+  were flushed, how many remain queued, whether any events were dropped as
+  undeliverable, and names the knobs to bound the backlog
+  (`AI_MEMORY_HOOK_END_BUDGET_MINUTES`, `AI_MEMORY_HOOK_INCREMENTAL_THRESHOLD`),
+  turning an otherwise silent, scary cancelled-hook symptom into an actionable,
+  self-documenting message. A fully-drained session stays silent. (#130)
+- `ai-memory uninstall --only skills` now removes ai-memory-managed Agent Skill
+  files from the default project/global `.claude/skills` and `.agents/skills`
+  roots after marker validation; custom `--target-dir` skill roots remain a
+  manual cleanup path.
+
+### Changed
+- Agent-facing routing prompts and auto-scope docs now call out that static MCP
+  clients running parallel sessions need explicit scope arguments or a
+  session-aware bridge that forwards the real lifecycle-hook session id.
+
+### Fixed
+- Thin-client HTTP CLI commands (`status`, `search`, `read-page`, `write-page`,
+  `delete-page`, `backup`, `embed`, and related admin commands) now fall back to
+  a stored OIDC device-flow token from `auth.json` when `AI_MEMORY_AUTH_TOKEN` /
+  `[auth].bearer_token` is absent. This sends a bearer for external OIDC-aware
+  gateways/bridges; native ai-memory server auth still uses the static root
+  bearer or DB-user tokens, and `/admin/*` remains root-only unless a gateway
+  translates accepted OIDC auth into upstream auth that ai-memory accepts.
+  Static bearer tokens still take precedence.
+
+## [1.3.0] - 2026-06-24
+
+### Added
+- `install-hooks --project-strategy repo-root` bakes a default project strategy
+  into the generated hooks, so every session resolves its project from the main
+  git repo root (collapsing subdirectories and worktrees) without a per-repo
+  `.ai-memory.toml` marker — preventing a persistent `cd` into a subdirectory
+  from forking memory into a phantom project. A marker's own `project_strategy`
+  still takes precedence, and the default (`basename`) bakes nothing, so existing
+  installs are unchanged. Covers every delivery path: POSIX/PowerShell hook
+  scripts, the native `hook` command, and the OpenCode / OMP / OpenClaw
+  TypeScript integrations. (#128)
+
+## [1.2.2] - 2026-06-23
+
+### Fixed
+- Long-session consolidation now favors later same-session corrections when the
+  observation projection cap forces sampling, and both consolidation prompts now
+  instruct the model to treat the most recent/final state as authoritative when
+  observations contradict earlier drafts.
+
+## [1.2.1] - 2026-06-23
+
+### Fixed
+- Hook spool batch drains now scale the `/hook/batch` request timeout with the
+  number of events in the chunk, reducing false timeout retries after a slow
+  server has successfully committed the batch.
+- Hook spool filenames now include a per-process monotonic suffix so tight loops
+  or long-lived helper processes cannot overwrite events created in the same
+  millisecond.
+- Contamination audits now treat `%` and `_` in stored `repo_path` values as
+  literal path bytes, matching runtime cwd-prefix resolution.
+- Auto-improve telemetry rejection aggregates now exclude rejected maintenance
+  report proposals (`curator_report` and `auto_improve_report`) from learning
+  rejection signals.
+- Auto-improve eval stdout capping now reads only `MAX+1` bytes before failing
+  closed, avoiding a flaky oversized-output test path while preserving the cap.
+- Updated `quinn-proto` to clear the new RustSec memory-exhaustion advisory.
+
+## [1.2.0] - 2026-06-23
+
+### Added
+- Added the standalone optional `companions/ai-memory-importer` package for
+  dry-run-by-default OMC flat Markdown wiki imports through public HTTP APIs;
+  it is isolated from the root Cargo workspace and root `cargo test --workspace`.
+- Auto-improvement reviews can now stage bounded patch proposals for existing
+  `_rules/` and `procedures/` pages using append, add-section, and checked
+  replace-section edits, with base-body hashes guarding materialize-to-stage
+  races.
+- Auto-improvement patch proposals now honor a per-run edit budget, and final
+  `_rules/` / `procedures/` pages have configurable token budgets to prevent
+  reviewer runs from growing policy or procedure pages too aggressively.
+- Auto-improvement now keeps a scoped rejection buffer for human rejects,
+  approval conflicts/failures, and validator rejected candidates, then feeds a
+  bounded summary into future reviewer prompts to avoid repeated failed edits.
+- Auto-improvement can now run an optional operator-supplied executable eval gate
+  under `[auto_improve.eval]` after LLM validation and before staging/approval for
+  selected targets (default `_rules` and `procedures`). The gate is disabled by
+  default, receives proposal JSON on stdin, fails closed on command/timeout/JSON
+  errors or insufficient score delta, and records eval failures as rejected
+  candidates without running from hook paths.
+- Added read-only auto-improvement telemetry reporting via
+  `POST /admin/auto-improve/report` and `ai-memory auto-improve-report`, with
+  JSON and human CLI output for recent run counts, proposal outcomes, terminal
+  rates, and operational findings without staging pending proposals; optional
+  `--stage` / `stage: true` creates one pending audit report page for approval.
+- Added `docs/auto-improve-eval-gates.md` plus dependency-free Python and shell
+  scorer templates for `[auto_improve.eval]` proposal gates.
+- Hook spool drains now use `POST /hook/batch` when the server supports it,
+  grouping compatible queued lifecycle events into bounded batches to amortize
+  remote request latency. Older servers fall back to the existing per-event
+  `POST /hook` path.
+
+### Fixed
+- Auto-improvement eval gates now apply timeouts to the full child interaction,
+  cap stdout at 64 KiB, cap eval rejection evidence, and make direct root admin
+  requests inherit server eval defaults unless the request explicitly overrides
+  them.
+- Hook project routing now stores git repo paths using the incoming cwd's visible
+  path spelling, so macOS `/var` vs `/private/var` aliases and symlinked cwd
+  aliases still prefix-match later events into the same project.
+- Updated `git2` to the patched 0.21 line to clear new RustSec unsoundness
+  advisories in libgit2 bindings.
+- Native Claude Code hooks now capture array-shaped `tool_response` content and
+  recognize the native `user-prompt-submit` event token, restoring prompt text
+  and tool output bodies for native installs.
+- The headless hook spool now warns (instead of silently swallowing) when it
+  cannot persist a bumped retry-attempt count back to disk, matching the v1.1.3
+  enqueue-failure fix. A failed atomic rewrite previously lost the in-memory
+  attempt bump, so a poison spool entry never reached `MAX_ATTEMPTS` and kept
+  retrying on every drain boundary with no operator signal until the 7-day
+  age-out pruned it. The warning is sanitized and carries no path (a raw spool
+  path can be a Windows verbatim `\\?\…` path).
+
+## [1.1.3] - 2026-06-20
+
+### Fixed
+- Native Windows Claude Code hooks no longer silently drop every captured event.
+  On Windows, `install-hooks` canonicalizes the data dir, which yields a verbatim
+  extended-length path (`\\?\C:\…`), and that prefix was baked verbatim into the
+  generated `--data-dir` for each native hook command. At capture time the
+  hook-spool write under a `\\?\`-prefixed data dir never lands, and the failure
+  was swallowed (`let _ = enqueue(...)`), so every `UserPromptSubmit` /
+  `PreToolUse` / `PostToolUse` / `PreCompact` / `Stop` / `SessionEnd` event was
+  lost while each hook still exited 0 — only `SessionStart` (handoff retrieval)
+  kept working, masking the loss. The data dir is now de-verbatim'd both when
+  rendering the hook command (new installs emit a plain `--data-dir`) and when
+  the hook resolves its data dir at capture time (an already-installed hook
+  recovers on the next session without re-running `install-hooks`), and future
+  spool enqueue failures emit a sanitized stderr warning instead of staying fully
+  silent. (issue #116)
+- `bin/release` now handles changelog entries containing backslashes, so Windows
+  path examples cannot abort the release after the version files are updated.
+
+## [1.1.2] - 2026-06-19
+
+### Added
+- Documented a migration checklist for users replacing another memory tool:
+  export first, scrub secrets, curate legacy material into reviewed Markdown,
+  configure one client at a time, and remove stale hooks/plugins/MCP servers only
+  after ai-memory capture and retrieval are verified. (issue #115)
+
+### Fixed
+- Handoff selection no longer strands a detailed manual handoff behind a vague
+  auto one. A manual handoff (`memory_handoff_begin`) typically has no cwd while
+  the SessionEnd auto handoff carries the session cwd; the read filtered by exact
+  `cwd` equality, so the next session — whose SessionStart hook always sends a
+  cwd — silently skipped the cwd-less manual handoff and consumed the cwd-bearing
+  auto one instead, leaving the manual one open but unreachable (handoffs have no
+  list/search surface). Selection now prefers a manual handoff over an auto one
+  deterministically: `memory_handoff_begin` always stores a null
+  `from_session_id` and the SessionEnd auto handoff always a non-null one, so
+  manual handoffs are treated as project-wide (always candidates, whatever cwd
+  they carry) and an explicit baton beats the heuristic one regardless of whether
+  the model passed a cwd. Among manual handoffs the most recent wins. Auto
+  handoffs are scoped by a cwd path-boundary (a handoff left in `/repo` reaches a
+  session in `/repo/api`, never `/repo-other`), with the most specific cwd then
+  the most recent as tiebreaks — the cwd-specificity tiebreak applies only to
+  auto handoffs, never reordering manual ones. The path-boundary is computed in
+  Rust, not SQL `LIKE`, so `%`/`_` in a path cannot act as wildcards.
+  The stored cwd is normalized (trailing slash stripped) at insert time so
+  trailing-slash drift between agent payloads cannot break the match.
+  Cross-project isolation is unchanged: handoffs remain scoped by `workspace_id`
+  + `project_id`.
+
+## [1.1.1] - 2026-06-18
+
+### Fixed
+- Internal consolidation and auto-improvement prompts now use a deterministic,
+  budgeted observation projection that preserves high-signal anchors instead of
+  suffix-only observation windows. Manual handoff fields and item lists are
+  capped after sanitizer scrub with visible truncation markers so oversized
+  handoffs do not overwhelm the next agent context; raw observations remain
+  unchanged.
+- `project_strategy = "repo-root"` no longer falls back to `basename(cwd)` for
+  git worktrees whose directory lives outside the main repo tree when the server
+  runs in a container. The server resolves repo-root via libgit2 on the incoming
+  `cwd`, which fails when that host path is not visible inside the container, so
+  every such worktree became its own project. Lifecycle hooks and generated
+  TypeScript plugins now resolve the main repo root host-side — following the
+  worktree commondir pointer with `git rev-parse --git-common-dir` (or the same
+  Rust/libgit2 helper for native hooks) — and send it as an explicit `project`,
+  so linked worktrees collapse to one stable project regardless of where the
+  worktree directory lives or how the server is deployed. The hook-side git
+  probe is silent outside real work trees, preserving the existing basename
+  fallback there. (issue #110)
+- Unscoped MCP queries could resolve to the wrong project on a shared
+  install. The cwd-to-project resolver recorded the bare working directory
+  as a project's `repo_path` whenever the cwd was not inside a git repo
+  (which, under the default basename strategy, was always), so opening a
+  session in a broad ancestor such as `$HOME` created a row that
+  prefix-matched every project nested beneath it and captured their unscoped
+  lookups. A project's `repo_path` is now the git working-tree root, or unset
+  when the cwd is not inside a git repo, never the bare cwd; under the
+  default basename strategy it is recorded only when the cwd is the
+  repository root, never a subdirectory. A read-time guard additionally
+  refuses to prefix-match a stored `repo_path` equal to the operator's
+  `$HOME`, and `ai-memory serve` heals existing installs on startup by
+  clearing any `repo_path` that is not a real git working-tree root (such as
+  a legacy `~/projects` or `/work` catch-all), not only `$HOME` and the
+  filesystem root, while leaving paths it cannot see locally (a remote or
+  multi-user client path, or an unmounted drive) untouched. (issue #103)
+- macOS Docker quick-start now produces a working native-agent setup out of the
+  box (issue #107). Three independent breakages are fixed: (1) the macOS wrapper
+  baked the container-only `host.docker.internal` URL into the *host* agent
+  config, so MCP and every capture hook failed silently — `install-mcp`,
+  `install-hooks`, and `setup-agent` now render the host-reachable
+  `http://127.0.0.1:49374`, decoupled from the `host.docker.internal` URL the
+  wrapper still uses for its own in-container thin-client commands; (2) those
+  thin-client commands were rejected with `403 forbidden host` because the
+  server's loopback-only Host allowlist excluded `host.docker.internal` — the
+  Docker image now ships it in the default `AI_MEMORY_ALLOWED_HOSTS` (native
+  installs stay loopback-only; exposed deployments still override it); and (3)
+  `setup-agent`/`install-hooks` could not locate the hooks bundle that ships
+  beside the binary in the release tarball (the probe derived a bogus
+  `/private/hooks/…`), so the binary-sibling `hooks/` directory is now on the
+  discovery search path and `--source` is no longer required.
+- Wiki reindex and checkpoint restore now preserve page `tier` and `pinned`
+  metadata from frontmatter instead of forcing every reindexed page back to
+  semantic/unpinned. Wiki writes now serialize canonical tier/pinned metadata so
+  later watcher reconciliation remains idempotent for episodic and pinned pages.
+
+### Added
+- `GET /admin/audit-contamination` (and `ai-memory audit-contamination`) — a
+  read-only, SQL-only structural cross-project contamination audit. Flags
+  sessions whose `cwd` longest-prefix-resolves to a different project than the
+  one they landed in (the auto-scope-bleed signature, resolved with the same
+  prefix logic the runtime uses) and observations whose project disagrees with
+  their owning session (a regression tripwire that should stay empty on a
+  healthy DB). Optional `?workspace=&project=` scope; reports only, never
+  mutates, so it is safe to run on any cadence. Purely semantic mislandings
+  (no cwd/session anomaly) are out of scope by design.
+- Mid-session hook-spool drain: on `post-tool-use`, once the local spool backlog
+  crosses a threshold, the hook runs a tightly time-boxed (~250 ms) catch-up
+  drain so a heavy session keeps the backlog flat instead of waiting for the next
+  session boundary. Tunable via `AI_MEMORY_HOOK_INCREMENTAL_THRESHOLD`
+  (default 32 events).
+- Added [`docs/macos.md`](docs/macos.md) covering macOS install paths (prebuilt
+  release binary, source build, and the Docker wrapper) and the `posix` vs
+  `posix-native` hook platform split, with troubleshooting notes for macOS
+  wrapper and hook-discovery issues. Linked it from the README support matrix, the docs
+  table, and `docs/install.md`, and bundled it into the macOS release tarballs
+  alongside `docs/install.md` (mirroring how the Windows zip ships
+  `docs/windows.md`).
+
+### Fixed
+- Bounded heuristic session-page raw observation dumps and single-page
+  consolidation prompts so very large sessions cannot re-include unbounded
+  `## Raw observations` history (issue #102).
+- Hook spool no longer counts a server `429` (saturation / `hook queue full`)
+  against a spooled event's `MAX_ATTEMPTS` retry budget: transient backpressure
+  keeps the event queued without burning an attempt (`MAX_AGE_MS` still bounds
+  it), so a saturation burst no longer silently discards real observations.
+
+## [1.1.0] - 2026-06-16
+
+### Fixed
+- Auto-improvement scheduling now scans every known project each tick instead of
+  only the server's startup/default project. Scheduler ticks remain
+  non-overlapping; if reviewing all projects takes longer than the configured
+  interval, the next tick is delayed until the current tick finishes.
+
+## [1.0.11] - 2026-06-15
+
+### Added
+- Added a server-side auto-improvement scheduler. When an LLM provider is
+  configured, `[auto_improve.scheduler] enabled = true` reviews newly completed
+  sessions in the background, stages validated proposals for audit, and then
+  follows the normal auto-improvement approval policy.
+- Added persistent scheduler state and per-session scheduler claims so upgrades
+  from the v1.0.3-era schema do not process historical session backlog
+  automatically, and failed scheduled reviews do not retry forever. Manual
+  `ai-memory auto-improve --session-id <uuid>` and MCP `memory_auto_improve`
+  remain the catch-up path for older or failed scheduled sessions.
+
+### Changed
+- Clarified that scheduling and approval are separate: disable automatic review
+  with `[auto_improve.scheduler] enabled = false`; keep proposals pending with
+  `[auto_improve] require_approval = true`.
+
+## [1.0.10] - 2026-06-15
+
+### Changed
+- `ai-memory auto-improve --session-id <uuid>` and `POST /admin/auto-improve`
+  now record validated proposals in the pending-writes audit trail and approve
+  them immediately through the normal wiki write path. Set
+  `[auto_improve] require_approval = true` to keep proposals pending for manual
+  review. The MCP `memory_auto_improve` tool uses the same behavior.
+- Existing project wikis need no migration. Existing server configs that
+  contain the old `[auto_improve] mode = ...` key keep working; the key is now
+  ignored and can be removed when convenient.
+
+## [1.0.9] - 2026-06-15
+
+### Fixed
+- Clarified architecture and auto-improvement design docs so CLI/admin
+  auto-improvement is described with pending-writes storage and approval
+  boundaries.
+
+## [1.0.8] - 2026-06-15
+
+### Added
+- Added auto-improvement proposal storage: `ai-memory auto-improve` and
+  `POST /admin/auto-improve` store validated proposals in durable SQLite-backed
+  pending-write rows with non-indexed `_pending/auto-improve/` sidecars. The new
+  `ai-memory pending-writes list|show|diff|approve|reject` commands and
+  `/admin/pending-writes*` routes let operators review, apply, or reject stored
+  proposal bodies through the normal wiki mutation path.
+- Added first-release curator support: `ai-memory curator` and
+  `POST /admin/curator` run a rule-based, no-LLM, report-only maintenance
+  review for an existing workspace/project. Dry-run is the default and writes
+  nothing; `--stage` creates exactly one pending report proposal for approval
+  through the existing pending-writes queue, without editing pages, deleting
+  content, rewriting links, or changing slots.
+
+## [1.0.7] - 2026-06-15
+
+### Added
+- Added the initial auto-improvement reviewer: `ai-memory auto-improve
+  --session-id <uuid>` calls `POST /admin/auto-improve`, reads one completed
+  session, applies preflight noise filters, samples large sessions via the
+  consolidated session page plus high-signal observations, asks the configured
+  LLM for structured durable wiki edit proposals, and validates
+  path/evidence/confidence plus duplicate existing path/title constraints.
+  Thresholds remain configurable: confidence, input budget, proposal cap,
+  `auto_improve` attribution, and `_pending/auto-improve` proposal path.
+- Added MCP tool `memory_auto_improve` so agents can run learning review for the
+  latest completed session (or a named session) without shelling out. The
+  canonical MCP instructions and installed CLAUDE.md/AGENTS.md routing snippet
+  now teach agents to treat `_rules/`, `gotchas/`, `procedures/`, and
+  `decisions/` as actionable guidance for proactive retrieval.
+
+### Changed
+- Clarified upgrade guidance: Docker-wrapper users should run
+  `ai-memory upgrade` on each agent machine to refresh the wrapper, pulled
+  image, and staged hook scripts; native package/source installs should rerun
+  `install-hooks --apply` after binary upgrades; remote servers still need a
+  separate redeploy; and existing projects can refresh the managed routing block
+  to pick up new proactive retrieval and `memory_auto_improve` guidance.
+
+### Fixed
+- `auto-improve` now tolerates common malformed LLM proposal shapes found during
+  live testing: evidence arrays may contain bare quote strings instead of
+  `{ page, quote }` objects, a missing `operation` defaults to the only supported
+  `create_or_update` operation, markdown bodies can arrive as `body`,
+  `markdown`, or `content`, plural/folder-style kind names are normalized before
+  path validation, and proposals still missing required target data are rejected
+  by validation instead of turning the whole review into a 502 response.
+- Admin destructive ops (`/admin/purge-project`, `/admin/move-project`) now
+  propagate the authenticated actor (from the auth middleware's
+  `Extension<ActorContext>`) into the admission context, so a `scope-guard`
+  admission webhook can authorize them by user. They previously built the
+  context with an empty actor, which a per-user scope-guard ACL rejected with
+  `403 user '' not allowed to purge_project`, making purge/move unusable on any
+  instance running scope-guard. `rename-project` is unaffected (it runs no
+  admission chain).
+## [1.0.6] - 2026-06-14
+
+### Changed
+- Centralized workspace/project scope resolution in `ai_memory_store::ScopeResolver`
+  and shared explicit helpers, then migrated MCP, admin, and web API routes onto
+  the common no-create/create-on-write policies.
+- Centralized auth checks behind `AuthLevel::authorize(Capability::...)` so admin,
+  user-management, and admission-skip behavior share one permission framework.
+- Tightened wiki/SQLite consistency semantics: markdown remains the source of
+  truth, batch writes install files before committing the derived SQL index, and
+  runtime SQL failures roll installed files back best-effort.
+
+### Added
+- Regression tests for shared scope policies, capability authorization, and
+  wiki-file rollback when `write_page` / `apply_batch` store upserts fail.
+
+## [1.0.5] - 2026-06-14
+
+### Fixed
+- Multi-user admin authorization is now enforced at the shared `/admin/*`
+  router boundary, including user-management routes, so DB-user tokens can use
+  normal MCP/API read-write surfaces for attribution but cannot reach any admin
+  endpoint. Added regression coverage for every admin route plus DB-user write
+  attribution.
+
+## [1.0.4] - 2026-06-14
+### Added
+- `install-hooks --agent grok` (plus `setup-agent` / `uninstall` coverage) for
+  the xAI **Grok Build CLI**. Grok's `~/.grok/hooks/ai-memory.json` shares Claude
+  Code's JSON shape and seven-event vocabulary, with a Grok-specific hook bundle
+  and native `ai-memory hook --event … --agent grok` commands.
+  ai-memory entries merge into a dedicated `ai-memory.json`, leaving any
+  third-party `~/.grok/hooks/*.json` untouched. NOTE: Grok ignores hook stdout on
+  `SessionStart`, so capture works but handoff injection does not. Grok's
+  `session-start` therefore skips the handoff fetch entirely — the fetch is
+  destructive (it marks the handoff accepted server-side) and Grok would discard
+  the result, silently losing the handoff; recover a prior session's handoff via
+  the MCP `memory_handoff_accept` tool instead. Adds `AgentKind::Grok` (`grok`
+  wire tag), the `AgentKind::session_start_injects_handoff` gate, and migration
+  `V20` extending the `sessions.agent_kind` CHECK so Grok sessions persist on
+  upgraded servers (the antigravity/`V11` precedent).
+
+### Fixed
+- Actor-scoped MCP tool calls no longer fall through to a user's or process's
+  latest hook-published project when the request carries a session id that does
+  not match hook activity. This prevents HTTP-remote shared servers from reading
+  or writing another same-user project when the MCP transport session id differs
+  from the hook session id ([#97]).
+- `memory_handoff_begin` and `memory_handoff_accept` now accept an optional
+  `workspace` argument alongside `project`, resolving through the same
+  workspace+project path as `memory_write_page` (begin, create-if-missing) and
+  `memory_handoff_cancel` (accept, find-only). They previously took `project`
+  only, so a cross-workspace handoff was routed by the per-actor active-project
+  fallback and could be written to — or read from — the wrong project.
+  `memory_handoff_cancel` already carried `workspace`.
+- Workspace/project resolution now fails closed across the MCP and admin
+  surfaces. Explicit MCP project misses no longer fall back to the active/default
+  project, write-style MCP calls reject `workspace` without `project`, admin
+  read/search/embed/lint/sweep paths use no-create lookups, and `/admin/reorg`
+  only moves sessions and graveyards latest pages inside the target workspace.
+
+## [1.0.3] - 2026-06-13
+### Added
+- Native macOS release tarballs (`ai-memory-macos-aarch64.tar.gz` for
+  Apple Silicon and `ai-memory-macos-x86_64.tar.gz` for Intel) are now
+  published on every tag, alongside the existing Linux tarballs and the
+  Windows zip. The macOS `release-build` CI job also runs on every push,
+  so a macOS-only release regression is caught before the tag rather
+  than after. Install instructions added to `README.md` and
+  `docs/install.md` ([#94]).
+
+## [1.0.2] - 2026-06-12
+### Fixed
+- Session-page tool-call counts no longer double every entry. The
+  no-LLM synthesizer was counting both `PreToolUse` and `PostToolUse`
+  observations into the same bucket, so a single Bash call rendered
+  as `Bash: 2` and two real calls as `Bash: 4`. It now counts only
+  `PostToolUse` (the "completed call" event), matching the user-facing
+  meaning of the heading.
+
+## [1.0.1] - 2026-06-12
+### Added
+- `install-mcp --client vscode-copilot` renders (and `--apply` writes) a
+  workspace-scoped `.vscode/mcp.json` for VS Code GitHub Copilot's agent
+  mode. The renderer uses VS Code's MCP framework schema — top-level
+  `servers` key, `type: "http"`, `url`, and an inline `headers` map for
+  the bearer token — and includes a note that VS Code Copilot does not
+  yet expose lifecycle hooks, so ai-memory's automatic capture is not
+  active there (the MCP tools must be called explicitly from chat).
+  Aliases: `copilot`, `github-copilot`. `uninstall --only mcp` strips
+  the same entry idempotently.
+
+## [1.0.0] - 2026-06-12
+### Added
+- Native hook drain and handoff timings can now be raised with
+  `AI_MEMORY_HOOK_DRAIN_TIMEOUT_MINUTES`,
+  `AI_MEMORY_HOOK_HANDOFF_TIMEOUT_MINUTES`,
+  `AI_MEMORY_HOOK_START_BUDGET_MINUTES`, and
+  `AI_MEMORY_HOOK_END_BUDGET_MINUTES` for high-latency or large-backlog
+  instances. Defaults preserve the existing short hook behavior; invalid,
+  zero, or overly large values fall back or clamp safely.
+
+## [0.16.0] - 2026-06-11
+### Added
+- Native Claude Code hooks on macOS/Linux now use the direct
+  `ai-memory hook --event ...` command by default, matching native Windows.
+  Native hook commands spool events locally and can authenticate with a stored
+  per-developer OIDC device token instead of a shared static hook token.
+- `ai-memory auth login oidc-device --issuer <url> --client-id <id>` stores a
+  generic OIDC device-flow token for native hook authentication.
+
+### Fixed
+- `ai-memory uninstall --only hooks` now recognizes and removes native
+  `ai-memory hook ...` commands as well as legacy script commands.
+
+## [0.15.0] - 2026-06-11
+### Added
+- Wiki recovery checkpoints now have first-class operator commands:
+  `ai-memory checkpoints` lists recent wiki git commits and
+  `ai-memory restore-page --path <page.md> --from <rev>` restores one page
+  from a checkpoint, writes a new post-restore checkpoint, and reindexes the
+  restored page into SQLite. Startup also creates a one-time upgrade baseline
+  checkpoint for existing wiki trees that had no git commits yet.
+
+### Fixed
+- Release publication now limits the GitHub Release asset download step to
+  `ai-memory-*` artifacts, avoiding Docker Buildx side artifacts that can make
+  tag workflows fail after binaries and Docker images are already published.
+
+## [0.14.0] - 2026-06-11
+### Added
+- Tagged releases now publish a native Windows x86_64 zip artifact
+  (`ai-memory-windows-x86_64.zip`) with `ai-memory.exe`, hooks, default
+  config template, checksums, and Windows install docs, giving native
+  Windows agents a no-toolchain path to the fast direct-binary hook mode.
+
+## [0.13.0] - 2026-06-08
+### Added
+- New `ai-memory reindex` lifecycle command rebuilds the derived SQLite page
+  index from the on-disk wiki. It recreates workspace/project rows from
+  per-scope `_meta.md` manifests while preserving the UUIDs encoded in the
+  wiki tree, then reindexes page markdown into pages, links, and FTS. The
+  command refuses to run unless the SQLite store is clean; operators should
+  stop the server, back up data, move/remove `db/memory.sqlite`, run
+  `reindex`, and recompute embeddings separately with `embed` when needed.
+- Wiki startup now backfills per-workspace and per-project `_meta.md` manifests
+  containing the human workspace/project names (and `repo_path` for projects)
+  so the markdown tree is self-describing enough to rebuild the derived DB.
+
+### Fixed
+- Wiki reindexing now treats `log.md` / `log-YYYY-MM.md` as raw hook ledgers
+  only when their content opens with the hook log prefix, so ordinary markdown
+  pages with reserved-looking names are no longer silently dropped. `_meta.md`
+  manifests and direct watcher events also reject symlinks before reading.
+
+## [0.12.3] - 2026-06-07
+
+## [0.12.2] - 2026-06-07
+### Fixed
+- The hook router no longer auto-creates fragment "projects" for
+  subdirectory cwds. When a tool call's cwd sits inside an existing
+  project's `repo_path` tree (for example a `Read` of
+  `manga-plus/reader/src/main.rs` while the session is attributed to
+  `manga-plus`), the resolver now picks the existing parent project
+  instead of materialising a `src` or `reader` project for the
+  subdirectory name. The schema column `projects.repo_path` has
+  always been there for exactly this kind of cwd matching; the
+  resolver finally queries it. Sub-projects declared via
+  `.ai-memory.toml` still win because their longer `repo_path` ranks
+  ahead. New `find_project_by_cwd_prefix` reader helper covers the
+  query. Three regression tests in `ai-memory-hooks::router::tests`
+  pin the parent / sub-project / cold-start paths.
+- V19 data-repair migration re-attributes pre-existing orphan
+  observations and handoffs to their session's project, then deletes
+  the now-truly-empty fragment project rows that were left behind
+  by the bug above. The session is the source of truth — observations
+  belong to the session that emitted them and the FK enforces
+  session existence. The migration is idempotent (re-running on a
+  repaired DB is a no-op) and runs once per data directory at server
+  startup via the existing refinery chain. `scratch` is explicitly
+  preserved per CLAUDE.md invariant #15a (defensive cwd-less
+  default).
+
+## [0.12.1] - 2026-06-07
+### Fixed
+- `GET /favicon.ico` now lives at the absolute host root, outside
+  `--base-path` and outside the `/web` nest, so the browser's
+  automatic favicon fetch actually reaches it. The 0.12.0 build mounted
+  the route inside the web router and ended up serving the icon only
+  at `/web/favicon.ico` — invisible to the browser's auto-fetch (the
+  icon still appeared via the in-page `<link rel="icon">` tag, so the
+  user-visible behaviour stayed correct, but the dedicated route was
+  unreachable). The new mount is also exempt from bearer auth and the
+  host allowlist so a fresh tab gets the icon without an HTTP Basic
+  prompt; the embedded PNG is the same one any visitor to `/web`
+  already sees, so the info-leak surface is nil. Surfaced by the
+  post-merge audit live test ([#79]).
+
+## [0.12.0] - 2026-06-07
+### Added
+- New `ai-memory hook` subcommand emits one lifecycle event natively (reads
+  the JSON payload from stdin, POSTs to `/hook`, GETs `/handoff` on
+  `session-start`) without spawning a shell. On native Windows, Claude Code
+  now defaults to the native hook command — measured ~3.5-5× faster per
+  tool-call hook (~735 ms shell → ~150-205 ms native on an i7-6700HQ).
+  Opt back into the previous Git Bash + `.sh` path with
+  `AI_MEMORY_HOOK_PLATFORM=windows-bash`. See
+  [`docs/windows.md`](docs/windows.md#native-hook-command-claude-code-on-windows)
+  ([#84]).
+- New `GET /favicon.ico` route on the web UI serves the same logo bytes as
+  the header, so the browser tab carries an icon without an extra asset
+  embed ([#79]).
+- Thin-client CLI commands (`status`, `write-page`, `search`, `read-page`,
+  `embed`, `lint`, `backup`, …) now respect the server's base-path mount
+  via `AI_MEMORY_BASE_PATH` or the path component of `AI_MEMORY_SERVER_URL`
+  (URL path wins), so deployments hosted behind a reverse proxy under a
+  subpath stop 404'ing — including the container `HEALTHCHECK`
+  (`ai-memory status`). Empty / unset means root mount, byte-identical to
+  the prior behaviour ([#82]).
+
+### Changed
+- The embedded web UI ships a single transparent 768×768 PNG (~126 KB,
+  down from a 992 KB JPEG mislabelled as PNG) used for both the header
+  logo and the favicon. README branding stays on the existing
+  light/dark pair via `<picture>` ([#79]).
+
+### Fixed
+- `install-hooks --apply` (and `ai-memory upgrade`, which calls it) now
+  MERGES into per-event hook arrays instead of replacing them, so
+  third-party hooks registered under the same event (e.g. a context-mode
+  `SessionStart` guard) survive re-apply. ai-memory-owned entries are
+  still swapped for the fresh ones; re-runs stay idempotent. Resolves
+  #80 ([#83]).
+- FTS5 searches for filenames carrying ASCII punctuation no longer error
+  or silently miss. `current.md` (which used to surface
+  `fts5: syntax error near "."`) and `ui-refresh` (which silently returned
+  zero hits despite `follow-ups/ui-refresh-scroll-restoration.md` existing)
+  both work end-to-end. Punctuated tokens are now quoted as both
+  whole-form and split-form phrases, OR'd, to satisfy the asymmetry
+  between the content tokenizer (`tokenchars '/_-'` keeps them inside
+  tokens) and the path index (which pre-expands `/_-.` to spaces)
+  ([#81]).
+
+## [0.11.0] - 2026-06-05
+### Added
+- New `[auto_scope]` config block (`mode`, `session_ttl_secs`,
+  `max_entries`) selects how the hook-published "currently active project"
+  pointer is shared across concurrent MCP callers. The default `single` mode
+  preserves the historical process-wide slot. Opt-in `per_session` keys the
+  pointer by `session_id` to isolate concurrent agent runs of the same
+  operator; opt-in `per_actor` keys by `(user, session_id)` to isolate
+  across operators as well, pairing with multi-user mode where `user`
+  comes from the `users` row that owns the bearer token. `per_actor`
+  also keeps a user-only fallback slot so authenticated MCP requests
+  from clients that cannot forward a session id do not inherit another
+  user's latest project; same-user session isolation still requires a
+  client/bridge that sends `X-Memory-Actor-Session-Id` or
+  `Mcp-Session-Id` on MCP tool calls. Per-key entries carry an insertion
+  timestamp and are TTL-evicted (default 1 hour) and
+  capped (default 4096) so adversarial / runaway clients cannot grow the
+  map without bound. Both opt-in modes still publish to the single slot
+  in parallel, so any caller without actor context falls back gracefully
+  to the most recent project rather than an empty pointer. All MCP read
+  tools (`memory_query`, `memory_recent`, `memory_read_page`,
+  `memory_status`, `memory_briefing`, `memory_explore`, `memory_lint`,
+  `memory_forget_sweep`, `memory_handoff_*`) now thread the request's
+  `ActorContext` into scope resolution, so opt-in isolation takes effect
+  for the full read surface.
+
+### Fixed
+- Claude Code lifecycle hooks now emit structured JSON on stdout. Fire-and-
+  forget hooks return `{}`, and `SessionStart` wraps pending handoff text in
+  `hookSpecificOutput.additionalContext`, avoiding Claude Code's repeated
+  "Hook output does not start with {" debug spam while preserving handoff
+  injection.
+- `POST /admin/rename-project` now returns `404 Not Found` when the project row
+  has been deleted (typically by a concurrent `purge-project`) between the
+  handler's id lookup and the writer's `UPDATE`. The pre-fix path silently
+  responded `200 OK` with `pages: 0` for an operation that affected zero rows,
+  which contradicted the concurrent purge's also-`200 OK` destruction of the
+  same project and gave operators no signal that the rename had been undone.
+
+## [0.10.0] - 2026-06-04
+### Added
+- New `POST /admin/delete-page` HTTP endpoint deletes a single page with
+  explicit `(workspace, project)`. Like `purge-project`/`rename-project`, it
+  uses no-create lookup — a delete on a typo'd or wrong scope now returns
+  `404 workspace 'X' not found` instead of silently auto-creating the
+  container and returning misleading `deleted: true`.
+- New `ai-memory delete-page --path <P> --workspace <W> --project <P>` CLI
+  subcommand, a thin client of `/admin/delete-page`. Mirrors the
+  write-page/read-page CLI shape so terminal users get a complete
+  delete-single-page surface for the first time.
+- New `memory_handoff_cancel` MCP tool marks an exact open handoff id expired,
+  giving agents a safe way to discard a mistakenly-created pending handoff
+  before the next session consumes stale context.
+
+### Fixed
+- MCP tool descriptions and routing snippets now draw a sharper boundary
+  between read-only `memory_briefing` and session-ending
+  `memory_handoff_begin`, reducing accidental dangling handoffs when an agent
+  was only asked for project status.
+- Custom `--web-ui-dir` SPAs mounted at a non-root `--web-slug` now serve the
+  injected shell at the trailing-slash root too (for example `/web/`), matching
+  `/web` and deep client routes instead of returning a refresh-only 404.
+- OpenCode and OMP generated hooks now derive `project_strategy = "repo-root"`
+  project names from the host-visible `.ai-memory.toml` marker directory before
+  sending hook payloads, so dockerized servers no longer fall back to git
+  discovery inside paths they cannot see.
+- `memory_delete_page` (MCP) now accepts `workspace` alongside `project` and
+  routes scope through `effective_ids_for_read_args`, the same path the read
+  tools use. Previously a project name that lived in multiple workspaces
+  could silently route the delete to the wrong slot and return `deleted:
+  true` for a page that was never touched. Operators on shared (multi-
+  workspace) servers should explicitly pass `workspace + project` to make
+  the target unambiguous.
+
+## [0.9.0] - 2026-06-02
+### Added
+- `openai-compat` LLM providers can now opt into strict JSON Schema structured
+  output with `AI_MEMORY_LLM_COMPAT_STRICT=true`. Strict mode sends
+  `response_format=json_schema` first for compatible Ollama, vLLM, LM Studio,
+  llama.cpp, and gateway endpoints, while the tolerant JSON-object parser
+  remains the default and the fallback for strict raw-call failures ([#70]).
+- The read-only web browser now renders `[[wiki links]]` as clickable internal
+  links to the target page. Supports `[[path]]`, `[[path|label]]`,
+  `[[project:path]]`, and `[[workspace/project:path]]`, resolved against the
+  current page's project unless the target carries its own scope; bare targets
+  get a `.md` suffix. External schemes, path traversal, and links inside fenced
+  or inline code are left as literal text ([#68]).
+- `ai-memory serve --transport http` can host the entire HTTP surface under a
+  configurable subpath with `--base-path` / `AI_MEMORY_BASE_PATH`; `/mcp`,
+  `/hook`, `/admin/*`, `/api/v1`, and the web UI all move under that prefix.
+  The web UI mount can also be changed with `--web-slug`, and custom
+  `--web-ui-dir` SPAs receive injected `<base href>` plus
+  `ai-memory-base-path` metadata for same-origin API calls behind reverse
+  proxies ([#65]).
+- `ai-memory move-project` can move projects across workspaces via the admin
+  API. Fresh destinations use a lossless true move that keeps the same
+  `project_id`, sessions, observations, handoffs, embeddings, and page history;
+  existing same-named destination projects use copy-purge merge with explicit
+  `on_conflict` handling. Admission webhooks can subscribe to the new
+  `move_project` event and receive destination names in the context ([#60]).
+- Page FTS now indexes normalized page paths, so searches can find pages by
+  filename or slug even when the slug does not appear in the title/body ([#62]).
+- Admission webhooks can now observe, mutate, or reject engine write/delete/
+  purge operations, with authenticated actor context, loop-prevention skip
+  lists for trusted re-entry, and non-blocking observer webhooks for mirrors
+  and backups ([#55]).
+- New `memory_delete_page` MCP tool deletes a single page by exact path,
+  updates the SQLite index directly, and fires `op=delete` admission hooks
+  before removal ([#55]).
+
+### Fixed
+- Backups no longer dereference symlinks under `wiki/`, preventing a planted
+  wiki symlink from pulling arbitrary readable host-file contents into
+  `backup.tar.gz`.
+- `ai-memory restore` now validates tar entries before extraction and accepts
+  only regular files/directories under the expected backup paths
+  (`wiki/`, `db/memory.sqlite`, and `config.toml`), rejecting links, special
+  files, unsafe paths, and unexpected archive entries.
+- In multi-user mode (`[auth].token_pepper` configured), operational
+  `/admin/*` endpoints now require the root token; DB-user tokens receive
+  403 while single-user installs keep the historical permissive admin behavior.
+- LLM provider clients now cap provider response bodies before JSON, text, or
+  SSE parsing, and truncate error bodies from bounded buffers instead of
+  buffering arbitrary-size responses.
+- Non-blocking admission webhooks now have a process-level in-flight cap and
+  webhook timeouts are clamped to a safe maximum, preventing observer hooks
+  from growing unbounded background work during write bursts.
+- Hook cwd/project resolution caching is now bounded with LRU-style eviction,
+  preventing unbounded process-lifetime growth from streams of unique cwd
+  values.
+- `memory_write_page` tool description and routing prompts now steer agents
+  toward writing the page title as a `# H1` on the first line of `body` and
+  omitting the `title` argument. ai-memory already auto-derived the title from
+  `# H1` (or path stem) when `title` was missing — the change is documentation
+  only, but it eliminates a known source of MCP `JSON parsing` errors when the
+  LLM failed to escape quotes/colons in `title` ([#67]).
+- Custom `--web-ui-dir` frontends no longer serve raw `/index.html` without
+  base-path injection; direct index requests and SPA fallback routes now return
+  the injected shell, while static assets remain untouched ([#65]).
+- `move-project` true moves now run through a wiki mutation gate: normal
+  page writes/reindexes validate the `(workspace_id, project_id)` pair before
+  touching disk, while true moves hold the exclusive side across the directory
+  rename and DB re-stamp. Stale old-workspace writes now fail without creating
+  orphan files, and V18 aborts if existing split-brain rows are present ([#60]).
+- `move-project` copy-purge conflict detection now treats body, frontmatter,
+  title, tier, and pinned status as the page identity under `on_conflict=block`,
+  preventing metadata-only overwrites from slipping through ([#60]).
+- `memory_write_page` calls that specify `project` without `workspace` now
+  default to the active workspace published by hooks, and project-only reads use
+  the same active-workspace resolution so the write can be read back without an
+  explicit workspace ([#61]).
+- `memory_read_page` now accepts explicit `workspace` + `project` for sibling
+  projects and falls back to the stored DB body only when the markdown file is
+  missing, not when the disk source of truth is corrupt or unreadable ([#63]).
+- `openai-oauth` now speaks the current ChatGPT/Codex responses stream format
+  for bootstrap/consolidation requests and avoids sending the unsupported
+  `max_output_tokens` field on that endpoint ([#64]).
+- `ai-memory write-page` now resolves an omitted `--project` through the same
+  current-project heuristic as `read-page` and `search`, preventing writes from
+  landing in `scratch` while the read-back targets the cwd-derived project
+  ([#66]).
+
+## [0.8.1] - 2026-05-30
+
+### Fixed
+- **Consolidation no longer fails on long sessions** (~5,000+ observations or
+  multi-hour agent runs). Two bugs surfaced trying to consolidate a real
+  16-hour / 7,234-observation session:
+  - **Prompt confusion (regression from the v0.8 `slot_kind` work):** the
+    multi-page consolidator prompt listed `slot_kind` values
+    (`state` / `invariant`) immediately above the `tier` values
+    (`working` / `episodic` / `semantic` / `procedural`). The LLM read them
+    as one list and emitted `tier: "state"` in structured responses, which
+    deserialisation rejected. Prompt now leads with `tier` (with explicit
+    "EXACTLY ONE OF FOUR strings" emphasis), then `kind`, then `slot_kind`
+    under its own clearly-scoped section that states "completely unrelated
+    to tier" and "only for `_slots/*` paths."
+  - **No token budget on the observation dump:** `build_request` and
+    `build_batch_request_with_slots` dumped every observation into the
+    prompt buffer, which exceeded the provider's 200k-token context on long
+    sessions (the sabadell run produced a 235k-token request → 400 from
+    the provider). New `window_observations_to_budget` walks the slice
+    from most-recent backward, keeping each entry whose render cost fits
+    in a 400k-char budget (~100k tokens), leaving room for the system
+    prompt + schema + LLM output. When entries are skipped, a prepended
+    note tells the LLM the context is partial so its summary doesn't
+    pretend to cover the early session. Both `PreCompact` and
+    `memory_consolidate` triggers benefit from the fix — both were silently
+    failing into the `warn!()` catchall on sessions this long.
+  - 5 unit tests guard the windowing invariants (empty input, fits-under-
+    budget passthrough, most-recent-preserved, single-too-large-obs drops
+    everything, observation-boundary alignment). No schema change, no
+    config knob, backward-compatible for sessions that already fit.
+
+## [0.8.0] - 2026-05-30
+
+### Added
+- **Multi-user attribution (v0.8 Phase 1, rolling out across milestones
+  P1.1–P1.8).** ai-memory's data model stays single-tenant — every
+  authenticated request sees every page — but writes can now be
+  attributed to a named user. Five `ai-memory user` subcommands
+  (`add`, `list`, `expire`, `revive`, `rotate-token`) manage a `users`
+  table; the auth middleware resolves every request to one of four
+  tiers (Anonymous, Root, DB user, 401), injects an
+  `Extension<ActorContext>` + `Extension<AuthLevel>` for downstream
+  consumers, and gates the root-only admin user-management endpoints.
+  Tokens are 32 bytes of OS CSPRNG, stored only as
+  `SHA-256(token || ":" || token_pepper)` (per-server pepper from
+  `[auth].token_pepper`, auto-generated on `ai-memory init`); see
+  [`docs/users.md`](docs/users.md) for the SHA-256-not-argon2id
+  rationale, the four-rung auth ladder, and the backward-compat
+  migration for pre-v0.8 installs. New v0.8 fields on `[auth]`:
+  `root_username` / `root_email` / `root_name` (label for the bearer
+  token's writes) and `token_pepper`. Per-page `author_id` + web UI
+  surfacing lands in P1.6/P1.7; this milestone set ships P1.1
+  (`ActorContext` + `UserId` in core), P1.2 (table + writer/reader
+  ops + V14 migration), P1.3 (auth middleware), P1.4 (root-gated
+  `POST/GET /admin/users` + `…/expire|revive|rotate-token`), and P1.5
+  (CLI subcommands). **No behaviour change for existing single-user
+  installs**: without `[auth].token_pepper` the multi-user lookup
+  stays dormant, user-management endpoints 503 with a clear
+  `multi-user not enabled` message pointing at `ai-memory init`,
+  and the existing `bearer_token`-only flow keeps authenticating
+  exactly as before.
+- **`memory_query { global: true }` — cross-project global search** that
+  reaches every project in every workspace in one call, with each hit
+  annotated by its workspace + project so the agent can tell where it
+  came from. Use when the agent doesn't know which project holds a
+  cross-cutting note (shared infra/ops, a sibling app). Mutually
+  exclusive with `scopes`/`project`/`workspace`. Routing snippet +
+  `MEMORY_INSTRUCTIONS` now teach both broadening modes (`scopes` for
+  named siblings, `global=true` for unknown locations) and explicitly
+  warn that `memory_query` returns snippets — use `memory_read_page`
+  for full bodies. The prompt-surface contradiction the original PR
+  shipped ("there is no global 'search everything' mode" right after
+  the bullet advertising `global=true`) was caught in the post-merge
+  audit and rewritten; the prompt regression test now refuses any
+  variant of that legacy phrasing
+  ([#56], thanks @djalmajr).
+- **Cross-project wiki links + dependency graph.** Wikilinks gain an
+  explicit scope qualifier: `[[project:path.md]]` for a sibling project
+  in the same workspace, `[[workspace/project:path.md]]` for another
+  workspace. Bare links are unchanged (resolve within the source's own
+  project). `links.to_workspace` / `links.to_project` join the primary
+  key so the same `to_path` can land in two different projects without
+  colliding. `memory_lint` now reports dangling cross-project refs
+  (typo'd project vs missing/renamed target page), `memory_briefing`
+  exposes `cross_project_dependents` / `cross_project_dependencies`
+  per project, and `GET /api/v1/graph` returns the resolved cross-
+  project edges for a graph view. Migration V13 rebuilds the `links`
+  table preserving existing rows as `(to_workspace=NULL,
+  to_project=NULL)` — same "local" semantics as before
+  ([#57], thanks @djalmajr).
+
+### Changed
+- **FTS5 queries OR-join bare multi-word inputs** instead of the
+  pre-existing AND default. A natural-language query like
+  `"have we discussed cross project search strategy"` previously
+  required every word to co-occur in one page — near-zero recall for
+  multi-word queries, which the caller silently mistook for "never
+  recorded". OR + BM25 ranking (callers already `ORDER BY rank`) keeps
+  the best-matching pages at the top of the list, so the user-visible
+  top-N is still AND-ish; OR just adds a relevant tail instead of
+  returning nothing. Explicit FTS5 syntax (`OR`/`AND`/`NOT`/`NEAR`,
+  quoted phrases, parens) is detected and preserved verbatim so the
+  exact-match escape hatch stays available. 5 new unit tests guard the
+  preservation contract (post-merge audit). Migration V12 rebuilds the
+  FTS tables with `unicode61 remove_diacritics 2` so accent-free
+  Portuguese queries (`"descricao da sessao"`) match accented stored
+  text (`"descrição da sessão"`); contentless FTS — source rows
+  untouched ([#58], thanks @djalmajr).
+- **MCP write tools now honour the session's project (and create
+  named projects on demand).** Three correctness fixes on
+  `memory_write_page` / `memory_lint` / `memory_forget_sweep`:
+  - A `memory_write_page { project: "X" }` for a project name that
+    doesn't exist used to silently fall through to the session's
+    active project (find-only resolution); writes meant for a fresh
+    project polluted the current one. A new `write_target_ids`
+    helper uses **get-or-create** for an explicit project name, so
+    a named write always lands where the agent asked.
+  - `memory_lint` + `memory_forget_sweep` previously always targeted
+    the server's baked `--project` regardless of the session, so a
+    cross-project lint or retention sweep could never reach the
+    project the user was actually working in. Both now resolve
+    through the same find-only `effective_ids_for_read_args` path
+    the read tools use, with the hook-published active project as
+    the fallback.
+  - Both `lint` / `sweep` and the new `write_page` add explicit
+    `workspace` + `project` args (defaulted to current session,
+    documented with the v0.5.2 "**Omit unless the user explicitly
+    names a *different* project.**" tail). 2 regression tests cover
+    "Bug B" (explicit-project write must create + land) and
+    "Bug C" (sweep must evaluate the named project, not the baked
+    default) ([#59], thanks @djalmajr).
+
+## [0.7.1] - 2026-05-29
+
+### Fixed
+- **`install-hooks --agent codex` no longer panics with `index not found`**
+  when `~/.codex/config.toml` carries an `[mcp_servers]` table that has other
+  MCP servers (context7, node_repl, …) but no `ai-memory` entry — a
+  perfectly valid setup since ai-memory can integrate via hooks alone.
+  `infer_codex_mcp_config` used `toml_edit`'s panicking `Index` impl with
+  bare `[]` chains; it now walks the table via `.get()` and returns `None`
+  on any missing key. Mirrors the safe pattern the JSON variant has used
+  all along. Adds 4 regression tests covering missing-entry,
+  missing-table, empty-doc, and bare-entry inputs
+  ([#53], thanks @Otavio-Machado-Santos).
+- **`install-hooks --agent claude-code` no longer silently stages 0 scripts
+  and points `settings.json` at an empty directory.** On macOS — and any
+  install where the binary lives outside the repo and the system package
+  paths (`/usr/local/share`, `/usr/share`) are absent — `resolve_hooks_dir`
+  fell through to the data-local candidate, which was *also* the staging
+  destination. The wipe-then-copy flow inside `stage_hook_scripts_in` then
+  deleted the very scripts it was about to read, leaving 0 copied; the
+  caller proceeded to rewrite `settings.json` anyway, disabling capture
+  with no error. The function now (a) canonicalizes source and destination
+  paths, skips the wipe + copy when they match and verifies in-place,
+  preserving any scripts a prior `setup-agent` run extracted there, and
+  (b) bails with an actionable error pointing at `--hooks-dir` or
+  `ai-memory setup-agent` whenever zero scripts are present in either
+  branch. Adds 3 regression tests
+  ([#52], thanks @Otavio-Machado-Santos).
+- **macOS thin-client wrapper no longer crashes with "Permission denied" in
+  the log file appender.** The `bin/ai-memory` wrapper passed
+  `-u $(id -u):$(id -g)` to the one-shot helper container, which on macOS
+  collides with the data volume owner (uid 1000 inside the container vs
+  uid 501/502 on the host). The wrapper now skips `-u` on Darwin so the
+  container runs as its default uid 1000 — Docker Desktop's file-sharing
+  layer handles host ownership transparently — while Linux and other
+  Unix systems continue to receive `-u`. Same change also hardens the
+  `${TTY_ARGS[@]}` / `${NETWORK_ARGS[@]}` / `${ENV_ARGS[@]}` /
+  `${USER_ARGS[@]}` expansions for `set -u` compatibility on macOS's
+  default bash 3.2 ([#51], thanks @abnersajr; supersedes [#50]).
+
+## [0.7.0] - 2026-05-29
+
+### Added
+- **`memory_read_page` MCP tool** (`read-only`) for fetching the FULL body of a
+  wiki page — pass `path` for a direct lookup or `query` to fetch the top FTS5
+  hit's full body. Complements `memory_query`'s 24-word snippets when an agent
+  needs to read an entire decision page end-to-end. Also exposed as
+  `GET /admin/read-page?workspace=…&project=…&path=…` (admin HTTP) and the new
+  `ai-memory read-page` CLI subcommand (thin HTTP client). All three surfaces
+  scope to the current project by default and route user-supplied paths through
+  `PagePath::new`, so traversal attempts (`../etc/passwd`) are rejected with
+  400. ARCHITECTURE.md's MCP-tool table grows from 12 to 13 rows ([#49]).
+- `_slots/*.md` pages can now declare `slot_kind: state` or
+  `slot_kind: invariant` frontmatter. `state` remains the default for existing
+  slots; `invariant` marks high-resistance project context or preferences that
+  consolidation should not rewrite unless observations directly contradict the
+  existing slot content ([#47], closes [#14]).
+
+### Fixed
+- **Windows PowerShell hooks no longer hang or stall the agent.** The shared
+  `hooks/lib/ai-memory-hook.ps1` read stdin via `[Console]::In.ReadToEnd()`,
+  which blocks indefinitely when the agent does not close the stdin pipe
+  (observed on Claude Code `PreCompact`); because the `Invoke-WebRequest`
+  timeout only starts after the read returns, a stuck read meant the hook
+  never POSTed anything. Stdin is now read asynchronously, guarded by
+  `[Console]::IsInputRedirected` with a 2s cap, so the hook can never freeze.
+  HTTP timeouts were also raised from 1s to 3s (POST) / 2s (handoff GET) to
+  tolerate remote servers over higher-latency links. The full raw payload is
+  still forwarded (parity with `_lib.sh`), so observation title/body stay
+  intact. Affects every agent still on the PowerShell hook runner
+  (Codex, Cursor, Gemini CLI, Antigravity, OpenCode on Windows) ([#48]).
+- Page upserts now treat frontmatter/title/tier/pinned changes as real page
+  updates instead of short-circuiting solely on unchanged body text, keeping
+  the SQLite index consistent with markdown frontmatter-only edits ([#47]).
+
+## [0.6.1] - 2026-05-28
+
+### Added
+- `Cache-Control: private, max-age=N` headers on all `/api/v1` read endpoints
+  (lists/search/recent/briefing/overview: 30–60s; single-page reads: 300s).
+  Errors stay uncached. A polling SPA no longer hits the DB on every request.
+- **ETag + conditional GET** on the single-page read endpoint
+  (`GET /api/v1/workspaces/{ws}/projects/{p}/pages/{*path}`): the response
+  carries `ETag: "<sha256>"` over the markdown body, and a follow-up request
+  with matching `If-None-Match` returns `304 Not Modified` with no body.
+- **`--cors-allow-origin`** flag (repeatable) and
+  `AI_MEMORY_CORS_ALLOW_ORIGINS=a,b,c` env var. When set, a `CorsLayer` is
+  attached **only to `/api/v1`** (`/mcp`, `/hook`, `/admin`, and `/web` are
+  intentionally untouched) so a separately-hosted SPA can call the API. Each
+  origin must include a scheme; `*` is rejected at startup (CORS spec forbids
+  credentials + wildcard). Empty list = same-origin only, unchanged behaviour.
+
+## [0.6.0] - 2026-05-28
+
+### Added
+- Read-only **`/api/v1`** JSON surface for third-party frontends: workspaces,
+  projects, pages (list + read with frontmatter, body, resolved links, and
+  back-links), recent, briefing, search (GET single/global + POST multi-scope
+  capped at 25 scopes), and workspace/project `overview` aggregates (handoff +
+  briefing + memory-health drill-down). Mounted before the bearer +
+  host-allowlist middleware so existing auth applies automatically. Read-only
+  by construction — zero writer calls in the handlers ([#7]).
+- **`--web-ui-dir`** flag on `ai-memory serve` to host any static SPA at
+  `/web` (same origin as the API, behind the same auth), with `index.html`
+  SPA fallback via `tower-http::ServeDir`. Validates the directory exists
+  and contains `index.html` before binding. When the flag is absent, the
+  built-in server-side `/web` browser stays the default ([#7]).
+- MCP read tools (`memory_query`, `memory_recent`, `memory_status`,
+  `memory_briefing`, `memory_explore`) accept optional `workspace` +
+  `scopes` args for explicit multi-project queries; existing single-`project`
+  behaviour is unchanged and remains the default ([#7]).
+- New reader queries powering the API: per-page outgoing links + incoming
+  back-links, workspace-aggregated briefing, memory-health (stale /
+  duplicate / orphan) counts and drill-down lists, workspace summaries
+  with last-update timestamps ([#7]).
+
+### Fixed
+- Antigravity `pre-tool-use` hook now emits the documented
+  `{"decision":"allow"}` JSON contract instead of an empty `{}`, while
+  keeping the `ai_memory_post_hook` call fully suppressed
+  (`>/dev/null 2>&1 || true`) so the `queued` body never bleeds into the
+  hook's stdout. Identical logic for `.sh` and `.ps1`; other hook scripts
+  remain silent and unchanged ([#44], thanks @ArtroxGabriel).
+
+### Docs
+- New **[`docs/frontend-api.md`](docs/frontend-api.md)** integration guide
+  for `/api/v1`: auth flow, response schemas (`PageHit`, `BriefingSnapshot`,
+  `HealthDetail`, `PageLinks`, …), error model, limits/pagination,
+  custom-UI hosting, a worked `fetch`/`curl` example, and pointers to the
+  canonical source-of-truth files.
+
+## [0.5.2] - 2026-05-28
+### Added
+- `ai-memory status` / `status --json` now includes passive process-scoped LLM
+  and embedding provider health based on the last real provider call, without
+  active probing or token spend ([#46]).
+
+### Changed
+- Agent-facing prompts (`MEMORY_INSTRUCTIONS`, the `CLAUDE.md`/`AGENTS.md`
+  routing snippet, and the per-tool `project`/`cwd` arg docstrings) now lead
+  with a clear "default to the current project — do not pass `project` or
+  `cwd` args unless the user names a *different* project" rule, plus a
+  reminder that the SessionStart auto-fetched handoff block already covers the
+  current project. Reduces cross-agent friction where a fresh agent surfaced
+  the wrong project's handoff because the LLM over-eagerly passed scoping
+  args. Doc-only, no behaviour change.
+
+### Fixed
+- Claude Code hook installs on native Windows now render Git Bash-compatible
+  `bash -c` commands that keep the POSIX `.sh` hook scripts and convert
+  drive-letter paths to Git Bash paths, matching Claude Code's actual hook
+  runner instead of emitting PowerShell commands ([#45]).
+- `ai-memory llm-test --provider anthropic-oauth` now parses and maps to the
+  Anthropic OAuth provider instead of being rejected by clap ([#43]).
+
+## [0.5.1] - 2026-05-27
+### Changed
+- Docker release publishing now builds Linux x86_64 and aarch64 artifacts once,
+  reuses those artifacts for Docker images, and smoke-tests both amd64 and arm64
+  images after assembling the multi-arch manifest.
+- The AUR `ai-memory-bin` package now supports aarch64 using the prebuilt Linux
+  aarch64 release artifact.
+- Docker source builds now use the vendored Tailwind CSS artifact, avoiding
+  cross-architecture Tailwind CLI cache collisions during multi-arch releases.
+
+## [0.5.0] - 2026-05-27
+### Fixed
+- Docker release images now publish both `linux/amd64` and `linux/arm64`
+  manifests, so Apple Silicon and ARM64 Linux hosts can pull the image without
+  forcing x86 emulation ([#41]).
+
+## [0.4.0] - 2026-05-27
+### Added
+- `anthropic-oauth` LLM provider: use a Claude Pro/Max subscription via
+  `claude setup-token` instead of an API key. In-Rust, reuses the existing
+  Anthropic Messages client (incl. structured output). **Unofficial and
+  against Anthropic's usage policies — use at your own risk** (docs warn
+  prominently).
+- Opt-in `AI_MEMORY_CONSOLIDATE_ON_SESSION_END`: when set and an LLM provider
+  is configured, SessionEnd additionally runs LLM consolidation on top of the
+  always-written rule-based summary page (non-fatal on failure) ([#40]).
+
+### Changed
+- Docs recommend a small/fast model (Haiku/mini class) for the OAuth /
+  subscription LLM backends — consolidation/lint/explore is summarisation, not
+  hard reasoning, and small models are far easier on subscription rate limits.
+- Aligned every prompt surface + doc with actual SessionEnd behavior: it always
+  writes a rule-based summary page + handoff; LLM consolidation runs on
+  PreCompact, on demand via `memory_consolidate`, and at session end only
+  behind the new opt-in flag ([#40]).
+
+### Fixed
+- Windows own-write detection: `inode_of` now returns the real NTFS file index
+  (was always `0`, which collapsed the watcher's own-write set) ([#37]).
+- `ai-memory upgrade` no longer fails with `invalid value 'lib' for --agent` —
+  the hook-refresh loop skips the shared `lib/` helper dir ([#38]).
+- Native packaging CI now supports non-root runners whose `systemd-tmpfiles`
+  lacks `--dry-run`, while still operating only inside a temporary alternate
+  root.
+
+## [0.3.2] - 2026-05-27
+### Fixed
+- AUR release publishing now runs with `HOME=/home/aurbuild` and an explicit
+  `GIT_SSH_COMMAND`, so the workflow uses the configured AUR deploy key.
+
+## [0.3.1] - 2026-05-27
+### Changed
+- Reissued the release after the initial AUR publish failure. This release was
+  superseded by 0.3.2 for the AUR SSH home fix.
+
+## [0.3.0] - 2026-05-27
+### Added
+- Arch Linux native packaging assets: source and prebuilt AUR package
+  definitions, system/user systemd units, sysusers/tmpfiles entries, native
+  config/env templates, CI-safe alternate-root packaging checks, and a manual
+  disposable-distrobox integration harness for validating real service startup
+  before publishing.
+- Tag-triggered release automation now validates that `vX.Y.Z` matches
+  `Cargo.toml`, publishes a native Linux release tarball, keeps Docker image
+  publishing behind Docker Hub secrets, and optionally publishes both AUR
+  package bases when `AUR_SSH_PRIVATE_KEY` is configured.
+- `memory_write_page` MCP tool for explicit durable annotations, so agents can
+  write permanent wiki knowledge without abusing single-use handoffs.
+- `openai-oauth` LLM provider for ChatGPT/Codex accounts, including
+  `ai-memory auth login|logout|status` device-flow commands and token storage
+  in `<data_dir>/auth.json`.
+- `copilot` LLM provider for GitHub Copilot Chat accounts. It stores a GitHub
+  token via `ai-memory auth login copilot`, exchanges it for a short-lived
+  Copilot API token, and sends Copilot Chat requests with `vscode-chat`
+  integration headers.
+
+### Fixed
+- `install-mcp`, `install-hooks`, and `setup-agent` now honor configured
+  `AI_MEMORY_SERVER_URL` defaults; `install-hooks` also reuses an existing
+  ai-memory MCP entry when present, preventing remote MCP setups from
+  regenerating loopback-only lifecycle hooks during installs/upgrades.
+- Filesystem watcher now reindexes a project when backends report only a
+  parent-directory event, improving external editor capture on macOS/FSEvents.
+- OpenAI strict structured-output schema normalization now strips generated
+  `$ref` annotation siblings and rewrites generated enum `oneOf` schemas to
+  `anyOf`, unblocking `memory_consolidate multi_page=true` on OpenAI models.
+- OpenAI-compatible embedding calls now truncate oversized page bodies, surface
+  provider errors returned in HTTP 200 bodies, retry bounded HTTP 429 responses,
+  and may reuse `LLM_API_KEY` when a custom embedding base URL is configured.
+- `ai-memory embed --force` without `--project` now re-embeds every project in
+  the workspace and purges stale/superseded embedding rows in the same scope.
+- Windows hook `cwd` values sent to a Linux server now resolve projects by the
+  final path component instead of treating the full backslash path as the
+  project name.
+
+## [0.2.0] - 2026-05-26
+### Added
+- `ai-memory bootstrap` now prunes collected sources before POSTing to the
+  server and supports `--chunk-input-tokens` to process large repositories via
+  sequential LLM calls instead of one oversized prompt.
+- Opt-in extension event metadata for `/hook`: custom integrations can
+  pass `extension=<namespace>` (and optionally `source_event=<name>`) to
+  preserve a validated third-party source event while storage keeps the
+  canonical `ObservationKind` closed. Unknown events without an extension
+  still collapse to `other` with no source-event metadata.
+- `.ai-memory.toml` marker file lets a directory tree declare its
+  `workspace` (required) and `project` (optional) without depending on
+  `basename($cwd)`. Lifecycle hook scripts walk up from `cwd` to find
+  the closest marker and forward `cwd` plus the declared names as
+  query params on `POST /hook` and `GET /handoff`. Markers can also set
+  `project_strategy = "repo-root"` to derive project identity from the
+  main git repository root, so linked worktrees share one project. Server
+  accepts the new params as optional overrides;
+  absent marker means the previous behaviour (`workspace = "default"`,
+  `project = basename(cwd)`) — fully backward compatible. See
+  [`docs/marker-file.md`](docs/marker-file.md).
+- Oh My Pi / OMP is now a first-class integration: `install-mcp --client pi`
+  and `--client omp` write native `~/.omp/agent/mcp.json` config, while
+  `install-hooks --agent omp` and `--agent pi` write the TypeScript extension
+  used for lifecycle capture and handoff injection.
+- Graph-aware retrieval: `memory_query` now combines FTS5, wikilink-neighbor
+  expansion, optional vector RRF, and bounded raw-observation fallback.
+- Observation FTS indexing and unresolved-link diagnostics surfaced through
+  admin/CLI status paths.
+- `_slots/` wiki pages are automatically pinned and surfaced in briefing /
+  explore snapshots.
+- Server-side scheduled maintenance for forget sweep and lint, with optional
+  embedding backfill scheduling.
+- Experimental native Windows support: PowerShell Docker wrapper,
+  `ai-memory.cmd`, `.ps1` lifecycle hooks in parity with `.sh` hooks, Windows
+  Tailwind hash/download support, and [`docs/windows.md`](docs/windows.md).
+- Google Gemini LLM provider via `AI_MEMORY_LLM_PROVIDER=gemini`, with
+  `gemini-2.5-flash` as the default hosted Google model and `GEMINI_API_KEY`
+  / `GOOGLE_API_KEY` support.
+- Google Gemini embeddings via `AI_MEMORY_EMBEDDING_PROVIDER=google` or
+  `gemini`, with `gemini-embedding-001` as the default embedding model and
+  `GEMINI_API_KEY` / `GOOGLE_API_KEY` support.
+- Antigravity CLI (`agy`) support for MCP config (`serverUrl`) and lifecycle
+  capture through its `PreInvocation`, `PreToolUse`, `PostToolUse`, and `Stop`
+  hook events.
+- README support matrix for operating systems, agent integrations, LLM
+  providers, and embedding providers.
+- `ai-memory uninstall` — removes ai-memory's hooks, MCP registration, and
+  CLAUDE.md/AGENTS.md instruction block across all detected agents (dry-run by
+  default; `--apply` to execute, with timestamped backups). `--purge-data`
+  wipes wiki/db/raw via the reset guard. `--only hooks|mcp|instructions` to
+  narrow. MCP matching is endpoint-based by default; pass `--mcp-url` when the
+  server was installed with a custom endpoint and `--mcp-name` only to narrow
+  removal to one matching entry. Docker/volume teardown is printed as a hint,
+  not executed.
+
+### Changed
+- Same-body page upserts are now true no-ops, avoiding periodic watcher
+  reconcile writes, FTS churn, and misleading recent-page timestamps.
+- Graph-neighbor expansion for hybrid search now batches all seed pages into
+  one SQL query instead of issuing incoming/outgoing lookups per seed.
+- Embedding backfill stores embeddings in chunks instead of one writer
+  command and SQLite transaction per page.
+- Hook ingestion now bounds in-flight processing and returns HTTP 429 when
+  saturated instead of spawning unbounded background tasks.
+- Documented the vector backend policy and the measured criteria required
+  before adding `sqlite-vec`.
+- Clarified Gemini CLI support docs: MCP registration, lifecycle hooks,
+  SessionStart handoff injection, and SessionEnd capture are now called out
+  consistently across README and install guides.
+- Added OpenClaw lifecycle support via a generated native plugin package and
+  updated Cursor / Claude Desktop / OpenClaw support docs against current
+  upstream MCP and hook documentation.
+- Docker images now bundle both POSIX and PowerShell hook scripts.
+- `ai-memory uninstall --purge-data` now previews the `wiki/`/`db/`/`raw/`
+  wipe in dry-run (mirroring `reset`) and refuses **up front** if an
+  `ai-memory` process is alive (all-or-nothing) instead of removing the
+  wiring and then skipping the purge. The data wipe is now shared with
+  `reset` via a single internal helper.
+- `ai-memory uninstall` only deletes generated plugin/extension files after
+  re-validating their ai-memory-generated content, and never treats a matching
+  filename or MCP server name alone as proof of ownership.
+
+### Fixed
+- `serve` now warns and starts when stored embedding rows were created with a
+  different `(provider, model, dim)` than the current config. Hybrid search
+  ignores stale rows until `ai-memory embed --force` or scheduled backfill
+  re-embeds them, avoiding the previous startup deadlock.
+- Session capture now persists every documented agent kind (`cursor`,
+  `gemini-cli`, `claude-desktop`, `openclaw`, `omp` / `pi`) instead of
+  failing the `sessions.agent_kind` database CHECK for agents added after
+  the initial schema.
+- `memory_handoff_begin` and `memory_handoff_accept` now resolve the active
+  project the same way the briefing/search tools do, so MCP handoffs land in
+  the project currently reported by hooks instead of the server's baked
+  default project.
+- Natural-language `memory_query` text containing bare colons, such as
+  `pick: handoff`, no longer trips FTS5 column syntax errors while explicit
+  FTS operators like `quick OR slow` remain supported.
+- Marker-file routing now reaches the generated OpenCode and OMP
+  TypeScript hook integrations, not only the POSIX/PowerShell script
+  hooks. POSIX helpers also preserve the outer hook `cwd` when nested
+  tool payloads contain their own `cwd`, and encode `+` correctly in
+  marker-derived query parameters.
+- `backup --to` now streams the tarball to disk instead of buffering the full
+  archive in CLI memory.
+- Hyphenated FTS5 queries such as `ai-memory` are normalized safely instead of
+  being parsed as column operators.
+- Gemini 2.5 Flash requests disable default dynamic thinking so hidden thought
+  tokens do not consume `maxOutputTokens` and truncate strict JSON responses.
+- `install-mcp --client claude-code` now prints the direct-edit JSON path as
+  `~/.claude.json`, matching the `--apply` path and `claude mcp add` behavior.
+- Hook routing now evicts a stale project-cache entry and retries once when a
+  live server sees a cached project deleted underneath it, such as after
+  `purge-project`, so capture resumes without restarting the server.
+- Session-start handoff hooks now include `cwd` even without a marker file, so
+  default `project = basename(cwd)` projects receive pending handoffs without
+  requiring `.ai-memory.toml`.
+- `ai-memory uninstall` now removes only ai-memory commands from mixed nested
+  hook entries, preserves third-party commands in the same matcher, and removes
+  legacy Codex inline-table MCP entries.
+- Generated POSIX hook commands now shell-quote script paths and env values
+  with metacharacters, fixing custom hook directories containing spaces and
+  preventing shell-active token/URL fragments.
+- OpenClaw's generated plugin now forwards marker-file routing params just like
+  the OpenCode and OMP generated integrations.
+- The Linux/macOS Docker wrapper now lets thin-client commands such as
+  `status` and `bootstrap` reach the local quick-start server bound on the
+  host's `127.0.0.1:49374`.
+
+## [0.1.3] - 2026-05-24
+
+### Added
+- `ai-memory lint --no-llm` (and `memory_lint` `no_llm` arg) to run only the
+  rule-based lint pass while leaving the LLM enabled for `memory_explore` /
+  `memory_consolidate` ([#4]).
+
+### Fixed
+- `memory_lint` LLM contradiction pass silently never contributed: the
+  `LintFinding` struct expected `severity`/`message` but the prompt asked for
+  `summary`/`detail`. The prompt is now aligned to the canonical shape and the
+  struct tolerates both (defaults `severity`, aliases `summary`→`message`,
+  captures optional `detail`) ([#4]).
+- Reasoning models (MiniMax M2.7, DeepSeek, Qwen, Kimi) that emit
+  `<think>…</think>` / `<analysis>…</analysis>` blocks before the JSON broke
+  structured-output parsing (`key must be a string at line 1 column 2`). The
+  openai-compat provider now strips reasoning blocks and surrounding markdown
+  fences before extracting the JSON object, so lint / consolidate / bootstrap
+  work with reasoning models ([#5]).
+- openai-compat base URLs with non-`v1` version segments (e.g. Z.AI's `/v4`)
+  or a full endpoint path no longer produce `…/v1/v1/…` 404s
+  ([#6], thanks @lucasliet).
+
+## [0.1.2] - 2026-05-24
+
+### Changed
+- HTTP transport now defaults to **stateless** mode (`json_response`, no
+  `Mcp-Session-Id` required), so stateless MCP clients (OpenCode
+  `type: "remote"`, `curl`) work without an `mcp-remote` stdio shim
+  ([#3]). New `serve --transport http --http-stateful` flag restores the
+  previous session+SSE behaviour for clients that need it.
+
+## [0.1.1] - 2026-05-24
+
+### Added
+- Wiki-structure migration framework: `wiki_migrations` SQL table (V06),
+  `WikiMigration` trait, migration registry, and `run_pending` runner
+  invoked at server startup before the watcher starts.
+- MCP read tools (`memory_query`, `memory_recent`, `memory_status`,
+  `memory_briefing`, `memory_explore`) accept an optional `project`
+  argument to target a specific project on a shared server.
+
+### Fixed
+- OpenCode hook events (`tool.execute.*`, `session.*`) were rejected with
+  "missing session_id" because OpenCode sends `sessionID` (capital `ID`)
+  and the extractor only matched `sessionId`. All spellings are now
+  accepted ([#1]).
+- MCP read tools were locked to the server's static `--project` (default
+  `scratch`), so on a shared HTTP server they returned empty memory even
+  while hooks populated the correct per-cwd project. The hook router now
+  publishes the active project to a shared pointer that the read tools
+  use as their default; an explicit `project` argument overrides it ([#2]).
+
+## [0.1.0] - 2026-05-23
+
+### Added
+- Per-project UUID-namespaced wiki layout: pages live at
+  `<wiki_root>/<workspace_id>/<project_id>/<page-path>`. Rename is now
+  a single column update; purge is `remove_dir_all` on the project dir.
+- CLI becomes a thin HTTP client: `bootstrap`, `status`, `search`,
+  `reorg`, `lint`, `forget-sweep`, `embed`, `commit`, `backup`,
+  `write-page` all delegate to the running server via `/admin/*` routes.
+  The server is the sole writer of wiki + SQLite.
+- `purge-project` command with cascade-delete indexes and per-project
+  isolation guard (refuses to delete files claimed by sibling projects).
+- `rename-project` command: column-only rename, no file moves.
+- `memory_install_self_routing` MCP tool: installs the agent-routing
+  snippet into CLAUDE.md / AGENTS.md / `.cursorrules` in one call.
+- Read-only HTTP wiki browser (`/web`) with project tree, page view,
+  and full-text search.
+- Bearer token auth (`AI_MEMORY_AUTH_TOKEN` / `generate-auth-token`),
+  Host-header allowlist, and 10 MB body cap for the HTTP server.
+- `backup` / `restore` commands using `.tar.gz` archives with live-process
+  guard (refuses to run if another `ai-memory` is active on the same data dir).
+- Per-cwd project routing in hooks: observations route to the project
+  matching the agent's working directory, not the server default.
+- `opencode` / `openclaw` aliases for the OpenCode MCP client.
+- Dockerised CLI wrapper (`bin/ai-memory`) with auto-restart for the
+  local container and nudge for remote upgrades.
+- `bootstrap` serialises parallel runs to prevent duplicate project creation
+  and handles the case where the CWD has no git repo.
+- Monthly log-md rotation to keep `log.md` from growing unbounded.
+- `memory_consolidate` PreCompact checkpointing falls back to rule-based
+  summarisation when no LLM is configured.
+- `docs/lifecycle-ops.md`: safety matrix for state-touching commands
+  (reset, restore, purge-project, rename-project).
+- `docs/wiki-migrations.md`: when and how to write a wiki migration.
+
+### Changed
+- `bin/ai-memory` forwards `AI_MEMORY_SERVER_URL` and no longer creates
+  `-w` mount-conflict directories.
+- `bootstrap` resolves the repo root via `libgit2`, removing the
+  `git` binary dependency.
+- Admin routes consolidated: dry-run support, correct status codes,
+  deduplicated handlers.
+- Host-header allowlist sourced from `Config.allowed_hosts`; logged at
+  startup so operators can verify the effective list.
+
+### Fixed
+- `AI_MEMORY_HOST_CWD` handling and dry-run no-project side effects.
+- Web page view: strip leading H1 from body to prevent title duplication.
+- `install-mcp` Codex config key was `bearer_token`, not
+  `http_headers` / `headers`.
+- Consolidator used server startup default project instead of the
+  session's actual project.
+
+[Unreleased]: https://github.com/akitaonrails/ai-memory/compare/v1.26.1...HEAD
+[1.26.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.26.1
+[1.26.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.26.0
+[1.25.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.25.0
+[1.24.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.24.0
+[1.23.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.23.0
+[1.22.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.22.0
+[1.21.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.21.0
+[1.20.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.20.2
+[1.20.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.20.1
+[1.20.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.20.0
+[1.19.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.19.2
+[1.19.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.19.1
+[1.19.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.19.0
+[1.18.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.18.0
+[1.17.3]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.3
+[1.17.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.2
+[1.17.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.1
+[1.17.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.17.0
+[1.16.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.16.0
+[1.15.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.15.0
+[1.14.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.14.0
+[1.13.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.13.0
+[1.12.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.12.0
+[1.11.4]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.11.4
+[1.11.3]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.11.3
+[1.11.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.11.2
+[1.11.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.11.1
+[1.11.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.11.0
+[1.10.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.10.1
+[1.10.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.10.0
+[1.9.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.9.1
+[1.9.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.9.0
+[1.8.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.8.0
+[1.7.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.7.1
+[1.7.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.7.0
+[1.6.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.6.0
+[1.5.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.5.0
+[1.4.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.4.1
+[1.4.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.4.0
+[1.3.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.3.0
+[1.2.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.2.2
+[1.2.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.2.1
+[1.2.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.2.0
+[1.1.3]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.1.3
+[1.1.2]: https://github.com/akitaonrails/ai-memory/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/akitaonrails/ai-memory/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.1.0
+[1.0.11]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.11
+[1.0.10]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.10
+[1.0.9]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.9
+[1.0.8]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.8
+[1.0.7]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.7
+[1.0.6]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.6
+[1.0.5]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.5
+[1.0.4]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.4
+[1.0.3]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.3
+[1.0.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.2
+[1.0.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.1
+[1.0.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v1.0.0
+[0.16.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.16.0
+[0.15.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.15.0
+[0.14.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.14.0
+[0.13.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.13.0
+[0.12.3]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.12.3
+[0.12.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.12.2
+[0.12.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.12.1
+[0.12.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.12.0
+[0.11.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.11.0
+[0.10.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.10.0
+[0.9.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.9.0
+[0.8.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.8.1
+[0.8.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.8.0
+[0.7.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.7.1
+[0.7.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.7.0
+[0.6.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.6.1
+[0.6.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.6.0
+[0.5.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.5.2
+[0.5.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.5.0
+[0.4.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.4.0
+[0.3.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.3.2
+[0.3.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.3.1
+[0.3.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.3.0
+[0.2.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.2.0
+[0.1.3]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.1.3
+[0.1.2]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.1.2
+[0.1.1]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.1.1
+[0.1.0]: https://github.com/akitaonrails/ai-memory/releases/tag/v0.1.0

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -957,6 +957,15 @@ pub struct RestoreArgs {
     /// Overwrite an existing non-empty data dir.
     #[arg(long)]
     pub force: bool,
+    /// Data directory whose tombstone ledger governs this restore.
+    ///
+    /// A snapshot taken before a `purge-session` still contains everything that
+    /// purge removed. Restoring into the SAME directory carries its ledger over
+    /// automatically; restoring into a FRESH one has no ledger to carry, so
+    /// point this at the directory that holds the current one. Without it, a
+    /// pre-purge backup cannot be declared a safe restoration (#387).
+    #[arg(long, value_name = "PATH")]
+    pub tombstones_from: Option<PathBuf>,
 }
 
 /// Arguments for `checkpoints`.

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -145,6 +145,12 @@ pub enum Command {
     /// observations, handoffs, embeddings, on-disk wiki files).
     /// This is irreversible — requires `--confirm`.
     PurgeProject(PurgeProjectArgs),
+    /// Permanently delete ONE session by its exact UUID, across every layer
+    /// ai-memory administers: rows, FTS indexes, derived pages, handoffs,
+    /// auto-improvement artifacts, and the wiki files. Leaves only a
+    /// content-free tombstone that stops a late spooled event from
+    /// resurrecting it. Irreversible — requires `--confirm`.
+    PurgeSession(PurgeSessionArgs),
     /// Rename a project within its workspace. No files move on disk —
     /// the wiki is flat and pages are differentiated by project_id only.
     /// Useful after renaming the project's directory on disk so the hook
@@ -553,6 +559,34 @@ pub struct PurgeProjectArgs {
     /// out — purging is destructive and irreversible.
     #[arg(long)]
     pub confirm: bool,
+}
+
+/// Arguments for `purge-session`.
+#[derive(Debug, Args)]
+pub struct PurgeSessionArgs {
+    /// Workspace name. Defaults to the nearest `.ai-memory.toml` marker's
+    /// `workspace`, else `default`.
+    #[arg(long)]
+    pub workspace: Option<String>,
+    /// Project name. When omitted, auto-derived from the basename of
+    /// the current git repo root (or CWD if no git repo).
+    #[arg(long)]
+    pub project: Option<String>,
+    /// The session's complete UUID. Prefixes, titles, and paths are
+    /// deliberately not accepted: this operation is irreversible, so it must
+    /// never guess which session an operator meant.
+    #[arg(long)]
+    pub session_id: String,
+    /// REQUIRED for the purge to run. Without this flag the CLI errors out.
+    #[arg(long)]
+    pub confirm: bool,
+    /// Purge even when the session is still open, a consolidation is queued,
+    /// or an auto-improvement claim is outstanding.
+    #[arg(long)]
+    pub force: bool,
+    /// Print the raw JSON receipt only, for scripting.
+    #[arg(long)]
+    pub json: bool,
 }
 
 /// Arguments for `rename-project`.

--- a/crates/ai-memory-cli/src/commands/hook_capture.rs
+++ b/crates/ai-memory-cli/src/commands/hook_capture.rs
@@ -334,6 +334,16 @@ pub enum PostOutcome {
     /// backpressure, the event was never processed. Keep it queued WITHOUT
     /// bumping attempts so saturation never burns the entry's retry budget.
     Saturated,
+    /// Server answered `410 Gone`: the session this event belongs to was
+    /// purged (#387). The event can never become deliverable, so the entry is
+    /// removed WITHOUT counting an attempt and without retrying — retrying
+    /// until the spool horizon expires would just delay the drain.
+    ///
+    /// This outcome deletes local data on the server's say-so, so it is only
+    /// safe because a non-loopback server cannot serve unauthenticated plain
+    /// HTTP: an injected `410` would otherwise let a network attacker discard
+    /// a client's pending observations.
+    Terminal,
     /// Any other non-2xx, or a transport error: a genuine miss that should
     /// count against `MAX_ATTEMPTS`.
     Failed,
@@ -364,6 +374,7 @@ pub async fn post_hook(
         Ok(resp) if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS => {
             PostOutcome::Saturated
         }
+        Ok(resp) if resp.status() == reqwest::StatusCode::GONE => PostOutcome::Terminal,
         Ok(_) => PostOutcome::Failed,
         Err(_) => PostOutcome::Failed,
     }
@@ -621,6 +632,16 @@ mod tests {
         let url = serve_once("429 Too Many Requests", "hook queue full").await;
         let outcome = post_hook(&build_client(), &url, "{}", None, Duration::from_secs(1)).await;
         assert_eq!(outcome, PostOutcome::Saturated);
+    }
+
+    #[tokio::test]
+    async fn post_hook_terminal_on_410_purged_session() {
+        // 410 = the session was purged, so this event can never be delivered.
+        // Distinct from Failed: the entry is dropped WITHOUT spending a retry
+        // attempt, instead of being retried until the spool horizon expires.
+        let url = serve_once("410 Gone", r#"{"code":"session_purged","terminal":true}"#).await;
+        let outcome = post_hook(&build_client(), &url, "{}", None, Duration::from_secs(1)).await;
+        assert_eq!(outcome, PostOutcome::Terminal);
     }
 
     #[tokio::test]

--- a/crates/ai-memory-cli/src/commands/hook_spool.rs
+++ b/crates/ai-memory-cli/src/commands/hook_spool.rs
@@ -25,6 +25,9 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use ai_memory_core::SessionId;
+use ai_memory_hooks::resolve_native_session_id;
+use anyhow::Result;
 use fs2::FileExt as _;
 use serde::{Deserialize, Serialize};
 
@@ -87,6 +90,134 @@ pub struct SpoolEntry {
     /// (with `created_ms`) to drop a permanently-undeliverable event.
     #[serde(default)]
     pub attempts: u32,
+}
+
+/// Remove every spooled entry belonging to `session_id`, by exact identity.
+///
+/// The server's tombstone already refuses these events with `410`, so the
+/// drain would eventually discard them anyway. This exists because a purge is
+/// a promise: an operator should not have to wait for a drain — or leave the
+/// content sitting in a plaintext spool file — before the deletion is real on
+/// this host.
+///
+/// Entries are matched by resolving each one's raw wire id through the SAME
+/// [`resolve_native_session_id`] the ingest path uses, so a session whose
+/// agent used an opaque string id (stored under its v5 hash) is still matched
+/// by its UUID. Comparing raw strings would silently miss exactly those.
+///
+/// Spools on OTHER hosts cannot be reached from here; the server-side
+/// tombstone is what stops those from resurrecting the session.
+///
+/// # Errors
+/// Returns an error only if the spool directory cannot be read. A file that
+/// cannot be parsed or removed is counted and skipped rather than aborting the
+/// sweep, so one bad entry cannot block the rest.
+pub fn sweep_session(data_dir: &Path, session_id: SessionId) -> Result<SpoolSweepResult> {
+    let dir = spool_dir(data_dir);
+    let mut result = SpoolSweepResult::default();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        // No spool at all is a successful sweep of nothing.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(result),
+        Err(e) => {
+            return Err(anyhow::anyhow!(
+                "reading spool directory {}: {e}",
+                dir.display()
+            ));
+        }
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            result.unreadable += 1;
+            continue;
+        };
+        let Ok(spooled) = serde_json::from_str::<SpoolEntry>(&raw) else {
+            result.unreadable += 1;
+            continue;
+        };
+        if spool_entry_session(&spooled).is_some_and(|id| id == session_id) {
+            if std::fs::remove_file(&path).is_ok() {
+                result.removed += 1;
+            } else {
+                result.unreadable += 1;
+            }
+        } else {
+            result.kept += 1;
+        }
+    }
+    Ok(result)
+}
+
+/// The durable session id a spooled entry belongs to, if it names one.
+///
+/// The body is the agent's own payload, so `session_id` is read from there
+/// first; the URL query is the bridge fallback used when a harness could not
+/// put it in the body.
+fn spool_entry_session(entry: &SpoolEntry) -> Option<SessionId> {
+    let from_body = serde_json::from_str::<serde_json::Value>(&entry.body)
+        .ok()
+        .and_then(|body| {
+            body.get("session_id")
+                .or_else(|| body.get("sessionId"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        });
+    let raw = from_body.or_else(|| {
+        entry.url.split('?').nth(1).and_then(|query| {
+            query.split('&').find_map(|pair| {
+                let (key, value) = pair.split_once('=')?;
+                (key == "session_id").then(|| percent_decode(value))
+            })
+        })
+    })?;
+    let trimmed = raw.trim();
+    (!trimmed.is_empty()).then(|| resolve_native_session_id(trimmed))
+}
+
+/// Minimal `%XX` decoder for the one query value this module reads back.
+fn percent_decode(raw: &str) -> String {
+    let bytes = raw.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'%' if i + 2 < bytes.len() => match u8::from_str_radix(&raw[i + 1..i + 3], 16) {
+                Ok(byte) => {
+                    out.push(byte);
+                    i += 3;
+                }
+                Err(_) => {
+                    out.push(bytes[i]);
+                    i += 1;
+                }
+            },
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            byte => {
+                out.push(byte);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Outcome of [`sweep_session`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SpoolSweepResult {
+    /// Entries removed because they belonged to the purged session.
+    pub removed: usize,
+    /// Entries left alone because they belong to other sessions.
+    pub kept: usize,
+    /// Entries that could not be read, parsed, or removed. Counted rather than
+    /// fatal: one corrupt file must not block the rest of the sweep.
+    pub unreadable: usize,
 }
 
 /// `<data_dir>/hook-spool` — the spool directory.
@@ -584,6 +715,13 @@ pub async fn drain(
                             PostOutcome::Saturated => {
                                 result.remaining += 1;
                             }
+                            PostOutcome::Terminal => {
+                                // The session was purged: drop the entry
+                                // instead of retrying an event that can never
+                                // be delivered (#387).
+                                let _ = std::fs::remove_file(path);
+                                result.dropped += 1;
+                            }
                             PostOutcome::Failed => {
                                 bump_or_drop(path, entry, &mut result);
                             }
@@ -621,6 +759,12 @@ pub async fn drain(
                 }
                 PostOutcome::Saturated => {
                     result.remaining += 1;
+                }
+                PostOutcome::Terminal => {
+                    // Purged session: terminal, so the entry goes without
+                    // spending a retry attempt (#387).
+                    let _ = std::fs::remove_file(&path);
+                    result.dropped += 1;
                 }
                 PostOutcome::Failed => {
                     bump_or_drop(&path, &entry, &mut result);
@@ -839,6 +983,112 @@ fn list_entries(spool: &Path) -> Option<Vec<PathBuf>> {
 
 #[cfg(test)]
 mod tests {
+
+    /// The sweep must key on the durable id, not the raw string: a session
+    /// whose agent used an opaque id is stored (and tombstoned) under its v5
+    /// hash, so a raw-string comparison would silently leave its spooled
+    /// events on disk after a purge claimed to have removed them.
+    #[test]
+    fn sweep_matches_opaque_session_ids_through_the_same_resolution() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = spool_dir(tmp.path());
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let opaque = "agent-run-1234";
+        let durable = resolve_native_session_id(opaque);
+        let write = |name: &str, body: serde_json::Value| {
+            let entry = SpoolEntry {
+                url: "http://127.0.0.1:49374/hook?event=user-prompt-submit&agent=codex".into(),
+                body: body.to_string(),
+                created_ms: 1,
+                auth_mode: AuthMode::Anonymous,
+                token: None,
+                attempts: 0,
+            };
+            std::fs::write(
+                dir.join(format!("{name}.json")),
+                serde_json::to_string(&entry).unwrap(),
+            )
+            .unwrap();
+        };
+        write(
+            "a",
+            serde_json::json!({ "session_id": opaque, "body": "canary" }),
+        );
+        write("b", serde_json::json!({ "session_id": "other-session" }));
+
+        let result = sweep_session(tmp.path(), durable).unwrap();
+        assert_eq!(result.removed, 1, "the opaque-id entry must be matched");
+        assert_eq!(result.kept, 1, "an unrelated session must be left alone");
+        assert!(!dir.join("a.json").exists());
+        assert!(dir.join("b.json").exists());
+    }
+
+    /// Some harnesses can only put the session id in the query string, so the
+    /// URL is the documented fallback. It arrives percent-encoded.
+    #[test]
+    fn sweep_falls_back_to_the_url_query_when_the_body_has_no_session() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = spool_dir(tmp.path());
+        std::fs::create_dir_all(&dir).unwrap();
+        let session_id = SessionId::new();
+        let entry = SpoolEntry {
+            url: format!(
+                "http://127.0.0.1:49374/hook?event=stop&agent=codex&session_id={session_id}"
+            ),
+            body: serde_json::json!({ "tool_name": "Bash" }).to_string(),
+            created_ms: 1,
+            auth_mode: AuthMode::Anonymous,
+            token: None,
+            attempts: 0,
+        };
+        std::fs::write(dir.join("q.json"), serde_json::to_string(&entry).unwrap()).unwrap();
+
+        let result = sweep_session(tmp.path(), session_id).unwrap();
+        assert_eq!(result.removed, 1);
+        assert!(!dir.join("q.json").exists());
+    }
+
+    /// One corrupt file must not abort the sweep and leave later entries for
+    /// the purged session on disk.
+    #[test]
+    fn sweep_counts_unreadable_entries_and_keeps_going() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = spool_dir(tmp.path());
+        std::fs::create_dir_all(&dir).unwrap();
+        let session_id = SessionId::new();
+        std::fs::write(dir.join("aaa-corrupt.json"), "{ not json").unwrap();
+        let entry = SpoolEntry {
+            url: "http://127.0.0.1:49374/hook?event=stop&agent=codex".into(),
+            body: serde_json::json!({ "session_id": session_id.to_string() }).to_string(),
+            created_ms: 1,
+            auth_mode: AuthMode::Anonymous,
+            token: None,
+            attempts: 0,
+        };
+        std::fs::write(
+            dir.join("zzz-target.json"),
+            serde_json::to_string(&entry).unwrap(),
+        )
+        .unwrap();
+
+        let result = sweep_session(tmp.path(), session_id).unwrap();
+        assert_eq!(result.unreadable, 1);
+        assert_eq!(
+            result.removed, 1,
+            "the corrupt file must not block the sweep"
+        );
+        assert!(!dir.join("zzz-target.json").exists());
+    }
+
+    /// A missing spool directory is a successful sweep of nothing, so
+    /// `purge-session` works on a host that has never spooled.
+    #[test]
+    fn sweep_of_a_missing_spool_directory_succeeds() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let result = sweep_session(tmp.path(), SessionId::new()).unwrap();
+        assert_eq!(result, SpoolSweepResult::default());
+    }
     use super::*;
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/mod.rs
+++ b/crates/ai-memory-cli/src/commands/mod.rs
@@ -40,6 +40,7 @@ pub mod path_util;
 pub mod pending_writes;
 pub mod project_registry;
 pub mod purge_project;
+pub mod purge_session;
 pub mod read_page;
 pub mod reindex;
 pub mod rename_project;

--- a/crates/ai-memory-cli/src/commands/purge_session.rs
+++ b/crates/ai-memory-cli/src/commands/purge_session.rs
@@ -1,0 +1,100 @@
+//! `ai-memory purge-session` — thin HTTP client for strong per-session
+//! deletion (#387).
+
+use anyhow::{Result, bail};
+use serde::Serialize;
+
+use crate::cli::PurgeSessionArgs;
+use crate::config::Config;
+use crate::http_client::{ServerEndpoint, post_json};
+
+/// Request sent to `POST /admin/purge-session`.
+#[derive(Serialize)]
+struct PurgeSessionRequest {
+    workspace: String,
+    project: String,
+    session_id: String,
+    confirm: bool,
+    /// Purge even when the session is open or has work in flight.
+    force: bool,
+}
+
+/// Run the `purge-session` subcommand.
+///
+/// The UUID is validated client-side before anything is sent: a typo that
+/// happened to name a different real session would be unrecoverable, so the
+/// only accepted form is a complete, well-formed session id.
+///
+/// # Errors
+/// Returns an error when `--confirm` is absent, `--session-id` is not a valid
+/// UUID, the server is unreachable, or the server returns a non-2xx response.
+pub async fn run(config: &Config, args: PurgeSessionArgs) -> Result<()> {
+    let (workspace, project) =
+        super::resolve_scope(config, args.workspace.as_deref(), args.project.as_deref())?;
+
+    let session_id: ai_memory_core::SessionId = args.session_id.trim().parse().map_err(|_| {
+        anyhow::anyhow!(
+            "--session-id must be a complete session UUID (got {:?}). \
+             Prefixes and titles are not accepted: this deletion is irreversible.",
+            args.session_id
+        )
+    })?;
+
+    if !args.confirm {
+        bail!(
+            "purge-session is destructive and irreversible. It removes the session, its\n\
+             observations, handoffs, derived pages, and auto-improvement artifacts across\n\
+             every layer, leaving only a content-free tombstone.\n\n\
+             Re-run with --confirm to proceed:\n\n  \
+             ai-memory purge-session --workspace {workspace} --project {project} \
+             --session-id {session_id} --confirm",
+        );
+    }
+
+    let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
+    let receipt: serde_json::Value = post_json(
+        &endpoint,
+        "/admin/purge-session",
+        &PurgeSessionRequest {
+            workspace: workspace.clone(),
+            project: project.clone(),
+            session_id: session_id.to_string(),
+            confirm: true,
+            force: args.force,
+        },
+    )
+    .await?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&receipt)?);
+        return Ok(());
+    }
+
+    let status = receipt["status"].as_str().unwrap_or("unknown");
+    let counts = &receipt["counts"];
+    let total: u64 = counts
+        .as_object()
+        .map(|map| map.values().filter_map(serde_json::Value::as_u64).sum())
+        .unwrap_or(0);
+
+    if status == "already_purged" {
+        println!("already purged: {workspace}/{project} session {session_id}");
+    } else {
+        println!("purged {workspace}/{project} session {session_id} ({total} rows)");
+        for (layer, value) in counts.as_object().into_iter().flatten() {
+            if value.as_u64().unwrap_or(0) > 0 {
+                println!("  {layer}: {value}");
+            }
+        }
+    }
+    if let Some(cutoff) = receipt["backup_cutoff"].as_str() {
+        println!("  backups taken before {cutoff} still contain this session");
+    }
+    for warning in receipt["warnings"].as_array().into_iter().flatten() {
+        if let Some(text) = warning.as_str() {
+            eprintln!("  warning: {text}");
+        }
+    }
+    println!("\n{}", serde_json::to_string_pretty(&receipt)?);
+    Ok(())
+}

--- a/crates/ai-memory-cli/src/commands/purge_session.rs
+++ b/crates/ai-memory-cli/src/commands/purge_session.rs
@@ -65,7 +65,20 @@ pub async fn run(config: &Config, args: PurgeSessionArgs) -> Result<()> {
     )
     .await?;
 
+    // The server's tombstone already refuses these events with 410, so a drain
+    // would discard them eventually. Sweeping now means the content is not
+    // still sitting in a plaintext spool file on this host while the operator
+    // believes the deletion is done. Spools on OTHER hosts cannot be reached
+    // from here — the tombstone is what protects those.
+    let sweep = crate::commands::hook_spool::sweep_session(&config.data_dir, session_id)?;
+
     if args.json {
+        let mut receipt = receipt;
+        receipt["local_spool"] = serde_json::json!({
+            "removed": sweep.removed,
+            "kept": sweep.kept,
+            "unreadable": sweep.unreadable,
+        });
         println!("{}", serde_json::to_string_pretty(&receipt)?);
         return Ok(());
     }
@@ -87,9 +100,21 @@ pub async fn run(config: &Config, args: PurgeSessionArgs) -> Result<()> {
             }
         }
     }
+    if sweep.removed > 0 {
+        println!("  local spool: {} queued events removed", sweep.removed);
+    }
+    if sweep.unreadable > 0 {
+        eprintln!(
+            "  warning: {} local spool entries could not be read or removed",
+            sweep.unreadable
+        );
+    }
     if let Some(cutoff) = receipt["backup_cutoff"].as_str() {
         println!("  backups taken before {cutoff} still contain this session");
     }
+    println!(
+        "  spools on other hosts are not reachable from here; the server tombstone refuses them with 410"
+    );
     for warning in receipt["warnings"].as_array().into_iter().flatten() {
         if let Some(text) = warning.as_str() {
             eprintln!("  warning: {text}");

--- a/crates/ai-memory-cli/src/commands/reindex.rs
+++ b/crates/ai-memory-cli/src/commands/reindex.rs
@@ -66,6 +66,16 @@ pub async fn run(config: &Config, _args: ReindexArgs) -> Result<()> {
         .reindex_all()
         .await
         .context("rebuilding index from wiki/")?;
+
+    // Reindex rebuilds pages from markdown, which cannot carry the relational
+    // provenance a purge relies on — so a session page whose file survived
+    // (restored from an old snapshot, say) would come back indexed. The
+    // tombstone ledger is the authority: drop anything it covers, by the
+    // deterministic `sessions/<uuid>.md` identity rather than by inspecting
+    // page text (#387).
+    let purged = drop_tombstoned_pages(config, &store, &wiki)
+        .await
+        .context("removing tombstoned pages after reindex")?;
     info!(
         workspaces = summary.workspaces,
         projects = summary.projects,
@@ -79,7 +89,59 @@ pub async fn run(config: &Config, _args: ReindexArgs) -> Result<()> {
         summary.workspaces,
         config.data_dir.join("wiki").display(),
     );
+    if purged > 0 {
+        println!("dropped {purged} page(s) covered by the session tombstone ledger");
+    }
     Ok(())
+}
+
+/// Remove pages the tombstone ledger says were purged, and their files.
+///
+/// Fails closed: if a tombstoned page cannot be removed, the reindex reports an
+/// error rather than leaving a rebuilt index that serves deleted content.
+async fn drop_tombstoned_pages(config: &Config, store: &Store, wiki: &Wiki) -> Result<usize> {
+    let db = store.db_path().to_path_buf();
+    let ledger = ai_memory_store::session_purge::read_ledger_from_db(&db)
+        .context("reading the tombstone ledger")?;
+    if ledger.is_empty() {
+        return Ok(0);
+    }
+    let mut removed = 0usize;
+    for tombstone in ledger {
+        let path = ai_memory_core::PagePath::new(format!("sessions/{}.md", tombstone.session_id))
+            .context("building the session page path")?;
+        let existed = store
+            .reader
+            .latest_page_id_by_ids(
+                tombstone.workspace_id,
+                tombstone.project_id,
+                path.as_str().to_string(),
+            )
+            .await
+            .context("looking up a tombstoned page")?
+            .is_some();
+        if !existed {
+            continue;
+        }
+        wiki.delete_page(
+            tombstone.workspace_id,
+            tombstone.project_id,
+            &path,
+            None,
+            None,
+        )
+        .await
+        .with_context(|| format!("removing tombstoned page {}", path.as_str()))?;
+        let abs = config
+            .data_dir
+            .join("wiki")
+            .join(tombstone.workspace_id.to_string())
+            .join(tombstone.project_id.to_string())
+            .join(path.as_str());
+        let _ = std::fs::remove_file(abs);
+        removed += 1;
+    }
+    Ok(removed)
 }
 
 #[cfg(test)]

--- a/crates/ai-memory-cli/src/commands/reindex.rs
+++ b/crates/ai-memory-cli/src/commands/reindex.rs
@@ -110,6 +110,7 @@ mod tests {
         store
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: proj,
                 path: PagePath::new("notes/stale.md").unwrap(),

--- a/crates/ai-memory-cli/src/commands/restore.rs
+++ b/crates/ai-memory-cli/src/commands/restore.rs
@@ -15,6 +15,7 @@
 //! proceed when any sibling `ai-memory` process is detected.
 
 use ai_memory_store::Store;
+use ai_memory_store::session_purge::SessionTombstone;
 use anyhow::{Context, Result, bail};
 use flate2::read::GzDecoder;
 use std::path::{Component, Path};
@@ -39,6 +40,9 @@ pub fn run(config: &Config, args: RestoreArgs) -> Result<()> {
     if !args.from.is_file() {
         bail!("source tarball {} not found", args.from.display());
     }
+
+    // Read the ledger BEFORE the overwrite destroys the database holding it.
+    let ledger = load_ledger(config, &args)?;
 
     let wiki = config.data_dir.join("wiki");
     let db = config.data_dir.join("db").join("memory.sqlite");
@@ -68,16 +72,89 @@ pub fn run(config: &Config, args: RestoreArgs) -> Result<()> {
         .with_context(|| format!("extracting into {}", config.data_dir.display()))?;
     info!(from = %args.from.display(), into = %config.data_dir.display(), "tarball extracted");
 
-    // Open + drop the store so refinery applies any pending migrations
-    // and the SQLite file is validated.
-    let _store = Store::open(&config.data_dir).context("opening restored store")?;
+    // Open the store so refinery applies any pending migrations and the SQLite
+    // file is validated.
+    let store = Store::open(&config.data_dir).context("opening restored store")?;
+
+    // Reapply the tombstone ledger BEFORE the restored state is available
+    // (#387). A snapshot taken before a purge contains everything that purge
+    // removed; restoring it without this silently resurrects deleted content,
+    // and the operator has no way to notice.
+    drop(store);
+    let reapplied = reapply_tombstones(config, &ledger)?;
+
     info!("restore complete");
     println!(
         "restored {} -> {}",
         args.from.display(),
         config.data_dir.display()
     );
+    if reapplied > 0 {
+        println!("re-purged {reapplied} session(s) the tombstone ledger says were deleted");
+    }
     Ok(())
+}
+
+/// Read the tombstone ledger that must survive this restore.
+///
+/// Prefers `--tombstones-from`, which is what makes restoring into a FRESH
+/// directory safe: there is no current database to carry a ledger over from, so
+/// without an explicit one a pre-purge snapshot cannot be declared a safe
+/// restoration.
+fn load_ledger(config: &Config, args: &RestoreArgs) -> Result<Vec<SessionTombstone>> {
+    let source = args
+        .tombstones_from
+        .clone()
+        .unwrap_or_else(|| config.data_dir.clone());
+    let db = source.join("db").join("memory.sqlite");
+    if args.tombstones_from.is_some() && !db.is_file() {
+        bail!(
+            "--tombstones-from {} has no db/memory.sqlite to read a tombstone ledger from",
+            source.display()
+        );
+    }
+    ai_memory_store::session_purge::read_ledger_from_db(&db)
+        .with_context(|| format!("reading the tombstone ledger from {}", db.display()))
+}
+
+/// Re-purge every session the ledger says was deleted but the snapshot brought
+/// back, then fail closed if any survives.
+fn reapply_tombstones(config: &Config, ledger: &[SessionTombstone]) -> Result<usize> {
+    if ledger.is_empty() {
+        return Ok(0);
+    }
+    let db = config.data_dir.join("db").join("memory.sqlite");
+    let repurged = ai_memory_store::session_purge::reapply_ledger(&db, ledger)
+        .context("reapplying the tombstone ledger to the restored database")?;
+
+    // The wiki files and git history came back with the snapshot too, so the
+    // filesystem layers must be reapplied, not just the rows.
+    let wiki_root = config.data_dir.join("wiki");
+    let mut repo_paths = Vec::new();
+    for session in &repurged {
+        for path in &session.repo_paths {
+            let _ = std::fs::remove_file(wiki_root.join(path));
+            repo_paths.push(path.clone());
+        }
+        info!(session = %session.session_id, pages = session.repo_paths.len(), "re-purged a resurrected session");
+    }
+    if !repo_paths.is_empty() {
+        ai_memory_wiki::git_purge::purge_paths_from_history(&wiki_root, &repo_paths)
+            .context("removing resurrected pages from restored wiki history")?;
+    }
+
+    // Fail closed: a restore that cannot prove the ledger holds is not a safe
+    // restoration, and reporting success would be worse than refusing.
+    let still_present = ai_memory_store::session_purge::count_resurrected(&db)
+        .context("verifying the restored state against the tombstone ledger")?;
+    if still_present > 0 {
+        bail!(
+            "restore aborted: {still_present} purged session(s) survive in the restored state. \
+             The data directory is NOT safe to serve."
+        );
+    }
+    info!(repurged = repurged.len(), "tombstone ledger reapplied");
+    Ok(repurged.len())
 }
 
 fn unpack_checked_archive<R: std::io::Read>(

--- a/crates/ai-memory-cli/src/commands/restore.rs
+++ b/crates/ai-memory-cli/src/commands/restore.rs
@@ -139,7 +139,11 @@ fn reapply_tombstones(config: &Config, ledger: &[SessionTombstone]) -> Result<us
         info!(session = %session.session_id, pages = session.repo_paths.len(), "re-purged a resurrected session");
     }
     if !repo_paths.is_empty() {
-        ai_memory_wiki::git_purge::purge_paths_from_history(&wiki_root, &repo_paths)
+        let spec = ai_memory_wiki::git_purge::HistoryPurgeSpec {
+            doomed_paths: repo_paths,
+            ..Default::default()
+        };
+        ai_memory_wiki::git_purge::purge_paths_from_history(&wiki_root, &spec)
             .context("removing resurrected pages from restored wiki history")?;
     }
 

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -408,6 +408,16 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
     // operators discover misconfiguration immediately.
     let sanitizer = Sanitizer::new(&config.sanitize)
         .context("compiling sanitizer.extra_patterns from config")?;
+    // Finish any wiki-history purge interrupted mid-swap BEFORE the wiki is
+    // opened for business (#387). Serving first would let a reader observe the
+    // pre-purge history this is here to finish removing, and an error keeps the
+    // server from starting rather than quietly leaving deleted content
+    // recoverable.
+    if ai_memory_wiki::git_purge::recover_interrupted_purge(&config.data_dir)
+        .context("recovering an interrupted wiki history purge")?
+    {
+        tracing::warn!("resolved an interrupted wiki history purge during startup");
+    }
     let wiki = Wiki::new(&config.data_dir, store.writer.clone())?
         .with_sanitizer(sanitizer.clone())
         // Reader attached unconditionally: admission name-resolution uses it

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -2365,6 +2365,7 @@ mod tests {
         tier: Tier,
     ) {
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: project,
             path: PagePath::new(path).unwrap(),
@@ -2676,6 +2677,7 @@ mod tests {
             .unwrap()
             .with_embedder(synthetic);
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("notes/old-embedding.md").unwrap(),

--- a/crates/ai-memory-cli/src/main.rs
+++ b/crates/ai-memory-cli/src/main.rs
@@ -134,6 +134,7 @@ async fn main() -> Result<()> {
         Command::InstallSkills(args) => commands::install_skills::run(&config, args),
         Command::Reorg(args) => commands::reorg::run(&config, args).await,
         Command::PurgeProject(args) => commands::purge_project::run(&config, args).await,
+        Command::PurgeSession(args) => commands::purge_session::run(&config, args).await,
         Command::RenameProject(args) => commands::rename_project::run(&config, args).await,
         Command::MoveProject(args) => commands::move_project::run(&config, args).await,
         Command::Uninstall(args) => commands::uninstall::run(&config, args),

--- a/crates/ai-memory-consolidate/src/bootstrap.rs
+++ b/crates/ai-memory-consolidate/src/bootstrap.rs
@@ -401,6 +401,7 @@ impl Bootstrap {
             };
             written_paths.push(page.path.clone());
             requests.push(WritePageRequest {
+                source_session_id: None,
                 workspace_id: cfg.workspace_id,
                 project_id: cfg.project_id,
                 path,
@@ -426,6 +427,7 @@ impl Bootstrap {
             llm_chunks,
         });
         requests.push(WritePageRequest {
+            source_session_id: None,
             workspace_id: cfg.workspace_id,
             project_id: cfg.project_id,
             path: PagePath::new("bootstrap.md").expect("static path"),

--- a/crates/ai-memory-consolidate/src/consolidator.rs
+++ b/crates/ai-memory-consolidate/src/consolidator.rs
@@ -192,6 +192,9 @@ impl Consolidator {
         let id = self
             .wiki
             .write_page(WritePageRequest {
+                // `build_frontmatter` omits `session_id`, so the relational
+                // link is the only provenance this rewrite carries (#387).
+                source_session_id: Some(session_id),
                 workspace_id: ws,
                 project_id: proj,
                 path: path.clone(),
@@ -476,7 +479,8 @@ impl Consolidator {
         let mut requests = Vec::with_capacity(batch.updates.len());
         let mut outcomes_preview = Vec::with_capacity(batch.updates.len());
         for upd in &batch.updates {
-            let (mut req, mut outcome) = build_update(ws, proj, upd, false, &actor, author_id)?;
+            let (mut req, mut outcome) =
+                build_update(ws, proj, Some(session_id), upd, false, &actor, author_id)?;
             // A slot the engine writes belongs to the operator whose session
             // produced it, and `build_update` keeps the model's path verbatim
             // for every non-Rule kind — so the path here is attacker-reachable
@@ -582,6 +586,7 @@ impl Consolidator {
 fn build_update(
     ws: WorkspaceId,
     proj: ProjectId,
+    source_session_id: Option<ai_memory_core::SessionId>,
     upd: &crate::types::ConsolidatedPageUpdate,
     dry_run: bool,
     actor: &ai_memory_core::ActorContext,
@@ -643,6 +648,7 @@ fn build_update(
     fm.insert("consolidated".into(), serde_json::Value::Bool(true));
 
     let req = WritePageRequest {
+        source_session_id,
         workspace_id: ws,
         project_id: proj,
         path: path.clone(),
@@ -1597,6 +1603,7 @@ mod tests {
         let (req, _) = build_update(
             WorkspaceId::new(),
             ProjectId::new(),
+            None,
             &update,
             true,
             &ai_memory_core::ActorContext::anonymous(),
@@ -1626,6 +1633,7 @@ mod tests {
         let (req, _) = build_update(
             WorkspaceId::new(),
             ProjectId::new(),
+            None,
             &update,
             false,
             &actor,
@@ -1664,6 +1672,7 @@ mod tests {
         let (req, _) = build_update(
             WorkspaceId::new(),
             ProjectId::new(),
+            None,
             &update,
             false,
             &ai_memory_core::ActorContext::anonymous(),
@@ -1693,6 +1702,7 @@ mod tests {
         let (req, _) = build_update(
             WorkspaceId::new(),
             ProjectId::new(),
+            None,
             &update,
             true,
             &ai_memory_core::ActorContext::anonymous(),
@@ -1942,6 +1952,7 @@ mod tests {
 
     async fn write_slot(wiki: &Wiki, ws: WorkspaceId, proj: ProjectId, path: &str, body: &str) {
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new(path).unwrap(),
@@ -2608,6 +2619,7 @@ mod tests {
         consolidator
             .wiki
             .write_page(WritePageRequest {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: proj,
                 path: PagePath::new(PROJECT_INSTRUCTIONS_PATH).unwrap(),
@@ -2647,6 +2659,7 @@ mod tests {
         consolidator
             .wiki
             .write_page(WritePageRequest {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: other,
                 path: PagePath::new(PROJECT_INSTRUCTIONS_PATH).unwrap(),
@@ -2679,6 +2692,7 @@ mod tests {
         consolidator
             .wiki
             .write_page(WritePageRequest {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: proj,
                 path: PagePath::new(PROJECT_INSTRUCTIONS_PATH).unwrap(),

--- a/crates/ai-memory-consolidate/src/curator.rs
+++ b/crates/ai-memory-consolidate/src/curator.rs
@@ -375,6 +375,7 @@ mod tests {
     ) -> PageId {
         fx.wiki
             .write_page(WritePageRequest {
+                source_session_id: None,
                 workspace_id: fx.ws,
                 project_id: fx.proj,
                 path: PagePath::new(path).unwrap(),
@@ -539,6 +540,7 @@ mod tests {
             .store
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id: fx.ws,
                 project_id: fx.proj,
                 path: PagePath::new("notes/fm-pinned.md").unwrap(),

--- a/crates/ai-memory-consolidate/src/lint.rs
+++ b/crates/ai-memory-consolidate/src/lint.rs
@@ -354,6 +354,7 @@ async fn write_report_page(
     let title = format!("Lint report {date}");
     let body = render_markdown(report);
     wiki.write_page(WritePageRequest {
+        source_session_id: None,
         workspace_id,
         project_id,
         path,

--- a/crates/ai-memory-consolidate/tests/access_breadth_sweep.rs
+++ b/crates/ai-memory-consolidate/tests/access_breadth_sweep.rs
@@ -81,6 +81,7 @@ async fn seed(store: &Store) -> (WorkspaceId, ProjectId) {
 async fn write_page(writer: &WriterHandle, ws: WorkspaceId, proj: ProjectId, path: &str) -> PageId {
     writer
         .upsert_page(NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new(path.to_string()).expect("path"),

--- a/crates/ai-memory-consolidate/tests/embed_backfill.rs
+++ b/crates/ai-memory-consolidate/tests/embed_backfill.rs
@@ -51,6 +51,7 @@ impl Fixture {
     async fn write_page(&self, path: &str, body: &str) {
         self.wiki
             .write_page(WritePageRequest {
+                source_session_id: None,
                 workspace_id: self.ws,
                 project_id: self.proj,
                 path: PagePath::new(path.to_string()).expect("path"),

--- a/crates/ai-memory-consolidate/tests/embeddings.rs
+++ b/crates/ai-memory-consolidate/tests/embeddings.rs
@@ -57,6 +57,7 @@ async fn m9_embeddings_roundtrip_via_synthetic() {
 
     for (path, body) in pages {
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new(path.to_string()).expect("path"),
@@ -179,6 +180,7 @@ async fn m9_embeddings_roundtrip_via_synthetic() {
     // 5. Re-writing a page produces a fresh embedding row (the
     //    ON CONFLICT in store_embedding does the replace).
     wiki.write_page(WritePageRequest {
+        source_session_id: None,
         workspace_id: ws,
         project_id: proj,
         path: PagePath::new("notes/karpathy.md".to_string()).expect("path"),

--- a/crates/ai-memory-consolidate/tests/lifecycle.rs
+++ b/crates/ai-memory-consolidate/tests/lifecycle.rs
@@ -193,6 +193,7 @@ async fn m8_retention_lifecycle_end_to_end() {
         }
         let id = wiki
             .write_page(WritePageRequest {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: proj,
                 path: PagePath::new(fx.path.to_string()).expect("page path"),
@@ -498,6 +499,7 @@ async fn ttl_expiry_lifecycle_end_to_end() {
             frontmatter.insert("pinned".into(), serde_json::Value::Bool(true));
         }
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new(path.to_string()).expect("page path"),
@@ -745,6 +747,7 @@ async fn aged_decay_cleanup_stays_within_the_requested_scope() {
         ),
     ] {
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id,
             project_id,
             path: PagePath::new(path).unwrap(),
@@ -855,6 +858,7 @@ async fn rewritten_decay_eviction_removes_the_file_and_entire_version_chain() {
     let path = PagePath::new("sessions/rewritten.md").unwrap();
 
     let write = |body: &str, entity: &str| WritePageRequest {
+        source_session_id: None,
         workspace_id: ws,
         project_id: proj,
         path: path.clone(),
@@ -957,6 +961,7 @@ async fn hard_delete_preserves_a_page_recreated_at_the_same_path() {
     let path = PagePath::new("sessions/recreated.md").unwrap();
 
     let write = |body: &str| WritePageRequest {
+        source_session_id: None,
         workspace_id: ws,
         project_id: proj,
         path: path.clone(),

--- a/crates/ai-memory-consolidate/tests/recall_eval.rs
+++ b/crates/ai-memory-consolidate/tests/recall_eval.rs
@@ -127,6 +127,7 @@ async fn recall_at_5_baseline() {
 
     for (path, body) in CORPUS {
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new(path.to_string()).expect("path"),
@@ -186,6 +187,7 @@ async fn graph_neighbor_expansion_recovers_linked_page() {
     let wiki = Wiki::new(tmp.path(), store.writer.clone()).expect("wiki");
 
     wiki.write_page(WritePageRequest {
+        source_session_id: None,
         workspace_id: ws,
         project_id: proj,
         path: PagePath::new("notes/hidden_target.md").expect("path"),
@@ -201,6 +203,7 @@ async fn graph_neighbor_expansion_recovers_linked_page() {
     .await
     .expect("write target");
     wiki.write_page(WritePageRequest {
+        source_session_id: None,
         workspace_id: ws,
         project_id: proj,
         path: PagePath::new("notes/source.md").expect("path"),
@@ -272,6 +275,7 @@ async fn entity_stream_recovers_a_probe_fts_and_graph_both_miss() {
     let wiki = Wiki::new(tmp.path(), store.writer.clone()).expect("wiki");
 
     wiki.write_page(WritePageRequest {
+        source_session_id: None,
         workspace_id: ws,
         project_id: proj,
         path: PagePath::new("decisions/queue-choice.md").expect("path"),

--- a/crates/ai-memory-core/src/page.rs
+++ b/crates/ai-memory-core/src/page.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
-use crate::ids::{PageId, PagePath, ProjectId, WorkspaceId};
+use crate::ids::{PageId, PagePath, ProjectId, SessionId, WorkspaceId};
 
 /// Lifetime classification for a page.
 ///
@@ -38,6 +38,18 @@ pub struct NewPage {
     pub workspace_id: WorkspaceId,
     /// Owning project.
     pub project_id: ProjectId,
+    /// Session this page's content was derived from, when it was derived from
+    /// exactly one (#387). `None` means "not declared by this write", NOT
+    /// "none": the store carries an existing page's provenance forward when a
+    /// new version does not declare one, so a hand edit, a watcher reindex, or
+    /// an LLM rewrite of a session page cannot quietly launder it into a page
+    /// that `purge-session` no longer recognizes as derived.
+    ///
+    /// Rebuilding an index from disk into an EMPTY database has nothing to
+    /// inherit from and does lose this link; the tombstone ledger is what keeps
+    /// purged content from returning in that case, not this column.
+    #[serde(default)]
+    pub source_session_id: Option<SessionId>,
     /// Relative path within the wiki tree.
     pub path: PagePath,
     /// Page title (rendered from frontmatter or the first H1).

--- a/crates/ai-memory-hooks/src/lib.rs
+++ b/crates/ai-memory-hooks/src/lib.rs
@@ -50,6 +50,7 @@ pub use router::{
     DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT, DEFAULT_INGEST_GATE_MAX_ENTRIES,
     DEFAULT_PROJECT_CACHE_MAX_ENTRIES, HookState, IngestGates, IngestRateLimiter, ProjectCache,
     ProjectCacheStore, SubagentSessionSet, SubagentSessions, hook_router,
+    resolve_native_session_id,
 };
 pub use synth::synthesize_session_page;
 pub use workstream::{WorkstreamState, workstream_router};

--- a/crates/ai-memory-hooks/src/log.rs
+++ b/crates/ai-memory-hooks/src/log.rs
@@ -22,7 +22,7 @@
 
 use std::io::Write;
 
-use ai_memory_core::{ProjectId, WorkspaceId};
+use ai_memory_core::{ProjectId, SessionId, WorkspaceId};
 use ai_memory_wiki::Wiki;
 use jiff::{Timestamp, tz::TimeZone};
 use tracing::debug;
@@ -51,11 +51,12 @@ pub fn append_event(
     when: Timestamp,
     event: HookEvent,
     title: &str,
+    session_id: SessionId,
 ) -> std::io::Result<()> {
     let log_path = wiki
         .project_root(workspace_id, project_id)
         .join(log_filename_for(when));
-    let line = format_line(when, event, title);
+    let line = format_line(when, event, title, session_id);
     debug!(path = %log_path.display(), bytes = line.len(), "appending log entry");
 
     if let Some(parent) = log_path.parent()
@@ -81,7 +82,11 @@ pub(crate) fn log_filename_for(when: Timestamp) -> String {
         .to_string()
 }
 
-fn format_line(when: Timestamp, event: HookEvent, title: &str) -> String {
+/// Re-exported so the appender and the purge cannot drift apart: the wiki crate
+/// owns both the marker format and the removal that keys on it (#387).
+use ai_memory_wiki::log_purge::session_marker;
+
+fn format_line(when: Timestamp, event: HookEvent, title: &str, session_id: SessionId) -> String {
     let stamp = when.to_zoned(TimeZone::UTC).strftime("%Y-%m-%dT%H:%M:%SZ");
     let kind = match event {
         HookEvent::SessionStart => "session-start",
@@ -102,7 +107,10 @@ fn format_line(when: Timestamp, event: HookEvent, title: &str) -> String {
         .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
         .take(120)
         .collect();
-    format!("## [{stamp}] {kind} | {one_line}\n")
+    format!(
+        "## [{stamp}] {kind} | {one_line} {}\n",
+        session_marker(session_id)
+    )
 }
 
 #[cfg(test)]
@@ -120,10 +128,12 @@ mod tests {
             .to_zoned(TimeZone::UTC)
             .unwrap()
             .timestamp();
-        let line = format_line(when, HookEvent::SessionStart, "hello world");
+        let session_id: SessionId = "11111111-1111-4111-8111-111111111111".parse().unwrap();
+        let line = format_line(when, HookEvent::SessionStart, "hello world", session_id);
         assert_eq!(
             line,
-            "## [2026-05-21T12:34:56Z] session-start | hello world\n",
+            "## [2026-05-21T12:34:56Z] session-start | hello world \
+             <!-- ai-memory:session=11111111-1111-4111-8111-111111111111 -->\n",
         );
     }
 
@@ -143,8 +153,27 @@ mod tests {
             .await
             .unwrap();
         let now = Timestamp::now();
-        append_event(&wiki, ws, proj, now, HookEvent::SessionStart, "first").unwrap();
-        append_event(&wiki, ws, proj, now, HookEvent::UserPrompt, "second").unwrap();
+        let session_id = SessionId::new();
+        append_event(
+            &wiki,
+            ws,
+            proj,
+            now,
+            HookEvent::SessionStart,
+            "first",
+            session_id,
+        )
+        .unwrap();
+        append_event(
+            &wiki,
+            ws,
+            proj,
+            now,
+            HookEvent::UserPrompt,
+            "second",
+            session_id,
+        )
+        .unwrap();
         let log_path = wiki.project_root(ws, proj).join(log_filename_for(now));
         let contents = std::fs::read_to_string(&log_path).unwrap();
         assert!(contents.contains("session-start | first"));
@@ -178,8 +207,27 @@ mod tests {
             .to_zoned(TimeZone::UTC)
             .unwrap()
             .timestamp();
-        append_event(&wiki, ws, proj, may, HookEvent::SessionStart, "may-evt").unwrap();
-        append_event(&wiki, ws, proj, june, HookEvent::UserPrompt, "june-evt").unwrap();
+        let session_id = SessionId::new();
+        append_event(
+            &wiki,
+            ws,
+            proj,
+            may,
+            HookEvent::SessionStart,
+            "may-evt",
+            session_id,
+        )
+        .unwrap();
+        append_event(
+            &wiki,
+            ws,
+            proj,
+            june,
+            HookEvent::UserPrompt,
+            "june-evt",
+            session_id,
+        )
+        .unwrap();
 
         let root = wiki.project_root(ws, proj);
         let may_log = std::fs::read_to_string(root.join("log-2026-05.md")).unwrap();
@@ -188,6 +236,115 @@ mod tests {
         assert!(!may_log.contains("june-evt"));
         assert!(june_log.contains("june-evt"));
         assert!(!june_log.contains("may-evt"));
+    }
+
+    /// The purge removes a session's entries by their provenance marker, and
+    /// leaves every other session's entries in the same file intact.
+    #[tokio::test]
+    async fn purge_removes_only_the_named_sessions_entries() {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
+        let ws = store
+            .writer
+            .get_or_create_workspace("default")
+            .await
+            .unwrap();
+        let proj = store
+            .writer
+            .get_or_create_project(ws, "scratch", None)
+            .await
+            .unwrap();
+        let now = Timestamp::now();
+        let doomed = SessionId::new();
+        let kept = SessionId::new();
+        append_event(
+            &wiki,
+            ws,
+            proj,
+            now,
+            HookEvent::UserPrompt,
+            "doomed-canary",
+            doomed,
+        )
+        .unwrap();
+        append_event(
+            &wiki,
+            ws,
+            proj,
+            now,
+            HookEvent::UserPrompt,
+            "kept-canary",
+            kept,
+        )
+        .unwrap();
+
+        let outcome =
+            ai_memory_wiki::log_purge::purge_session_lines(&wiki, ws, proj, doomed, false).unwrap();
+        assert_eq!(outcome.removed, 1);
+        assert!(outcome.unattributed_files.is_empty());
+
+        let body = std::fs::read_to_string(wiki.project_root(ws, proj).join(log_filename_for(now)))
+            .unwrap();
+        assert!(!body.contains("doomed-canary"), "{body}");
+        assert!(body.contains("kept-canary"), "{body}");
+    }
+
+    /// Entries written before per-entry provenance existed cannot be attributed
+    /// to any session. They are reported rather than removed by inference —
+    /// matching log text would delete other sessions' entries and still miss
+    /// this one's.
+    #[tokio::test]
+    async fn legacy_entries_block_instead_of_being_guessed_at() {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
+        let ws = store
+            .writer
+            .get_or_create_workspace("default")
+            .await
+            .unwrap();
+        let proj = store
+            .writer
+            .get_or_create_project(ws, "scratch", None)
+            .await
+            .unwrap();
+        let now = Timestamp::now();
+        let doomed = SessionId::new();
+        append_event(
+            &wiki,
+            ws,
+            proj,
+            now,
+            HookEvent::UserPrompt,
+            "new-entry",
+            doomed,
+        )
+        .unwrap();
+
+        // A pre-#387 line: no marker, so no session owns it.
+        let log_path = wiki.project_root(ws, proj).join(log_filename_for(now));
+        let mut existing = std::fs::read_to_string(&log_path).unwrap();
+        existing.push_str("## [2026-01-01T00:00:00Z] user-prompt | legacy-canary\n");
+        std::fs::write(&log_path, &existing).unwrap();
+
+        let outcome =
+            ai_memory_wiki::log_purge::purge_session_lines(&wiki, ws, proj, doomed, false).unwrap();
+        assert_eq!(outcome.removed, 1, "attributed entries still go");
+        assert_eq!(
+            outcome.unattributed_files,
+            vec![log_filename_for(now)],
+            "the operator must be told the month is not provably clean"
+        );
+        let body = std::fs::read_to_string(&log_path).unwrap();
+        assert!(body.contains("legacy-canary"), "legacy lines are preserved");
+
+        // `--force` removes the whole retention unit: the only way to guarantee
+        // nothing of the session survives, at the cost of that month.
+        let outcome =
+            ai_memory_wiki::log_purge::purge_session_lines(&wiki, ws, proj, doomed, true).unwrap();
+        assert!(outcome.unattributed_files.is_empty());
+        assert!(!log_path.exists(), "forced purge removes the monthly log");
     }
 
     #[test]

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -588,7 +588,7 @@ async fn handle_hook(
     level_ext: Option<axum::Extension<ai_memory_core::AuthLevel>>,
     headers: HeaderMap,
     Json(mut body): Json<serde_json::Value>,
-) -> impl IntoResponse {
+) -> axum::response::Response {
     // Unconditional backstop (#196): drop any raw assistant-message field on the
     // `Value` before it becomes a `HookEnvelope`, so the field can never reach
     // `body_excerpt`, tracing, or the store — regardless of client version.
@@ -599,7 +599,7 @@ async fn handle_hook(
     // Any gate failure leaves an empty Stop with the same 202 "queued" response.
     crate::assistant_capture::apply_assistant_backstop(&mut env, state.capture_assistant_enabled);
     let Some(env) = inspect_capture_envelope(env) else {
-        return (StatusCode::ACCEPTED, "capture policy dropped");
+        return (StatusCode::ACCEPTED, "capture policy dropped").into_response();
     };
     // Accept-but-drop subagent captures (incl. the unmarked tail of tracked
     // subagent sessions) when the operator opts in. Returning 202 (not an error)
@@ -616,11 +616,27 @@ async fn handle_hook(
     let skip_webhooks = admission_skips(level_ext, &headers);
     let actor_storage_key = actor.as_ref().map(IdentityKey::storage_key);
     if should_drop_subagent(&state, &env).await {
-        return (StatusCode::ACCEPTED, "subagent capture dropped");
+        return (StatusCode::ACCEPTED, "subagent capture dropped").into_response();
+    }
+    // A purged session is terminal for every later delivery, including one
+    // spooled by a client that was offline during the purge. Checked here,
+    // before the semaphore, so a replay of purged content consumes no ingest
+    // capacity. `resolve_native_session_id` (not a bare parse) because an agent
+    // whose session id is an opaque string is stored under its v5 hash, and a
+    // tombstone must match the same key its session was purged under.
+    if let Some(session_id) = env.session_id.as_deref().map(resolve_native_session_id)
+        && state
+            .reader
+            .is_session_tombstoned(session_id)
+            .await
+            .unwrap_or(false)
+    {
+        info!(session = %session_id, "refusing hook event for a purged session");
+        return session_purged_response();
     }
     let Ok(permit) = state.ingest_semaphore.clone().try_acquire_owned() else {
         warn!("hook ingest saturated; dropping event with 429");
-        return (StatusCode::TOO_MANY_REQUESTS, "hook queue full");
+        return (StatusCode::TOO_MANY_REQUESTS, "hook queue full").into_response();
     };
     let rate_key = ingest_rate_key(&env, actor_storage_key.as_deref());
     if !state
@@ -630,7 +646,7 @@ async fn handle_hook(
         .try_take(&rate_key, std::time::Instant::now())
     {
         warn!(source = %log_rate_key(&rate_key), "hook ingest rate limit exceeded for source; dropping event with 429");
-        return (StatusCode::TOO_MANY_REQUESTS, "hook source rate limited");
+        return (StatusCode::TOO_MANY_REQUESTS, "hook source rate limited").into_response();
     }
     tokio::spawn(async move {
         let _permit = permit;
@@ -643,7 +659,21 @@ async fn handle_hook(
         )
         .await;
     });
-    (StatusCode::ACCEPTED, "queued")
+    (StatusCode::ACCEPTED, "queued").into_response()
+}
+
+/// The terminal response for an event naming a purged session (#387).
+///
+/// `410` rather than an error status: the event will never become deliverable,
+/// so a spooling client must drop it instead of retrying until its horizon
+/// expires. `terminal: true` says so explicitly, for drainers that would
+/// otherwise treat any 4xx as retryable.
+fn session_purged_response() -> axum::response::Response {
+    (
+        StatusCode::GONE,
+        Json(serde_json::json!({ "code": "session_purged", "terminal": true })),
+    )
+        .into_response()
 }
 
 /// One event in a `POST /hook/batch` request — the same `{url, body}` pair a
@@ -785,6 +815,22 @@ async fn handle_hook_batch(
             accepted_indices.push(idx);
             continue;
         }
+        // A purged session is terminal (#387). Counting the item as ACCEPTED is
+        // what makes it terminal for the client: the drainer clears committed
+        // items from its spool, so the event is dropped rather than retried
+        // until its horizon expires. Failing the batch here would instead stall
+        // every later item behind an event that can never be delivered.
+        if let Some(session_id) = env.session_id.as_deref().map(resolve_native_session_id)
+            && state
+                .reader
+                .is_session_tombstoned(session_id)
+                .await
+                .unwrap_or(false)
+        {
+            info!(session = %session_id, "dropping batched hook event for a purged session");
+            accepted_indices.push(idx);
+            continue;
+        }
         let Ok(permit) = state.ingest_semaphore.clone().try_acquire_owned() else {
             warn!(
                 accepted = accepted_indices.len(),
@@ -818,9 +864,9 @@ async fn handle_hook_batch(
         {
             if matches!(
                 e.downcast_ref::<StoreError>(),
-                Some(StoreError::SessionCollision)
+                Some(StoreError::SessionCollision | StoreError::SessionPurged)
             ) {
-                warn!("hook batch session collision/recovery rejection dropped");
+                warn!("hook batch session collision/purge rejection dropped");
                 accepted_indices.push(idx);
                 continue;
             }
@@ -2182,6 +2228,11 @@ async fn process_envelope(
     if let Err(e) = process_authorized(&state, env, actor, level, skip_webhooks).await {
         if matches!(
             e.downcast_ref::<StoreError>(),
+            Some(StoreError::SessionPurged)
+        ) {
+            info!("hook event for a purged session dropped");
+        } else if matches!(
+            e.downcast_ref::<StoreError>(),
             Some(StoreError::SessionCollision)
         ) {
             warn!("hook session collision dropped");
@@ -2266,12 +2317,13 @@ async fn process(
     )
     .await
     {
-        // Match the asynchronous hook envelope: collisions are terminal
-        // rejections, but fire-and-forget ingress acknowledges the delivery.
+        // Match the asynchronous hook envelope: collisions and purged sessions
+        // are terminal rejections, but fire-and-forget ingress acknowledges the
+        // delivery.
         Err(error)
             if matches!(
                 error.downcast_ref::<StoreError>(),
-                Some(StoreError::SessionCollision)
+                Some(StoreError::SessionCollision | StoreError::SessionPurged)
             ) =>
         {
             Ok(())
@@ -2364,6 +2416,21 @@ async fn process_authorized(
             .await?
         }
     };
+
+    // Authoritative purge guard (#387). The HTTP edge refuses a purged session
+    // early so the client gets a terminal 410, but that check runs before scope
+    // resolution and outside this transaction's view. Re-checking here on the
+    // RESOLVED scope is what actually stops a resurrection: it also covers the
+    // batch path, any in-process caller, and a purge that lands between the
+    // edge check and admission.
+    if state
+        .reader
+        .is_session_purged(ws, proj, session_id)
+        .await
+        .unwrap_or(false)
+    {
+        return Err(StoreError::SessionPurged.into());
+    }
 
     // Hooks are fire-and-forget and may arrive out of order. Begin the
     // session idempotently before every observation so a resumed agent
@@ -2575,6 +2642,7 @@ async fn process_authorized(
         Timestamp::now(),
         env.event,
         log_title.as_str(),
+        session_id,
     ) {
         warn!(error = %e, "log.md append failed");
     }
@@ -2842,7 +2910,13 @@ fn resolve_session_id(env: &HookEnvelope) -> anyhow::Result<SessionId> {
     anyhow::bail!("hook payload missing session_id and event is not session-start")
 }
 
-fn resolve_native_session_id(raw: &str) -> SessionId {
+/// Map a raw wire session id to its durable [`SessionId`].
+///
+/// Public because the spool sweep must key on the SAME value the ingest path
+/// stored: an agent whose session id is an opaque string lives under its v5
+/// hash, so a sweep comparing raw strings would silently miss its entries.
+#[must_use]
+pub fn resolve_native_session_id(raw: &str) -> SessionId {
     // Accept either a UUID (canonical) or any string, hashing the latter to a
     // deterministic UUID v5 so hook POSTs and startup GETs share one key.
     SessionId::from_str(raw)
@@ -4239,6 +4313,81 @@ mod tests {
                 .unwrap()
                 .is_some(),
             "an untagged override must stay authoritative under sticky"
+        );
+    }
+
+    /// A purged session is terminal for every later delivery, including one
+    /// spooled by a client that was offline during the purge (#387). The
+    /// response has to be distinguishable from an error so the drainer drops
+    /// the entry instead of retrying it until its horizon expires.
+    #[tokio::test]
+    async fn hook_for_a_purged_session_is_refused_as_terminal() {
+        let tmp = TempDir::new().unwrap();
+        let state = make_state(&tmp).await;
+        let sid = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+        let session_id: SessionId = sid.parse().unwrap();
+        let cwd = tmp.path().join("proj");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let fire = |event: &str| {
+            HookEnvelope::from_query_and_body(
+                HookQuery {
+                    event: event.into(),
+                    agent: Some("claude-code".into()),
+                    cwd: Some(cwd.to_string_lossy().into_owned()),
+                    ..Default::default()
+                },
+                serde_json::json!({
+                    "session_id": sid,
+                    "cwd": cwd.to_string_lossy(),
+                    "tool_name": "Bash",
+                }),
+            )
+        };
+        process(&state, fire("session-start"), None, Vec::new())
+            .await
+            .unwrap();
+
+        let (ws, proj, _) = state
+            .reader
+            .find_session_scope(session_id)
+            .await
+            .unwrap()
+            .expect("session exists");
+        assert!(
+            !state
+                .reader
+                .is_session_tombstoned(session_id)
+                .await
+                .unwrap()
+        );
+
+        state
+            .writer
+            .purge_session(ws, proj, session_id)
+            .await
+            .unwrap();
+
+        assert!(
+            state
+                .reader
+                .is_session_tombstoned(session_id)
+                .await
+                .unwrap(),
+            "the tombstone is what refuses a late replay"
+        );
+        // The observations are gone, and a replayed event must not recreate
+        // them by re-opening the session.
+        process(&state, fire("post-tool-use"), None, Vec::new())
+            .await
+            .unwrap_or(());
+        assert!(
+            state
+                .reader
+                .observations_for_session(session_id)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a replay must not resurrect a purged session"
         );
     }
 

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -2666,6 +2666,7 @@ async fn process_authorized(
         let page_id = state
             .wiki
             .write_page(ai_memory_wiki::WritePageRequest {
+                source_session_id: None,
                 workspace_id: new_page.workspace_id,
                 project_id: new_page.project_id,
                 path: new_page.path.clone(),
@@ -3028,6 +3029,7 @@ async fn consolidate_or_synth(
     state
         .wiki
         .write_page(ai_memory_wiki::WritePageRequest {
+            source_session_id: None,
             workspace_id: new_page.workspace_id,
             project_id: new_page.project_id,
             path: new_page.path,
@@ -8902,6 +8904,7 @@ mod tests {
         let page_id = state
             .wiki
             .write_page(ai_memory_wiki::WritePageRequest {
+                source_session_id: None,
                 workspace_id,
                 project_id,
                 path: page.path,
@@ -9633,6 +9636,7 @@ mod tests {
         pinned: bool,
     ) -> ai_memory_core::NewPage {
         ai_memory_core::NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: ai_memory_core::PagePath::new(path).unwrap(),

--- a/crates/ai-memory-hooks/src/synth.rs
+++ b/crates/ai-memory-hooks/src/synth.rs
@@ -33,6 +33,9 @@ pub fn synthesize_session_page(
     let path = PagePath::new(format!("sessions/{session_id}.md"))
         .expect("hard-coded sessions/<uuid>.md is always valid");
     NewPage {
+        // The heuristic session page is derived from exactly this session, and
+        // every later version of the path inherits the link (#387).
+        source_session_id: Some(session_id),
         workspace_id,
         project_id,
         path,

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -5485,6 +5485,29 @@ async fn handle_purge_session(
         }
     }
 
+    // Monthly log entries are attributed per line. Entries written before that
+    // provenance existed cannot be assigned to any session, so they are
+    // reported rather than guessed at — matching log text would delete other
+    // sessions' entries and still miss this one's.
+    match ai_memory_wiki::log_purge::purge_session_lines(
+        &state.wiki,
+        ws_id,
+        proj_id,
+        session_id,
+        req.force,
+    ) {
+        Ok(outcome) => {
+            for file in outcome.unattributed_files {
+                warnings.push(format!(
+                    "{file} still holds log entries written before per-entry provenance; \
+                     they cannot be attributed to a session. Re-run with force=true to remove \
+                     that month's log entirely."
+                ));
+            }
+        }
+        Err(e) => warnings.push(format!("could not purge monthly log entries: {e}")),
+    }
+
     (
         StatusCode::OK,
         Json(

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -5399,6 +5399,29 @@ pub struct PurgeSessionReceipt {
     pub warnings: Vec<String>,
 }
 
+/// Repo-relative paths of a project's monthly logs.
+///
+/// Shared files: every session that wrote during that month has entries in
+/// them, so a purge scrubs its own marked lines rather than removing the path.
+fn monthly_log_paths(
+    wiki: &Wiki,
+    workspace_id: ai_memory_core::WorkspaceId,
+    project_id: ai_memory_core::ProjectId,
+) -> Vec<String> {
+    let root = wiki.project_root(workspace_id, project_id);
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            (name.starts_with("log-") && name.ends_with(".md"))
+                .then(|| format!("{workspace_id}/{project_id}/{name}"))
+        })
+        .collect()
+}
+
 async fn handle_purge_session(
     State(state): State<Arc<AdminState>>,
     author_ext: Option<axum::Extension<ai_memory_core::UserId>>,
@@ -5519,10 +5542,21 @@ async fn handle_purge_session(
         .iter()
         .map(|path| format!("{ws_id}/{proj_id}/{}", path.as_str()))
         .collect();
-    let git_report = if repo_paths.is_empty() {
+    // The monthly log is shared with every other session that wrote to it, so
+    // its path must survive while THIS session's marked lines are scrubbed from
+    // every historical version. Commit messages embed the session's own prompt
+    // text and are matched by its short-id handle.
+    let session_text = session_id.to_string();
+    let spec = ai_memory_wiki::git_purge::HistoryPurgeSpec {
+        doomed_paths: repo_paths.clone(),
+        scrub_paths: monthly_log_paths(&state.wiki, ws_id, proj_id),
+        line_marker: ai_memory_wiki::log_purge::session_marker(session_id),
+        commit_prefix: format!("session {}", &session_text[..8]),
+    };
+    let git_report = if spec.is_empty() {
         ai_memory_wiki::git_purge::GitPurgeReport::default()
     } else {
-        match ai_memory_wiki::git_purge::purge_paths_from_history(state.wiki.root(), &repo_paths) {
+        match ai_memory_wiki::git_purge::purge_paths_from_history(state.wiki.root(), &spec) {
             Ok(report) => report,
             Err(e) => {
                 // The rows are already gone, so this cannot be rolled back —
@@ -5564,6 +5598,8 @@ async fn handle_purge_session(
                     "git_repositories_rebuilt": git_report.repositories_rebuilt,
                     "git_commits_rewritten": git_report.commits_rewritten,
                     "git_blobs_destroyed": git_report.blobs_destroyed,
+                    "git_blobs_scrubbed": git_report.blobs_scrubbed,
+                    "git_messages_redacted": git_report.messages_redacted,
                 }),
                 backup_cutoff: receipt.backup_cutoff.to_string(),
                 warnings,

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -5508,6 +5508,36 @@ async fn handle_purge_session(
         Err(e) => warnings.push(format!("could not purge monthly log entries: {e}")),
     }
 
+    // Strong deletion (#387): removing the file and committing would leave
+    // every prior version reachable in git history, and `restore-page` would
+    // hand one back. Rebuild the repository without those paths so the content
+    // is gone from the object database itself, not merely unreferenced.
+    //
+    // The wiki tree is shared, so paths are repo-relative: `<ws>/<proj>/<path>`.
+    let repo_paths: Vec<String> = receipt
+        .removed_pages
+        .iter()
+        .map(|path| format!("{ws_id}/{proj_id}/{}", path.as_str()))
+        .collect();
+    let git_report = if repo_paths.is_empty() {
+        ai_memory_wiki::git_purge::GitPurgeReport::default()
+    } else {
+        match ai_memory_wiki::git_purge::purge_paths_from_history(state.wiki.root(), &repo_paths) {
+            Ok(report) => report,
+            Err(e) => {
+                // The rows are already gone, so this cannot be rolled back —
+                // but it MUST be loud: history still holds the content, and an
+                // operator who believes otherwise has been misled.
+                warnings.push(format!(
+                    "GIT HISTORY NOT PURGED: {e}. The database rows are removed, but earlier \
+                     versions of the affected pages remain recoverable from wiki git history. \
+                     Re-run purge-session to retry."
+                ));
+                ai_memory_wiki::git_purge::GitPurgeReport::default()
+            }
+        }
+    };
+
     (
         StatusCode::OK,
         Json(
@@ -5531,6 +5561,9 @@ async fn handle_purge_session(
                     "auto_improve_proposal_events": receipt.counts.auto_improve_proposal_events,
                     "auto_improve_rejections": receipt.counts.auto_improve_rejections,
                     "page_versions": receipt.counts.page_versions,
+                    "git_repositories_rebuilt": git_report.repositories_rebuilt,
+                    "git_commits_rewritten": git_report.commits_rewritten,
+                    "git_blobs_destroyed": git_report.blobs_destroyed,
                 }),
                 backup_cutoff: receipt.backup_cutoff.to_string(),
                 warnings,

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -21,6 +21,7 @@
 //! - `GET  /admin/checkpoints`    — list recent wiki git checkpoints.
 //! - `POST /admin/restore-page`   — restore one page from a checkpoint.
 //! - `POST /admin/purge-project`  — delete a project and all its data.
+//! - `POST /admin/purge-session`  — strong per-session deletion (#387).
 //! - `POST /admin/rename-project` — rename a project (column-only; no files move).
 //! - `POST /admin/rename-workspace` — rename a workspace and refresh scope manifests.
 //! - `POST /admin/delete-workspace` — delete a workspace and all of its projects.
@@ -581,6 +582,7 @@ pub fn admin_router_with_decay_breadth(state: AdminState, breadth_weight: f64) -
         .route("/admin/checkpoints", get(handle_checkpoints))
         .route("/admin/restore-page", post(handle_restore_page))
         .route("/admin/purge-project", post(handle_purge_project))
+        .route("/admin/purge-session", post(handle_purge_session))
         .route("/admin/rename-project", post(handle_rename_project))
         .route("/admin/move-project", post(handle_move_project))
         .route("/admin/delete-workspace", post(handle_delete_workspace))
@@ -4430,6 +4432,7 @@ async fn copy_purge_merge(
         used_dest_paths.insert(dest_path.as_str().to_string());
         let new_page_id = match copy_wiki
             .write_page(WritePageRequest {
+                source_session_id: None,
                 workspace_id: dst_ws,
                 project_id: dst_proj,
                 path: dest_path.clone(),
@@ -4916,6 +4919,7 @@ async fn handle_write_page(
     let page_id = state
         .wiki
         .write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: path.clone(),
@@ -5339,6 +5343,178 @@ fn map_user_store_err(e: ai_memory_store::StoreError) -> (StatusCode, Json<serde
         }
         other => internal_err(other.to_string()),
     }
+}
+
+// ---------------------------------------------------------------------
+// purge-session (#387)
+// ---------------------------------------------------------------------
+
+/// JSON request body for `POST /admin/purge-session`.
+#[derive(Deserialize)]
+struct PurgeSessionRequest {
+    /// Workspace name. Must already exist.
+    workspace: String,
+    /// Project name. Must already exist.
+    project: String,
+    /// The session's complete, validated UUID. Never a prefix, title, or path:
+    /// a deletion that guessed its target would be worse than no deletion.
+    session_id: String,
+    /// Mandatory confirmation. Without `confirm: true` the server returns 400.
+    confirm: bool,
+    /// Purge even when the session is still open, a consolidation is queued,
+    /// or an auto-improvement claim is outstanding. Off by default: those
+    /// would otherwise be cut off mid-flight.
+    #[serde(default)]
+    force: bool,
+}
+
+/// Receipt returned by `POST /admin/purge-session`.
+///
+/// Deliberately echoes no deleted content — only identity, counts, and the
+/// cutoff an operator needs to invalidate older snapshots.
+#[derive(Debug, Serialize)]
+pub struct PurgeSessionReceipt {
+    /// Contract version of this receipt.
+    pub schema_version: i64,
+    /// `purged` or `already_purged`.
+    pub status: String,
+    /// Workspace name as requested.
+    pub workspace: String,
+    /// Project name as requested.
+    pub project: String,
+    /// The purged session's UUID.
+    pub session_id: String,
+    /// Which identity space this session belongs to. Managed workstreams are
+    /// out of scope for this API and are never matched by coincidence.
+    pub session_kind: String,
+    /// Stable id of the tombstone covering this session.
+    pub tombstone_id: String,
+    /// RFC3339 instant the session was purged.
+    pub purged_at: String,
+    /// Rows removed per layer.
+    pub counts: serde_json::Value,
+    /// Snapshots older than this may still contain the purged content.
+    pub backup_cutoff: String,
+    /// Non-fatal conditions, e.g. a wiki file that could not be removed.
+    pub warnings: Vec<String>,
+}
+
+async fn handle_purge_session(
+    State(state): State<Arc<AdminState>>,
+    author_ext: Option<axum::Extension<ai_memory_core::UserId>>,
+    Json(req): Json<PurgeSessionRequest>,
+) -> impl IntoResponse {
+    let author_id = author_ext.map(|axum::Extension(u)| u);
+    if !req.confirm {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "destructive operation requires confirm=true"
+            })),
+        );
+    }
+    // Full UUID only. A prefix or a free-form label could resolve to more than
+    // one session, and this operation is irreversible.
+    let Ok(session_id) = req.session_id.parse::<ai_memory_core::SessionId>() else {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(serde_json::json!({
+                "error": "session_id must be a complete session UUID"
+            })),
+        );
+    };
+
+    let (ws_id, proj_id) =
+        match lookup_ws_proj_no_create(&state, &req.workspace, &req.project).await {
+            Ok(ids) => ids,
+            Err(e) => return e,
+        };
+
+    if !req.force {
+        match state.reader.session_purge_is_busy(session_id).await {
+            Ok(Some(reason)) => {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({
+                        "error": format!("session is busy: {reason}"),
+                        "hint": "retry with force=true to cancel and purge anyway",
+                    })),
+                );
+            }
+            Ok(None) => {}
+            Err(e) => return internal_err(e.to_string()),
+        }
+    }
+
+    let receipt = match state.writer.purge_session(ws_id, proj_id, session_id).await {
+        Ok(receipt) => receipt,
+        Err(ai_memory_store::StoreError::NotFound(_)) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({
+                    "error": "no such session in this workspace and project"
+                })),
+            );
+        }
+        Err(ai_memory_store::StoreError::InvalidState(msg))
+            if msg.contains("different workspace or project") =>
+        {
+            // Deliberately indistinguishable from "not found": confirming that
+            // the id exists elsewhere would leak another project's session.
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({
+                    "error": "no such session in this workspace and project"
+                })),
+            );
+        }
+        Err(e) => return internal_err(e.to_string()),
+    };
+
+    // The index is clean; the working tree is not. Remove the authoritative
+    // markdown for every page whose versions were all derived from this
+    // session. Git history is rewritten separately.
+    let mut warnings = receipt.warnings.clone();
+    for path in &receipt.removed_pages {
+        if let Err(e) = state
+            .wiki
+            .delete_page(ws_id, proj_id, path, None, author_id)
+            .await
+        {
+            warnings.push(format!("could not remove wiki file {}: {e}", path.as_str()));
+        }
+    }
+
+    (
+        StatusCode::OK,
+        Json(
+            serde_json::to_value(PurgeSessionReceipt {
+                schema_version: ai_memory_store::session_purge::SESSION_PURGE_SCHEMA_VERSION,
+                status: receipt.status.as_str().to_string(),
+                workspace: req.workspace,
+                project: req.project,
+                session_id: session_id.to_string(),
+                session_kind: "native_lifecycle".to_string(),
+                tombstone_id: receipt.tombstone_id.to_string(),
+                purged_at: receipt.purged_at.to_string(),
+                counts: serde_json::json!({
+                    "sessions": receipt.counts.sessions,
+                    "observations": receipt.counts.observations,
+                    "handoffs": receipt.counts.handoffs,
+                    "consolidation_jobs": receipt.counts.consolidation_jobs,
+                    "auto_improve_scheduler_claims": receipt.counts.auto_improve_scheduler_claims,
+                    "auto_improve_runs": receipt.counts.auto_improve_runs,
+                    "auto_improve_proposals": receipt.counts.auto_improve_proposals,
+                    "auto_improve_proposal_events": receipt.counts.auto_improve_proposal_events,
+                    "auto_improve_rejections": receipt.counts.auto_improve_rejections,
+                    "page_versions": receipt.counts.page_versions,
+                }),
+                backup_cutoff: receipt.backup_cutoff.to_string(),
+                warnings,
+            })
+            .unwrap_or_else(|e| serde_json::json!({ "error": e.to_string() })),
+        ),
+    )
 }
 
 #[cfg(test)]
@@ -6197,6 +6373,38 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
+    /// Like [`read_page_test_router`] but also hands back the writer, so a test
+    /// can seed real sessions before exercising the route.
+    fn purge_session_test_router() -> (TempDir, Router, WriterHandle) {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let wiki = Wiki::new(tmp.path(), store.writer.clone())
+            .unwrap()
+            .with_store_reader(store.reader.clone());
+        let writer = store.writer.clone();
+        let router = admin_router(AdminState {
+            writer: store.writer.clone(),
+            reader: store.reader.clone(),
+            wiki,
+            llm: None,
+            auto_improve_require_approval: false,
+            auto_improve_review_config: Default::default(),
+            embedder: None,
+            provider_health: ProviderHealth::default(),
+            decay_params: DecayParams::default(),
+            data_dir: tmp.path().to_path_buf(),
+            db_path: store.db_path().to_path_buf(),
+            bind: "127.0.0.1:49374".to_string(),
+            home_dir: None,
+            bootstrap_lock: Arc::new(tokio::sync::Mutex::new(())),
+            token_pepper: None,
+            active_project: ai_memory_core::ActiveProject::new(),
+            scope_invalidator: None,
+            trusted_proxy_identity: false,
+        });
+        (tmp, router, writer)
+    }
+
     fn read_page_test_router() -> (TempDir, Router) {
         let tmp = TempDir::new().unwrap();
         let store = Store::open(tmp.path()).unwrap();
@@ -6502,6 +6710,7 @@ mod tests {
             .unwrap();
 
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("_slots/current-focus.md").unwrap(),
@@ -6657,6 +6866,7 @@ mod tests {
             .unwrap();
 
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("_slots/current-focus.md").unwrap(),
@@ -6796,6 +7006,7 @@ mod tests {
         .await;
 
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("_slots/current-focus.md").unwrap(),
@@ -6913,6 +7124,7 @@ mod tests {
         .await;
 
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("_slots/current-focus.md").unwrap(),
@@ -9499,6 +9711,218 @@ mod tests {
             post_delete_page(&router, "default", "audit", "notes/never-existed.md").await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(json["deleted"], true);
+    }
+
+    // ── purge-session (#387) ─────────────────────────────────────────────
+
+    async fn post_purge_session(
+        router: &Router,
+        body: serde_json::Value,
+    ) -> (StatusCode, serde_json::Value) {
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/admin/purge-session")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+        (status, json)
+    }
+
+    /// Seed a real session with an observation so the purge has something to
+    /// remove, and return its id.
+    async fn seed_purgeable_session(writer: &WriterHandle, ws: &str, project: &str) -> String {
+        let workspace_id = writer.get_or_create_workspace(ws).await.unwrap();
+        let project_id = writer
+            .get_or_create_project(workspace_id, project, None)
+            .await
+            .unwrap();
+        let session_id = ai_memory_core::SessionId::new();
+        writer
+            .begin_session(ai_memory_core::NewSession {
+                id: session_id,
+                workspace_id,
+                project_id,
+                agent_kind: ai_memory_core::AgentKind::Codex,
+                cwd: None,
+                actor_user: None,
+            })
+            .await
+            .unwrap();
+        writer
+            .insert_observation(ai_memory_core::Sanitized::new(
+                ai_memory_core::NewObservation {
+                    session_id,
+                    workspace_id,
+                    project_id,
+                    kind: ai_memory_core::ObservationKind::UserPrompt,
+                    extension: None,
+                    source_event: None,
+                    title: "prompt".into(),
+                    body: "secret-canary-payload".into(),
+                    importance: 5,
+                },
+                &ai_memory_core::Sanitizer::default(),
+            ))
+            .await
+            .unwrap();
+        writer.end_session(session_id, None).await.unwrap();
+        session_id.to_string()
+    }
+
+    #[tokio::test]
+    async fn purge_session_requires_confirm() {
+        let (_tmp, router, writer) = purge_session_test_router();
+        let session_id = seed_purgeable_session(&writer, "default", "audit").await;
+        let (status, json) = post_purge_session(
+            &router,
+            serde_json::json!({
+                "workspace": "default",
+                "project": "audit",
+                "session_id": session_id,
+                "confirm": false,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(
+            json["error"].as_str().unwrap().contains("confirm=true"),
+            "{json}"
+        );
+    }
+
+    #[tokio::test]
+    async fn purge_session_rejects_a_partial_uuid() {
+        let (_tmp, router, writer) = purge_session_test_router();
+        let session_id = seed_purgeable_session(&writer, "default", "audit").await;
+        // A prefix of a REAL session id must still be refused: the deletion is
+        // irreversible, so it may never resolve a target by guessing.
+        let (status, _) = post_purge_session(
+            &router,
+            serde_json::json!({
+                "workspace": "default",
+                "project": "audit",
+                "session_id": &session_id[..8],
+                "confirm": true,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn purge_session_removes_the_session_and_is_idempotent() {
+        let (_tmp, router, writer) = purge_session_test_router();
+        let session_id = seed_purgeable_session(&writer, "default", "audit").await;
+        let body = serde_json::json!({
+            "workspace": "default",
+            "project": "audit",
+            "session_id": session_id,
+            "confirm": true,
+        });
+
+        let (status, json) = post_purge_session(&router, body.clone()).await;
+        assert_eq!(status, StatusCode::OK, "{json}");
+        assert_eq!(json["status"], "purged");
+        assert_eq!(json["counts"]["sessions"], 1);
+        assert_eq!(json["counts"]["observations"], 1);
+        assert_eq!(json["session_kind"], "native_lifecycle");
+        assert!(json["tombstone_id"].as_str().is_some());
+        let first_tombstone = json["tombstone_id"].as_str().unwrap().to_string();
+
+        let (status, json) = post_purge_session(&router, body).await;
+        assert_eq!(status, StatusCode::OK, "{json}");
+        assert_eq!(json["status"], "already_purged");
+        assert_eq!(json["tombstone_id"].as_str().unwrap(), first_tombstone);
+        assert_eq!(json["counts"]["sessions"], 0);
+    }
+
+    #[tokio::test]
+    async fn purge_session_in_the_wrong_project_is_indistinguishable_from_absent() {
+        let (_tmp, router, writer) = purge_session_test_router();
+        let session_id = seed_purgeable_session(&writer, "default", "audit").await;
+        // Seed the other project so the scope itself resolves.
+        seed_purgeable_session(&writer, "default", "other").await;
+
+        let (status, json) = post_purge_session(
+            &router,
+            serde_json::json!({
+                "workspace": "default",
+                "project": "other",
+                "session_id": session_id,
+                "confirm": true,
+            }),
+        )
+        .await;
+        // Confirming that the id exists elsewhere would leak another project's
+        // session, so a scope conflict reads exactly like "no such session".
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(
+            json["error"].as_str().unwrap(),
+            "no such session in this workspace and project"
+        );
+
+        // And the real session must be untouched by the misdirected attempt.
+        let (status, json) = post_purge_session(
+            &router,
+            serde_json::json!({
+                "workspace": "default",
+                "project": "audit",
+                "session_id": session_id,
+                "confirm": true,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{json}");
+        assert_eq!(json["status"], "purged");
+    }
+
+    #[tokio::test]
+    async fn purge_session_refuses_an_open_session_without_force() {
+        let (_tmp, router, writer) = purge_session_test_router();
+        let workspace_id = writer.get_or_create_workspace("default").await.unwrap();
+        let project_id = writer
+            .get_or_create_project(workspace_id, "audit", None)
+            .await
+            .unwrap();
+        let session_id = ai_memory_core::SessionId::new();
+        writer
+            .begin_session(ai_memory_core::NewSession {
+                id: session_id,
+                workspace_id,
+                project_id,
+                agent_kind: ai_memory_core::AgentKind::Codex,
+                cwd: None,
+                actor_user: None,
+            })
+            .await
+            .unwrap();
+
+        let body = serde_json::json!({
+            "workspace": "default",
+            "project": "audit",
+            "session_id": session_id.to_string(),
+            "confirm": true,
+        });
+        let (status, json) = post_purge_session(&router, body.clone()).await;
+        assert_eq!(status, StatusCode::CONFLICT, "{json}");
+        assert!(json["error"].as_str().unwrap().contains("still open"));
+
+        let mut forced = body;
+        forced["force"] = serde_json::Value::Bool(true);
+        let (status, json) = post_purge_session(&router, forced).await;
+        assert_eq!(status, StatusCode::OK, "{json}");
+        assert_eq!(json["status"], "purged");
     }
 
     #[tokio::test]

--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -2821,6 +2821,7 @@ impl AiMemoryServer {
 
         let page_id = wiki
             .write_page(WritePageRequest {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: proj,
                 path: path.clone(),
@@ -4112,6 +4113,7 @@ mod tests {
         store
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: proj,
                 path: PagePath::new("foo.md").unwrap(),
@@ -4408,6 +4410,7 @@ mod tests {
         store
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: other,
                 path: PagePath::new("foo.md").unwrap(),
@@ -5259,6 +5262,7 @@ mod tests {
             .unwrap();
         let path = PagePath::new("notes/shared.md").unwrap();
         let make_page = |project_id, body: &str| NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id,
             path: path.clone(),
@@ -5893,6 +5897,7 @@ mod tests {
         // A page findable ONLY via its entities (body avoids the query
         // word), and a page findable ONLY via a link from an FTS hit.
         let mut entity_only = NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("concepts/broker.md").unwrap(),
@@ -5915,6 +5920,7 @@ mod tests {
         store
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: proj,
                 path: PagePath::new("concepts/seed.md").unwrap(),
@@ -6003,6 +6009,7 @@ mod tests {
         store
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id: global.workspace_id,
                 project_id: global.project_id,
                 path: PagePath::new("preferences/style.md").unwrap(),
@@ -6537,6 +6544,7 @@ mod tests {
         store
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: pages,
                 path: PagePath::new("page-hit.md").unwrap(),
@@ -6619,6 +6627,7 @@ mod tests {
         store
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id: practice_ws,
                 project_id: testing,
                 path: PagePath::new("patterns.md").unwrap(),
@@ -6795,6 +6804,7 @@ mod tests {
             .await
             .unwrap();
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: practice_ws,
             project_id: docs,
             path: PagePath::new("notes/sibling.md").unwrap(),
@@ -6846,6 +6856,7 @@ mod tests {
         store
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: proj,
                 path: PagePath::new("notes/db-only-tool.md").unwrap(),
@@ -6966,6 +6977,7 @@ mod tests {
         store
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: product,
                 path: PagePath::new("product.md").unwrap(),
@@ -6984,6 +6996,7 @@ mod tests {
         store
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id: practice_ws,
                 project_id: testing,
                 path: PagePath::new("patterns.md").unwrap(),
@@ -7002,6 +7015,7 @@ mod tests {
         store
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: hidden,
                 path: PagePath::new("hidden.md").unwrap(),
@@ -7098,6 +7112,7 @@ mod tests {
             store
                 .writer
                 .upsert_page(NewPage {
+                    source_session_id: None,
                     workspace_id: w,
                     project_id: p,
                     path: PagePath::new(path).unwrap(),
@@ -7117,6 +7132,7 @@ mod tests {
         store
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: other,
                 path: PagePath::new("expired.md").unwrap(),
@@ -7233,6 +7249,7 @@ mod tests {
             store
                 .writer
                 .upsert_page(NewPage {
+                    source_session_id: None,
                     workspace_id: w,
                     project_id: p,
                     path: PagePath::new(path).unwrap(),
@@ -7518,6 +7535,7 @@ mod tests {
             store
                 .writer
                 .upsert_page(NewPage {
+                    source_session_id: None,
                     workspace_id: w,
                     project_id: p,
                     path: PagePath::new(path).unwrap(),

--- a/crates/ai-memory-mcp/tests/admin_backup.rs
+++ b/crates/ai-memory-mcp/tests/admin_backup.rs
@@ -63,6 +63,7 @@ async fn seed_page(state: &AdminState, store: &Store, path: &str, body: &str) {
     state
         .wiki
         .write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new(path).unwrap(),

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -152,6 +152,7 @@ async fn seed_page_with_metadata(
         .await
         .unwrap();
     wiki.write_page(WritePageRequest {
+        source_session_id: None,
         workspace_id: ws_id,
         project_id: proj,
         path: PagePath::new(path.to_string()).unwrap(),
@@ -675,6 +676,7 @@ async fn true_move_stale_source_write_fails_before_creating_file() {
     let stale_path = PagePath::new("notes/stale.md".to_string()).unwrap();
     let err = stale_wiki
         .write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: src_ws,
             project_id: src_proj,
             path: stale_path.clone(),

--- a/crates/ai-memory-mcp/tests/admin_phase3.rs
+++ b/crates/ai-memory-mcp/tests/admin_phase3.rs
@@ -489,6 +489,7 @@ async fn reorg_live_graveyards_only_default_workspace_pages() {
     store
         .writer
         .upsert_page(NewPage {
+            source_session_id: None,
             workspace_id: default_ws,
             project_id: default_proj,
             path: PagePath::new("notes/default-latest.md").unwrap(),
@@ -518,6 +519,7 @@ async fn reorg_live_graveyards_only_default_workspace_pages() {
     store
         .writer
         .upsert_page(NewPage {
+            source_session_id: None,
             workspace_id: sibling_ws,
             project_id: sibling_proj,
             path: PagePath::new("notes/sibling-latest.md").unwrap(),
@@ -598,6 +600,7 @@ async fn lint_dry_run_returns_lint_report_shape() {
     store
         .writer
         .upsert_page(NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("notes/test.md").unwrap(),
@@ -768,6 +771,7 @@ async fn embed_all_projects_rebuilds_workspace_projects() {
     state
         .wiki
         .write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: alpha,
             path: PagePath::new("notes/a.md").unwrap(),
@@ -785,6 +789,7 @@ async fn embed_all_projects_rebuilds_workspace_projects() {
     state
         .wiki
         .write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: beta,
             path: PagePath::new("notes/b.md").unwrap(),
@@ -877,6 +882,7 @@ async fn commit_with_new_page_returns_committed_true_and_40char_oid() {
     state
         .wiki
         .write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("notes/commit-test.md").unwrap(),
@@ -927,6 +933,7 @@ async fn checkpoints_list_and_restore_page_round_trip() {
     state
         .wiki
         .write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: path.clone(),
@@ -946,6 +953,7 @@ async fn checkpoints_list_and_restore_page_round_trip() {
     state
         .wiki
         .write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: path.clone(),

--- a/crates/ai-memory-mcp/tests/admin_purge.rs
+++ b/crates/ai-memory-mcp/tests/admin_purge.rs
@@ -93,6 +93,7 @@ async fn seed_two_projects(store: &Store, wiki: &Wiki) -> (WorkspaceId, ProjectI
 
     // Write pages through the wiki so they land on disk in per-project dirs.
     wiki.write_page(WritePageRequest {
+        source_session_id: None,
         workspace_id: ws,
         project_id: keep,
         path: PagePath::new("notes/keep.md").unwrap(),
@@ -109,6 +110,7 @@ async fn seed_two_projects(store: &Store, wiki: &Wiki) -> (WorkspaceId, ProjectI
     .unwrap();
 
     wiki.write_page(WritePageRequest {
+        source_session_id: None,
         workspace_id: ws,
         project_id: doomed,
         path: PagePath::new("notes/doomed.md").unwrap(),

--- a/crates/ai-memory-mcp/tests/admin_read_page.rs
+++ b/crates/ai-memory-mcp/tests/admin_read_page.rs
@@ -78,6 +78,7 @@ async fn read_page_falls_back_to_db_when_file_missing() {
     store
         .writer
         .upsert_page(NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("notes/db-only.md").unwrap(),
@@ -129,6 +130,7 @@ async fn read_page_serves_on_disk_page() {
     state
         .wiki
         .write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("notes/on-disk.md").unwrap(),
@@ -179,6 +181,7 @@ async fn read_page_does_not_fall_back_when_disk_frontmatter_is_malformed() {
     state
         .wiki
         .write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: path.clone(),

--- a/crates/ai-memory-mcp/tests/admin_rename.rs
+++ b/crates/ai-memory-mcp/tests/admin_rename.rs
@@ -77,6 +77,7 @@ async fn seed_page(store: &Store, wiki: &Wiki, project: &str) -> String {
         .unwrap();
     let path = format!("notes/{project}.md");
     wiki.write_page(WritePageRequest {
+        source_session_id: None,
         workspace_id: ws,
         project_id: proj,
         path: PagePath::new(path.clone()).unwrap(),

--- a/crates/ai-memory-mcp/tests/admin_status_search.rs
+++ b/crates/ai-memory-mcp/tests/admin_status_search.rs
@@ -52,6 +52,7 @@ async fn seed_page(store: &Store, title: &str, path: &str, body: &str) {
         .await
         .unwrap();
     let page = NewPage {
+        source_session_id: None,
         workspace_id: ws,
         project_id: proj,
         path: PagePath::new(path).unwrap(),
@@ -143,6 +144,7 @@ async fn list_projects_returns_workspace_project_pairs() {
     store
         .writer
         .upsert_page(NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("notes/b.md").unwrap(),

--- a/crates/ai-memory-mcp/tests/autoscope_multiuser.rs
+++ b/crates/ai-memory-mcp/tests/autoscope_multiuser.rs
@@ -103,6 +103,7 @@ impl MultiUserHarness {
             store
                 .writer
                 .upsert_page(ai_memory_core::NewPage {
+                    source_session_id: None,
                     workspace_id: ws,
                     project_id: proj,
                     path: ai_memory_core::PagePath::new("marker.md").expect("path"),

--- a/crates/ai-memory-mcp/tests/autoscope_stress.rs
+++ b/crates/ai-memory-mcp/tests/autoscope_stress.rs
@@ -111,6 +111,7 @@ impl Harness {
             store
                 .writer
                 .upsert_page(ai_memory_core::NewPage {
+                    source_session_id: None,
                     workspace_id: ws,
                     project_id: proj,
                     path: ai_memory_core::PagePath::new("marker.md").expect("path"),

--- a/crates/ai-memory-store/migrations/V50__session_purge_provenance.sql
+++ b/crates/ai-memory-store/migrations/V50__session_purge_provenance.sql
@@ -1,0 +1,86 @@
+-- Strong per-session deletion (#387), part 1: the durable tombstone ledger and
+-- the structural provenance a purge needs to find derived content.
+--
+-- Why provenance columns rather than following the existing foreign keys: the
+-- links that would identify derived rows are exactly the ones the delete
+-- destroys. `auto_improve_runs.session_id` and
+-- `auto_improve_rejections.source_run_id` / `.source_proposal_id` are all
+-- `ON DELETE SET NULL`, so deleting the session first silently orphans the
+-- evidence instead of removing it. These columns are deliberately FK-free and
+-- write-once: they must outlive the row they point at so the purge can collect
+-- targets before cutting anything, and so a partially-applied purge converges
+-- on a retry instead of losing its bearings.
+
+-- One row per purged session. Content-free by contract: scope, id, when, the
+-- schema version of the purge that produced it, and the audit-log id. Never a
+-- title, path, body, or count — a tombstone that quoted the deleted session
+-- would defeat the deletion it records.
+CREATE TABLE session_tombstones (
+    session_id      BLOB PRIMARY KEY NOT NULL,
+    workspace_id    BLOB NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    project_id      BLOB NOT NULL REFERENCES projects(id)   ON DELETE CASCADE,
+    tombstone_id    BLOB NOT NULL,
+    schema_version  INTEGER NOT NULL,
+    purged_at       INTEGER NOT NULL,
+    audit_id        INTEGER
+) WITHOUT ROWID;
+
+-- The ledger is consulted on every ingest for a session that no longer exists,
+-- so the lookup must be keyed the same way the hook path resolves scope.
+CREATE INDEX idx_session_tombstones_scope
+    ON session_tombstones(workspace_id, project_id, purged_at DESC);
+
+-- Backup snapshots taken before this instant may still contain purged content;
+-- restore reapplies the ledger, so the newest purge time is the cutoff.
+CREATE INDEX idx_session_tombstones_purged_at
+    ON session_tombstones(purged_at DESC);
+
+-- Which session a page version was derived from. NULL means "not derived from
+-- a single session" (hand-written pages, multi-source consolidations that
+-- predate this column) — never "unknown", so the purge can distinguish a page
+-- it may keep from one it must rebuild or remove.
+--
+-- Deliberately not a foreign key: a purge deletes the session row, and this
+-- must still name it while the derived rows are being collected.
+ALTER TABLE pages ADD COLUMN source_session_id BLOB;
+
+CREATE INDEX idx_pages_source_session
+    ON pages(source_session_id)
+    WHERE source_session_id IS NOT NULL;
+
+-- Immutable copy of `auto_improve_runs.session_id`, which is `SET NULL` on
+-- delete and therefore useless to a purge that has already begun.
+ALTER TABLE auto_improve_runs ADD COLUMN source_session_id BLOB;
+
+CREATE INDEX idx_auto_improve_runs_source_session
+    ON auto_improve_runs(source_session_id)
+    WHERE source_session_id IS NOT NULL;
+
+-- Rejections keep reason, summary, and evidence derived from the session, and
+-- reach it only through run/proposal pointers that are themselves `SET NULL`.
+ALTER TABLE auto_improve_rejections ADD COLUMN source_session_id BLOB;
+
+CREATE INDEX idx_auto_improve_rejections_source_session
+    ON auto_improve_rejections(source_session_id)
+    WHERE source_session_id IS NOT NULL;
+
+-- Backfill what is still recoverable at migration time. Runs whose session was
+-- already reaped have a NULL `session_id` and stay NULL here: this migration
+-- recovers provenance, it does not invent it.
+UPDATE auto_improve_runs
+   SET source_session_id = session_id
+ WHERE session_id IS NOT NULL;
+
+UPDATE auto_improve_rejections
+   SET source_session_id = (
+           SELECT r.source_session_id
+             FROM auto_improve_runs r
+            WHERE r.id = auto_improve_rejections.source_run_id
+       )
+ WHERE source_run_id IS NOT NULL;
+
+-- `pages` is intentionally NOT backfilled. The heuristic session page is
+-- addressed by the deterministic path `sessions/<uuid>.md`, which the purge
+-- resolves by identity, and SQLite cannot parse a UUID text into the BLOB
+-- form stored in `sessions.id`. Guessing provenance from page text would be
+-- exactly the textual search the deletion contract forbids.

--- a/crates/ai-memory-store/src/error.rs
+++ b/crates/ai-memory-store/src/error.rs
@@ -58,6 +58,12 @@ pub enum StoreError {
     #[error("session collision")]
     SessionCollision,
 
+    /// A hook named a session that was purged (#387). Terminal, not transient:
+    /// the event can never become deliverable, so a client must drop it rather
+    /// than retry. Deliberately carries no row details.
+    #[error("session purged")]
+    SessionPurged,
+
     /// A `spawn_blocking` task panicked or was cancelled.
     #[error("reader pool task did not complete: {0}")]
     PoolPanic(String),

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -24,6 +24,7 @@ mod ops;
 mod reader;
 mod scope;
 mod session_consolidation;
+pub mod session_purge;
 pub mod users;
 mod workstream;
 mod writer;
@@ -202,6 +203,7 @@ mod tests {
 
     fn sample_page(ws: WorkspaceId, proj: ProjectId, path: &str, body: &str) -> NewPage {
         NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new(path).unwrap(),
@@ -3968,6 +3970,7 @@ mod tests {
             .await
             .unwrap();
         let page = NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("decisions/d1.md").unwrap(),

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -645,12 +645,27 @@ pub(crate) fn upsert_page_in_tx(
             "UPDATE pages SET is_latest = 0 WHERE id = ?1",
             params![&existing.id],
         )?;
+        // Session provenance is sticky across versions (#387): a rewrite that
+        // does not declare one inherits the superseded version's, so an LLM
+        // rewrite or a hand edit of a session-derived page cannot launder it
+        // into a page `purge-session` no longer recognizes as derived.
+        let source_session_id: Option<Vec<u8>> = match page.source_session_id {
+            Some(session_id) => Some(session_id.as_bytes().to_vec()),
+            None => tx
+                .query_row(
+                    "SELECT source_session_id FROM pages WHERE id = ?1",
+                    params![&existing.id],
+                    |row| row.get::<_, Option<Vec<u8>>>(0),
+                )
+                .optional()?
+                .flatten(),
+        };
         tx.execute(
             "INSERT INTO pages \
              (id, workspace_id, project_id, path, path_search, title, tier, body, body_sha256, \
               frontmatter_json, is_latest, supersedes, pinned, author_id, \
-              created_at, updated_at, expires_at) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 1, ?11, ?12, ?13, ?14, ?14, ?15)",
+              created_at, updated_at, expires_at, source_session_id) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 1, ?11, ?12, ?13, ?14, ?14, ?15, ?16)",
             params![
                 new_id.as_bytes(),
                 page.workspace_id.as_bytes(),
@@ -667,6 +682,7 @@ pub(crate) fn upsert_page_in_tx(
                 page.author_id.map(|id| id.as_bytes().to_vec()),
                 now,
                 page.expires_at.map(|ts| ts.as_microsecond()),
+                source_session_id,
             ],
         )?;
         replace_links_in_tx(tx, &new_id, page)?;
@@ -689,8 +705,9 @@ pub(crate) fn upsert_page_in_tx(
     tx.execute(
         "INSERT INTO pages \
          (id, workspace_id, project_id, path, path_search, title, tier, body, body_sha256, \
-          frontmatter_json, is_latest, pinned, author_id, created_at, updated_at, expires_at) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 1, ?11, ?12, ?13, ?13, ?14)",
+          frontmatter_json, is_latest, pinned, author_id, created_at, updated_at, expires_at, \
+          source_session_id) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 1, ?11, ?12, ?13, ?13, ?14, ?15)",
         params![
             new_id.as_bytes(),
             page.workspace_id.as_bytes(),
@@ -706,6 +723,7 @@ pub(crate) fn upsert_page_in_tx(
             page.author_id.map(|id| id.as_bytes().to_vec()),
             now,
             page.expires_at.map(|ts| ts.as_microsecond()),
+            page.source_session_id.map(|id| id.as_bytes().to_vec()),
         ],
     )?;
     replace_links_in_tx(tx, &new_id, page)?;
@@ -2450,7 +2468,7 @@ fn observation_kind_as_str(kind: ObservationKind) -> &'static str {
     kind.as_str()
 }
 
-fn audit(
+pub(crate) fn audit(
     tx: &rusqlite::Transaction<'_>,
     op: &str,
     workspace_id: Option<&[u8; 16]>,
@@ -3503,6 +3521,7 @@ pub(crate) mod tests {
         body: &str,
     ) -> NewPage {
         NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new(path).unwrap(),

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -2020,6 +2020,37 @@ impl ReaderPool {
         .await
     }
 
+    /// Whether ingest for this exact `(workspace, project, session)` must be
+    /// refused as terminal because the session was purged (#387).
+    ///
+    /// # Errors
+    /// Returns [`StoreError`] on pool or SQLite failure.
+    pub async fn is_session_purged(
+        &self,
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+        session_id: SessionId,
+    ) -> StoreResult<bool> {
+        self.with_conn(move |conn| {
+            crate::session_purge::is_session_purged(conn, workspace_id, project_id, session_id)
+        })
+        .await
+    }
+
+    /// Why a purge would be destructive right now, if it would be: an open
+    /// session, a queued or running consolidation, or an outstanding
+    /// auto-improvement claim. `None` means the purge is safe to run.
+    ///
+    /// # Errors
+    /// Returns [`StoreError`] on pool or SQLite failure.
+    pub async fn session_purge_is_busy(
+        &self,
+        session_id: SessionId,
+    ) -> StoreResult<Option<String>> {
+        self.with_conn(move |conn| crate::session_purge::session_purge_is_busy(conn, session_id))
+            .await
+    }
+
     /// How a `SessionEnd` should treat its target session (issue #152).
     ///
     /// The old boolean ("is the session open?") conflated two very different

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -2020,6 +2020,24 @@ impl ReaderPool {
         .await
     }
 
+    /// Whether any tombstone covers this session id, regardless of scope
+    /// (#387).
+    ///
+    /// The hook edge uses this rather than the scoped
+    /// [`Self::is_session_purged`] because it runs before scope resolution,
+    /// and because a durable `SessionId` is globally unique: once purged, that
+    /// id is dead everywhere, and a later event carrying it is a replay of the
+    /// purged session rather than a new one.
+    ///
+    /// # Errors
+    /// Returns [`StoreError`] on pool or SQLite failure.
+    pub async fn is_session_tombstoned(&self, session_id: SessionId) -> StoreResult<bool> {
+        self.with_conn(move |conn| {
+            Ok(crate::session_purge::find_session_tombstone(conn, session_id)?.is_some())
+        })
+        .await
+    }
+
     /// Whether ingest for this exact `(workspace, project, session)` must be
     /// refused as terminal because the session was purged (#387).
     ///

--- a/crates/ai-memory-store/src/session_purge.rs
+++ b/crates/ai-memory-store/src/session_purge.rs
@@ -22,6 +22,8 @@ use jiff::Timestamp;
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 use uuid::Uuid;
 
+use tracing::warn;
+
 use crate::error::{StoreError, StoreResult};
 
 /// Contract version stamped on every tombstone this code writes.
@@ -255,6 +257,81 @@ pub fn purge_session(
     project_id: ProjectId,
     session_id: SessionId,
 ) -> StoreResult<SessionPurgeReceipt> {
+    // Zero freed pages as the delete proceeds. SQLite normally leaves deleted
+    // content in place and only marks the pages reusable, so without this the
+    // purged bytes stay legible in the database file — a "deletion" anyone with
+    // the file could read back. Restored below so ordinary writes keep their
+    // default (cheaper) behavior.
+    let previous_secure_delete: i32 = conn
+        .query_row("PRAGMA secure_delete", [], |row| row.get(0))
+        .unwrap_or(0);
+    conn.execute_batch("PRAGMA secure_delete = ON;")?;
+
+    let outcome = purge_session_inner(conn, workspace_id, project_id, session_id);
+
+    // Restore the pragma before propagating any error, so one failed purge does
+    // not silently change how the rest of the process deletes.
+    let _ = conn.execute_batch(&format!("PRAGMA secure_delete = {previous_secure_delete};"));
+    let receipt = outcome?;
+
+    reclaim_purged_bytes(conn);
+    Ok(receipt)
+}
+
+/// Make the deletion true of the FILES, not just of the tables.
+///
+/// Two residues survive an ordinary `DELETE`, and both were found by searching
+/// the data directory for a purged canary rather than by querying for it:
+///
+/// 1. **The write-ahead log.** Until a checkpoint runs, the deleted rows are
+///    still readable in `memory.sqlite-wal` — sitting beside the database and
+///    ready to be copied into the next backup.
+/// 2. **Freed pages in the database file.** `secure_delete` zeroes content as
+///    a delete proceeds, but pages freed by earlier writes (a superseded page
+///    version, say) keep their bytes until the file is rebuilt.
+/// 3. **FTS5 index segments.** An FTS5 delete is logical — it writes a delete
+///    marker and leaves the original terms in the existing segments. The index
+///    must be rebuilt from its content table or the purged text stays readable
+///    in the shadow tables.
+///
+/// Neither is fatal to correctness of the index, which is exactly why both are
+/// easy to miss: every query says the content is gone while the bytes are still
+/// on disk. Failures are logged rather than fatal — the rows ARE deleted, and
+/// refusing the whole purge over an incomplete vacuum would leave the operator
+/// worse off.
+fn reclaim_purged_bytes(conn: &Connection) {
+    // Rebuild the FTS indexes from their content tables. FTS5 deletes are
+    // LOGICAL: removing a row writes a delete marker and leaves the original
+    // terms inside the existing index segments until a merge happens to rewrite
+    // them. `MATCH` correctly returns nothing, which is exactly why this is easy
+    // to miss — the queries all say the content is gone while the purged text is
+    // still legible in `pages_fts_data` / `observations_fts_data`.
+    for table in ["pages_fts", "observations_fts"] {
+        if let Err(e) =
+            conn.execute_batch(&format!("INSERT INTO {table}({table}) VALUES('rebuild');"))
+        {
+            warn!(error = %e, table, "purge could not rebuild the FTS index; purged terms may remain in its segments");
+        }
+    }
+    if let Err(e) = conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
+        warn!(error = %e, "purge could not truncate the WAL; purged bytes may remain in memory.sqlite-wal until the next checkpoint");
+    }
+    if let Err(e) = conn.execute_batch("VACUUM;") {
+        warn!(error = %e, "purge could not vacuum the database; purged bytes may remain in freed pages of memory.sqlite");
+    }
+    // VACUUM writes the rebuilt database through the WAL, so checkpoint again
+    // or the bytes it just reclaimed reappear in the log it wrote them through.
+    if let Err(e) = conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
+        warn!(error = %e, "purge could not truncate the WAL after vacuum");
+    }
+}
+
+fn purge_session_inner(
+    conn: &mut Connection,
+    workspace_id: WorkspaceId,
+    project_id: ProjectId,
+    session_id: SessionId,
+) -> StoreResult<SessionPurgeReceipt> {
     // Immediate: the purge decides what to delete from rows it has read, so a
     // deferred transaction could upgrade mid-way and lose to a writer that
     // added derived rows in between.
@@ -437,6 +514,242 @@ pub fn purge_session(
         removed_proposal_sidecars: sidecars,
         warnings: Vec::new(),
     })
+}
+
+/// Every tombstone in this database, newest first.
+///
+/// A restore carries this ledger across the overwrite: without it, restoring a
+/// pre-purge snapshot silently resurrects everything a purge removed, and the
+/// operator has no way to know.
+///
+/// # Errors
+/// Returns [`StoreError`] on SQLite failure or a malformed stored row.
+pub fn all_tombstones(conn: &Connection) -> StoreResult<Vec<SessionTombstone>> {
+    let mut stmt = conn.prepare(
+        "SELECT session_id, workspace_id, project_id, tombstone_id, schema_version, purged_at \
+         FROM session_tombstones ORDER BY purged_at DESC",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, Vec<u8>>(0)?,
+            row.get::<_, Vec<u8>>(1)?,
+            row.get::<_, Vec<u8>>(2)?,
+            row.get::<_, Vec<u8>>(3)?,
+            row.get::<_, i64>(4)?,
+            row.get::<_, i64>(5)?,
+        ))
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        let (session, ws, proj, tombstone, schema_version, purged_at) = row?;
+        out.push(SessionTombstone {
+            session_id: SessionId::from_slice(&session)?,
+            workspace_id: WorkspaceId::from_slice(&ws)?,
+            project_id: ProjectId::from_slice(&proj)?,
+            tombstone_id: uuid_from_slice(&tombstone)?,
+            schema_version,
+            purged_at: Timestamp::from_microsecond(purged_at)
+                .map_err(|e| StoreError::InvalidState(format!("tombstone timestamp: {e}")))?,
+        });
+    }
+    Ok(out)
+}
+
+/// Insert tombstones carried over from another database, keeping any already
+/// present.
+///
+/// Used by restore: the ledger is imported BEFORE the restored state is made
+/// available, so a session purged after the snapshot was taken is re-purged
+/// rather than served.
+///
+/// Returns the number of rows newly inserted.
+///
+/// # Errors
+/// Returns [`StoreError`] on SQLite failure.
+pub fn import_tombstones(
+    conn: &mut Connection,
+    tombstones: &[SessionTombstone],
+) -> StoreResult<usize> {
+    let tx = conn.transaction()?;
+    let mut inserted = 0usize;
+    for tombstone in tombstones {
+        // The scope rows may not exist in the restored database (the project
+        // could have been purged too), so the ledger is inserted without
+        // requiring them — a tombstone must never be droppable by a cascade.
+        let affected = tx.execute(
+            "INSERT OR IGNORE INTO session_tombstones \
+             (session_id, workspace_id, project_id, tombstone_id, schema_version, purged_at, audit_id) \
+             SELECT ?1, ?2, ?3, ?4, ?5, ?6, NULL \
+             WHERE EXISTS (SELECT 1 FROM workspaces WHERE id = ?2) \
+               AND EXISTS (SELECT 1 FROM projects WHERE id = ?3)",
+            params![
+                tombstone.session_id.as_bytes(),
+                tombstone.workspace_id.as_bytes(),
+                tombstone.project_id.as_bytes(),
+                tombstone.tombstone_id.as_bytes(),
+                tombstone.schema_version,
+                tombstone.purged_at.as_microsecond(),
+            ],
+        )?;
+        inserted += affected;
+    }
+    tx.commit()?;
+    Ok(inserted)
+}
+
+/// Session ids that a tombstone covers but whose rows are still present.
+///
+/// After a restore this is the work list: each one is a session the ledger says
+/// was deleted and the restored snapshot brought back. An empty result is the
+/// fail-closed check that the restore is safe to expose.
+///
+/// # Errors
+/// Returns [`StoreError`] on SQLite failure or a malformed stored row.
+pub fn resurrected_sessions(conn: &Connection) -> StoreResult<Vec<SessionTombstone>> {
+    Ok(all_tombstones(conn)?
+        .into_iter()
+        .filter(|tombstone| {
+            conn.query_row(
+                "SELECT 1 FROM sessions WHERE id = ?1",
+                params![tombstone.session_id.as_bytes()],
+                |_| Ok(()),
+            )
+            .optional()
+            .ok()
+            .flatten()
+            .is_some()
+        })
+        .collect())
+}
+
+/// Purge a session whose rows came back with a restored snapshot.
+///
+/// Distinct from [`purge_session`] because the tombstone already exists: the
+/// ordinary path would short-circuit on it and report `AlreadyPurged` without
+/// removing the resurrected rows.
+///
+/// # Errors
+/// Returns [`StoreError`] on SQLite failure.
+pub fn repurge_tombstoned_session(
+    conn: &mut Connection,
+    tombstone: &SessionTombstone,
+) -> StoreResult<SessionPurgeReceipt> {
+    // Drop the ledger row, run the ordinary purge, then restore the ORIGINAL
+    // tombstone id and time: the receipt an operator already holds must keep
+    // identifying this deletion.
+    conn.execute(
+        "DELETE FROM session_tombstones WHERE session_id = ?1",
+        params![tombstone.session_id.as_bytes()],
+    )?;
+    let mut receipt = purge_session(
+        conn,
+        tombstone.workspace_id,
+        tombstone.project_id,
+        tombstone.session_id,
+    )?;
+    conn.execute(
+        "UPDATE session_tombstones SET tombstone_id = ?2, purged_at = ?3 WHERE session_id = ?1",
+        params![
+            tombstone.session_id.as_bytes(),
+            tombstone.tombstone_id.as_bytes(),
+            tombstone.purged_at.as_microsecond(),
+        ],
+    )?;
+    receipt.tombstone_id = tombstone.tombstone_id;
+    receipt.purged_at = tombstone.purged_at;
+    Ok(receipt)
+}
+
+/// Read the tombstone ledger from a database file directly.
+///
+/// Restore runs with the server stopped, so it uses a plain connection rather
+/// than the writer actor: there is no concurrent writer to serialize against,
+/// and the ledger must be read before the actor's database is overwritten.
+///
+/// A database that predates the ledger (no `session_tombstones` table) yields
+/// an empty ledger rather than an error, so restoring an old backup still works.
+///
+/// # Errors
+/// Returns [`StoreError`] when the file exists but cannot be read.
+pub fn read_ledger_from_db(db_path: &std::path::Path) -> StoreResult<Vec<SessionTombstone>> {
+    if !db_path.is_file() {
+        return Ok(Vec::new());
+    }
+    let conn = Connection::open(db_path)?;
+    let has_table: Option<i64> = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'session_tombstones'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if has_table.is_none() {
+        return Ok(Vec::new());
+    }
+    all_tombstones(&conn)
+}
+
+/// One session that a restore brought back and this call removed again.
+#[derive(Debug, Clone)]
+pub struct RepurgedSession {
+    /// The session the ledger said was deleted.
+    pub session_id: SessionId,
+    /// Wiki paths, relative to the wiki root, whose files and history the
+    /// caller must still remove. Scoped `<workspace>/<project>/<page path>`
+    /// because that is how they sit in the shared wiki tree.
+    pub repo_paths: Vec<String>,
+}
+
+/// Import `ledger` into the restored database and re-purge anything it covers
+/// that came back with the snapshot.
+///
+/// Returns what was re-purged, so the caller can reapply the filesystem and git
+/// layers the snapshot also restored.
+///
+/// # Errors
+/// Returns [`StoreError`] on SQLite failure. A non-empty
+/// [`resurrected_sessions`] result after this returns means the restore is NOT
+/// safe to expose and the caller must refuse.
+pub fn reapply_ledger(
+    db_path: &std::path::Path,
+    ledger: &[SessionTombstone],
+) -> StoreResult<Vec<RepurgedSession>> {
+    let mut conn = Connection::open(db_path)?;
+    conn.pragma_update(None, "foreign_keys", "ON")?;
+    import_tombstones(&mut conn, ledger)?;
+
+    let mut repurged = Vec::new();
+    for tombstone in resurrected_sessions(&conn)? {
+        let receipt = repurge_tombstoned_session(&mut conn, &tombstone)?;
+        repurged.push(RepurgedSession {
+            session_id: tombstone.session_id,
+            repo_paths: receipt
+                .removed_pages
+                .iter()
+                .map(|page| {
+                    format!(
+                        "{}/{}/{}",
+                        tombstone.workspace_id,
+                        tombstone.project_id,
+                        page.as_str()
+                    )
+                })
+                .collect(),
+        });
+    }
+    Ok(repurged)
+}
+
+/// How many purged sessions still have rows in this database.
+///
+/// The fail-closed check a restore runs last: anything other than zero means
+/// the restored state serves content the ledger says was deleted.
+///
+/// # Errors
+/// Returns [`StoreError`] on SQLite failure.
+pub fn count_resurrected(db_path: &std::path::Path) -> StoreResult<usize> {
+    let conn = Connection::open(db_path)?;
+    Ok(resurrected_sessions(&conn)?.len())
 }
 
 fn collect_blob_ids(

--- a/crates/ai-memory-store/src/session_purge.rs
+++ b/crates/ai-memory-store/src/session_purge.rs
@@ -1,0 +1,976 @@
+//! Strong per-session deletion (#387): the relational half.
+//!
+//! This module removes a session and everything derived from it inside one
+//! transaction, and records a content-free tombstone. It does NOT touch the
+//! filesystem — the wiki files, sidecars, spool entries, and git objects are
+//! the caller's responsibility, driven by the paths this returns.
+//!
+//! Two rules shape the whole implementation:
+//!
+//! 1. **Collect before cutting.** Every link that identifies derived content
+//!    (`auto_improve_runs.session_id`, `auto_improve_rejections.source_run_id`,
+//!    `pages.supersedes`) is `ON DELETE SET NULL`, so deleting the session
+//!    first destroys the very evidence needed to find what it produced. All
+//!    targets are resolved up front, into owned id lists.
+//! 2. **Identity only, never text.** Targets are chosen by UUID, foreign key,
+//!    or the deterministic `sessions/<uuid>.md` path. Searching page bodies for
+//!    something that "looks like" the session would both miss content and
+//!    delete innocent pages.
+
+use ai_memory_core::{PagePath, ProjectId, SessionId, WorkspaceId};
+use jiff::Timestamp;
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
+use uuid::Uuid;
+
+use crate::error::{StoreError, StoreResult};
+
+/// Contract version stamped on every tombstone this code writes.
+///
+/// A restore reapplies tombstones written by older builds, so the reader must
+/// be able to tell which guarantees a given row was produced under.
+pub const SESSION_PURGE_SCHEMA_VERSION: i64 = 1;
+
+/// Whether the purge did the work or found it already done.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionPurgeStatus {
+    /// The session existed and was removed by this call.
+    Purged,
+    /// A tombstone already covered this session; nothing was left to remove.
+    AlreadyPurged,
+}
+
+impl SessionPurgeStatus {
+    /// Stable wire representation for the CLI/HTTP receipt.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Purged => "purged",
+            Self::AlreadyPurged => "already_purged",
+        }
+    }
+}
+
+/// Rows removed, per layer. Counts are for the operator's receipt and the
+/// audit trail; they never carry deleted content.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SessionPurgeCounts {
+    /// `sessions` rows (0 or 1).
+    pub sessions: u64,
+    /// `observations` rows; their FTS rows go with them via `observations_fts_ad`.
+    pub observations: u64,
+    /// Handoffs produced by, or accepted by, this session.
+    pub handoffs: u64,
+    /// Queued SessionEnd consolidation jobs.
+    pub consolidation_jobs: u64,
+    /// Auto-improvement scheduler claims.
+    pub auto_improve_scheduler_claims: u64,
+    /// Auto-improvement runs derived from this session.
+    pub auto_improve_runs: u64,
+    /// Proposals staged by those runs.
+    pub auto_improve_proposals: u64,
+    /// Lifecycle events of those proposals.
+    pub auto_improve_proposal_events: u64,
+    /// Rejections whose reason/summary/evidence came from this session.
+    pub auto_improve_rejections: u64,
+    /// Page versions removed across every affected path.
+    pub page_versions: u64,
+}
+
+/// What a purge removed, plus what the filesystem layers still must remove.
+#[derive(Clone, Debug)]
+pub struct SessionPurgeReceipt {
+    /// Whether this call did the work.
+    pub status: SessionPurgeStatus,
+    /// Stable id of the tombstone covering this session.
+    pub tombstone_id: Uuid,
+    /// When the session was purged (the first purge, on a repeat call).
+    pub purged_at: Timestamp,
+    /// Snapshots taken before this instant may still contain purged content.
+    pub backup_cutoff: Timestamp,
+    /// Rows removed per layer.
+    pub counts: SessionPurgeCounts,
+    /// Wiki pages whose every version was removed. The caller deletes these
+    /// files and rewrites git history; the index is already clean.
+    pub removed_pages: Vec<PagePath>,
+    /// Proposal ids whose `_pending/auto-improve/<id>.md` sidecars must be
+    /// removed from disk. Sidecars are not indexed, so nothing else names them.
+    pub removed_proposal_sidecars: Vec<Uuid>,
+    /// Non-fatal conditions the operator should see, e.g. shared pages that
+    /// could not be rebuilt from surviving sources.
+    pub warnings: Vec<String>,
+}
+
+/// A tombstone as stored. Content-free by contract.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SessionTombstone {
+    /// The purged session.
+    pub session_id: SessionId,
+    /// Owning workspace.
+    pub workspace_id: WorkspaceId,
+    /// Owning project.
+    pub project_id: ProjectId,
+    /// Stable receipt id.
+    pub tombstone_id: Uuid,
+    /// Contract version of the purge that wrote this row.
+    pub schema_version: i64,
+    /// When the purge completed.
+    pub purged_at: Timestamp,
+}
+
+/// The deterministic wiki path of a session's heuristic page.
+///
+/// This is an identity, not a search: the synthesizer writes exactly this path,
+/// so a purge can claim every version of it without inspecting any page body.
+/// LLM single-page consolidation rewrites the same path, and its
+/// `build_frontmatter` omits `session_id`, so the relational
+/// `pages.source_session_id` link alone would miss those later versions.
+fn session_page_path(session_id: SessionId) -> String {
+    format!("sessions/{session_id}.md")
+}
+
+/// Read the tombstone covering `session_id`, if any.
+pub fn find_session_tombstone(
+    conn: &Connection,
+    session_id: SessionId,
+) -> StoreResult<Option<SessionTombstone>> {
+    conn.query_row(
+        "SELECT workspace_id, project_id, tombstone_id, schema_version, purged_at \
+         FROM session_tombstones WHERE session_id = ?1",
+        params![session_id.as_bytes()],
+        |row| {
+            Ok((
+                row.get::<_, Vec<u8>>(0)?,
+                row.get::<_, Vec<u8>>(1)?,
+                row.get::<_, Vec<u8>>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(4)?,
+            ))
+        },
+    )
+    .optional()?
+    .map(|(ws, proj, tombstone, schema_version, purged_at)| {
+        Ok(SessionTombstone {
+            session_id,
+            workspace_id: WorkspaceId::from_slice(&ws)?,
+            project_id: ProjectId::from_slice(&proj)?,
+            tombstone_id: uuid_from_slice(&tombstone)?,
+            schema_version,
+            purged_at: Timestamp::from_microsecond(purged_at)
+                .map_err(|e| StoreError::InvalidState(format!("tombstone timestamp: {e}")))?,
+        })
+    })
+    .transpose()
+}
+
+/// Whether ingest for this exact `(workspace, project, session)` must be
+/// refused as terminal. Scope is part of the check so a tombstone can never
+/// suppress a same-UUID session legitimately living in another project.
+pub fn is_session_purged(
+    conn: &Connection,
+    workspace_id: WorkspaceId,
+    project_id: ProjectId,
+    session_id: SessionId,
+) -> StoreResult<bool> {
+    Ok(conn
+        .query_row(
+            "SELECT 1 FROM session_tombstones \
+             WHERE session_id = ?1 AND workspace_id = ?2 AND project_id = ?3",
+            params![
+                session_id.as_bytes(),
+                workspace_id.as_bytes(),
+                project_id.as_bytes()
+            ],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some())
+}
+
+fn uuid_from_slice(raw: &[u8]) -> StoreResult<Uuid> {
+    <[u8; 16]>::try_from(raw)
+        .map(Uuid::from_bytes)
+        .map_err(|_| StoreError::InvalidState("malformed uuid blob".into()))
+}
+
+/// SQLite reports affected rows as `usize`; receipts use `u64` so the JSON
+/// shape does not vary by platform pointer width.
+fn rows(affected: usize) -> StoreResult<u64> {
+    u64::try_from(affected)
+        .map_err(|_| StoreError::InvalidState("affected row count does not fit u64".into()))
+}
+
+/// Whether a live session, queued consolidation, or in-flight auto-improvement
+/// run would be cut off by purging now. Callers surface this as `409` unless
+/// the operator passed `--force`.
+pub fn session_purge_is_busy(
+    conn: &Connection,
+    session_id: SessionId,
+) -> StoreResult<Option<String>> {
+    let open: Option<i64> = conn
+        .query_row(
+            "SELECT 1 FROM sessions WHERE id = ?1 AND ended_at IS NULL",
+            params![session_id.as_bytes()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if open.is_some() {
+        return Ok(Some("session is still open".into()));
+    }
+    let running: Option<i64> = conn
+        .query_row(
+            "SELECT 1 FROM session_consolidation_jobs \
+             WHERE session_id = ?1 AND state IN ('pending', 'running')",
+            params![session_id.as_bytes()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if running.is_some() {
+        return Ok(Some("a consolidation job is queued or running".into()));
+    }
+    let claimed: Option<i64> = conn
+        .query_row(
+            "SELECT 1 FROM auto_improve_scheduler_claims WHERE session_id = ?1",
+            params![session_id.as_bytes()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if claimed.is_some() {
+        return Ok(Some("an auto-improvement claim is outstanding".into()));
+    }
+    Ok(None)
+}
+
+/// Remove a session and everything derived from it.
+///
+/// `workspace_id` / `project_id` must be the session's own scope: a UUID that
+/// exists in a different project is a scope conflict, not a target, so an
+/// operator cannot purge someone else's session by naming the wrong project.
+///
+/// Idempotent. A second call for the same id returns
+/// [`SessionPurgeStatus::AlreadyPurged`] with the original tombstone and zero
+/// counts, and does not fail on the absence of the rows the first call removed.
+pub fn purge_session(
+    conn: &mut Connection,
+    workspace_id: WorkspaceId,
+    project_id: ProjectId,
+    session_id: SessionId,
+) -> StoreResult<SessionPurgeReceipt> {
+    // Immediate: the purge decides what to delete from rows it has read, so a
+    // deferred transaction could upgrade mid-way and lose to a writer that
+    // added derived rows in between.
+    let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+
+    if let Some(existing) = find_session_tombstone(&tx, session_id)? {
+        if existing.workspace_id != workspace_id || existing.project_id != project_id {
+            return Err(StoreError::InvalidState(
+                "session id belongs to a different workspace or project".into(),
+            ));
+        }
+        return Ok(SessionPurgeReceipt {
+            status: SessionPurgeStatus::AlreadyPurged,
+            tombstone_id: existing.tombstone_id,
+            purged_at: existing.purged_at,
+            backup_cutoff: existing.purged_at,
+            counts: SessionPurgeCounts::default(),
+            removed_pages: Vec::new(),
+            removed_proposal_sidecars: Vec::new(),
+            warnings: Vec::new(),
+        });
+    }
+
+    let scope: Option<(Vec<u8>, Vec<u8>)> = tx
+        .query_row(
+            "SELECT workspace_id, project_id FROM sessions WHERE id = ?1",
+            params![session_id.as_bytes()],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?;
+    let Some((session_ws, session_proj)) = scope else {
+        return Err(StoreError::NotFound("session".into()));
+    };
+    if session_ws.as_slice() != workspace_id.as_bytes()
+        || session_proj.as_slice() != project_id.as_bytes()
+    {
+        return Err(StoreError::InvalidState(
+            "session id belongs to a different workspace or project".into(),
+        ));
+    }
+
+    // ── collect ────────────────────────────────────────────────────────────
+    // Everything below is read BEFORE any delete: the pointers used here are
+    // `ON DELETE SET NULL` and would be erased by the first statement.
+
+    let run_ids = collect_blob_ids(
+        &tx,
+        "SELECT id FROM auto_improve_runs \
+         WHERE source_session_id = ?1 OR session_id = ?1",
+        session_id,
+    )?;
+    let proposal_ids = collect_children(&tx, "auto_improve_proposals", "run_id", &run_ids)?;
+
+    // Page versions derived from this session: the relational link, plus the
+    // deterministic session-page path whose later LLM-rewritten versions carry
+    // no frontmatter `session_id`.
+    let page_paths = collect_page_paths(&tx, workspace_id, project_id, session_id, &proposal_ids)?;
+
+    let sidecars = proposal_ids
+        .iter()
+        .map(|id| uuid_from_slice(id))
+        .collect::<StoreResult<Vec<_>>>()?;
+
+    // ── delete, children first ─────────────────────────────────────────────
+    let proposal_events = delete_children(
+        &tx,
+        "auto_improve_proposal_events",
+        "proposal_id",
+        &proposal_ids,
+    )?;
+    let rejections = delete_rejections(&tx, session_id, &run_ids, &proposal_ids)?;
+    let proposals = delete_children(&tx, "auto_improve_proposals", "id", &proposal_ids)?;
+    let runs = delete_children(&tx, "auto_improve_runs", "id", &run_ids)?;
+
+    let scheduler_claims = rows(tx.execute(
+        "DELETE FROM auto_improve_scheduler_claims WHERE session_id = ?1",
+        params![session_id.as_bytes()],
+    )?)?;
+    let consolidation_jobs = rows(tx.execute(
+        "DELETE FROM session_consolidation_jobs WHERE session_id = ?1",
+        params![session_id.as_bytes()],
+    )?)?;
+    // Handoffs link the session twice and both links are `SET NULL`, so the
+    // rows must be deleted explicitly or the baton survives its session with a
+    // dangling pointer and its body intact.
+    let handoffs = rows(tx.execute(
+        "DELETE FROM handoffs WHERE from_session_id = ?1 OR accepted_by_session = ?1",
+        params![session_id.as_bytes()],
+    )?)?;
+
+    let mut page_versions = 0u64;
+    for path in &page_paths {
+        page_versions += rows(tx.execute(
+            "DELETE FROM pages WHERE workspace_id = ?1 AND project_id = ?2 AND path = ?3",
+            params![
+                workspace_id.as_bytes(),
+                project_id.as_bytes(),
+                path.as_str()
+            ],
+        )?)?;
+    }
+    if page_versions > 0 {
+        // Entities are shared; drop only the ones nothing links to anymore.
+        tx.execute(
+            "DELETE FROM entities \
+             WHERE workspace_id = ?1 AND project_id = ?2 \
+               AND NOT EXISTS ( \
+                   SELECT 1 FROM entity_page_links l WHERE l.entity_id = entities.id \
+               )",
+            params![workspace_id.as_bytes(), project_id.as_bytes()],
+        )?;
+    }
+
+    // Observations last among the derived rows: `observations_fts_ad` clears
+    // the external-content index as they go.
+    let observations = rows(tx.execute(
+        "DELETE FROM observations WHERE session_id = ?1",
+        params![session_id.as_bytes()],
+    )?)?;
+    let sessions = rows(tx.execute(
+        "DELETE FROM sessions WHERE id = ?1",
+        params![session_id.as_bytes()],
+    )?)?;
+
+    let counts = SessionPurgeCounts {
+        sessions,
+        observations,
+        handoffs,
+        consolidation_jobs,
+        auto_improve_scheduler_claims: scheduler_claims,
+        auto_improve_runs: runs,
+        auto_improve_proposals: proposals,
+        auto_improve_proposal_events: proposal_events,
+        auto_improve_rejections: rejections,
+        page_versions,
+    };
+
+    // ── tombstone ──────────────────────────────────────────────────────────
+    // Truncate to what the column actually stores, so the first receipt and
+    // every later read of this tombstone report the identical instant.
+    let now = Timestamp::from_microsecond(Timestamp::now().as_microsecond())
+        .map_err(|e| StoreError::InvalidState(format!("purge timestamp: {e}")))?;
+    let tombstone_id = Uuid::new_v4();
+    crate::ops::audit(
+        &tx,
+        "purge_session",
+        Some(workspace_id.as_bytes()),
+        Some(project_id.as_bytes()),
+        None,
+        None,
+        now.as_microsecond(),
+    )?;
+    // The receipt points at the audit row rather than repeating its detail,
+    // which is what keeps the tombstone content-free.
+    let audit_id = tx.last_insert_rowid();
+    tx.execute(
+        "INSERT INTO session_tombstones \
+         (session_id, workspace_id, project_id, tombstone_id, schema_version, purged_at, audit_id) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            session_id.as_bytes(),
+            workspace_id.as_bytes(),
+            project_id.as_bytes(),
+            tombstone_id.as_bytes(),
+            SESSION_PURGE_SCHEMA_VERSION,
+            now.as_microsecond(),
+            audit_id,
+        ],
+    )?;
+
+    tx.commit()?;
+
+    Ok(SessionPurgeReceipt {
+        status: SessionPurgeStatus::Purged,
+        tombstone_id,
+        purged_at: now,
+        backup_cutoff: now,
+        counts,
+        removed_pages: page_paths,
+        removed_proposal_sidecars: sidecars,
+        warnings: Vec::new(),
+    })
+}
+
+fn collect_blob_ids(
+    tx: &rusqlite::Transaction<'_>,
+    sql: &str,
+    session_id: SessionId,
+) -> StoreResult<Vec<Vec<u8>>> {
+    let mut stmt = tx.prepare(sql)?;
+    let rows = stmt.query_map(params![session_id.as_bytes()], |row| {
+        row.get::<_, Vec<u8>>(0)
+    })?;
+    Ok(rows.collect::<Result<Vec<_>, _>>()?)
+}
+
+fn collect_children(
+    tx: &rusqlite::Transaction<'_>,
+    table: &str,
+    column: &str,
+    parents: &[Vec<u8>],
+) -> StoreResult<Vec<Vec<u8>>> {
+    if parents.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    // One statement per parent rather than a built IN-list: the id count is
+    // small and bounded, and this keeps every value parameterized.
+    let mut stmt = tx.prepare(&format!("SELECT id FROM {table} WHERE {column} = ?1"))?;
+    for parent in parents {
+        let rows = stmt.query_map(params![parent], |row| row.get::<_, Vec<u8>>(0))?;
+        for row in rows {
+            out.push(row?);
+        }
+    }
+    Ok(out)
+}
+
+fn delete_children(
+    tx: &rusqlite::Transaction<'_>,
+    table: &str,
+    column: &str,
+    ids: &[Vec<u8>],
+) -> StoreResult<u64> {
+    if ids.is_empty() {
+        return Ok(0);
+    }
+    let mut stmt = tx.prepare(&format!("DELETE FROM {table} WHERE {column} = ?1"))?;
+    let mut removed = 0u64;
+    for id in ids {
+        removed += rows(stmt.execute(params![id])?)?;
+    }
+    Ok(removed)
+}
+
+/// Rejections reach the session three ways, and all three must be cut: the
+/// immutable provenance column, the run they came from, and the proposal they
+/// rejected. The latter two are `SET NULL`, so a rejection whose run is deleted
+/// first would keep its session-derived `reason` / `summary` / `evidence_json`
+/// with no pointer left to find it by.
+fn delete_rejections(
+    tx: &rusqlite::Transaction<'_>,
+    session_id: SessionId,
+    run_ids: &[Vec<u8>],
+    proposal_ids: &[Vec<u8>],
+) -> StoreResult<u64> {
+    let mut removed = rows(tx.execute(
+        "DELETE FROM auto_improve_rejections WHERE source_session_id = ?1",
+        params![session_id.as_bytes()],
+    )?)?;
+    removed += delete_children(tx, "auto_improve_rejections", "source_run_id", run_ids)?;
+    removed += delete_children(
+        tx,
+        "auto_improve_rejections",
+        "source_proposal_id",
+        proposal_ids,
+    )?;
+    Ok(removed)
+}
+
+/// Every wiki path whose content is derived from this session.
+///
+/// Three sources, all by identity: the relational provenance column, the
+/// deterministic `sessions/<uuid>.md` path, and pages applied from this
+/// session's auto-improvement proposals.
+fn collect_page_paths(
+    tx: &rusqlite::Transaction<'_>,
+    workspace_id: WorkspaceId,
+    project_id: ProjectId,
+    session_id: SessionId,
+    proposal_ids: &[Vec<u8>],
+) -> StoreResult<Vec<PagePath>> {
+    let mut paths: Vec<String> = Vec::new();
+
+    let mut stmt = tx.prepare(
+        "SELECT DISTINCT path FROM pages \
+         WHERE workspace_id = ?1 AND project_id = ?2 \
+           AND (source_session_id = ?3 OR path = ?4)",
+    )?;
+    let rows = stmt.query_map(
+        params![
+            workspace_id.as_bytes(),
+            project_id.as_bytes(),
+            session_id.as_bytes(),
+            session_page_path(session_id),
+        ],
+        |row| row.get::<_, String>(0),
+    )?;
+    for row in rows {
+        paths.push(row?);
+    }
+
+    if !proposal_ids.is_empty() {
+        let mut stmt = tx.prepare(
+            "SELECT DISTINCT p.path FROM pages p \
+             JOIN auto_improve_proposals ap ON ap.applied_page_id = p.id \
+             WHERE ap.id = ?1",
+        )?;
+        for proposal in proposal_ids {
+            let rows = stmt.query_map(params![proposal], |row| row.get::<_, String>(0))?;
+            for row in rows {
+                paths.push(row?);
+            }
+        }
+    }
+
+    paths.sort_unstable();
+    paths.dedup();
+    paths
+        .into_iter()
+        .map(|p| PagePath::new(&p).map_err(|e| StoreError::InvalidState(format!("page path: {e}"))))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use ai_memory_core::{
+        AgentKind, NewHandoff, NewObservation, NewPage, NewSession, ObservationKind, Tier,
+    };
+    use rusqlite::Connection;
+
+    use super::*;
+    use crate::ops::{
+        begin_session, get_or_create_project, get_or_create_workspace, insert_handoff,
+        insert_observation, upsert_page,
+    };
+
+    /// Every fixture writes a canary string. The tests assert on identity AND
+    /// on the canary, because absent relational rows with a live FTS index is
+    /// exactly the failure the issue reproduced.
+    const CANARY_A: &str = "canary-alpha-9f3c";
+    const CANARY_B: &str = "canary-bravo-71de";
+
+    struct Fixture {
+        _tmp: tempfile::TempDir,
+        conn: Connection,
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+    }
+
+    fn fixture() -> Fixture {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut conn = Connection::open(tmp.path().join("test.sqlite")).unwrap();
+        conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+        crate::migrations::run(&mut conn).unwrap();
+        let workspace_id = get_or_create_workspace(&mut conn, "default").unwrap();
+        let project_id = get_or_create_project(&mut conn, &workspace_id, "proj", None).unwrap();
+        Fixture {
+            _tmp: tmp,
+            conn,
+            workspace_id,
+            project_id,
+        }
+    }
+
+    /// A session with an observation, a handoff, and its heuristic page — the
+    /// minimum shape every layer of the purge has to reach.
+    fn seed_session(fx: &mut Fixture, canary: &str) -> SessionId {
+        let session_id = SessionId::new();
+        begin_session(
+            &mut fx.conn,
+            &NewSession {
+                id: session_id,
+                workspace_id: fx.workspace_id,
+                project_id: fx.project_id,
+                agent_kind: AgentKind::Codex,
+                cwd: None,
+                actor_user: None,
+            },
+        )
+        .unwrap();
+        insert_observation(
+            &mut fx.conn,
+            &NewObservation {
+                session_id,
+                workspace_id: fx.workspace_id,
+                project_id: fx.project_id,
+                kind: ObservationKind::UserPrompt,
+                extension: None,
+                source_event: None,
+                title: "prompt".into(),
+                body: canary.into(),
+                importance: 5,
+            },
+        )
+        .unwrap();
+        insert_handoff(
+            &mut fx.conn,
+            &NewHandoff {
+                workspace_id: fx.workspace_id,
+                project_id: fx.project_id,
+                from_session_id: Some(session_id),
+                from_agent: AgentKind::Codex,
+                to_agent: None,
+                cwd: None,
+                summary: canary.into(),
+                open_questions: Vec::new(),
+                next_steps: Vec::new(),
+                files_touched: Vec::new(),
+                owner_user: None,
+            },
+        )
+        .unwrap();
+        upsert_page(
+            &mut fx.conn,
+            &NewPage {
+                source_session_id: Some(session_id),
+                workspace_id: fx.workspace_id,
+                project_id: fx.project_id,
+                path: PagePath::new(format!("sessions/{session_id}.md")).unwrap(),
+                title: "session".into(),
+                body: canary.into(),
+                tier: Tier::Episodic,
+                frontmatter_json: serde_json::json!({}),
+                pinned: false,
+                links: Vec::new(),
+                entities: Vec::new(),
+                author_id: None,
+                expires_at: None,
+            },
+        )
+        .unwrap();
+        session_id
+    }
+
+    fn count(conn: &Connection, sql: &str, canary: &str) -> i64 {
+        conn.query_row(sql, params![canary], |row| row.get(0))
+            .unwrap()
+    }
+
+    /// FTS5 reads `-` as an operator and `x:` as a column filter, so a canary
+    /// has to be matched as a quoted phrase rather than a bare term.
+    fn fts_count(conn: &Connection, sql: &str, canary: &str) -> i64 {
+        count(conn, sql, &format!("\"{canary}\""))
+    }
+
+    /// Search every layer that can retain content, by canary rather than by id.
+    fn canary_hits(conn: &Connection, canary: &str) -> Vec<&'static str> {
+        let mut hits = Vec::new();
+        if count(
+            conn,
+            "SELECT COUNT(*) FROM observations WHERE body LIKE '%' || ?1 || '%'",
+            canary,
+        ) > 0
+        {
+            hits.push("observations");
+        }
+        if fts_count(
+            conn,
+            "SELECT COUNT(*) FROM observations_fts WHERE observations_fts MATCH ?1",
+            canary,
+        ) > 0
+        {
+            hits.push("observations_fts");
+        }
+        if count(
+            conn,
+            "SELECT COUNT(*) FROM handoffs WHERE summary LIKE '%' || ?1 || '%'",
+            canary,
+        ) > 0
+        {
+            hits.push("handoffs");
+        }
+        if count(
+            conn,
+            "SELECT COUNT(*) FROM pages WHERE body LIKE '%' || ?1 || '%'",
+            canary,
+        ) > 0
+        {
+            hits.push("pages");
+        }
+        if fts_count(
+            conn,
+            "SELECT COUNT(*) FROM pages_fts WHERE pages_fts MATCH ?1",
+            canary,
+        ) > 0
+        {
+            hits.push("pages_fts");
+        }
+        hits
+    }
+
+    #[test]
+    fn purge_removes_every_layer_and_leaves_only_a_tombstone() {
+        let mut fx = fixture();
+        let session_id = seed_session(&mut fx, CANARY_A);
+        assert!(
+            !canary_hits(&fx.conn, CANARY_A).is_empty(),
+            "fixture must actually store the canary"
+        );
+
+        let receipt =
+            purge_session(&mut fx.conn, fx.workspace_id, fx.project_id, session_id).unwrap();
+
+        assert_eq!(receipt.status, SessionPurgeStatus::Purged);
+        assert_eq!(receipt.counts.sessions, 1);
+        assert_eq!(receipt.counts.observations, 1);
+        assert_eq!(receipt.counts.handoffs, 1);
+        assert_eq!(receipt.counts.page_versions, 1);
+        assert_eq!(
+            receipt.removed_pages,
+            vec![PagePath::new(format!("sessions/{session_id}.md")).unwrap()]
+        );
+
+        // Identity is gone.
+        assert_eq!(
+            fx.conn
+                .query_row(
+                    "SELECT COUNT(*) FROM sessions WHERE id = ?1",
+                    params![session_id.as_bytes()],
+                    |row| row.get::<_, i64>(0)
+                )
+                .unwrap(),
+            0
+        );
+        // And so is the content, including both external-content FTS indexes:
+        // absent relational rows with a live index is not deletion.
+        assert_eq!(canary_hits(&fx.conn, CANARY_A), Vec::<&str>::new());
+
+        let tombstone = find_session_tombstone(&fx.conn, session_id)
+            .unwrap()
+            .expect("a tombstone must survive");
+        assert_eq!(tombstone.tombstone_id, receipt.tombstone_id);
+        assert_eq!(tombstone.schema_version, SESSION_PURGE_SCHEMA_VERSION);
+        assert_eq!(tombstone.workspace_id, fx.workspace_id);
+    }
+
+    #[test]
+    fn purge_leaves_a_sibling_session_untouched() {
+        let mut fx = fixture();
+        let session_a = seed_session(&mut fx, CANARY_A);
+        let session_b = seed_session(&mut fx, CANARY_B);
+
+        purge_session(&mut fx.conn, fx.workspace_id, fx.project_id, session_a).unwrap();
+
+        assert_eq!(canary_hits(&fx.conn, CANARY_A), Vec::<&str>::new());
+        assert_eq!(
+            canary_hits(&fx.conn, CANARY_B),
+            vec![
+                "observations",
+                "observations_fts",
+                "handoffs",
+                "pages",
+                "pages_fts"
+            ],
+            "B must survive in every layer"
+        );
+        assert!(
+            find_session_tombstone(&fx.conn, session_b)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn purge_is_idempotent_and_keeps_the_original_tombstone() {
+        let mut fx = fixture();
+        let session_id = seed_session(&mut fx, CANARY_A);
+
+        let first =
+            purge_session(&mut fx.conn, fx.workspace_id, fx.project_id, session_id).unwrap();
+        let second =
+            purge_session(&mut fx.conn, fx.workspace_id, fx.project_id, session_id).unwrap();
+
+        assert_eq!(second.status, SessionPurgeStatus::AlreadyPurged);
+        assert_eq!(second.tombstone_id, first.tombstone_id);
+        assert_eq!(second.purged_at, first.purged_at);
+        assert_eq!(second.counts, SessionPurgeCounts::default());
+        // A repeat must not fail on the absence of what the first call removed.
+        assert_eq!(canary_hits(&fx.conn, CANARY_A), Vec::<&str>::new());
+    }
+
+    #[test]
+    fn purge_refuses_a_session_that_lives_in_another_project() {
+        let mut fx = fixture();
+        let session_id = seed_session(&mut fx, CANARY_A);
+        let other = get_or_create_project(&mut fx.conn, &fx.workspace_id, "other", None).unwrap();
+
+        let err = purge_session(&mut fx.conn, fx.workspace_id, other, session_id).unwrap_err();
+        assert!(
+            matches!(err, StoreError::InvalidState(ref m) if m.contains("different workspace or project")),
+            "unexpected error: {err:?}"
+        );
+        // Naming the wrong project must not have removed anything.
+        assert!(!canary_hits(&fx.conn, CANARY_A).is_empty());
+    }
+
+    #[test]
+    fn purge_refuses_an_unknown_session() {
+        let mut fx = fixture();
+        let err = purge_session(
+            &mut fx.conn,
+            fx.workspace_id,
+            fx.project_id,
+            SessionId::new(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, StoreError::NotFound(_)), "{err:?}");
+    }
+
+    #[test]
+    fn tombstones_are_scoped_so_a_same_id_session_elsewhere_still_ingests() {
+        let mut fx = fixture();
+        let session_id = seed_session(&mut fx, CANARY_A);
+        let other = get_or_create_project(&mut fx.conn, &fx.workspace_id, "other", None).unwrap();
+        purge_session(&mut fx.conn, fx.workspace_id, fx.project_id, session_id).unwrap();
+
+        assert!(is_session_purged(&fx.conn, fx.workspace_id, fx.project_id, session_id).unwrap());
+        assert!(
+            !is_session_purged(&fx.conn, fx.workspace_id, other, session_id).unwrap(),
+            "a tombstone must not suppress the same UUID in a different project"
+        );
+    }
+
+    #[test]
+    fn busy_detection_reports_an_open_session() {
+        let mut fx = fixture();
+        let session_id = seed_session(&mut fx, CANARY_A);
+        assert_eq!(
+            session_purge_is_busy(&fx.conn, session_id)
+                .unwrap()
+                .as_deref(),
+            Some("session is still open")
+        );
+        fx.conn
+            .execute(
+                "UPDATE sessions SET ended_at = 1 WHERE id = ?1",
+                params![session_id.as_bytes()],
+            )
+            .unwrap();
+        assert_eq!(session_purge_is_busy(&fx.conn, session_id).unwrap(), None);
+    }
+
+    /// The `SET NULL` trap: a later page version that declares no provenance
+    /// inherits the superseded version's, so an LLM rewrite of a session page
+    /// cannot launder it out of the purge's reach.
+    #[test]
+    fn page_provenance_survives_a_rewrite_that_declares_none() {
+        let mut fx = fixture();
+        let session_id = seed_session(&mut fx, CANARY_A);
+        let path = PagePath::new(format!("sessions/{session_id}.md")).unwrap();
+
+        upsert_page(
+            &mut fx.conn,
+            &NewPage {
+                source_session_id: None,
+                workspace_id: fx.workspace_id,
+                project_id: fx.project_id,
+                path: path.clone(),
+                title: "rewritten".into(),
+                body: format!("rewritten {CANARY_A}"),
+                tier: Tier::Episodic,
+                frontmatter_json: serde_json::json!({}),
+                pinned: false,
+                links: Vec::new(),
+                entities: Vec::new(),
+                author_id: None,
+                expires_at: None,
+            },
+        )
+        .unwrap();
+
+        let inherited: Option<Vec<u8>> = fx
+            .conn
+            .query_row(
+                "SELECT source_session_id FROM pages WHERE path = ?1 AND is_latest = 1",
+                params![path.as_str()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            inherited.as_deref(),
+            Some(&session_id.as_bytes()[..]),
+            "a rewrite must inherit the superseded version's provenance"
+        );
+
+        let receipt =
+            purge_session(&mut fx.conn, fx.workspace_id, fx.project_id, session_id).unwrap();
+        assert_eq!(receipt.counts.page_versions, 2, "both versions must go");
+        assert_eq!(canary_hits(&fx.conn, CANARY_A), Vec::<&str>::new());
+    }
+
+    /// Multi-page consolidation writes arbitrary paths, so only the relational
+    /// link can find them. Without it the page would survive the purge.
+    #[test]
+    fn purge_removes_multi_page_output_by_provenance_alone() {
+        let mut fx = fixture();
+        let session_id = seed_session(&mut fx, CANARY_A);
+        let derived = PagePath::new("architecture/decisions.md").unwrap();
+        upsert_page(
+            &mut fx.conn,
+            &NewPage {
+                source_session_id: Some(session_id),
+                workspace_id: fx.workspace_id,
+                project_id: fx.project_id,
+                path: derived.clone(),
+                title: "derived".into(),
+                body: format!("derived from {CANARY_A}"),
+                tier: Tier::Semantic,
+                frontmatter_json: serde_json::json!({}),
+                pinned: false,
+                links: Vec::new(),
+                entities: Vec::new(),
+                author_id: None,
+                expires_at: None,
+            },
+        )
+        .unwrap();
+
+        let receipt =
+            purge_session(&mut fx.conn, fx.workspace_id, fx.project_id, session_id).unwrap();
+        assert!(
+            receipt.removed_pages.contains(&derived),
+            "removed pages must include multi-page output: {:?}",
+            receipt.removed_pages
+        );
+        assert_eq!(canary_hits(&fx.conn, CANARY_A), Vec::<&str>::new());
+    }
+}

--- a/crates/ai-memory-store/src/writer.rs
+++ b/crates/ai-memory-store/src/writer.rs
@@ -105,6 +105,12 @@ pub(crate) enum WriteCmd {
         summary_page_id: Option<PageId>,
         reply: oneshot::Sender<StoreResult<()>>,
     },
+    PurgeSession {
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+        session_id: SessionId,
+        reply: oneshot::Sender<StoreResult<crate::session_purge::SessionPurgeReceipt>>,
+    },
     EndSessionWithHandoff {
         session_id: SessionId,
         summary_page_id: Option<PageId>,
@@ -580,6 +586,33 @@ impl WriterHandle {
         self.send(WriteCmd::EndSession {
             session_id,
             summary_page_id,
+            reply: tx,
+        })
+        .await?;
+        rx.await.map_err(|_| StoreError::WriterClosed)?
+    }
+
+    /// Permanently remove a session and everything derived from it, leaving
+    /// only a content-free tombstone (#387).
+    ///
+    /// The returned receipt names the wiki pages and pending auto-improvement
+    /// sidecars the caller must still remove from disk: the index is clean when
+    /// this returns, but the files and git history are not.
+    ///
+    /// # Errors
+    /// Returns [`StoreError::NotFound`] for an unknown session and
+    /// [`StoreError::InvalidState`] when the id belongs to another scope.
+    pub async fn purge_session(
+        &self,
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+        session_id: SessionId,
+    ) -> StoreResult<crate::session_purge::SessionPurgeReceipt> {
+        let (tx, rx) = oneshot::channel();
+        self.send(WriteCmd::PurgeSession {
+            workspace_id,
+            project_id,
+            session_id,
             reply: tx,
         })
         .await?;
@@ -1801,6 +1834,20 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
                 let result = ops::end_session(&mut conn, &session_id, summary_page_id.as_ref());
                 send_or_warn(reply, result, "end_session");
             }
+            WriteCmd::PurgeSession {
+                workspace_id,
+                project_id,
+                session_id,
+                reply,
+            } => {
+                let result = crate::session_purge::purge_session(
+                    &mut conn,
+                    workspace_id,
+                    project_id,
+                    session_id,
+                );
+                send_or_warn(reply, result, "purge_session");
+            }
             WriteCmd::EndSessionWithHandoff {
                 session_id,
                 summary_page_id,
@@ -2336,6 +2383,7 @@ mod tests {
 
     fn sample_page(ws: WorkspaceId, proj: ProjectId, path: &str, body: &str) -> NewPage {
         NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new(path).unwrap(),

--- a/crates/ai-memory-store/tests/access_breadth.rs
+++ b/crates/ai-memory-store/tests/access_breadth.rs
@@ -113,6 +113,7 @@ async fn per_actor_rows_accumulate_without_replacing_the_scalar() {
     let page = store
         .writer
         .upsert_page(NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("notes/x.md").unwrap(),
@@ -212,6 +213,7 @@ async fn a_stale_page_id_does_not_cost_the_rest_of_the_batch_its_bump() {
             store
                 .writer
                 .upsert_page(NewPage {
+                    source_session_id: None,
                     workspace_id: ws,
                     project_id: proj,
                     path: PagePath::new(path).unwrap(),

--- a/crates/ai-memory-store/tests/fts_drift_status.rs
+++ b/crates/ai-memory-store/tests/fts_drift_status.rs
@@ -29,6 +29,7 @@ async fn page_fts_rows_report_index_drift() {
     store
         .writer
         .upsert_page(NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("notes/one.md").unwrap(),

--- a/crates/ai-memory-store/tests/session_purge_e2e.rs
+++ b/crates/ai-memory-store/tests/session_purge_e2e.rs
@@ -1,0 +1,540 @@
+//! End-to-end verification of strong per-session deletion (#387).
+//!
+//! The issue's reproduction is the shape this test follows: seed two sessions
+//! with distinct canaries, purge one, then search **every retained layer** for
+//! both canaries — by identity AND by content. Absent relational rows with a
+//! live FTS index, a surviving wiki file, or a recoverable git blob is not
+//! deletion, and only a content search catches those.
+//!
+//! Session B is the control throughout: a purge that also damages unrelated
+//! sessions is not a correct purge, so every check that asserts A is gone has a
+//! partner asserting B is untouched.
+
+use ai_memory_core::{
+    AgentKind, NewHandoff, NewObservation, NewPage, NewSession, ObservationKind, PagePath,
+    Sanitized, Sanitizer, SessionId, Tier,
+};
+use ai_memory_store::Store;
+use ai_memory_store::session_purge::{
+    SessionPurgeStatus, count_resurrected, purge_session, read_ledger_from_db, reapply_ledger,
+};
+use rusqlite::Connection;
+
+/// Unique per session, so a hit anywhere is unambiguous evidence.
+const CANARY_A: &str = "canaryalpha9f3c";
+const CANARY_B: &str = "canarybravo71de";
+
+struct Seeded {
+    session_id: SessionId,
+    page: PagePath,
+}
+
+async fn seed(store: &Store, canary: &str) -> Seeded {
+    let ws = store
+        .writer
+        .get_or_create_workspace("default".to_string())
+        .await
+        .unwrap();
+    let proj = store
+        .writer
+        .get_or_create_project(ws, "audit".to_string(), None)
+        .await
+        .unwrap();
+    let session_id = SessionId::new();
+    store
+        .writer
+        .begin_session(NewSession {
+            id: session_id,
+            workspace_id: ws,
+            project_id: proj,
+            agent_kind: AgentKind::Codex,
+            cwd: None,
+            actor_user: None,
+        })
+        .await
+        .unwrap();
+    store
+        .writer
+        .insert_observation(Sanitized::new(
+            NewObservation {
+                session_id,
+                workspace_id: ws,
+                project_id: proj,
+                kind: ObservationKind::UserPrompt,
+                extension: None,
+                source_event: None,
+                title: "prompt".into(),
+                body: format!("please remember {canary}"),
+                importance: 7,
+            },
+            &Sanitizer::default(),
+        ))
+        .await
+        .unwrap();
+    store
+        .writer
+        .insert_handoff(NewHandoff {
+            workspace_id: ws,
+            project_id: proj,
+            from_session_id: Some(session_id),
+            from_agent: AgentKind::Codex,
+            to_agent: None,
+            cwd: None,
+            summary: format!("handoff mentioning {canary}"),
+            open_questions: Vec::new(),
+            next_steps: Vec::new(),
+            files_touched: Vec::new(),
+            owner_user: None,
+        })
+        .await
+        .unwrap();
+    let page = PagePath::new(format!("sessions/{session_id}.md")).unwrap();
+    store
+        .writer
+        .upsert_page(NewPage {
+            source_session_id: Some(session_id),
+            workspace_id: ws,
+            project_id: proj,
+            path: page.clone(),
+            title: "session".into(),
+            body: format!("session page holding {canary}"),
+            tier: Tier::Episodic,
+            frontmatter_json: serde_json::json!({}),
+            pinned: false,
+            links: Vec::new(),
+            entities: Vec::new(),
+            author_id: None,
+            expires_at: None,
+        })
+        .await
+        .unwrap();
+    // A second, arbitrarily-named page, as multi-page consolidation produces.
+    // Only the relational provenance can find this one.
+    store
+        .writer
+        .upsert_page(NewPage {
+            source_session_id: Some(session_id),
+            workspace_id: ws,
+            project_id: proj,
+            path: PagePath::new(format!("derived/{session_id}-notes.md")).unwrap(),
+            title: "derived".into(),
+            body: format!("derived note quoting {canary}"),
+            tier: Tier::Semantic,
+            frontmatter_json: serde_json::json!({}),
+            pinned: false,
+            links: Vec::new(),
+            entities: Vec::new(),
+            author_id: None,
+            expires_at: None,
+        })
+        .await
+        .unwrap();
+    Seeded { session_id, page }
+}
+
+/// Every layer that can retain content, searched by canary rather than by id.
+fn layers_holding(conn: &Connection, canary: &str) -> Vec<&'static str> {
+    let count = |sql: &str, param: &str| -> i64 {
+        conn.query_row(sql, rusqlite::params![param], |row| row.get(0))
+            .unwrap()
+    };
+    let mut hits = Vec::new();
+    if count(
+        "SELECT COUNT(*) FROM observations WHERE body LIKE '%' || ?1 || '%'",
+        canary,
+    ) > 0
+    {
+        hits.push("observations");
+    }
+    if count(
+        "SELECT COUNT(*) FROM observations_fts WHERE observations_fts MATCH ?1",
+        canary,
+    ) > 0
+    {
+        hits.push("observations_fts");
+    }
+    if count(
+        "SELECT COUNT(*) FROM handoffs WHERE summary LIKE '%' || ?1 || '%'",
+        canary,
+    ) > 0
+    {
+        hits.push("handoffs");
+    }
+    if count(
+        "SELECT COUNT(*) FROM pages WHERE body LIKE '%' || ?1 || '%'",
+        canary,
+    ) > 0
+    {
+        hits.push("pages");
+    }
+    if count(
+        "SELECT COUNT(*) FROM pages_fts WHERE pages_fts MATCH ?1",
+        canary,
+    ) > 0
+    {
+        hits.push("pages_fts");
+    }
+    hits
+}
+
+/// Any file under the data dir whose bytes contain the canary.
+fn files_holding(root: &std::path::Path, canary: &str) -> Vec<std::path::PathBuf> {
+    let mut hits = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if std::fs::read(&path)
+                .map(|bytes| String::from_utf8_lossy(&bytes).contains(canary))
+                .unwrap_or(false)
+            {
+                hits.push(path);
+            }
+        }
+    }
+    hits
+}
+
+/// Copy the database the way a backup must: checkpoint first, so the snapshot
+/// is a complete database rather than one missing whatever is still in the WAL.
+fn snapshot_db(db_path: &std::path::Path, dest: &std::path::Path) {
+    let conn = Connection::open(db_path).unwrap();
+    conn.pragma_update(None, "wal_checkpoint", "TRUNCATE")
+        .unwrap();
+    drop(conn);
+    std::fs::copy(db_path, dest).unwrap();
+}
+
+#[tokio::test]
+async fn purge_removes_a_session_from_every_layer_and_spares_its_sibling() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let a = seed(&store, CANARY_A).await;
+    let b = seed(&store, CANARY_B).await;
+    let db_path = store.db_path().to_path_buf();
+
+    // The fixture must genuinely store both canaries, or the test proves
+    // nothing about the purge.
+    {
+        let conn = Connection::open(&db_path).unwrap();
+        assert!(!layers_holding(&conn, CANARY_A).is_empty());
+        assert!(!layers_holding(&conn, CANARY_B).is_empty());
+    }
+
+    let (ws, proj, _) = store
+        .reader
+        .find_session_scope(a.session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let receipt = store
+        .writer
+        .purge_session(ws, proj, a.session_id)
+        .await
+        .unwrap();
+    assert_eq!(receipt.status, SessionPurgeStatus::Purged);
+    assert!(
+        receipt.removed_pages.contains(&a.page),
+        "the session page must be among the removed pages"
+    );
+    assert_eq!(
+        receipt.removed_pages.len(),
+        2,
+        "multi-page output is found by provenance, not just the session path"
+    );
+
+    let conn = Connection::open(&db_path).unwrap();
+    assert_eq!(
+        layers_holding(&conn, CANARY_A),
+        Vec::<&str>::new(),
+        "A must be gone from every layer, including both FTS indexes"
+    );
+    assert_eq!(
+        layers_holding(&conn, CANARY_B),
+        vec![
+            "observations",
+            "observations_fts",
+            "handoffs",
+            "pages",
+            "pages_fts"
+        ],
+        "B must be untouched in every layer"
+    );
+    assert!(
+        store
+            .reader
+            .find_session_scope(a.session_id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        store
+            .reader
+            .find_session_scope(b.session_id)
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        store
+            .reader
+            .is_session_tombstoned(a.session_id)
+            .await
+            .unwrap()
+    );
+    assert!(
+        !store
+            .reader
+            .is_session_tombstoned(b.session_id)
+            .await
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn a_restored_pre_purge_snapshot_is_re_purged_before_it_can_be_served() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let a = seed(&store, CANARY_A).await;
+    seed(&store, CANARY_B).await;
+    let db_path = store.db_path().to_path_buf();
+
+    // Snapshot BEFORE the purge — the dangerous case: it holds everything the
+    // purge is about to remove.
+    let snapshot = tmp.path().join("pre-purge.sqlite");
+    snapshot_db(&db_path, &snapshot);
+
+    let (ws, proj, _) = store
+        .reader
+        .find_session_scope(a.session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .writer
+        .purge_session(ws, proj, a.session_id)
+        .await
+        .unwrap();
+
+    // The ledger is what has to survive the restore.
+    let ledger = read_ledger_from_db(&db_path).unwrap();
+    assert_eq!(ledger.len(), 1);
+    drop(store);
+
+    // Restoring the snapshot brings the purged session back...
+    std::fs::copy(&snapshot, &db_path).unwrap();
+    {
+        let conn = Connection::open(&db_path).unwrap();
+        assert!(
+            !layers_holding(&conn, CANARY_A).is_empty(),
+            "the snapshot must genuinely resurrect A, or this proves nothing"
+        );
+    }
+    assert_eq!(
+        count_resurrected(&db_path).unwrap(),
+        0,
+        "the restored snapshot has no ledger of its own yet"
+    );
+
+    // ...and reapplying the ledger must remove it again.
+    let repurged = reapply_ledger(&db_path, &ledger).unwrap();
+    assert_eq!(repurged.len(), 1);
+    assert_eq!(repurged[0].session_id, a.session_id);
+    assert_eq!(
+        repurged[0].repo_paths.len(),
+        2,
+        "the caller is told which files and history to reapply"
+    );
+
+    let conn = Connection::open(&db_path).unwrap();
+    assert_eq!(
+        layers_holding(&conn, CANARY_A),
+        Vec::<&str>::new(),
+        "a restore must not serve content the ledger says was deleted"
+    );
+    assert_eq!(
+        layers_holding(&conn, CANARY_B),
+        vec![
+            "observations",
+            "observations_fts",
+            "handoffs",
+            "pages",
+            "pages_fts"
+        ],
+        "reapplying the ledger must not harm sessions it does not cover"
+    );
+    assert_eq!(
+        count_resurrected(&db_path).unwrap(),
+        0,
+        "the fail-closed check must pass once the ledger is reapplied"
+    );
+
+    // The original receipt must keep identifying this deletion.
+    let after = read_ledger_from_db(&db_path).unwrap();
+    assert_eq!(after.len(), 1);
+    assert_eq!(after[0].tombstone_id, ledger[0].tombstone_id);
+    assert_eq!(after[0].purged_at, ledger[0].purged_at);
+}
+
+#[tokio::test]
+async fn a_snapshot_taken_after_the_purge_carries_the_tombstone_and_not_the_data() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let a = seed(&store, CANARY_A).await;
+    let db_path = store.db_path().to_path_buf();
+    let (ws, proj, _) = store
+        .reader
+        .find_session_scope(a.session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let receipt = store
+        .writer
+        .purge_session(ws, proj, a.session_id)
+        .await
+        .unwrap();
+    drop(store);
+
+    let post = tmp.path().join("post-purge.sqlite");
+    snapshot_db(&db_path, &post);
+
+    let conn = Connection::open(&post).unwrap();
+    assert_eq!(
+        layers_holding(&conn, CANARY_A),
+        Vec::<&str>::new(),
+        "a post-purge snapshot must not contain the purged content"
+    );
+    let ledger = read_ledger_from_db(&post).unwrap();
+    assert_eq!(ledger.len(), 1, "and it must carry the tombstone");
+    assert_eq!(ledger[0].tombstone_id, receipt.tombstone_id);
+    assert!(receipt.backup_cutoff >= receipt.purged_at);
+}
+
+#[tokio::test]
+async fn a_purge_leaves_no_trace_of_the_canary_anywhere_under_the_data_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let a = seed(&store, CANARY_A).await;
+    seed(&store, CANARY_B).await;
+
+    assert!(
+        !files_holding(tmp.path(), CANARY_A).is_empty(),
+        "the fixture must write A's canary to disk"
+    );
+
+    let (ws, proj, _) = store
+        .reader
+        .find_session_scope(a.session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let receipt = store
+        .writer
+        .purge_session(ws, proj, a.session_id)
+        .await
+        .unwrap();
+
+    // The store purge clears the index; the caller removes the files it names.
+    let wiki_root = tmp.path().join("wiki");
+    for page in &receipt.removed_pages {
+        let abs = wiki_root
+            .join(ws.to_string())
+            .join(proj.to_string())
+            .join(page.as_str());
+        let _ = std::fs::remove_file(abs);
+    }
+    // Checkpoint so the deletions are reflected in the working tree state the
+    // next reader sees.
+    drop(store);
+
+    let remaining = files_holding(tmp.path(), CANARY_A);
+    assert!(
+        remaining.is_empty(),
+        "A's canary must not survive in any file under the data dir: {remaining:?}"
+    );
+    assert!(
+        !files_holding(tmp.path(), CANARY_B).is_empty(),
+        "B's files must survive"
+    );
+}
+
+#[tokio::test]
+async fn purging_a_second_time_changes_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let a = seed(&store, CANARY_A).await;
+    let db_path = store.db_path().to_path_buf();
+    let (ws, proj, _) = store
+        .reader
+        .find_session_scope(a.session_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let first = store
+        .writer
+        .purge_session(ws, proj, a.session_id)
+        .await
+        .unwrap();
+    let counts_after_first = {
+        let conn = Connection::open(&db_path).unwrap();
+        conn.query_row("SELECT COUNT(*) FROM pages", [], |row| row.get::<_, i64>(0))
+            .unwrap()
+    };
+
+    let second = store
+        .writer
+        .purge_session(ws, proj, a.session_id)
+        .await
+        .unwrap();
+    assert_eq!(second.status, SessionPurgeStatus::AlreadyPurged);
+    assert_eq!(second.tombstone_id, first.tombstone_id);
+    assert_eq!(second.purged_at, first.purged_at);
+
+    let conn = Connection::open(&db_path).unwrap();
+    let counts_after_second = conn
+        .query_row("SELECT COUNT(*) FROM pages", [], |row| row.get::<_, i64>(0))
+        .unwrap();
+    assert_eq!(
+        counts_after_first, counts_after_second,
+        "a repeat purge must not change any counts"
+    );
+}
+
+#[tokio::test]
+async fn a_purge_cannot_be_aimed_at_another_projects_session() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut conn_holder = Store::open(tmp.path()).unwrap();
+    let a = seed(&conn_holder, CANARY_A).await;
+    let ws = conn_holder
+        .writer
+        .get_or_create_workspace("default".to_string())
+        .await
+        .unwrap();
+    let other = conn_holder
+        .writer
+        .get_or_create_project(ws, "other".to_string(), None)
+        .await
+        .unwrap();
+    let db_path = conn_holder.db_path().to_path_buf();
+    conn_holder = Store::open(tmp.path()).unwrap();
+    drop(conn_holder);
+
+    let mut conn = Connection::open(&db_path).unwrap();
+    conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+    let err = purge_session(&mut conn, ws, other, a.session_id).unwrap_err();
+    assert!(
+        format!("{err}").contains("different workspace or project"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        !layers_holding(&conn, CANARY_A).is_empty(),
+        "a misdirected purge must not remove anything"
+    );
+}

--- a/crates/ai-memory-store/tests/slot_visibility.rs
+++ b/crates/ai-memory-store/tests/slot_visibility.rs
@@ -43,6 +43,7 @@ async fn write_slot(store: &Store, ws: WorkspaceId, proj: ProjectId, path: &str)
     store
         .writer
         .upsert_page(NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new(path).unwrap(),
@@ -547,6 +548,7 @@ async fn expiry_and_slot_visibility_both_apply() {
         store
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: proj,
                 path: PagePath::new(path).unwrap(),

--- a/crates/ai-memory-web/tests/routes.rs
+++ b/crates/ai-memory-web/tests/routes.rs
@@ -28,6 +28,7 @@ fn new_page(
     body: &str,
 ) -> NewPage {
     NewPage {
+        source_session_id: None,
         workspace_id: ws,
         project_id: proj,
         path: PagePath::new(path).unwrap(),
@@ -50,6 +51,7 @@ fn wiki_req(
     body: &str,
 ) -> WritePageRequest {
     WritePageRequest {
+        source_session_id: None,
         workspace_id: ws,
         project_id: proj,
         path: PagePath::new(path).unwrap(),
@@ -613,6 +615,7 @@ async fn api_pages_derives_kind_from_path_when_frontmatter_absent() {
     store
         .writer
         .upsert_page(NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("decisions/adr-x.md").unwrap(),
@@ -634,6 +637,7 @@ async fn api_pages_derives_kind_from_path_when_frontmatter_absent() {
     store
         .writer
         .upsert_page(NewPage {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("notes/anything.md").unwrap(),
@@ -2240,6 +2244,7 @@ async fn api_page_handler_emits_etag_and_supports_if_none_match() {
         .await
         .unwrap();
     wiki.write_page(WritePageRequest {
+        source_session_id: None,
         workspace_id: ws,
         project_id: proj,
         path: PagePath::new("etag-test.md").unwrap(),
@@ -2321,6 +2326,7 @@ async fn api_page_handler_etag_differs_per_page() {
         .await
         .unwrap();
     wiki.write_page(WritePageRequest {
+        source_session_id: None,
         workspace_id: ws,
         project_id: proj,
         path: PagePath::new("page-a.md").unwrap(),
@@ -2336,6 +2342,7 @@ async fn api_page_handler_etag_differs_per_page() {
     .await
     .unwrap();
     wiki.write_page(WritePageRequest {
+        source_session_id: None,
         workspace_id: ws,
         project_id: proj,
         path: PagePath::new("page-b.md").unwrap(),

--- a/crates/ai-memory-wiki/src/git_purge.rs
+++ b/crates/ai-memory-wiki/src/git_purge.rs
@@ -69,6 +69,42 @@ enum JournalState {
     Swapping,
 }
 
+/// What a history purge must remove, and how.
+///
+/// Three distinct kinds of residue, because the naive "delete these paths" only
+/// covers the first — and a live end-to-end run is what surfaced the other two:
+///
+/// 1. **Whole paths**, e.g. the session's own pages: removed from every commit.
+/// 2. **Shared files**, e.g. the monthly log: the file belongs to every session
+///    that wrote to it, so removing the path would destroy other sessions'
+///    history. Instead each historical version is rewritten with the purged
+///    session's marked lines removed.
+/// 3. **Commit messages**, which embed the session's own prompt text. The
+///    rebuilt commit carries the message verbatim unless it is redacted.
+#[derive(Debug, Clone, Default)]
+pub struct HistoryPurgeSpec {
+    /// Repo-relative paths removed from every commit outright.
+    pub doomed_paths: Vec<String>,
+    /// Repo-relative paths kept, with `line_marker` lines scrubbed from every
+    /// historical version.
+    pub scrub_paths: Vec<String>,
+    /// Marker identifying the purged session's lines inside a scrubbed file.
+    /// Empty disables line scrubbing.
+    pub line_marker: String,
+    /// Commit-message prefix identifying commits this session produced, e.g.
+    /// `session 11111111`. Matched as an identity handle, never as free text.
+    /// Empty disables message redaction.
+    pub commit_prefix: String,
+}
+
+impl HistoryPurgeSpec {
+    /// Whether this spec would change anything.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.doomed_paths.is_empty() && self.scrub_paths.is_empty()
+    }
+}
+
 /// What a history purge removed.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct GitPurgeReport {
@@ -84,6 +120,11 @@ pub struct GitPurgeReport {
     pub blobs_destroyed: usize,
     /// Repositories rebuilt (0 when there was no history to rewrite, else 1).
     pub repositories_rebuilt: usize,
+    /// Historical versions of shared files rewritten to drop the purged
+    /// session's lines.
+    pub blobs_scrubbed: usize,
+    /// Commit messages redacted because they carried the session's own text.
+    pub messages_redacted: usize,
 }
 
 fn git_err(e: git2::Error) -> WikiError {
@@ -108,10 +149,14 @@ fn purge_err(msg: impl Into<String>) -> WikiError {
 /// Returns [`WikiError`] if the repository cannot be read, the rebuild fails
 /// verification, or the swap cannot be completed. On a verification failure the
 /// live repository is left untouched.
-pub fn purge_paths_from_history(root: &Path, paths: &[String]) -> WikiResult<GitPurgeReport> {
-    if paths.is_empty() {
+pub fn purge_paths_from_history(
+    root: &Path,
+    spec: &HistoryPurgeSpec,
+) -> WikiResult<GitPurgeReport> {
+    if spec.is_empty() {
         return Ok(GitPurgeReport::default());
     }
+    let paths = &spec.doomed_paths;
     let doomed: HashSet<&str> = paths.iter().map(String::as_str).collect();
     let repo = Repository::open(root).map_err(git_err)?;
 
@@ -133,7 +178,14 @@ pub fn purge_paths_from_history(root: &Path, paths: &[String]) -> WikiResult<Git
     let _ = std::fs::remove_dir_all(&scratch);
     let _ = std::fs::remove_dir_all(&retired);
 
-    let report = build_replacement(&repo, &scratch, &doomed, objects_before, &doomed_blobs);
+    let report = build_replacement(
+        &repo,
+        &scratch,
+        &doomed,
+        spec,
+        objects_before,
+        &doomed_blobs,
+    );
     let mut report = match report {
         Ok(report) => report,
         Err(e) => {
@@ -144,7 +196,7 @@ pub fn purge_paths_from_history(root: &Path, paths: &[String]) -> WikiResult<Git
 
     // Verify BEFORE anything destructive: a failure here must leave the live
     // repository exactly as it was.
-    if let Err(e) = verify_replacement(&scratch, &doomed, &doomed_blobs) {
+    if let Err(e) = verify_replacement(&scratch, &doomed, spec, &doomed_blobs) {
         let _ = std::fs::remove_dir_all(&scratch);
         return Err(e);
     }
@@ -363,6 +415,7 @@ fn build_replacement(
     repo: &Repository,
     scratch: &Path,
     doomed: &HashSet<&str>,
+    spec: &HistoryPurgeSpec,
     objects_before: usize,
     doomed_blobs: &HashSet<Oid>,
 ) -> WikiResult<GitPurgeReport> {
@@ -378,15 +431,27 @@ fn build_replacement(
     walk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::REVERSE)
         .map_err(git_err)?;
 
+    let scrub: HashSet<&str> = spec.scrub_paths.iter().map(String::as_str).collect();
     let mut remapped: HashMap<Oid, Oid> = HashMap::new();
     let mut commits_rewritten = 0usize;
+    let mut blobs_scrubbed = 0usize;
+    let mut messages_redacted = 0usize;
     let mut last_new = None;
 
     for oid in walk {
         let oid = oid.map_err(git_err)?;
         let commit = repo.find_commit(oid).map_err(git_err)?;
         let tree = commit.tree().map_err(git_err)?;
-        let new_tree_oid = copy_tree_without(repo, &new_repo, &tree, "", doomed)?;
+        let new_tree_oid = copy_tree_without(
+            repo,
+            &new_repo,
+            &tree,
+            "",
+            doomed,
+            &scrub,
+            &spec.line_marker,
+            &mut blobs_scrubbed,
+        )?;
         let new_tree = new_repo.find_tree(new_tree_oid).map_err(git_err)?;
 
         let parents: Vec<_> = commit
@@ -400,12 +465,26 @@ fn build_replacement(
             .map_err(git_err)?;
         let parent_refs: Vec<&git2::Commit<'_>> = parent_commits.iter().collect();
 
+        // A commit message embeds the session's own prompt text, so a rebuilt
+        // commit would carry the purged content in plain sight. Matched by the
+        // session's short-id handle rather than by searching the text.
+        let original = commit.message().unwrap_or("");
+        let message = if !spec.commit_prefix.is_empty()
+            && original
+                .trim_start()
+                .starts_with(spec.commit_prefix.as_str())
+        {
+            messages_redacted += 1;
+            format!("{} (purged)", spec.commit_prefix)
+        } else {
+            original.to_string()
+        };
         let new_oid = new_repo
             .commit(
                 None,
                 &commit.author(),
                 &commit.committer(),
-                commit.message().unwrap_or(""),
+                &message,
                 &new_tree,
                 &parent_refs,
             )
@@ -451,16 +530,22 @@ fn build_replacement(
         objects_after,
         blobs_destroyed: 0,
         repositories_rebuilt: 0,
+        blobs_scrubbed,
+        messages_redacted,
     })
 }
 
 /// Copy `tree` into `dest`, omitting any entry whose full path is doomed.
+#[allow(clippy::too_many_arguments)]
 fn copy_tree_without(
     src: &Repository,
     dest: &Repository,
     tree: &git2::Tree<'_>,
     prefix: &str,
     doomed: &HashSet<&str>,
+    scrub: &HashSet<&str>,
+    line_marker: &str,
+    scrubbed: &mut usize,
 ) -> WikiResult<Oid> {
     let mut builder = dest.treebuilder(None).map_err(git_err)?;
     for entry in tree.iter() {
@@ -470,7 +555,16 @@ fn copy_tree_without(
             Some(git2::ObjectType::Tree) => {
                 let subtree = src.find_tree(entry.id()).map_err(git_err)?;
                 let sub_prefix = format!("{full}/");
-                let new_sub = copy_tree_without(src, dest, &subtree, &sub_prefix, doomed)?;
+                let new_sub = copy_tree_without(
+                    src,
+                    dest,
+                    &subtree,
+                    &sub_prefix,
+                    doomed,
+                    scrub,
+                    line_marker,
+                    scrubbed,
+                )?;
                 // Drop directories that became empty, so a purge cannot leave
                 // an empty shell where a session's pages used to live.
                 let new_tree = dest.find_tree(new_sub).map_err(git_err)?;
@@ -485,7 +579,26 @@ fn copy_tree_without(
                     continue;
                 }
                 let blob = src.find_blob(entry.id()).map_err(git_err)?;
-                let new_id = dest.blob(blob.content()).map_err(git_err)?;
+                // A shared file (the monthly log) belongs to every session that
+                // wrote to it, so the path must survive while THIS session's
+                // marked lines are removed from every historical version.
+                let content = if scrub.contains(full.as_str()) && !line_marker.is_empty() {
+                    let text = String::from_utf8_lossy(blob.content());
+                    if text.contains(line_marker) {
+                        *scrubbed += 1;
+                        let kept: String = text
+                            .lines()
+                            .filter(|line| !line.contains(line_marker))
+                            .map(|line| format!("{line}\n"))
+                            .collect();
+                        kept.into_bytes()
+                    } else {
+                        blob.content().to_vec()
+                    }
+                } else {
+                    blob.content().to_vec()
+                };
+                let new_id = dest.blob(&content).map_err(git_err)?;
                 builder
                     .insert(name, new_id, entry.filemode())
                     .map_err(git_err)?;
@@ -510,6 +623,7 @@ fn copy_tree_without(
 fn verify_replacement(
     scratch: &Path,
     doomed: &HashSet<&str>,
+    spec: &HistoryPurgeSpec,
     doomed_blobs: &HashSet<Oid>,
 ) -> WikiResult<()> {
     let repo = Repository::open(scratch).map_err(git_err)?;
@@ -561,6 +675,39 @@ fn verify_replacement(
             "git purge: rebuilt object database still contains purged blob {oid}"
         )));
     }
+
+    // 3. No object anywhere may still carry the session's line marker, and no
+    //    commit message may still be attributed to it. Checked across the whole
+    //    database rather than only reachable objects, for the same reason as
+    //    above: an unreachable copy is still a copy.
+    if !spec.line_marker.is_empty() || !spec.commit_prefix.is_empty() {
+        let mut offender = None;
+        odb.foreach(|oid| {
+            let Ok(obj) = odb.read(*oid) else {
+                return true;
+            };
+            let carries_marker = !spec.line_marker.is_empty()
+                && matches!(obj.kind(), git2::ObjectType::Blob)
+                && String::from_utf8_lossy(obj.data()).contains(spec.line_marker.as_str());
+            let carries_attribution = !spec.commit_prefix.is_empty()
+                && matches!(obj.kind(), git2::ObjectType::Commit)
+                && String::from_utf8_lossy(obj.data())
+                    .contains(&format!("{} ", spec.commit_prefix))
+                && !String::from_utf8_lossy(obj.data())
+                    .contains(&format!("{} (purged)", spec.commit_prefix));
+            if carries_marker || carries_attribution {
+                offender = Some(*oid);
+                return false;
+            }
+            true
+        })
+        .map_err(git_err)?;
+        if let Some(oid) = offender {
+            return Err(purge_err(format!(
+                "git purge: rebuilt object database still attributes content to the purged session ({oid})"
+            )));
+        }
+    }
     Ok(())
 }
 
@@ -593,6 +740,13 @@ mod tests {
     /// database is unambiguous evidence the deletion failed.
     const DOOMED_CANARY: &str = "doomed-canary-4b7e91";
     const KEPT_CANARY: &str = "kept-canary-2f8c03";
+
+    fn doomed_spec() -> HistoryPurgeSpec {
+        HistoryPurgeSpec {
+            doomed_paths: vec!["sessions/doomed.md".to_string()],
+            ..Default::default()
+        }
+    }
 
     struct Fixture {
         _tmp: tempfile::TempDir,
@@ -684,8 +838,7 @@ mod tests {
         let fx = fixture();
         assert!(canary_in_any_object(&fx.root, DOOMED_CANARY));
 
-        let report =
-            purge_paths_from_history(&fx.root, &["sessions/doomed.md".to_string()]).unwrap();
+        let report = purge_paths_from_history(&fx.root, &doomed_spec()).unwrap();
 
         assert_eq!(report.repositories_rebuilt, 1);
         assert_eq!(
@@ -709,7 +862,7 @@ mod tests {
     #[test]
     fn purge_leaves_no_scratch_or_retired_directory_behind() {
         let fx = fixture();
-        purge_paths_from_history(&fx.root, &["sessions/doomed.md".to_string()]).unwrap();
+        purge_paths_from_history(&fx.root, &doomed_spec()).unwrap();
         assert_eq!(
             leftover_scratch_dirs(&fx.root),
             Vec::<PathBuf>::new(),
@@ -724,7 +877,7 @@ mod tests {
     #[test]
     fn purge_preserves_history_and_the_surviving_pages_content() {
         let fx = fixture();
-        purge_paths_from_history(&fx.root, &["sessions/doomed.md".to_string()]).unwrap();
+        purge_paths_from_history(&fx.root, &doomed_spec()).unwrap();
 
         let repo = Repository::open(&fx.root).unwrap();
         let mut walk = repo.revwalk().unwrap();
@@ -759,7 +912,7 @@ mod tests {
             "shared content",
         );
 
-        let report = purge_paths_from_history(&root, &["sessions/doomed.md".to_string()]).unwrap();
+        let report = purge_paths_from_history(&root, &doomed_spec()).unwrap();
         assert_eq!(
             report.blobs_destroyed, 0,
             "a blob the surviving page also uses must be spared"
@@ -785,7 +938,7 @@ mod tests {
     #[test]
     fn purge_drops_directories_it_empties() {
         let fx = fixture();
-        purge_paths_from_history(&fx.root, &["sessions/doomed.md".to_string()]).unwrap();
+        purge_paths_from_history(&fx.root, &doomed_spec()).unwrap();
         let repo = Repository::open(&fx.root).unwrap();
         let tree = repo
             .head()
@@ -800,10 +953,96 @@ mod tests {
         );
     }
 
+    /// Regression for two residues that fixtures with generic commit messages
+    /// and no shared files could never surface — a live end-to-end run did.
+    ///
+    /// The monthly log belongs to EVERY session that wrote that month, so
+    /// removing its path would destroy the other sessions' history. Its
+    /// historical versions must instead be rewritten without the purged
+    /// session's marked lines. And a commit message embeds the session's own
+    /// prompt text, so the rebuilt commit carries the purged content in plain
+    /// sight unless it is redacted.
+    #[test]
+    fn purge_scrubs_shared_log_history_and_redacts_commit_messages() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().join("wiki");
+        std::fs::create_dir_all(&root).unwrap();
+        let repo = Repository::init(&root).unwrap();
+
+        let marker_a = "<!-- ai-memory:session=11111111 -->";
+        let marker_b = "<!-- ai-memory:session=22222222 -->";
+        // Version 1 of the log holds A's line...
+        commit(
+            &repo,
+            &root,
+            &[(
+                "log-2026-08.md",
+                &format!("## [t1] user-prompt | {DOOMED_CANARY} {marker_a}\n"),
+            )],
+            &format!("session 11111111: {DOOMED_CANARY}"),
+        );
+        // ...and version 2 adds B's, so the file is genuinely shared.
+        commit(
+            &repo,
+            &root,
+            &[(
+                "log-2026-08.md",
+                &format!(
+                    "## [t1] user-prompt | {DOOMED_CANARY} {marker_a}\n\
+                     ## [t2] user-prompt | {KEPT_CANARY} {marker_b}\n"
+                ),
+            )],
+            &format!("session 22222222: {KEPT_CANARY}"),
+        );
+
+        let spec = HistoryPurgeSpec {
+            doomed_paths: Vec::new(),
+            scrub_paths: vec!["log-2026-08.md".to_string()],
+            line_marker: marker_a.to_string(),
+            commit_prefix: "session 11111111".to_string(),
+        };
+        let report = purge_paths_from_history(&root, &spec).unwrap();
+
+        assert!(
+            report.blobs_scrubbed >= 2,
+            "both log versions must be rewritten"
+        );
+        assert_eq!(
+            report.messages_redacted, 1,
+            "A's commit message must be redacted"
+        );
+        assert!(
+            !canary_in_any_object(&root, DOOMED_CANARY),
+            "A's text must not survive in ANY object — log blob or commit message"
+        );
+        assert!(
+            canary_in_any_object(&root, KEPT_CANARY),
+            "B's log line and commit message must survive"
+        );
+
+        // The shared file itself must still exist, with B's line intact.
+        let repo = Repository::open(&root).unwrap();
+        let tree = repo
+            .head()
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .tree()
+            .unwrap();
+        let entry = tree.get_path(Path::new("log-2026-08.md")).unwrap();
+        let body = repo.find_blob(entry.id()).unwrap();
+        let body = String::from_utf8_lossy(body.content());
+        assert!(
+            body.contains(KEPT_CANARY),
+            "the shared log must keep B: {body}"
+        );
+        assert!(!body.contains(marker_a), "and lose A: {body}");
+    }
+
     #[test]
     fn purging_nothing_is_a_no_op() {
         let fx = fixture();
-        let report = purge_paths_from_history(&fx.root, &[]).unwrap();
+        let report = purge_paths_from_history(&fx.root, &HistoryPurgeSpec::default()).unwrap();
         assert_eq!(report, GitPurgeReport::default());
         assert!(canary_in_any_object(&fx.root, DOOMED_CANARY));
     }
@@ -820,7 +1059,15 @@ mod tests {
         let purge_id = "deadbeefdeadbeef".to_string();
         let scratch = fx.root.join(format!("{SCRATCH_PREFIX}new-{purge_id}"));
         let retired = fx.root.join(format!("{SCRATCH_PREFIX}old-{purge_id}"));
-        build_replacement(&repo, &scratch, &doomed, objects_before, &doomed_blobs).unwrap();
+        build_replacement(
+            &repo,
+            &scratch,
+            &doomed,
+            &doomed_spec(),
+            objects_before,
+            &doomed_blobs,
+        )
+        .unwrap();
         drop(repo);
 
         // Simulate the crash: journal says Swapping, old .git moved aside,

--- a/crates/ai-memory-wiki/src/git_purge.rs
+++ b/crates/ai-memory-wiki/src/git_purge.rs
@@ -1,0 +1,884 @@
+//! Physical removal of paths from the managed wiki repository's history
+//! (#387, stage C).
+//!
+//! Deleting a file and committing leaves every prior version reachable in git
+//! history — and `restore-page` will happily hand one back. Strong deletion
+//! means the content must be gone from the object database itself, not merely
+//! unreferenced: working tree, index, refs, reflogs, loose objects, packs, and
+//! dangling objects alike.
+//!
+//! ## Why a rebuild rather than an in-place rewrite
+//!
+//! git never mutates objects; it only stops referencing them. Rewriting history
+//! in place therefore leaves the old commits, trees, and blobs in the ODB,
+//! reachable through reflogs and recoverable by `git fsck --unreachable` long
+//! after the rewrite "succeeded". Building a NEW repository and keeping only
+//! what survives is the only construction where the absence is a property of
+//! the result rather than of a cleanup pass that might not have run.
+//!
+//! ## Crash safety
+//!
+//! The swap is two renames (Rust offers no portable atomic directory exchange,
+//! and `renameat2(RENAME_EXCHANGE)` would require `unsafe`, which this
+//! workspace forbids). A durable journal records the purge across them, so an
+//! interrupted swap converges on the purged state when
+//! [`recover_interrupted_purge`] runs at startup rather than silently leaving
+//! the old history in place.
+//!
+//! Everything here runs on fixture repositories in tests; the caller is
+//! expected to hold the wiki mutation lock for the whole operation.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use git2::{Oid, Repository, TreeWalkMode, TreeWalkResult};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info, warn};
+
+use crate::error::{WikiError, WikiResult};
+
+/// Filename of the durable purge journal, written in the wiki root.
+const JOURNAL_NAME: &str = ".ai-memory-purge-journal.json";
+
+/// Prefix for both transient directories, so recovery can recognize them and
+/// no other code mistakes them for wiki content.
+const SCRATCH_PREFIX: &str = ".ai-memory-purge-";
+
+/// Durable record of an in-flight history purge.
+///
+/// Written before the first rename and removed only after the last one, so its
+/// presence at startup always means "a purge was interrupted mid-swap".
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PurgeJournal {
+    /// Unique id of this purge, and the suffix of its scratch directories.
+    purge_id: String,
+    /// Repo-relative paths being removed from every commit.
+    paths: Vec<String>,
+    /// How far the swap got.
+    state: JournalState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum JournalState {
+    /// The replacement repository is built and verified but not yet installed.
+    /// The live `.git` is still the old one.
+    Prepared,
+    /// The old `.git` has been moved aside; the replacement may or may not be
+    /// installed yet. Recovery finishes the install.
+    Swapping,
+}
+
+/// What a history purge removed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GitPurgeReport {
+    /// Commits carried over into the rebuilt repository.
+    pub commits_rewritten: usize,
+    /// Objects in the old database, counted before the rebuild.
+    pub objects_before: usize,
+    /// Objects in the rebuilt database.
+    pub objects_after: usize,
+    /// Blob objects that existed only through the purged paths and are absent
+    /// from the rebuilt database. This is the number that makes the deletion
+    /// real rather than merely unreferenced.
+    pub blobs_destroyed: usize,
+    /// Repositories rebuilt (0 when there was no history to rewrite, else 1).
+    pub repositories_rebuilt: usize,
+}
+
+fn git_err(e: git2::Error) -> WikiError {
+    WikiError::Io(std::io::Error::other(format!("git purge: {e}")))
+}
+
+fn io_err(context: &str, e: std::io::Error) -> WikiError {
+    WikiError::Io(std::io::Error::other(format!("git purge: {context}: {e}")))
+}
+
+fn purge_err(msg: impl Into<String>) -> WikiError {
+    WikiError::Io(std::io::Error::other(msg.into()))
+}
+
+/// Remove `paths` from every commit in the wiki repository at `root`.
+///
+/// Returns a report whose `blobs_destroyed` count is the load-bearing one: it
+/// is the number of blob objects that existed only through the purged paths and
+/// are provably absent from the rebuilt object database.
+///
+/// # Errors
+/// Returns [`WikiError`] if the repository cannot be read, the rebuild fails
+/// verification, or the swap cannot be completed. On a verification failure the
+/// live repository is left untouched.
+pub fn purge_paths_from_history(root: &Path, paths: &[String]) -> WikiResult<GitPurgeReport> {
+    if paths.is_empty() {
+        return Ok(GitPurgeReport::default());
+    }
+    let doomed: HashSet<&str> = paths.iter().map(String::as_str).collect();
+    let repo = Repository::open(root).map_err(git_err)?;
+
+    let objects_before = count_objects(&repo)?;
+    let doomed_blobs = blobs_reachable_only_through(&repo, &doomed)?;
+
+    // Distinct per attempt so a crashed run's scratch directories can never be
+    // mistaken for this one's; the journal records which id is live.
+    let purge_id = Oid::hash_object(
+        git2::ObjectType::Blob,
+        format!("{}-{}", root.display(), objects_before).as_bytes(),
+    )
+    .map_err(git_err)?
+    .to_string()[..16]
+        .to_string();
+    let scratch = root.join(format!("{SCRATCH_PREFIX}new-{purge_id}"));
+    let retired = root.join(format!("{SCRATCH_PREFIX}old-{purge_id}"));
+    // A previous crashed attempt must not be mistaken for this one's output.
+    let _ = std::fs::remove_dir_all(&scratch);
+    let _ = std::fs::remove_dir_all(&retired);
+
+    let report = build_replacement(&repo, &scratch, &doomed, objects_before, &doomed_blobs);
+    let mut report = match report {
+        Ok(report) => report,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&scratch);
+            return Err(e);
+        }
+    };
+
+    // Verify BEFORE anything destructive: a failure here must leave the live
+    // repository exactly as it was.
+    if let Err(e) = verify_replacement(&scratch, &doomed, &doomed_blobs) {
+        let _ = std::fs::remove_dir_all(&scratch);
+        return Err(e);
+    }
+
+    write_journal(
+        root,
+        &PurgeJournal {
+            purge_id: purge_id.clone(),
+            paths: paths.to_vec(),
+            state: JournalState::Prepared,
+        },
+    )?;
+
+    install_replacement(root, &scratch, &retired, &purge_id, paths)?;
+
+    report.blobs_destroyed = doomed_blobs.len();
+    report.repositories_rebuilt = 1;
+    info!(
+        commits = report.commits_rewritten,
+        objects_before = report.objects_before,
+        objects_after = report.objects_after,
+        blobs_destroyed = report.blobs_destroyed,
+        "wiki history rebuilt without purged paths"
+    );
+    Ok(report)
+}
+
+/// Move the rebuilt `.git` into place and destroy the old one.
+///
+/// Ordered so that every interruption is recoverable: the journal advances to
+/// `Swapping` before the live `.git` moves, and is only removed once the old
+/// directory is physically gone.
+fn install_replacement(
+    root: &Path,
+    scratch: &Path,
+    retired: &Path,
+    purge_id: &str,
+    paths: &[String],
+) -> WikiResult<()> {
+    let live_git = root.join(".git");
+    let new_git = scratch.join(".git");
+
+    write_journal(
+        root,
+        &PurgeJournal {
+            purge_id: purge_id.to_string(),
+            paths: paths.to_vec(),
+            state: JournalState::Swapping,
+        },
+    )?;
+
+    std::fs::rename(&live_git, retired).map_err(|e| io_err("retiring old .git", e))?;
+    if let Err(e) = std::fs::rename(&new_git, &live_git) {
+        // Put the original back rather than leaving the wiki without a repo.
+        let _ = std::fs::rename(retired, &live_git);
+        let _ = std::fs::remove_dir_all(scratch);
+        let _ = remove_journal(root);
+        return Err(io_err("installing rebuilt .git", e));
+    }
+
+    // Physically remove the old object database BEFORE reporting success: an
+    // old pack left on disk is exactly the residue this whole module exists to
+    // prevent.
+    std::fs::remove_dir_all(retired).map_err(|e| io_err("removing retired .git", e))?;
+    let _ = std::fs::remove_dir_all(scratch);
+    remove_journal(root)?;
+    Ok(())
+}
+
+/// Finish or roll back a purge interrupted mid-swap.
+///
+/// Called at startup. Returns `Ok(true)` when a journal was found and resolved.
+/// Reads and ingest must stay blocked until this returns, or a reader could
+/// observe the pre-purge history that the journal exists to finish removing.
+///
+/// # Errors
+/// Returns [`WikiError`] when the journal exists but cannot be resolved, which
+/// deliberately keeps the caller from opening the wiki for business.
+pub fn recover_interrupted_purge(root: &Path) -> WikiResult<bool> {
+    let journal_path = root.join(JOURNAL_NAME);
+    let raw = match std::fs::read_to_string(&journal_path) {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(io_err("reading purge journal", e)),
+    };
+    let journal: PurgeJournal = serde_json::from_str(&raw)
+        .map_err(|e| purge_err(format!("git purge: unreadable journal: {e}")))?;
+    warn!(
+        purge_id = %journal.purge_id,
+        state = ?journal.state,
+        "resuming an interrupted wiki history purge"
+    );
+
+    let live_git = root.join(".git");
+    let scratch = root.join(format!("{SCRATCH_PREFIX}new-{}", journal.purge_id));
+    let retired = root.join(format!("{SCRATCH_PREFIX}old-{}", journal.purge_id));
+    let new_git = scratch.join(".git");
+
+    match journal.state {
+        // Nothing destructive happened yet: discard the replacement and let the
+        // operator re-run the purge. Rolling forward would install a repository
+        // that was never verified against THIS process's inputs.
+        JournalState::Prepared => {
+            let _ = std::fs::remove_dir_all(&scratch);
+            let _ = std::fs::remove_dir_all(&retired);
+        }
+        JournalState::Swapping => {
+            if !live_git.exists() && new_git.exists() {
+                std::fs::rename(&new_git, &live_git)
+                    .map_err(|e| io_err("installing rebuilt .git during recovery", e))?;
+            } else if !live_git.exists() && retired.exists() {
+                // The rebuilt repo is gone but the old one survives: restore it
+                // so the wiki has a repository, and report the purge unfinished.
+                std::fs::rename(&retired, &live_git)
+                    .map_err(|e| io_err("restoring old .git during recovery", e))?;
+                remove_journal(root)?;
+                return Err(purge_err(
+                    "git purge: interrupted before the rebuilt repository was installed; \
+                     the purge must be re-run",
+                ));
+            }
+            if retired.exists() {
+                std::fs::remove_dir_all(&retired)
+                    .map_err(|e| io_err("removing retired .git during recovery", e))?;
+            }
+            let _ = std::fs::remove_dir_all(&scratch);
+        }
+    }
+    remove_journal(root)?;
+    Ok(true)
+}
+
+fn write_journal(root: &Path, journal: &PurgeJournal) -> WikiResult<()> {
+    let body = serde_json::to_vec_pretty(journal)
+        .map_err(|e| purge_err(format!("git purge: encoding journal: {e}")))?;
+    let path = root.join(JOURNAL_NAME);
+    let tmp = root.join(format!("{JOURNAL_NAME}.tmp"));
+    std::fs::write(&tmp, &body).map_err(|e| io_err("writing purge journal", e))?;
+    // fsync the journal itself, then rename: a journal that is not durable is
+    // not a journal.
+    let file = std::fs::File::open(&tmp).map_err(|e| io_err("opening purge journal", e))?;
+    file.sync_all()
+        .map_err(|e| io_err("syncing purge journal", e))?;
+    std::fs::rename(&tmp, &path).map_err(|e| io_err("installing purge journal", e))?;
+    Ok(())
+}
+
+fn remove_journal(root: &Path) -> WikiResult<()> {
+    match std::fs::remove_file(root.join(JOURNAL_NAME)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(io_err("removing purge journal", e)),
+    }
+}
+
+fn count_objects(repo: &Repository) -> WikiResult<usize> {
+    let odb = repo.odb().map_err(git_err)?;
+    let mut count = 0usize;
+    // `foreach` visits EVERY object — loose and packed, reachable or not. That
+    // breadth is the point: a reachability-based count would report success
+    // while dangling copies of the purged content sat in the same database.
+    odb.foreach(|_| {
+        count += 1;
+        true
+    })
+    .map_err(git_err)?;
+    Ok(count)
+}
+
+/// Blob oids that are reachable ONLY through the doomed paths.
+///
+/// Content-identical blobs shared with a surviving path are deliberately
+/// excluded: git stores one object for identical content, so destroying it
+/// would corrupt the page that legitimately keeps it.
+fn blobs_reachable_only_through(
+    repo: &Repository,
+    doomed: &HashSet<&str>,
+) -> WikiResult<HashSet<Oid>> {
+    let mut through_doomed = HashSet::new();
+    let mut through_survivors = HashSet::new();
+
+    let mut walk = repo.revwalk().map_err(git_err)?;
+    walk.push_glob("refs/*").map_err(git_err)?;
+    if repo.head().is_ok() {
+        let _ = walk.push_head();
+    }
+    for oid in walk {
+        let oid = oid.map_err(git_err)?;
+        let commit = repo.find_commit(oid).map_err(git_err)?;
+        let tree = commit.tree().map_err(git_err)?;
+        tree.walk(TreeWalkMode::PreOrder, |dir, entry| {
+            if entry.kind() != Some(git2::ObjectType::Blob) {
+                return TreeWalkResult::Ok;
+            }
+            let Ok(name) = entry.name() else {
+                return TreeWalkResult::Ok;
+            };
+            let full = format!("{dir}{name}");
+            if doomed.contains(full.as_str()) {
+                through_doomed.insert(entry.id());
+            } else {
+                through_survivors.insert(entry.id());
+            }
+            TreeWalkResult::Ok
+        })
+        .map_err(git_err)?;
+    }
+    Ok(through_doomed
+        .difference(&through_survivors)
+        .copied()
+        .collect())
+}
+
+/// Build a replacement repository containing the same history minus `doomed`.
+fn build_replacement(
+    repo: &Repository,
+    scratch: &Path,
+    doomed: &HashSet<&str>,
+    objects_before: usize,
+    doomed_blobs: &HashSet<Oid>,
+) -> WikiResult<GitPurgeReport> {
+    std::fs::create_dir_all(scratch).map_err(|e| io_err("creating scratch directory", e))?;
+    let new_repo = Repository::init(scratch).map_err(git_err)?;
+
+    let mut walk = repo.revwalk().map_err(git_err)?;
+    walk.push_glob("refs/*").map_err(git_err)?;
+    if repo.head().is_ok() {
+        let _ = walk.push_head();
+    }
+    // Oldest first: a commit can only be rebuilt once its parents have new ids.
+    walk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::REVERSE)
+        .map_err(git_err)?;
+
+    let mut remapped: HashMap<Oid, Oid> = HashMap::new();
+    let mut commits_rewritten = 0usize;
+    let mut last_new = None;
+
+    for oid in walk {
+        let oid = oid.map_err(git_err)?;
+        let commit = repo.find_commit(oid).map_err(git_err)?;
+        let tree = commit.tree().map_err(git_err)?;
+        let new_tree_oid = copy_tree_without(repo, &new_repo, &tree, "", doomed)?;
+        let new_tree = new_repo.find_tree(new_tree_oid).map_err(git_err)?;
+
+        let parents: Vec<_> = commit
+            .parent_ids()
+            .filter_map(|p| remapped.get(&p).copied())
+            .collect();
+        let parent_commits: Vec<_> = parents
+            .iter()
+            .map(|p| new_repo.find_commit(*p))
+            .collect::<Result<_, _>>()
+            .map_err(git_err)?;
+        let parent_refs: Vec<&git2::Commit<'_>> = parent_commits.iter().collect();
+
+        let new_oid = new_repo
+            .commit(
+                None,
+                &commit.author(),
+                &commit.committer(),
+                commit.message().unwrap_or(""),
+                &new_tree,
+                &parent_refs,
+            )
+            .map_err(git_err)?;
+        remapped.insert(oid, new_oid);
+        last_new = Some(new_oid);
+        commits_rewritten += 1;
+    }
+
+    // Point the rebuilt repo's HEAD branch at the rewritten tip. Reflogs are
+    // not carried over: a fresh repository starts with none, which is precisely
+    // the property that makes the old versions unrecoverable.
+    if let Some(tip) = last_new {
+        let branch = repo
+            .head()
+            .ok()
+            .and_then(|h| h.shorthand().ok().map(str::to_owned))
+            .unwrap_or_else(|| "main".to_string());
+        new_repo
+            .reference(
+                &format!("refs/heads/{branch}"),
+                tip,
+                true,
+                "ai-memory history purge",
+            )
+            .map_err(git_err)?;
+        new_repo
+            .set_head(&format!("refs/heads/{branch}"))
+            .map_err(git_err)?;
+    }
+
+    let objects_after = count_objects(&new_repo)?;
+    debug!(
+        commits_rewritten,
+        objects_before,
+        objects_after,
+        doomed_blobs = doomed_blobs.len(),
+        "replacement repository built"
+    );
+    Ok(GitPurgeReport {
+        commits_rewritten,
+        objects_before,
+        objects_after,
+        blobs_destroyed: 0,
+        repositories_rebuilt: 0,
+    })
+}
+
+/// Copy `tree` into `dest`, omitting any entry whose full path is doomed.
+fn copy_tree_without(
+    src: &Repository,
+    dest: &Repository,
+    tree: &git2::Tree<'_>,
+    prefix: &str,
+    doomed: &HashSet<&str>,
+) -> WikiResult<Oid> {
+    let mut builder = dest.treebuilder(None).map_err(git_err)?;
+    for entry in tree.iter() {
+        let Ok(name) = entry.name() else { continue };
+        let full = format!("{prefix}{name}");
+        match entry.kind() {
+            Some(git2::ObjectType::Tree) => {
+                let subtree = src.find_tree(entry.id()).map_err(git_err)?;
+                let sub_prefix = format!("{full}/");
+                let new_sub = copy_tree_without(src, dest, &subtree, &sub_prefix, doomed)?;
+                // Drop directories that became empty, so a purge cannot leave
+                // an empty shell where a session's pages used to live.
+                let new_tree = dest.find_tree(new_sub).map_err(git_err)?;
+                if new_tree.iter().count() > 0 {
+                    builder
+                        .insert(name, new_sub, entry.filemode())
+                        .map_err(git_err)?;
+                }
+            }
+            Some(git2::ObjectType::Blob) => {
+                if doomed.contains(full.as_str()) {
+                    continue;
+                }
+                let blob = src.find_blob(entry.id()).map_err(git_err)?;
+                let new_id = dest.blob(blob.content()).map_err(git_err)?;
+                builder
+                    .insert(name, new_id, entry.filemode())
+                    .map_err(git_err)?;
+            }
+            // Submodules and anything else are carried by id; the wiki never
+            // creates them, so this is a pass-through rather than a policy.
+            _ => {
+                builder
+                    .insert(name, entry.id(), entry.filemode())
+                    .map_err(git_err)?;
+            }
+        }
+    }
+    builder.write().map_err(git_err)
+}
+
+/// Fail closed unless the rebuilt repository provably lacks the purged content.
+///
+/// Two independent checks, because either alone can pass while the deletion is
+/// incomplete: a path check would miss a blob still present under a different
+/// name, and an object check would miss a path re-added by a later commit.
+fn verify_replacement(
+    scratch: &Path,
+    doomed: &HashSet<&str>,
+    doomed_blobs: &HashSet<Oid>,
+) -> WikiResult<()> {
+    let repo = Repository::open(scratch).map_err(git_err)?;
+
+    // 1. No commit in the rebuilt history may still contain a purged path.
+    let mut walk = repo.revwalk().map_err(git_err)?;
+    walk.push_glob("refs/*").map_err(git_err)?;
+    if repo.head().is_ok() {
+        let _ = walk.push_head();
+    }
+    for oid in walk {
+        let oid = oid.map_err(git_err)?;
+        let commit = repo.find_commit(oid).map_err(git_err)?;
+        let tree = commit.tree().map_err(git_err)?;
+        let mut offending = None;
+        tree.walk(TreeWalkMode::PreOrder, |dir, entry| {
+            let Ok(name) = entry.name() else {
+                return TreeWalkResult::Ok;
+            };
+            let full = format!("{dir}{name}");
+            if doomed.contains(full.as_str()) {
+                offending = Some(full);
+                return TreeWalkResult::Abort;
+            }
+            TreeWalkResult::Ok
+        })
+        .map_err(git_err)?;
+        if let Some(path) = offending {
+            return Err(purge_err(format!(
+                "git purge: rebuilt history still contains {path} at commit {oid}"
+            )));
+        }
+    }
+
+    // 2. No object that existed only through a purged path may survive —
+    //    including as a dangling object no ref points at.
+    let odb = repo.odb().map_err(git_err)?;
+    let mut survivor = None;
+    odb.foreach(|oid| {
+        if doomed_blobs.contains(oid) {
+            survivor = Some(*oid);
+            return false;
+        }
+        true
+    })
+    .map_err(git_err)?;
+    if let Some(oid) = survivor {
+        return Err(purge_err(format!(
+            "git purge: rebuilt object database still contains purged blob {oid}"
+        )));
+    }
+    Ok(())
+}
+
+/// Paths of any purge scratch directory left inside `root`.
+///
+/// The contract is that none remain after a successful purge, so this exists to
+/// let callers and tests assert it rather than assume it.
+#[must_use]
+pub fn leftover_scratch_dirs(root: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with(SCRATCH_PREFIX))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use git2::{Repository, Signature};
+
+    /// Canaries are unique strings, so finding one anywhere in the object
+    /// database is unambiguous evidence the deletion failed.
+    const DOOMED_CANARY: &str = "doomed-canary-4b7e91";
+    const KEPT_CANARY: &str = "kept-canary-2f8c03";
+
+    struct Fixture {
+        _tmp: tempfile::TempDir,
+        root: PathBuf,
+    }
+
+    fn commit(repo: &Repository, root: &Path, files: &[(&str, &str)], message: &str) {
+        for (path, body) in files {
+            let abs = root.join(path);
+            if let Some(parent) = abs.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&abs, body).unwrap();
+        }
+        let mut index = repo.index().unwrap();
+        index
+            .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        let sig = Signature::now("t", "t@example.com").unwrap();
+        let parents: Vec<git2::Commit<'_>> = repo
+            .head()
+            .ok()
+            .and_then(|h| h.target())
+            .and_then(|oid| repo.find_commit(oid).ok())
+            .into_iter()
+            .collect();
+        let parent_refs: Vec<&git2::Commit<'_>> = parents.iter().collect();
+        repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parent_refs)
+            .unwrap();
+    }
+
+    /// A repo whose history contains the doomed page in several versions, plus
+    /// an unrelated page that must survive untouched.
+    fn fixture() -> Fixture {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().join("wiki");
+        std::fs::create_dir_all(&root).unwrap();
+        let repo = Repository::init(&root).unwrap();
+        commit(
+            &repo,
+            &root,
+            &[
+                ("sessions/doomed.md", &format!("v1 {DOOMED_CANARY}")),
+                ("notes/keep.md", &format!("v1 {KEPT_CANARY}")),
+            ],
+            "first",
+        );
+        commit(
+            &repo,
+            &root,
+            &[("sessions/doomed.md", &format!("v2 {DOOMED_CANARY} more"))],
+            "second",
+        );
+        commit(
+            &repo,
+            &root,
+            &[("notes/keep.md", &format!("v2 {KEPT_CANARY} more"))],
+            "third",
+        );
+        Fixture { _tmp: tmp, root }
+    }
+
+    /// Search EVERY object in the database, reachable or not, for a canary.
+    /// This is the check that distinguishes real deletion from unreferencing:
+    /// a reachability-based search passes while dangling copies survive.
+    fn canary_in_any_object(root: &Path, canary: &str) -> bool {
+        let repo = Repository::open(root).unwrap();
+        let odb = repo.odb().unwrap();
+        let mut found = false;
+        odb.foreach(|oid| {
+            if let Ok(obj) = odb.read(*oid)
+                && obj.kind() == git2::ObjectType::Blob
+                && String::from_utf8_lossy(obj.data()).contains(canary)
+            {
+                found = true;
+                return false;
+            }
+            true
+        })
+        .unwrap();
+        found
+    }
+
+    #[test]
+    fn purge_destroys_every_historical_version_of_the_path() {
+        let fx = fixture();
+        assert!(canary_in_any_object(&fx.root, DOOMED_CANARY));
+
+        let report =
+            purge_paths_from_history(&fx.root, &["sessions/doomed.md".to_string()]).unwrap();
+
+        assert_eq!(report.repositories_rebuilt, 1);
+        assert_eq!(
+            report.commits_rewritten, 3,
+            "history is preserved, not squashed"
+        );
+        assert_eq!(
+            report.blobs_destroyed, 2,
+            "both versions of the doomed page must be destroyed"
+        );
+        assert!(
+            !canary_in_any_object(&fx.root, DOOMED_CANARY),
+            "the doomed canary must not survive in ANY object, reachable or not"
+        );
+        assert!(
+            canary_in_any_object(&fx.root, KEPT_CANARY),
+            "the unrelated page must survive"
+        );
+    }
+
+    #[test]
+    fn purge_leaves_no_scratch_or_retired_directory_behind() {
+        let fx = fixture();
+        purge_paths_from_history(&fx.root, &["sessions/doomed.md".to_string()]).unwrap();
+        assert_eq!(
+            leftover_scratch_dirs(&fx.root),
+            Vec::<PathBuf>::new(),
+            "no quarantine copy, .bak, or swap directory may remain"
+        );
+        assert!(
+            !fx.root.join(JOURNAL_NAME).exists(),
+            "the journal must be removed once the purge is complete"
+        );
+    }
+
+    #[test]
+    fn purge_preserves_history_and_the_surviving_pages_content() {
+        let fx = fixture();
+        purge_paths_from_history(&fx.root, &["sessions/doomed.md".to_string()]).unwrap();
+
+        let repo = Repository::open(&fx.root).unwrap();
+        let mut walk = repo.revwalk().unwrap();
+        walk.push_head().unwrap();
+        let commits: Vec<_> = walk.map(|o| o.unwrap()).collect();
+        assert_eq!(commits.len(), 3, "commit history survives the rewrite");
+
+        // The surviving page keeps BOTH of its versions: a purge must not cost
+        // unrelated pages their history.
+        let head = repo.head().unwrap().peel_to_commit().unwrap();
+        let tree = head.tree().unwrap();
+        let entry = tree.get_path(Path::new("notes/keep.md")).unwrap();
+        let blob = repo.find_blob(entry.id()).unwrap();
+        assert!(String::from_utf8_lossy(blob.content()).contains("v2"));
+        assert!(tree.get_path(Path::new("sessions/doomed.md")).is_err());
+    }
+
+    /// A blob shared with a surviving path must NOT be destroyed: git stores
+    /// one object for identical content, so removing it would corrupt the page
+    /// that legitimately keeps it.
+    #[test]
+    fn purge_spares_a_blob_shared_with_a_surviving_page() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().join("wiki");
+        std::fs::create_dir_all(&root).unwrap();
+        let repo = Repository::init(&root).unwrap();
+        let shared = "identical body shared by two pages";
+        commit(
+            &repo,
+            &root,
+            &[("sessions/doomed.md", shared), ("notes/keep.md", shared)],
+            "shared content",
+        );
+
+        let report = purge_paths_from_history(&root, &["sessions/doomed.md".to_string()]).unwrap();
+        assert_eq!(
+            report.blobs_destroyed, 0,
+            "a blob the surviving page also uses must be spared"
+        );
+        let repo = Repository::open(&root).unwrap();
+        let tree = repo
+            .head()
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .tree()
+            .unwrap();
+        assert!(tree.get_path(Path::new("sessions/doomed.md")).is_err());
+        let kept = tree.get_path(Path::new("notes/keep.md")).unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(repo.find_blob(kept.id()).unwrap().content()),
+            shared,
+            "the surviving page must still resolve its content"
+        );
+    }
+
+    /// Directories emptied by the purge must not survive as shells.
+    #[test]
+    fn purge_drops_directories_it_empties() {
+        let fx = fixture();
+        purge_paths_from_history(&fx.root, &["sessions/doomed.md".to_string()]).unwrap();
+        let repo = Repository::open(&fx.root).unwrap();
+        let tree = repo
+            .head()
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .tree()
+            .unwrap();
+        assert!(
+            tree.get_path(Path::new("sessions")).is_err(),
+            "the emptied directory must be gone, not left as an empty tree"
+        );
+    }
+
+    #[test]
+    fn purging_nothing_is_a_no_op() {
+        let fx = fixture();
+        let report = purge_paths_from_history(&fx.root, &[]).unwrap();
+        assert_eq!(report, GitPurgeReport::default());
+        assert!(canary_in_any_object(&fx.root, DOOMED_CANARY));
+    }
+
+    /// A crash after the old `.git` was moved aside must converge on the
+    /// purged state, not leave the wiki without a repository.
+    #[test]
+    fn recovery_finishes_a_swap_interrupted_after_the_old_repo_moved() {
+        let fx = fixture();
+        let repo = Repository::open(&fx.root).unwrap();
+        let doomed: HashSet<&str> = ["sessions/doomed.md"].into_iter().collect();
+        let objects_before = count_objects(&repo).unwrap();
+        let doomed_blobs = blobs_reachable_only_through(&repo, &doomed).unwrap();
+        let purge_id = "deadbeefdeadbeef".to_string();
+        let scratch = fx.root.join(format!("{SCRATCH_PREFIX}new-{purge_id}"));
+        let retired = fx.root.join(format!("{SCRATCH_PREFIX}old-{purge_id}"));
+        build_replacement(&repo, &scratch, &doomed, objects_before, &doomed_blobs).unwrap();
+        drop(repo);
+
+        // Simulate the crash: journal says Swapping, old .git moved aside,
+        // replacement not yet installed.
+        write_journal(
+            &fx.root,
+            &PurgeJournal {
+                purge_id,
+                paths: vec!["sessions/doomed.md".to_string()],
+                state: JournalState::Swapping,
+            },
+        )
+        .unwrap();
+        std::fs::rename(fx.root.join(".git"), &retired).unwrap();
+
+        assert!(recover_interrupted_purge(&fx.root).unwrap());
+
+        assert!(
+            fx.root.join(".git").exists(),
+            "the wiki must have a repo again"
+        );
+        assert!(
+            !canary_in_any_object(&fx.root, DOOMED_CANARY),
+            "recovery must converge on the PURGED state, not restore the old history"
+        );
+        assert_eq!(leftover_scratch_dirs(&fx.root), Vec::<PathBuf>::new());
+        assert!(!fx.root.join(JOURNAL_NAME).exists());
+    }
+
+    /// A crash before anything destructive happened discards the unverified
+    /// replacement and leaves the live repository intact.
+    #[test]
+    fn recovery_rolls_back_a_purge_interrupted_before_the_swap() {
+        let fx = fixture();
+        let scratch = fx.root.join(format!("{SCRATCH_PREFIX}new-abc123"));
+        std::fs::create_dir_all(&scratch).unwrap();
+        write_journal(
+            &fx.root,
+            &PurgeJournal {
+                purge_id: "abc123".to_string(),
+                paths: vec!["sessions/doomed.md".to_string()],
+                state: JournalState::Prepared,
+            },
+        )
+        .unwrap();
+
+        assert!(recover_interrupted_purge(&fx.root).unwrap());
+        assert_eq!(leftover_scratch_dirs(&fx.root), Vec::<PathBuf>::new());
+        assert!(!fx.root.join(JOURNAL_NAME).exists());
+        assert!(
+            canary_in_any_object(&fx.root, DOOMED_CANARY),
+            "an unverified replacement must not be installed by recovery"
+        );
+    }
+
+    #[test]
+    fn recovery_is_a_no_op_without_a_journal() {
+        let fx = fixture();
+        assert!(!recover_interrupted_purge(&fx.root).unwrap());
+    }
+}

--- a/crates/ai-memory-wiki/src/lib.rs
+++ b/crates/ai-memory-wiki/src/lib.rs
@@ -9,6 +9,7 @@ pub mod admission;
 mod atomic;
 mod error;
 mod git;
+pub mod git_purge;
 pub mod log_purge;
 mod markdown;
 pub mod migrations;

--- a/crates/ai-memory-wiki/src/lib.rs
+++ b/crates/ai-memory-wiki/src/lib.rs
@@ -9,6 +9,7 @@ pub mod admission;
 mod atomic;
 mod error;
 mod git;
+pub mod log_purge;
 mod markdown;
 pub mod migrations;
 mod watcher;

--- a/crates/ai-memory-wiki/src/log_purge.rs
+++ b/crates/ai-memory-wiki/src/log_purge.rs
@@ -1,0 +1,115 @@
+//! Removal of one session's monthly-log entries (#387).
+//!
+//! Lives here rather than beside the appender because the monthly log is a file
+//! in the wiki tree, and both the hook ingress (which writes entries) and the
+//! admin route (which purges them) depend on this crate — putting it here keeps
+//! the marker format and the removal that keys on it in one place, and avoids
+//! making the transport crate depend on the ingress crate.
+
+use ai_memory_core::{ProjectId, SessionId, WorkspaceId};
+
+use crate::Wiki;
+
+/// Marker that attributes a log line to its session (#387).
+///
+/// An HTML comment so it is invisible in every markdown renderer while staying
+/// exact: a purge removes the lines whose marker matches its session id, and
+/// never guesses from the human-readable text. Lines written before this
+/// existed carry no marker and are deliberately NOT removable by inference —
+/// see [`purge_session_lines`].
+const SESSION_MARKER_PREFIX: &str = "<!-- ai-memory:session=";
+
+/// The exact marker string a log entry for `session_id` carries.
+#[must_use]
+pub fn session_marker(session_id: SessionId) -> String {
+    format!("{SESSION_MARKER_PREFIX}{session_id} -->")
+}
+
+/// Outcome of removing one session's entries from the monthly logs.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LogPurgeOutcome {
+    /// Attributed lines removed because they belong to the purged session.
+    pub removed: usize,
+    /// Monthly log files that still hold entries written before per-entry
+    /// provenance existed. Those lines cannot be attributed to any session, so
+    /// they are neither removed nor claimed to be clean.
+    ///
+    /// Text search is explicitly not a fallback: matching a log line because it
+    /// mentions something the session also mentioned would delete other
+    /// sessions' entries and still miss this one's.
+    pub unattributed_files: Vec<String>,
+}
+
+/// Remove every log entry attributed to `session_id` from a project's monthly
+/// logs (#387).
+///
+/// With `force`, a file that still contains unattributed legacy entries is
+/// removed whole — the monthly log is the retention unit, so this is the only
+/// way to guarantee the session left nothing behind, at the cost of other
+/// sessions' entries for that month. Without it, such files are reported in
+/// [`LogPurgeOutcome::unattributed_files`] and left intact.
+///
+/// # Errors
+/// Returns any filesystem error other than a missing project directory.
+pub fn purge_session_lines(
+    wiki: &Wiki,
+    workspace_id: WorkspaceId,
+    project_id: ProjectId,
+    session_id: SessionId,
+    force: bool,
+) -> std::io::Result<LogPurgeOutcome> {
+    let root = wiki.project_root(workspace_id, project_id);
+    let mut outcome = LogPurgeOutcome::default();
+    let entries = match std::fs::read_dir(&root) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(outcome),
+        Err(e) => return Err(e),
+    };
+    let marker = session_marker(session_id);
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let is_log = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("log-") && n.ends_with(".md"));
+        if !is_log {
+            continue;
+        }
+        let body = std::fs::read_to_string(&path)?;
+        let mut kept = String::with_capacity(body.len());
+        let mut removed = 0usize;
+        let mut unattributed = false;
+        for line in body.lines() {
+            if line.contains(&marker) {
+                removed += 1;
+                continue;
+            }
+            // Only entry headers carry provenance; continuation lines belong to
+            // whichever entry precedes them.
+            if line.starts_with("## [") && !line.contains(SESSION_MARKER_PREFIX) {
+                unattributed = true;
+            }
+            kept.push_str(line);
+            kept.push('\n');
+        }
+        if unattributed {
+            if force {
+                std::fs::remove_file(&path)?;
+                outcome.removed += removed;
+                continue;
+            }
+            outcome.unattributed_files.push(
+                path.file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+        }
+        if removed > 0 {
+            std::fs::write(&path, kept)?;
+            outcome.removed += removed;
+        }
+    }
+    outcome.unattributed_files.sort_unstable();
+    Ok(outcome)
+}

--- a/crates/ai-memory-wiki/src/wiki.rs
+++ b/crates/ai-memory-wiki/src/wiki.rs
@@ -408,6 +408,7 @@ impl Wiki {
         let id = self
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id,
                 project_id,
                 path,
@@ -1033,6 +1034,7 @@ impl Wiki {
         let entities = parse_entities(&path, &markdown.frontmatter)?;
         let emitted = emit(&markdown)?;
         let page = NewPage {
+            source_session_id: None,
             workspace_id,
             project_id,
             path: path.clone(),
@@ -1145,6 +1147,7 @@ impl Wiki {
         let id = self
             .writer
             .upsert_page(NewPage {
+                source_session_id: None,
                 workspace_id,
                 project_id,
                 path,
@@ -1423,6 +1426,7 @@ impl Wiki {
                 .iter()
                 .map(|(req, _, _, _)| {
                     Ok(ai_memory_core::NewPage {
+                        source_session_id: req.source_session_id,
                         workspace_id: req.workspace_id,
                         project_id: req.project_id,
                         path: req.path.clone(),
@@ -1490,6 +1494,7 @@ impl Wiki {
     /// Returns [`WikiError`] for any filesystem, parsing, or store error.
     pub async fn write_page(&self, req: WritePageRequest) -> WikiResult<PageId> {
         let WritePageRequest {
+            source_session_id,
             workspace_id,
             project_id,
             path,
@@ -1586,6 +1591,7 @@ impl Wiki {
             match self
                 .writer
                 .upsert_page(NewPage {
+                    source_session_id,
                     workspace_id,
                     project_id,
                     path,
@@ -1651,6 +1657,15 @@ impl Wiki {
 /// identity (`workspace_id`, `project_id`, `path`) plus body & metadata.
 #[derive(Debug, Clone)]
 pub struct WritePageRequest {
+    /// Session this page's content was derived from, when it was derived from
+    /// exactly one (#387). Propagates to `pages.source_session_id` so
+    /// `purge-session` can find multi-page consolidation output, whose paths
+    /// are arbitrary and therefore not resolvable by identity any other way.
+    ///
+    /// `None` means "not declared by this write": the store carries an existing
+    /// page's provenance forward, so the many internal callers that leave this
+    /// unset (lint rewriters, hand edits, the watcher) cannot strip it.
+    pub source_session_id: Option<ai_memory_core::SessionId>,
     /// Owning workspace.
     pub workspace_id: WorkspaceId,
     /// Owning project.
@@ -2187,6 +2202,7 @@ mod tests {
         fm: serde_json::Value,
     ) -> WritePageRequest {
         WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new(path).unwrap(),
@@ -3145,6 +3161,7 @@ mod tests {
         let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
         let batch: Vec<_> = (0..5)
             .map(|i| WritePageRequest {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: proj,
                 path: PagePath::new(format!("batch/{i}.md")).unwrap(),
@@ -3308,6 +3325,7 @@ mod tests {
 
         let ids = wiki
             .apply_batch(vec![WritePageRequest {
+                source_session_id: None,
                 workspace_id: ws,
                 project_id: proj,
                 path: PagePath::new("batch/admitted.md").unwrap(),
@@ -3465,6 +3483,7 @@ mod tests {
         let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
 
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj_a,
             path: PagePath::new("decisions/foo.md").unwrap(),
@@ -3481,6 +3500,7 @@ mod tests {
         .unwrap();
 
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj_b,
             path: PagePath::new("decisions/foo.md").unwrap(),
@@ -3601,6 +3621,7 @@ mod tests {
             .with_store_reader(store.reader.clone());
 
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("notes/x.md").unwrap(),
@@ -3751,6 +3772,7 @@ mod tests {
             .unwrap();
 
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("notes/note.md").unwrap(),
@@ -3807,6 +3829,7 @@ mod tests {
             .unwrap();
 
         wiki.write_page(WritePageRequest {
+            source_session_id: None,
             workspace_id: ws,
             project_id: proj,
             path: PagePath::new("notes/anon.md").unwrap(),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -425,9 +425,9 @@ lint                 curator              auto-improve-report
 auto-improve         finalize-session     pending-writes
 embed                generate-auth-token  setup-agent
 bootstrap            install-instructions install-skills
-reorg                purge-project        rename-project
-move-project         uninstall            auth
-user                 completions
+reorg                purge-project        purge-session
+rename-project       move-project         uninstall
+auth                 user                 completions
 ```
 
 Run `ai-memory --help` for the full tree.

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -9,6 +9,7 @@ on a homelab box where mistakes are harder to undo.
 | Command | Safe with server **running**? | Wipes data? | Reversible? | Notes |
 |---|---|---|---|---|
 | `purge-project --confirm` | ✅ yes | the one project's data | no | Deletes the UUID-namespaced wiki root and raw workstream segments; sibling projects remain untouched. Refuses with `409` while a managed workstream under the project holds a live run lease — `--force` overrides. |
+| `purge-session --session-id --confirm` | ✅ yes | one session and everything derived from it | no | Removes the session, its observations and both FTS indexes, its handoffs, queued consolidation, auto-improvement runs/proposals/events/rejections, every version of its derived pages, and the wiki files. Leaves only a content-free tombstone. Refuses with `409` while the session is open or has work in flight — `--force` overrides. |
 | `rename-project --from --to` | ✅ yes | no | yes (rename back) | Column-only update on `projects.name`. The on-disk dir is keyed by `project_id` (UUID), so the rename never moves a file. |
 | `/admin/rename-workspace` | ✅ yes | no | yes (rename back) | Column-only update on `workspaces.name`; refreshes `_meta.md` scope manifests and checkpoints the wiki tree. |
 | `/admin/delete-workspace` | ✅ yes | the workspace and every child project | no | Runs `purge_workspace` admission first, deletes SQLite rows in one cascade, removes the UUID-keyed workspace directory and managed-workstream raw segments, reports filesystem partial failures, and dispatches mirror notification after durable work. |
@@ -125,6 +126,70 @@ Why this is safe with the server running:
   watcher even mid-write - at worst the watcher emits delete
   events for files we just removed, which it ignores (no DB row
   to reindex).
+
+### `purge-session`
+
+```bash
+ai-memory purge-session \
+    --workspace default --project acme-api \
+    --session-id 11111111-1111-4111-8111-111111111111 \
+    --confirm
+```
+
+Strong deletion of **one** session, for when an application has promised
+"forget this conversation" and has to be able to keep that promise. Where
+`purge-project` is too broad and `delete-page` removes only one wiki path, this
+removes a session across every layer ai-memory administers.
+
+**What it removes**
+
+- the `sessions` row, its `observations`, and both external-content FTS indexes
+- handoffs the session produced *or* accepted (both links are `ON DELETE SET
+  NULL`, so the rows are deleted explicitly rather than orphaned)
+- queued SessionEnd consolidation jobs and auto-improvement scheduler claims
+- auto-improvement runs, proposals, proposal events, and rejections derived
+  from it, including their reasons, summaries, and evidence
+- every version of each derived page — the heuristic `sessions/<uuid>.md`, its
+  LLM rewrites, and multi-page consolidation output — plus the wiki files
+- entities left with no remaining page links
+
+**How targets are chosen.** Only by identity: the session UUID, a foreign key,
+or the deterministic `sessions/<uuid>.md` path. Never by searching page text —
+a deletion that guessed would both miss content and remove innocent pages. Page
+provenance is structural (`pages.source_session_id`) and sticky: a rewrite that
+declares no provenance inherits the superseded version's, so an LLM rewrite or
+a hand edit cannot launder a page out of the purge's reach.
+
+**Safety rules**
+
+- Root-only, like every `/admin/*` route once the first user exists.
+- `--confirm` is mandatory.
+- The full UUID is required. A prefix of a real session id is refused with
+  `422`, because this operation is irreversible and must never guess.
+- A session id that exists in a *different* project reads exactly like "no such
+  session" (`404`), so the response cannot be used to probe another project.
+- Idempotent: a second call returns `already_purged` with the original
+  tombstone and zero counts, and does not fail on the absence of what the first
+  call removed.
+- Refuses with `409` while the session is open, a consolidation is queued or
+  running, or an auto-improvement claim is outstanding. `--force` overrides.
+
+**The tombstone.** The only permitted residue: scope, session UUID, purge time,
+schema version, and an audit-log id. No title, path, body, or count — a
+tombstone that quoted the session would defeat the deletion it records. It is
+what stops a late spooled event from a client that was offline during the purge
+from recreating the session.
+
+**`backup_cutoff`.** The receipt reports the purge instant. Snapshots taken
+before it still contain the purged content and should be invalidated by
+whatever rotates your backups; ai-memory does not operate that system.
+
+**Out of scope.** Managed workstreams are not touched. Their
+`native_session_id` columns are free text with no foreign key to `sessions.id`,
+so matching a purge against them by coincidence of value would delete unrelated
+history. That needs the composite `(workstream_id, agent_kind,
+native_session_id)` identity and a separate API. Histories kept by Claude Code,
+Codex, OpenCode, or any other harness are likewise outside ai-memory's control.
 
 ### `rename-project`
 

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -199,6 +199,41 @@ If the history rebuild fails, the receipt carries a loud
 `GIT HISTORY NOT PURGED` warning: the rows are already gone, but earlier page
 versions remain recoverable until you re-run the command.
 
+**The database files.** Deleting rows is not enough to make the bytes go away,
+and each of these was found by searching the data directory for a purged canary
+rather than by querying for it:
+
+- **FTS5 index segments.** An FTS5 delete is *logical*: it writes a delete
+  marker and leaves the original terms in the existing segments. `MATCH`
+  correctly returns nothing while the purged text stays readable in
+  `pages_fts_data` / `observations_fts_data`. The indexes are rebuilt from
+  their content tables.
+- **The write-ahead log.** Until a checkpoint runs, the deleted rows remain
+  readable in `memory.sqlite-wal`, beside the database and ready to be copied
+  into the next backup.
+- **Freed pages.** `secure_delete` zeroes content as the delete proceeds, and a
+  vacuum reclaims pages freed by earlier writes.
+
+If any of these cannot complete, the purge logs a warning rather than failing:
+the rows are genuinely deleted, and refusing the whole operation over an
+incomplete vacuum would leave you worse off.
+
+**Shared files and commit messages.** The monthly log belongs to every session
+that wrote that month, so its path is kept and each historical version is
+rewritten with only the purged session's marked lines removed. Commit messages
+embed the session's own prompt text, so commits attributed to it are redacted,
+matched by its short-id handle rather than by searching text.
+
+**Restore and reindex.** A snapshot taken before a purge contains everything
+that purge removed. `restore` therefore reads the tombstone ledger *before* the
+overwrite destroys it, reapplies it to the restored state, and **fails closed**
+if any purged session survives — a restore that cannot prove the ledger holds
+is not a safe restoration. Restoring into a fresh directory has no ledger of its
+own, so pass `--tombstones-from <path>` pointing at the directory that holds the
+current one. `reindex` drops pages the ledger covers by their deterministic
+`sessions/<uuid>.md` identity, because markdown rebuilt from disk cannot carry
+the relational provenance a purge relies on.
+
 **The tombstone.** The only permitted residue: scope, session UUID, purge time,
 schema version, and an audit-log id. No title, path, body, or count — a
 tombstone that quoted the session would defeat the deletion it records. It is

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -174,6 +174,31 @@ a hand edit cannot launder a page out of the purge's reach.
 - Refuses with `409` while the session is open, a consolidation is queued or
   running, or an auto-improvement claim is outstanding. `--force` overrides.
 
+**Git history.** Removing the file and committing would leave every earlier
+version reachable, and `restore-page` would hand one back. So the wiki
+repository is rebuilt without those paths and the old object database is
+physically destroyed — the content is gone from the ODB itself, not merely
+unreferenced. Properties worth knowing:
+
+- **History is preserved, not squashed.** Every commit is carried over minus
+  the purged paths; unrelated pages keep their full version history.
+- **Shared blobs are spared.** git stores one object for identical content, so
+  a blob a surviving page also uses is never destroyed.
+- **Verification precedes destruction.** The rebuilt repository is checked
+  against both the purged paths and the object database *before* the swap; a
+  failed check leaves the live repository exactly as it was.
+- **Interrupted swaps converge.** A durable journal is written across the swap
+  and resolved at the next startup, before the wiki is opened for business. If
+  the rebuilt repository was lost mid-swap, the old one is restored and the
+  server refuses to start until the purge is re-run — it will not quietly serve
+  content it claimed to have deleted.
+- **No residue.** No quarantine copy, `.bak`, old pack, or swap directory
+  remains in the data dir.
+
+If the history rebuild fails, the receipt carries a loud
+`GIT HISTORY NOT PURGED` warning: the rows are already gone, but earlier page
+versions remain recoverable until you re-run the command.
+
 **The tombstone.** The only permitted residue: scope, session UUID, purge time,
 schema version, and an audit-log id. No title, path, body, or count — a
 tombstone that quoted the session would defeat the deletion it records. It is


### PR DESCRIPTION
**Draft — not for 1.27.0.** Held back pending a production-scale test; see "Before this merges" below. Stacked on #398.

## What changed

Implements #387: `ai-memory purge-session` and `POST /admin/purge-session`, so an application that promises "forget this conversation" can keep that promise. Five commits, following the staging the issue itself asked for.

**Stage A — core + provenance.** Migration V50 adds a content-free tombstone ledger and FK-free `source_session_id` columns. Everything that identifies derived content (`auto_improve_runs.session_id`, `rejections.source_run_id`/`.source_proposal_id`) is `ON DELETE SET NULL`, so deleting the session first destroys the evidence — targets are collected before anything is cut, by identity only, never by searching page text.

**Stage B — no way back in.** `410 {"code":"session_purged","terminal":true}` on ingest, a `Terminal` drainer outcome that drops the spool entry without spending a retry, a local spool sweep by exact identity, and per-entry session markers in the monthly log.

**Stage C — git strong deletion.** Deleting a file and committing leaves every prior version reachable, and `restore-page` hands one back. The repository is rebuilt without those paths and the old object database physically destroyed. History is preserved (not squashed), blobs shared with surviving pages are spared, verification runs before anything destructive, and an interrupted swap converges from a durable journal at startup.

**Stage D — files, not just tables.** FTS5 deletes are *logical*: they write a delete marker and leave the original terms in the index segments, so `MATCH` returned nothing while the purged text stayed readable in `pages_fts_data`. Plus WAL checkpointing and page reclamation. Restore reapplies the tombstone ledger and fails closed; reindex drops tombstoned pages.

## What the verification found

Three bugs that unit tests structurally could not reach:

1. **FTS5 logical deletes** — every relational assertion passed while the content sat on disk. Caught by searching *files* for a canary rather than querying tables.
2. **Historical versions of the shared monthly log** — the current file was scrubbed, earlier committed versions were not.
3. **Commit messages** — they embed the session's own prompt text and were carried into the rebuilt history verbatim.

The last two were found only by running the purge end-to-end against a live server; the fixtures used generic commit messages and had no shared files.

## Verified live

Canary absent from 0 DB layers, 0 files, and **0 git objects** (all objects, reachable or not) while the sibling session stayed intact in all five layers. `410` on replay without resurrection, `already_purged` on repeat with a stable tombstone, 401/401/400/422 across the authz matrix, no prompt content in any server log. V50 applies cleanly to a genuine v1.26.1 database (49 → 50, all rows preserved), and a legacy pre-V50 session purges via the deterministic path fallback while its provenance-less log correctly refuses to guess until `--force`.

## Before this merges

- [ ] **Production-scale test.** The purge runs *synchronously inside the admin HTTP request* and rebuilds the entire wiki repository commit-by-commit plus `VACUUM`s the database. Fixtures had 3 commits. A production instance with ~2000 sessions and ~5000 page versions is untested — if it exceeds the HTTP timeout, the git rebuild likely needs to move off the request path, which is a design change better made before the API ships.
- [ ] **Remaining E2E gaps**, covered by unit tests but not stitched into the combined flow: LLM-simulated single/multi-page consolidation, auto-improve artifacts and sidecars, spool SHA-256 comparison, tarball extraction and inspection.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `TAILWIND_SKIP=1 cargo test --workspace` — 2428 tests
- [x] `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- [x] `tests/hooks/test_lib.sh` — 44 passed; companion importer — 11 passed
- [x] Live end-to-end against a running server

## CHANGELOG

- [x] `[Unreleased]` entries under `Added`, referencing #387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)