### PR TITLE
feat: move-session admin command and route (transactional, dry-run first)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when its page needs nothing), and the batch form enumerates sessions with a `sessions` row in
   the source OR observations stamped into it, so a phantom project holding
   only observations of sessions rooted elsewhere can be emptied. New
-  admission op `move_session`. (#402)
+  admission op `move_session`. The dry run and the `/admin/move-session`
+  response name every scope the move would drain (`source_scopes`), because
+  gathering by session id can empty a project the caller never named and
+  moving back does not restore the original split. (#402)
 - Added a read path for one session's raw hook observations, before any
   consolidation: the MCP tool `memory_read_session_observations` and the
   `/api/v1` routes `GET .../projects/{project}/sessions` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ai-memory move-session <session-id> --to <project> [--to-workspace]
   [--pages move|regenerate] [--confirm] [--force] [--create]`, its batch form
   `--from-project <project> [--from-workspace]`, and `POST /admin/move-session`
-  to move one session (or every session of a project) to another project, in
-  the same or another workspace. One transaction per session re-stamps the
-  `sessions` row, its `observations`, the `handoffs` it produced, its
-  consolidation jobs, auto-improve runs and scheduler claim, and its
-  `sessions/<id>.md` page: `--pages move` (default) carries every version and
+  to move one session (or every session touching a project) to another
+  project, in the same or another workspace. One transaction per session
+  re-stamps the `sessions` row, its `observations` (wherever they landed), the
+  `handoffs` it produced, its consolidation jobs, auto-improve runs and
+  scheduler claim, and its `sessions/<id>.md` page: `--pages move` (default)
+  carries every version and
   the file along (409 when the destination already has that page), `--pages
   regenerate` retires the source page and removes its file so the next
   consolidation rewrites it in the destination. Without `--confirm` the server
@@ -24,8 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   running consolidation job, or (batch) the active source project refuse with
   409 unless `--force`. `sessions.cwd` stays as recorded (the response warns
   when its basename is not the destination), and `auto_improve_proposals`,
-  `entities` and `page_feedback` are not re-stamped. New admission op
-  `move_session`. (#402)
+  `entities` and `page_feedback` are not re-stamped. A session already rooted
+  in the destination is re-homed instead of refused: its row stays
+  (`session_moved: false`) and only its rows still lying in other scopes are
+  gathered, and the batch form enumerates sessions with a `sessions` row in
+  the source OR observations stamped into it, so a phantom project holding
+  only observations of sessions rooted elsewhere can be emptied. New
+  admission op `move_session`. (#402)
 
 ## [1.27.0] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `ai-memory move-session <session-id> --to <project> [--to-workspace]
+  [--pages move|regenerate] [--confirm] [--force] [--create]`, its batch form
+  `--from-project <project> [--from-workspace]`, and `POST /admin/move-session`
+  to move one session (or every session of a project) to another project, in
+  the same or another workspace. One transaction per session re-stamps the
+  `sessions` row, its `observations`, the `handoffs` it produced, its
+  consolidation jobs, auto-improve runs and scheduler claim, and its
+  `sessions/<id>.md` page: `--pages move` (default) carries every version and
+  the file along (409 when the destination already has that page), `--pages
+  regenerate` retires the source page and removes its file so the next
+  consolidation rewrites it in the destination. Without `--confirm` the server
+  runs the same transaction and rolls it back, so the summary is an exact dry
+  run and the CLI prints the command to apply. An open session, a pending or
+  running consolidation job, or (batch) the active source project refuse with
+  409 unless `--force`. `sessions.cwd` stays as recorded (the response warns
+  when its basename is not the destination), and `auto_improve_proposals`,
+  `entities` and `page_feedback` are not re-stamped. New admission op
+  `move_session`. (#402)
+
 ## [1.27.0] - 2026-08-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,17 +18,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scheduler claim, and its `sessions/<id>.md` page: `--pages move` (default)
   carries every version and
   the file along (409 when the destination already has that page), `--pages
-  regenerate` retires the source page and removes its file so the next
-  consolidation rewrites it in the destination. Without `--confirm` the server
+  regenerate` retires the source page (clearing the session's
+  `summary_page_id`) and removes its file so the next consolidation rewrites
+  it in the destination. Without `--confirm` the server
   runs the same transaction and rolls it back, so the summary is an exact dry
-  run and the CLI prints the command to apply. An open session, a pending or
+  run and the CLI prints the command to apply (with `--create` the dry run
+  reports `would_create_project` and creates nothing). An open session, a pending or
   running consolidation job, or (batch) the active source project refuse with
   409 unless `--force`. `sessions.cwd` stays as recorded (the response warns
   when its basename is not the destination), and `auto_improve_proposals`,
   `entities` and `page_feedback` are not re-stamped. A session already rooted
   in the destination is re-homed instead of refused: its row stays
-  (`session_moved: false`) and only its rows still lying in other scopes are
-  gathered, and the batch form enumerates sessions with a `sessions` row in
+  (`session_moved: false`, open-session guard not applied) and only its rows
+  still lying in other scopes are gathered (`page: already in destination`
+  when its page needs nothing), and the batch form enumerates sessions with a `sessions` row in
   the source OR observations stamped into it, so a phantom project holding
   only observations of sessions rooted elsewhere can be emptied. New
   admission op `move_session`. (#402)

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ priors are at the [bottom](#influences-and-prior-art).
   bridge via `install-mcp --session-aware`.
 - **Thin-client CLI.** `ai-memory status`, `bootstrap`, `checkpoints`,
   `restore-page`, `purge-project`, `rename-project`, `move-project`,
+  `move-session`,
   `audit-contamination`, `lint`, `curator`, `auto-improve`,
   `auto-improve-report`, `pending-writes`, `embed`, `forget-sweep`, `backup`,
   `finalize-session` are

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -613,15 +613,15 @@ pub struct MoveProjectArgs {
 }
 
 /// Arguments for `move-session`.
+///
+/// Exactly one of `<SESSION_ID>` and `--from-project` names what moves; the
+/// `what` group makes clap's error name both when neither is given.
 #[derive(Debug, Args)]
+#[command(group = clap::ArgGroup::new("what").required(true).args(["session_id", "from_project"]))]
 pub struct MoveSessionArgs {
     /// Session id (UUID) to move. Omit it and pass `--from-project` to move
     /// every session touching one project. A session already rooted in the
     /// destination is re-homed: its row stays and only its stray rows move.
-    #[arg(
-        required_unless_present = "from_project",
-        conflicts_with = "from_project"
-    )]
     pub session_id: Option<ai_memory_core::SessionId>,
     /// Batch form: move every session touching this project (a session row
     /// here or observations stamped into it). Resolved like other commands

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -157,6 +157,11 @@ pub enum Command {
     /// copy+purge (only durable pages migrate, source purged). Either way the
     /// operation is irreversible — requires `--confirm`.
     MoveProject(MoveProjectArgs),
+    /// Move one session (or every session of a project) to another project,
+    /// re-stamping its observations, handoffs, consolidation jobs and its
+    /// `sessions/<id>.md` page in one transaction. Without `--confirm` it
+    /// prints what would move (a real dry run, rolled back server-side).
+    MoveSession(MoveSessionArgs),
     /// Remove ai-memory's wiring (hooks, MCP, instructions, and default-root
     /// managed skills) from all detected agents. Dry-run unless `--apply`.
     Uninstall(UninstallArgs),
@@ -605,6 +610,50 @@ pub struct MoveProjectArgs {
     /// lands under a de-duplicated path).
     #[arg(long, value_parser = ["block", "overwrite", "duplicate"], default_value = "block")]
     pub on_conflict: String,
+}
+
+/// Arguments for `move-session`.
+#[derive(Debug, Args)]
+pub struct MoveSessionArgs {
+    /// Session id (UUID) to move. Omit it and pass `--from-project` to move
+    /// every session of one project.
+    #[arg(
+        required_unless_present = "from_project",
+        conflicts_with = "from_project"
+    )]
+    pub session_id: Option<ai_memory_core::SessionId>,
+    /// Batch form: move every session of this project. Resolved like other
+    /// commands (marker, else literal); the sessions move one at a time and
+    /// the batch stops at the first refusal, reporting how far it got.
+    #[arg(long)]
+    pub from_project: Option<String>,
+    /// Workspace of `--from-project`. Defaults to the nearest
+    /// `.ai-memory.toml` marker's `workspace`, else `default`.
+    #[arg(long, requires = "from_project")]
+    pub from_workspace: Option<String>,
+    /// Destination project name (literal, not marker-resolved).
+    #[arg(long)]
+    pub to: String,
+    /// Destination workspace. Defaults to the source workspace.
+    #[arg(long)]
+    pub to_workspace: Option<String>,
+    /// What happens to the session's `sessions/<id>.md` page: `move` carries
+    /// the page and its history along (refused when the destination already
+    /// has one at that path); `regenerate` retires it so the next
+    /// consolidation writes a fresh page in the destination.
+    #[arg(long, value_parser = ["move", "regenerate"], default_value = "move")]
+    pub pages: String,
+    /// REQUIRED to apply. Without it the command prints the dry-run summary
+    /// and the exact command to re-run.
+    #[arg(long)]
+    pub confirm: bool,
+    /// Skip the live-session guards (open session, pending consolidation job,
+    /// active project of the hook router in the batch form).
+    #[arg(long)]
+    pub force: bool,
+    /// Create the destination workspace/project when it does not exist yet.
+    #[arg(long)]
+    pub create: bool,
 }
 
 /// Arguments for `install-instructions`.

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -616,15 +616,17 @@ pub struct MoveProjectArgs {
 #[derive(Debug, Args)]
 pub struct MoveSessionArgs {
     /// Session id (UUID) to move. Omit it and pass `--from-project` to move
-    /// every session of one project.
+    /// every session touching one project. A session already rooted in the
+    /// destination is re-homed: its row stays and only its stray rows move.
     #[arg(
         required_unless_present = "from_project",
         conflicts_with = "from_project"
     )]
     pub session_id: Option<ai_memory_core::SessionId>,
-    /// Batch form: move every session of this project. Resolved like other
-    /// commands (marker, else literal); the sessions move one at a time and
-    /// the batch stops at the first refusal, reporting how far it got.
+    /// Batch form: move every session touching this project (a session row
+    /// here or observations stamped into it). Resolved like other commands
+    /// (marker, else literal); the sessions move one at a time and the batch
+    /// stops at the first refusal, reporting how far it got.
     #[arg(long)]
     pub from_project: Option<String>,
     /// Workspace of `--from-project`. Defaults to the nearest

--- a/crates/ai-memory-cli/src/commands/mod.rs
+++ b/crates/ai-memory-cli/src/commands/mod.rs
@@ -35,6 +35,7 @@ pub mod lint;
 pub mod llm_test;
 pub mod mcp_bridge;
 pub mod move_project;
+pub mod move_session;
 pub mod openclaw_plugin;
 pub mod path_util;
 pub mod pending_writes;

--- a/crates/ai-memory-cli/src/commands/move_session.rs
+++ b/crates/ai-memory-cli/src/commands/move_session.rs
@@ -107,6 +107,7 @@ fn print_session_report(report: &serde_json::Value, applied: bool) {
         scope(&report["from"]),
         scope(&report["to"]),
     );
+    print_would_create(report);
     println!(
         "  session row:         {}",
         session_row_line(report, applied)
@@ -117,6 +118,26 @@ fn print_session_report(report: &serde_json::Value, applied: bool) {
     );
     if let Some(warning) = report["cwd_warning"].as_str() {
         println!("Warning: {warning}");
+    }
+    print_checkpoints(report);
+}
+
+/// Dry run with `--create` against a destination that does not exist yet.
+fn print_would_create(report: &serde_json::Value) {
+    if report["would_create_project"].as_bool().unwrap_or(false) {
+        println!(
+            "  would create project {} (absent; created on --confirm)",
+            scope(&report["to"])
+        );
+    }
+}
+
+/// The wiki checkpoints a confirmed run took: `pre_checkpoint` only when the
+/// tree had uncommitted changes before the move, `checkpoint` when the move
+/// changed the tree.
+fn print_checkpoints(report: &serde_json::Value) {
+    if let Some(oid) = report["pre_checkpoint"].as_str() {
+        println!("Pre-move checkpoint: {oid}");
     }
     if let Some(oid) = report["checkpoint"].as_str() {
         println!("Checkpoint: {oid}");
@@ -132,15 +153,16 @@ fn print_batch_report(report: &serde_json::Value, applied: bool) {
         scope(&report["from"]),
         scope(&report["to"]),
     );
+    print_would_create(report);
     if let Some(sessions) = report["sessions"].as_array() {
         println!(
-            "{:<38} {:<8} {:>6} {:>8} {:>5} {:<12} cwd",
+            "{:<38} {:<8} {:>6} {:>8} {:>5} {:<22} cwd",
             "session_id", "row", "obs", "handoffs", "jobs", "page"
         );
-        println!("{}", "-".repeat(99));
+        println!("{}", "-".repeat(109));
         for s in sessions {
             println!(
-                "{:<38} {:<8} {:>6} {:>8} {:>5} {:<12} {}",
+                "{:<38} {:<8} {:>6} {:>8} {:>5} {:<22} {}",
                 s["session_id"].as_str().unwrap_or("?"),
                 if s["session_moved"].as_bool().unwrap_or(false) {
                     "moved"
@@ -176,9 +198,7 @@ fn print_batch_report(report: &serde_json::Value, applied: bool) {
             );
         }
     }
-    if let Some(oid) = report["checkpoint"].as_str() {
-        println!("Checkpoint: {oid}");
-    }
+    print_checkpoints(report);
 }
 
 fn print_counts(summary: &serde_json::Value, page: &str) {

--- a/crates/ai-memory-cli/src/commands/move_session.rs
+++ b/crates/ai-memory-cli/src/commands/move_session.rs
@@ -1,0 +1,239 @@
+//! `ai-memory move-session` — thin HTTP client for moving one session (or
+//! every session of a project) to another project.
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::cli::MoveSessionArgs;
+use crate::config::Config;
+use crate::http_client::{ServerEndpoint, post_json};
+
+/// Request sent to `POST /admin/move-session`. Exactly one of `session_id`
+/// / `from_project` is set.
+#[derive(Serialize)]
+struct MoveSessionRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    from_workspace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    from_project: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace: Option<String>,
+    project: String,
+    pages: String,
+    confirm: bool,
+    force: bool,
+    create: bool,
+}
+
+/// Run the `move-session` subcommand.
+///
+/// Without `--confirm` the server runs the move inside a rolled-back
+/// transaction and this prints what would change plus the exact command to
+/// apply it. With `--confirm` it prints the report.
+///
+/// # Errors
+/// Returns an error when the server is unreachable or answers non-2xx (404
+/// unknown session/target, 409 guard or page collision, 422 same scope).
+pub async fn run(config: &Config, args: MoveSessionArgs) -> Result<()> {
+    let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
+
+    // The batch source is a scope like any other command's: marker, else
+    // literal. The destination stays literal.
+    let (from_workspace, from_project) = match args.from_project.as_deref() {
+        Some(project) => {
+            let (ws, proj) =
+                super::resolve_scope(config, args.from_workspace.as_deref(), Some(project))?;
+            (Some(ws), Some(proj))
+        }
+        None => (None, None),
+    };
+    let request = MoveSessionRequest {
+        session_id: args.session_id.map(|id| id.to_string()),
+        from_workspace,
+        from_project,
+        workspace: args.to_workspace.clone(),
+        project: args.to.clone(),
+        pages: args.pages.clone(),
+        confirm: args.confirm,
+        force: args.force,
+        create: args.create,
+    };
+    let report: serde_json::Value = post_json(&endpoint, "/admin/move-session", &request).await?;
+
+    if request.session_id.is_some() {
+        print_session_report(&report, args.confirm);
+    } else {
+        print_batch_report(&report, args.confirm);
+    }
+    if !args.confirm {
+        println!(
+            "\n(dry run; nothing was written)\nRe-run with --confirm to apply:\n\n  {}",
+            apply_command(&args)
+        );
+    }
+    Ok(())
+}
+
+fn scope(label: &serde_json::Value) -> String {
+    format!(
+        "{}/{}",
+        label["workspace"].as_str().unwrap_or("?"),
+        label["project"].as_str().unwrap_or("?")
+    )
+}
+
+fn print_session_report(report: &serde_json::Value, applied: bool) {
+    let verb = if applied { "Moved" } else { "Would move" };
+    println!(
+        "{verb} session {} from {} to {}:",
+        report["session_id"].as_str().unwrap_or("?"),
+        scope(&report["from"]),
+        scope(&report["to"]),
+    );
+    print_counts(
+        &report["summary"],
+        report["page"].as_str().unwrap_or("none"),
+    );
+    if let Some(warning) = report["cwd_warning"].as_str() {
+        println!("Warning: {warning}");
+    }
+    if let Some(oid) = report["checkpoint"].as_str() {
+        println!("Checkpoint: {oid}");
+    }
+}
+
+fn print_batch_report(report: &serde_json::Value, applied: bool) {
+    let verb = if applied { "Moved" } else { "Would move" };
+    let total = report["total"].as_u64().unwrap_or(0);
+    let moved = report["moved"].as_u64().unwrap_or(0);
+    println!(
+        "{verb} {moved} of {total} session(s) from {} to {}:",
+        scope(&report["from"]),
+        scope(&report["to"]),
+    );
+    if let Some(sessions) = report["sessions"].as_array() {
+        println!(
+            "{:<38} {:>6} {:>8} {:>5} {:<12} cwd",
+            "session_id", "obs", "handoffs", "jobs", "page"
+        );
+        println!("{}", "-".repeat(90));
+        for s in sessions {
+            println!(
+                "{:<38} {:>6} {:>8} {:>5} {:<12} {}",
+                s["session_id"].as_str().unwrap_or("?"),
+                s["summary"]["observations"].as_u64().unwrap_or(0),
+                s["summary"]["handoffs"].as_u64().unwrap_or(0),
+                s["summary"]["consolidation_jobs"].as_u64().unwrap_or(0),
+                s["page"].as_str().unwrap_or("none"),
+                s["cwd"].as_str().unwrap_or(""),
+            );
+        }
+        let warned = sessions
+            .iter()
+            .filter(|s| s["cwd_warning"].is_string())
+            .count();
+        if warned > 0 {
+            println!(
+                "Warning: {warned} session(s) have a cwd whose basename is not the destination \
+                 project; new sessions from those directories still resolve by basename unless \
+                 a .ai-memory.toml marker pins the project."
+            );
+        }
+    }
+    if let Some(oid) = report["checkpoint"].as_str() {
+        println!("Checkpoint: {oid}");
+    }
+}
+
+fn print_counts(summary: &serde_json::Value, page: &str) {
+    let n = |key: &str| summary[key].as_u64().unwrap_or(0);
+    println!("  observations:        {}", n("observations"));
+    println!("  handoffs:            {}", n("handoffs"));
+    println!("  consolidation jobs:  {}", n("consolidation_jobs"));
+    println!("  auto-improve runs:   {}", n("auto_improve_runs"));
+    println!("  auto-improve claims: {}", n("auto_improve_claims"));
+    println!(
+        "  page:                {page} ({} version(s) moved, {} retired)",
+        n("page_versions_moved"),
+        n("pages_regenerated")
+    );
+}
+
+/// The exact command that applies what the dry run showed.
+fn apply_command(args: &MoveSessionArgs) -> String {
+    let mut cmd = String::from("ai-memory move-session");
+    if let Some(id) = args.session_id {
+        cmd.push(' ');
+        cmd.push_str(&id.to_string());
+    }
+    if let Some(project) = &args.from_project {
+        cmd.push_str(&format!(" --from-project {project}"));
+    }
+    if let Some(ws) = &args.from_workspace {
+        cmd.push_str(&format!(" --from-workspace {ws}"));
+    }
+    cmd.push_str(&format!(" --to {}", args.to));
+    if let Some(ws) = &args.to_workspace {
+        cmd.push_str(&format!(" --to-workspace {ws}"));
+    }
+    if args.pages != "move" {
+        cmd.push_str(&format!(" --pages {}", args.pages));
+    }
+    if args.force {
+        cmd.push_str(" --force");
+    }
+    if args.create {
+        cmd.push_str(" --create");
+    }
+    cmd.push_str(" --confirm");
+    cmd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(session_id: Option<&str>, from_project: Option<&str>) -> MoveSessionArgs {
+        MoveSessionArgs {
+            session_id: session_id.map(|s| s.parse().unwrap()),
+            from_project: from_project.map(str::to_string),
+            from_workspace: None,
+            to: "target".into(),
+            to_workspace: None,
+            pages: "move".into(),
+            confirm: false,
+            force: false,
+            create: false,
+        }
+    }
+
+    #[test]
+    fn apply_command_repeats_the_single_form_with_confirm() {
+        let id = "0192b6a1-4c2e-7d3f-8a5b-1234567890ab";
+        let mut a = args(Some(id), None);
+        a.pages = "regenerate".into();
+        a.to_workspace = Some("other".into());
+        assert_eq!(
+            apply_command(&a),
+            format!(
+                "ai-memory move-session {id} --to target --to-workspace other \
+                 --pages regenerate --confirm"
+            )
+        );
+    }
+
+    #[test]
+    fn apply_command_repeats_the_batch_form_and_flags() {
+        let mut a = args(None, Some("ghost"));
+        a.from_workspace = Some("default".into());
+        a.force = true;
+        a.create = true;
+        assert_eq!(
+            apply_command(&a),
+            "ai-memory move-session --from-project ghost --from-workspace default --to target \
+             --force --create --confirm"
+        );
+    }
+}

--- a/crates/ai-memory-cli/src/commands/move_session.rs
+++ b/crates/ai-memory-cli/src/commands/move_session.rs
@@ -116,6 +116,7 @@ fn print_session_report(report: &serde_json::Value, applied: bool) {
         &report["summary"],
         report["page"].as_str().unwrap_or("none"),
     );
+    print_source_scopes(report, &scope(&report["to"]));
     if let Some(warning) = report["cwd_warning"].as_str() {
         println!("Warning: {warning}");
     }
@@ -199,6 +200,43 @@ fn print_batch_report(report: &serde_json::Value, applied: bool) {
         }
     }
     print_checkpoints(report);
+}
+
+/// Name every scope the move will drain, when it is more than the one the
+/// caller asked about.
+///
+/// A move gathers dependent rows by session id alone, so it can empty a
+/// project nobody named — and moving back afterwards cannot restore the
+/// original split. The operator sees that here, in the dry run, rather than
+/// inferring it from a count that came out larger than expected.
+fn print_source_scopes(report: &serde_json::Value, destination: &str) {
+    let Some(scopes) = report["source_scopes"].as_array() else {
+        return;
+    };
+    let others: Vec<_> = scopes
+        .iter()
+        .filter(|s| s["observations"].as_u64().unwrap_or(0) > 0)
+        .collect();
+    if others.len() < 2 {
+        return;
+    }
+    println!(
+        "  gathering observations out of {} scopes into {destination}:",
+        others.len()
+    );
+    for s in &others {
+        println!(
+            "    {}/{}: {} observation(s)",
+            s["workspace"].as_str().unwrap_or("?"),
+            s["project"].as_str().unwrap_or("?"),
+            s["observations"].as_u64().unwrap_or(0),
+        );
+    }
+    println!(
+        "  Note: this empties every scope listed above, not only the one named as the source. \
+         Moving the session back later returns all rows to a single project — the split shown \
+         here is not restored."
+    );
 }
 
 fn print_counts(summary: &serde_json::Value, page: &str) {

--- a/crates/ai-memory-cli/src/commands/move_session.rs
+++ b/crates/ai-memory-cli/src/commands/move_session.rs
@@ -33,9 +33,14 @@ struct MoveSessionRequest {
 /// transaction and this prints what would change plus the exact command to
 /// apply it. With `--confirm` it prints the report.
 ///
+/// A session already rooted in the destination is re-homed: the report says
+/// `session row: already in destination` and the counts are the stray rows
+/// gathered into it (zero when there were none).
+///
 /// # Errors
 /// Returns an error when the server is unreachable or answers non-2xx (404
-/// unknown session/target, 409 guard or page collision, 422 same scope).
+/// unknown session/target, 409 guard or page collision, 422 batch source
+/// equal to the destination).
 pub async fn run(config: &Config, args: MoveSessionArgs) -> Result<()> {
     let endpoint = ServerEndpoint::from_config_resolving_auth(config).await;
 
@@ -84,6 +89,16 @@ fn scope(label: &serde_json::Value) -> String {
     )
 }
 
+/// One line saying whether the `sessions` row itself changes scope; a
+/// re-home leaves it and only gathers stray rows.
+fn session_row_line(report: &serde_json::Value, applied: bool) -> &'static str {
+    match (report["session_moved"].as_bool().unwrap_or(false), applied) {
+        (true, true) => "moved",
+        (true, false) => "would move",
+        (false, _) => "already in destination (re-home: only stray rows gathered)",
+    }
+}
+
 fn print_session_report(report: &serde_json::Value, applied: bool) {
     let verb = if applied { "Moved" } else { "Would move" };
     println!(
@@ -91,6 +106,10 @@ fn print_session_report(report: &serde_json::Value, applied: bool) {
         report["session_id"].as_str().unwrap_or("?"),
         scope(&report["from"]),
         scope(&report["to"]),
+    );
+    println!(
+        "  session row:         {}",
+        session_row_line(report, applied)
     );
     print_counts(
         &report["summary"],
@@ -115,19 +134,34 @@ fn print_batch_report(report: &serde_json::Value, applied: bool) {
     );
     if let Some(sessions) = report["sessions"].as_array() {
         println!(
-            "{:<38} {:>6} {:>8} {:>5} {:<12} cwd",
-            "session_id", "obs", "handoffs", "jobs", "page"
+            "{:<38} {:<8} {:>6} {:>8} {:>5} {:<12} cwd",
+            "session_id", "row", "obs", "handoffs", "jobs", "page"
         );
-        println!("{}", "-".repeat(90));
+        println!("{}", "-".repeat(99));
         for s in sessions {
             println!(
-                "{:<38} {:>6} {:>8} {:>5} {:<12} {}",
+                "{:<38} {:<8} {:>6} {:>8} {:>5} {:<12} {}",
                 s["session_id"].as_str().unwrap_or("?"),
+                if s["session_moved"].as_bool().unwrap_or(false) {
+                    "moved"
+                } else {
+                    "re-home"
+                },
                 s["summary"]["observations"].as_u64().unwrap_or(0),
                 s["summary"]["handoffs"].as_u64().unwrap_or(0),
                 s["summary"]["consolidation_jobs"].as_u64().unwrap_or(0),
                 s["page"].as_str().unwrap_or("none"),
                 s["cwd"].as_str().unwrap_or(""),
+            );
+        }
+        let rehomed = sessions
+            .iter()
+            .filter(|s| !s["session_moved"].as_bool().unwrap_or(false))
+            .count();
+        if rehomed > 0 {
+            println!(
+                "Note: {rehomed} session(s) marked re-home already had their session row in the \
+                 destination; only their stray rows (the counts above) were gathered."
             );
         }
         let warned = sessions

--- a/crates/ai-memory-cli/src/main.rs
+++ b/crates/ai-memory-cli/src/main.rs
@@ -136,6 +136,7 @@ async fn main() -> Result<()> {
         Command::PurgeProject(args) => commands::purge_project::run(&config, args).await,
         Command::RenameProject(args) => commands::rename_project::run(&config, args).await,
         Command::MoveProject(args) => commands::move_project::run(&config, args).await,
+        Command::MoveSession(args) => commands::move_session::run(&config, args).await,
         Command::Uninstall(args) => commands::uninstall::run(&config, args),
         Command::Auth(args) => commands::auth::run(&config, args).await,
         Command::User(args) => commands::user::run(&config, args).await,

--- a/crates/ai-memory-cli/tests/completions.rs
+++ b/crates/ai-memory-cli/tests/completions.rs
@@ -67,6 +67,7 @@ fn scripts_cover_subcommands_from_across_the_tree() {
             "serve",
             "write-page",
             "purge-project",
+            "move-session",
             "user",
             "rotate-token",
             "auth",

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -4217,6 +4217,8 @@ struct MoveSessionRequest {
     #[serde(default)]
     force: bool,
     /// Create the destination workspace/project when absent instead of 404.
+    /// A dry run never creates: it reports `would_create_project: true` and
+    /// the counts computed against an absent target.
     #[serde(default)]
     create: bool,
 }
@@ -4260,6 +4262,10 @@ pub struct MoveSessionReport {
     /// row already sat in the destination and only stray rows (the counts
     /// below) were gathered into it.
     pub session_moved: bool,
+    /// Dry run with `create` against a destination that does not exist yet:
+    /// the confirm run will create it. Never set on a confirmed move.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub would_create_project: bool,
     /// Scope the session came from.
     pub from: ScopeLabel,
     /// Scope the session now belongs to.
@@ -4267,7 +4273,9 @@ pub struct MoveSessionReport {
     /// Row counts.
     pub summary: MoveSessionCounts,
     /// What happened (or would happen) to `sessions/<id>.md`: `"moved"`,
-    /// `"regenerated"`, or `"none"` when the session has no page.
+    /// `"regenerated"`, `"already in destination"` (re-home whose page rows
+    /// all sit in the destination), or `"none"` when the session has no page
+    /// anywhere.
     pub page: &'static str,
     /// The session's recorded working directory, left untouched.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4288,6 +4296,9 @@ pub struct MoveSessionReport {
 pub struct MoveSessionBatchReport {
     /// `true` when nothing was written (no `confirm`).
     pub dry_run: bool,
+    /// Dry run with `create` against a destination that does not exist yet.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub would_create_project: bool,
     /// Source scope.
     pub from: ScopeLabel,
     /// Destination scope.
@@ -4316,7 +4327,7 @@ struct MoveSessionPlan {
     /// well sit elsewhere, even in `to`).
     from: (WorkspaceId, ProjectId),
     from_label: ScopeLabel,
-    to: (WorkspaceId, ProjectId),
+    to: MoveTarget,
     to_label: ScopeLabel,
     /// Where the `sessions` row sits right now.
     row_scope: (WorkspaceId, ProjectId),
@@ -4326,7 +4337,24 @@ struct MoveSessionPlan {
 impl MoveSessionPlan {
     /// The row already sits in the destination: only stray rows move.
     fn is_rehome(&self) -> bool {
-        self.row_scope == self.to
+        self.to.existing() == Some(self.row_scope)
+    }
+}
+
+/// The destination of a move: an existing scope, or (dry run with `create`
+/// only) a scope that does not exist yet and would be created on confirm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MoveTarget {
+    Existing((WorkspaceId, ProjectId)),
+    WouldCreate,
+}
+
+impl MoveTarget {
+    fn existing(self) -> Option<(WorkspaceId, ProjectId)> {
+        match self {
+            Self::Existing(scope) => Some(scope),
+            Self::WouldCreate => None,
+        }
     }
 }
 
@@ -4384,18 +4412,52 @@ async fn scope_label(state: &AdminState, ws: WorkspaceId, proj: ProjectId) -> Sc
     ScopeLabel { workspace, project }
 }
 
-/// Resolve the destination scope: existing only (404) unless `create`.
+/// Resolve the destination scope: existing only (404) unless `create`. A
+/// dry run never writes, so with `create` and no `confirm` an absent
+/// destination resolves to [`MoveTarget::WouldCreate`] instead of a row.
 async fn resolve_move_session_target(
     state: &AdminState,
     workspace: &str,
     project: &str,
     create: bool,
-) -> Result<(WorkspaceId, ProjectId), MoveErr> {
-    if create {
-        create_ws_proj(state, workspace, project).await
-    } else {
-        lookup_ws_proj_no_create(state, workspace, project).await
+    confirm: bool,
+) -> Result<MoveTarget, MoveErr> {
+    if create && confirm {
+        return create_ws_proj(state, workspace, project)
+            .await
+            .map(MoveTarget::Existing);
     }
+    match lookup_existing_scope(&state.reader, workspace, project).await {
+        Ok(scope) => Ok(MoveTarget::Existing(scope.as_tuple())),
+        Err(e) if create && e.is_not_found() => Ok(MoveTarget::WouldCreate),
+        Err(e) => Err(scope_err(e)),
+    }
+}
+
+/// Dry-run counts of a move into a destination that does not exist yet:
+/// nothing of the session can already be there, so every row keyed to it
+/// moves, and the page rows are those of `from` (moved or retired per
+/// `pages`). Read-only; the store never sees the absent target.
+async fn preview_move_into_absent_target(
+    reader: &ReaderPool,
+    session_id: SessionId,
+    from: (WorkspaceId, ProjectId),
+    pages: PagesMode,
+) -> Result<MoveSessionCounts, StoreError> {
+    let rows = reader.session_dependent_rows(session_id, from).await?;
+    let (page_versions_moved, pages_regenerated) = match pages {
+        PagesMode::Move => (rows.page_versions, 0),
+        PagesMode::Regenerate => (0, rows.page_latest),
+    };
+    Ok(MoveSessionCounts {
+        observations: rows.observations,
+        handoffs: rows.handoffs,
+        consolidation_jobs: rows.consolidation_jobs,
+        auto_improve_runs: rows.auto_improve_runs,
+        auto_improve_claims: rows.auto_improve_claims,
+        page_versions_moved,
+        pages_regenerated,
+    })
 }
 
 /// `(session still open, consolidation job pending or running)` for the
@@ -4506,8 +4568,10 @@ fn move_session_page_label(
     pages: PagesMode,
     touched_rows: bool,
     touched_file: bool,
+    already_in_target: bool,
 ) -> &'static str {
     match (pages, touched_rows || touched_file) {
+        (_, false) if already_in_target => "already in destination",
         (_, false) => "none",
         (PagesMode::Move, true) => "moved",
         (PagesMode::Regenerate, true) => "regenerated",
@@ -4541,7 +4605,7 @@ async fn move_planned_session(
                 Json(serde_json::json!({
                     "error": format!(
                         "session {sid} is still open (no session end recorded); \
-                         finish it or re-run with force=true"
+                         finish it or force the move (--force / force: true)"
                     )
                 })),
             ));
@@ -4552,41 +4616,72 @@ async fn move_planned_session(
                 Json(serde_json::json!({
                     "error": format!(
                         "session {sid} has a pending or running consolidation job; \
-                         wait for it or re-run with force=true"
+                         wait for it or force the move (--force / force: true)"
                     )
                 })),
             ));
         }
     }
 
-    // A page file already at the destination blocks a page move; checked here
-    // too so the dry run predicts what the wiki re-checks under its lock. When
-    // the source scope IS the destination (single-form re-home) there is no
-    // file to move and the wiki skips the file step too.
+    let cwd_warning = move_session_cwd_warning(plan.cwd.as_deref(), &plan.to_label.project);
     let file_name = format!("{sid}.md");
     let src_file = state
         .wiki
         .project_root(plan.from.0, plan.from.1)
         .join("sessions")
         .join(&file_name);
+
+    // Dry run with `create` against an absent destination: nothing exists to
+    // collide with, and the store cannot re-stamp into a scope that has no
+    // row, so the counts come from a read-only preview.
+    let to = match plan.to {
+        MoveTarget::Existing(to) => to,
+        MoveTarget::WouldCreate => {
+            debug_assert!(
+                !req.confirm,
+                "an absent target is only planned for a dry run"
+            );
+            let counts = preview_move_into_absent_target(&state.reader, sid, plan.from, req.pages)
+                .await
+                .map_err(|e| internal_err(e.to_string()))?;
+            let touched_rows = counts.page_versions_moved > 0 || counts.pages_regenerated > 0;
+            return Ok(MoveSessionReport {
+                session_id: sid.to_string(),
+                dry_run: true,
+                session_moved: true,
+                would_create_project: true,
+                from: plan.from_label,
+                to: plan.to_label,
+                page: move_session_page_label(req.pages, touched_rows, src_file.is_file(), false),
+                summary: counts,
+                cwd: plan.cwd,
+                cwd_warning,
+                pre_checkpoint: None,
+                checkpoint: None,
+            });
+        }
+    };
+
+    // A page file already at the destination blocks a page move; checked here
+    // too so the dry run predicts what the wiki re-checks under its lock. When
+    // the source scope IS the destination (single-form re-home) there is no
+    // file to move and the wiki skips the file step too.
     let dst_file = state
         .wiki
-        .project_root(plan.to.0, plan.to.1)
+        .project_root(to.0, to.1)
         .join("sessions")
         .join(&file_name);
-    let file_moves = plan.from != plan.to && src_file.is_file();
+    let file_moves = plan.from != to && src_file.is_file();
     if req.pages == PagesMode::Move && file_moves && dst_file.exists() {
         return Err(move_session_wiki_err(WikiError::DestinationPageExists(
             dst_file.display().to_string(),
         )));
     }
 
-    let cwd_warning = move_session_cwd_warning(plan.cwd.as_deref(), &plan.to_label.project);
-
     if !req.confirm {
         let summary = state
             .writer
-            .move_session(sid, plan.to.0, plan.to.1, req.pages, author_id, false)
+            .move_session(sid, to.0, to.1, req.pages, author_id, false)
             .await
             .map_err(move_session_store_err)?;
         let touched_rows = summary.page_versions_moved > 0 || summary.pages_regenerated > 0;
@@ -4594,10 +4689,16 @@ async fn move_planned_session(
             session_id: sid.to_string(),
             dry_run: true,
             session_moved: summary.session_moved,
+            would_create_project: false,
             from: plan.from_label,
             to: plan.to_label,
             summary: move_session_counts(&summary),
-            page: move_session_page_label(req.pages, touched_rows, file_moves),
+            page: move_session_page_label(
+                req.pages,
+                touched_rows,
+                file_moves,
+                summary.page_versions_in_target > 0,
+            ),
             cwd: plan.cwd,
             cwd_warning,
             pre_checkpoint: None,
@@ -4618,14 +4719,7 @@ async fn move_planned_session(
     // re-stamp, and the file rollback on SQL failure.
     let outcome = state
         .wiki
-        .move_session_page(
-            sid,
-            plan.from,
-            plan.to,
-            req.pages,
-            author_id,
-            Some(move_ctx),
-        )
+        .move_session_page(sid, plan.from, to, req.pages, author_id, Some(move_ctx))
         .await
         .map_err(move_session_wiki_err)?;
     let touched_rows =
@@ -4634,6 +4728,7 @@ async fn move_planned_session(
         session_id: sid.to_string(),
         dry_run: false,
         session_moved: outcome.summary.session_moved,
+        would_create_project: false,
         from: plan.from_label,
         to: plan.to_label,
         summary: move_session_counts(&outcome.summary),
@@ -4641,6 +4736,7 @@ async fn move_planned_session(
             req.pages,
             touched_rows,
             outcome.file != SessionPageFile::Absent,
+            outcome.summary.page_versions_in_target > 0,
         ),
         cwd: plan.cwd,
         cwd_warning,
@@ -4672,7 +4768,9 @@ async fn move_single_session(
         .workspace
         .clone()
         .unwrap_or_else(|| from_label.workspace.clone());
-    let to = resolve_move_session_target(state, &to_workspace, &req.project, req.create).await?;
+    let to =
+        resolve_move_session_target(state, &to_workspace, &req.project, req.create, req.confirm)
+            .await?;
     let plan = MoveSessionPlan {
         session_id,
         from: (from_ws, from_proj),
@@ -4725,9 +4823,16 @@ async fn move_session_batch(
         .workspace
         .clone()
         .unwrap_or_else(|| from_workspace.clone());
-    let to = match resolve_move_session_target(state, &to_workspace, &req.project, req.create).await
+    let to = match resolve_move_session_target(
+        state,
+        &to_workspace,
+        &req.project,
+        req.create,
+        req.confirm,
+    )
+    .await
     {
-        Ok(ids) => ids,
+        Ok(target) => target,
         Err(e) => return e.into_response(),
     };
     let from_label = ScopeLabel {
@@ -4738,7 +4843,7 @@ async fn move_session_batch(
         workspace: to_workspace,
         project: req.project.clone(),
     };
-    if from == to {
+    if to.existing() == Some(from) {
         return (
             StatusCode::UNPROCESSABLE_ENTITY,
             Json(serde_json::json!({
@@ -4754,8 +4859,8 @@ async fn move_session_batch(
             StatusCode::CONFLICT,
             Json(serde_json::json!({
                 "error": format!(
-                    "{}/{} is the active session's project; re-run with force=true to move its \
-                     sessions anyway",
+                    "{}/{} is the active session's project; force the move (--force / \
+                     force: true) to move its sessions anyway",
                     from_label.workspace, from_label.project
                 )
             })),
@@ -4789,7 +4894,8 @@ async fn move_session_batch(
         // where its row sits; a session already rooted in the destination is
         // re-homed and its stray page file, if any, is looked for in the
         // source.
-        let (plan_from, plan_from_label) = if row_scope == from || row_scope == to {
+        let (plan_from, plan_from_label) = if row_scope == from || to.existing() == Some(row_scope)
+        {
             (from, from_label.clone())
         } else {
             (
@@ -4844,6 +4950,7 @@ async fn move_session_batch(
     }
     let report = MoveSessionBatchReport {
         dry_run: !req.confirm,
+        would_create_project: to == MoveTarget::WouldCreate,
         from: from_label,
         to: to_label,
         total,

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -4251,6 +4251,17 @@ pub struct MoveSessionCounts {
     pub pages_regenerated: u64,
 }
 
+/// One scope a move gathers observations out of, for the operator's report.
+#[derive(Debug, Serialize)]
+pub struct MoveSessionScopeCount {
+    /// Workspace name.
+    pub workspace: String,
+    /// Project name.
+    pub project: String,
+    /// Observations of the session currently stamped into that scope.
+    pub observations: u64,
+}
+
 /// Wire-format report for one session in `POST /admin/move-session`.
 #[derive(Debug, Serialize)]
 pub struct MoveSessionReport {
@@ -4266,6 +4277,12 @@ pub struct MoveSessionReport {
     /// the confirm run will create it. Never set on a confirmed move.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub would_create_project: bool,
+    /// Every scope holding observations of this session other than the
+    /// destination, with counts. More than one entry — or one that is not
+    /// `from` — means the move drains a project the caller did not name.
+    /// Empty when everything already sits in the destination.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub source_scopes: Vec<MoveSessionScopeCount>,
     /// Scope the session came from.
     pub from: ScopeLabel,
     /// Scope the session now belongs to.
@@ -4552,6 +4569,20 @@ fn move_session_cwd_warning(cwd: Option<&str>, to_project: &str) -> Option<Strin
     ))
 }
 
+fn move_session_source_scopes(
+    summary: &ai_memory_store::MoveSessionSummary,
+) -> Vec<MoveSessionScopeCount> {
+    summary
+        .source_scopes
+        .iter()
+        .map(|scope| MoveSessionScopeCount {
+            workspace: scope.workspace_name.clone(),
+            project: scope.project_name.clone(),
+            observations: scope.observations,
+        })
+        .collect()
+}
+
 fn move_session_counts(summary: &ai_memory_store::MoveSessionSummary) -> MoveSessionCounts {
     MoveSessionCounts {
         observations: summary.observations,
@@ -4650,6 +4681,7 @@ async fn move_planned_session(
                 dry_run: true,
                 session_moved: true,
                 would_create_project: true,
+                source_scopes: Vec::new(),
                 from: plan.from_label,
                 to: plan.to_label,
                 page: move_session_page_label(req.pages, touched_rows, src_file.is_file(), false),
@@ -4690,6 +4722,7 @@ async fn move_planned_session(
             dry_run: true,
             session_moved: summary.session_moved,
             would_create_project: false,
+            source_scopes: move_session_source_scopes(&summary),
             from: plan.from_label,
             to: plan.to_label,
             summary: move_session_counts(&summary),
@@ -4729,6 +4762,7 @@ async fn move_planned_session(
         dry_run: false,
         session_moved: outcome.summary.session_moved,
         would_create_project: false,
+        source_scopes: move_session_source_scopes(&outcome.summary),
         from: plan.from_label,
         to: plan.to_label,
         summary: move_session_counts(&outcome.summary),

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -4181,7 +4181,10 @@ async fn move_project_core(
 ///
 /// Two shapes share the route: a single move names `session_id`; a batch
 /// names `from_project` (plus optional `from_workspace`) and moves every
-/// session of that scope. Exactly one of the two must be present.
+/// session touching that scope (a `sessions` row there OR observations
+/// stamped into it). Exactly one of the two must be present. A session whose
+/// row already sits in the destination is re-homed: only its rows still
+/// lying elsewhere move (`session_moved: false`).
 #[derive(Deserialize)]
 struct MoveSessionRequest {
     /// The session to move (single form).
@@ -4190,7 +4193,7 @@ struct MoveSessionRequest {
     /// Source workspace of the batch form. Defaults to `default`.
     #[serde(default)]
     from_workspace: Option<String>,
-    /// Source project of the batch form: every session in it moves.
+    /// Source project of the batch form: every session touching it moves.
     #[serde(default)]
     from_project: Option<String>,
     /// Destination workspace. Defaults to the source workspace.
@@ -4208,8 +4211,9 @@ struct MoveSessionRequest {
     #[serde(default)]
     confirm: bool,
     /// Skip the live-session guards: an open session (no session end
-    /// recorded), a `pending`/`running` consolidation job, and, for the batch
-    /// form, the hook router's active-project pointer.
+    /// recorded; not applied to a re-home, whose row does not move), a
+    /// `pending`/`running` consolidation job, and, for the batch form, the
+    /// hook router's active-project pointer.
     #[serde(default)]
     force: bool,
     /// Create the destination workspace/project when absent instead of 404.
@@ -4252,6 +4256,10 @@ pub struct MoveSessionReport {
     pub session_id: String,
     /// `true` when nothing was written (no `confirm`).
     pub dry_run: bool,
+    /// Whether the `sessions` row changed scope. `false` for a re-home: the
+    /// row already sat in the destination and only stray rows (the counts
+    /// below) were gathered into it.
+    pub session_moved: bool,
     /// Scope the session came from.
     pub from: ScopeLabel,
     /// Scope the session now belongs to.
@@ -4284,11 +4292,13 @@ pub struct MoveSessionBatchReport {
     pub from: ScopeLabel,
     /// Destination scope.
     pub to: ScopeLabel,
-    /// Sessions found in the source scope.
+    /// Sessions touching the source scope (a `sessions` row there or at
+    /// least one observation stamped into it).
     pub total: usize,
-    /// Sessions moved (or, for a dry run, that would move).
+    /// Sessions moved or re-homed (or, for a dry run, that would be).
     pub moved: usize,
-    /// One report per session, in `started_at` order.
+    /// One report per session, oldest first (row `started_at` or first
+    /// observation in the source).
     pub sessions: Vec<MoveSessionReport>,
     /// Pre-move checkpoint, if the tree had uncommitted changes.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4301,11 +4311,23 @@ pub struct MoveSessionBatchReport {
 /// One session move, resolved and validated, before any guard runs.
 struct MoveSessionPlan {
     session_id: SessionId,
+    /// Scope the rows are gathered from: the session row's own scope in the
+    /// single form, the batch source in the batch form (where the row may
+    /// well sit elsewhere, even in `to`).
     from: (WorkspaceId, ProjectId),
     from_label: ScopeLabel,
     to: (WorkspaceId, ProjectId),
     to_label: ScopeLabel,
+    /// Where the `sessions` row sits right now.
+    row_scope: (WorkspaceId, ProjectId),
     cwd: Option<String>,
+}
+
+impl MoveSessionPlan {
+    /// The row already sits in the destination: only stray rows move.
+    fn is_rehome(&self) -> bool {
+        self.row_scope == self.to
+    }
 }
 
 async fn handle_move_session(
@@ -4400,41 +4422,27 @@ async fn session_move_blockers(
         .await
 }
 
-/// `(session_id, cwd)` of every session in a scope, oldest first.
+/// `(session_id, row scope, cwd)` of every session touching a scope (a
+/// `sessions` row there or observations stamped into it), oldest first. The
+/// row scope may differ from the queried scope: that is the phantom-bucket
+/// case the batch re-homes.
 async fn list_scope_sessions(
     reader: &ReaderPool,
     workspace_id: WorkspaceId,
     project_id: ProjectId,
-) -> Result<Vec<(SessionId, Option<String>)>, StoreError> {
-    reader
-        .with_conn(move |conn| {
-            let mut stmt = conn.prepare(
-                "SELECT id, cwd FROM sessions \
-                 WHERE workspace_id = ?1 AND project_id = ?2 \
-                 ORDER BY started_at, id",
-            )?;
-            let rows = stmt.query_map(
-                [
-                    workspace_id.as_bytes().as_slice(),
-                    project_id.as_bytes().as_slice(),
-                ],
-                |row| {
-                    let id_bytes: Vec<u8> = row.get(0)?;
-                    let cwd: Option<String> = row.get(1)?;
-                    Ok((id_bytes, cwd))
-                },
-            )?;
-            let mut out = Vec::new();
-            for r in rows {
-                let (id_bytes, cwd) = r?;
-                out.push((
-                    SessionId::from_slice(&id_bytes).map_err(StoreError::Memory)?,
-                    cwd,
-                ));
-            }
-            Ok(out)
-        })
-        .await
+) -> Result<Vec<(SessionId, (WorkspaceId, ProjectId), Option<String>)>, StoreError> {
+    let ids = reader
+        .session_ids_touching_scope(workspace_id, project_id)
+        .await?;
+    let mut out = Vec::with_capacity(ids.len());
+    for sid in ids {
+        // Observations reference `sessions` (FK on), so a listed id always
+        // has a row; a concurrent purge is the only way to lose it here.
+        if let Some((ws, proj, cwd)) = reader.find_session_scope(sid).await? {
+            out.push((sid, (ws, proj), cwd));
+        }
+    }
+    Ok(out)
 }
 
 fn move_session_store_err(e: StoreError) -> MoveErr {
@@ -4517,26 +4525,17 @@ async fn move_planned_session(
     actor: &ai_memory_core::ActorContext,
 ) -> Result<MoveSessionReport, MoveErr> {
     let sid = plan.session_id;
-    if plan.from == plan.to {
-        return Err((
-            StatusCode::UNPROCESSABLE_ENTITY,
-            Json(serde_json::json!({
-                "error": format!(
-                    "session {sid} already belongs to {}/{}",
-                    plan.to_label.workspace, plan.to_label.project
-                )
-            })),
-        ));
-    }
+    let rehome = plan.is_rehome();
 
     // Live-session guards. An open session may still receive events, and a
     // queued consolidation would write the page under the old scope; both
-    // are the operator's call with `force`.
+    // are the operator's call with `force`. A re-home leaves the row where
+    // it is, so an open session is no reason to refuse gathering its strays.
     let (open, pending_job) = session_move_blockers(&state.reader, sid)
         .await
         .map_err(|e| internal_err(e.to_string()))?;
     if !req.force {
-        if open {
+        if open && !rehome {
             return Err((
                 StatusCode::CONFLICT,
                 Json(serde_json::json!({
@@ -4561,7 +4560,9 @@ async fn move_planned_session(
     }
 
     // A page file already at the destination blocks a page move; checked here
-    // too so the dry run predicts what the wiki re-checks under its lock.
+    // too so the dry run predicts what the wiki re-checks under its lock. When
+    // the source scope IS the destination (single-form re-home) there is no
+    // file to move and the wiki skips the file step too.
     let file_name = format!("{sid}.md");
     let src_file = state
         .wiki
@@ -4573,7 +4574,8 @@ async fn move_planned_session(
         .project_root(plan.to.0, plan.to.1)
         .join("sessions")
         .join(&file_name);
-    if req.pages == PagesMode::Move && src_file.is_file() && dst_file.exists() {
+    let file_moves = plan.from != plan.to && src_file.is_file();
+    if req.pages == PagesMode::Move && file_moves && dst_file.exists() {
         return Err(move_session_wiki_err(WikiError::DestinationPageExists(
             dst_file.display().to_string(),
         )));
@@ -4591,10 +4593,11 @@ async fn move_planned_session(
         return Ok(MoveSessionReport {
             session_id: sid.to_string(),
             dry_run: true,
+            session_moved: summary.session_moved,
             from: plan.from_label,
             to: plan.to_label,
             summary: move_session_counts(&summary),
-            page: move_session_page_label(req.pages, touched_rows, src_file.is_file()),
+            page: move_session_page_label(req.pages, touched_rows, file_moves),
             cwd: plan.cwd,
             cwd_warning,
             pre_checkpoint: None,
@@ -4630,6 +4633,7 @@ async fn move_planned_session(
     Ok(MoveSessionReport {
         session_id: sid.to_string(),
         dry_run: false,
+        session_moved: outcome.summary.session_moved,
         from: plan.from_label,
         to: plan.to_label,
         summary: move_session_counts(&outcome.summary),
@@ -4678,6 +4682,7 @@ async fn move_single_session(
             workspace: to_workspace,
             project: req.project.clone(),
         },
+        row_scope: (from_ws, from_proj),
         cwd,
     };
 
@@ -4778,13 +4783,27 @@ async fn move_session_batch(
     let total = sessions.len();
     let mut reports = Vec::with_capacity(total);
     let mut failure: Option<(SessionId, MoveErr)> = None;
-    for (session_id, cwd) in sessions {
+    for (session_id, row_scope, cwd) in sessions {
+        // The page file follows the page rows: a session rooted in a third
+        // scope (only some observations in the source) is moved whole from
+        // where its row sits; a session already rooted in the destination is
+        // re-homed and its stray page file, if any, is looked for in the
+        // source.
+        let (plan_from, plan_from_label) = if row_scope == from || row_scope == to {
+            (from, from_label.clone())
+        } else {
+            (
+                row_scope,
+                scope_label(state, row_scope.0, row_scope.1).await,
+            )
+        };
         let plan = MoveSessionPlan {
             session_id,
-            from,
-            from_label: from_label.clone(),
+            from: plan_from,
+            from_label: plan_from_label,
             to,
             to_label: to_label.clone(),
+            row_scope,
             cwd,
         };
         match move_planned_session(state, req, plan, author_id, &actor).await {

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -58,11 +58,13 @@ use ai_memory_core::{
 use ai_memory_llm::{Embedder, LlmProvider, ProviderHealth, ProviderHealthSnapshot};
 use ai_memory_store::{
     ApproveAutoImproveProposalResult, AutoImproveProposalOperation, AutoImproveProposalStatus,
-    DecayParams, NewAutoImproveProposal, ReaderPool, RejectAutoImproveProposal,
+    DecayParams, NewAutoImproveProposal, PagesMode, ReaderPool, RejectAutoImproveProposal,
     ScopeResolutionError, SkippedProposal, StageAutoImproveRun, StoreError, WriterHandle,
     create_explicit_scope, f32_vec_to_bytes, lookup_existing_scope, lookup_existing_workspace,
 };
-use ai_memory_wiki::{AdmissionContext, AdmissionOp, Markdown, Wiki, WikiError, WritePageRequest};
+use ai_memory_wiki::{
+    AdmissionContext, AdmissionOp, Markdown, SessionPageFile, Wiki, WikiError, WritePageRequest,
+};
 use axum::Json;
 use axum::Router;
 use axum::body::Body;
@@ -525,6 +527,7 @@ fn hex_to_sha256(hex: &str) -> Result<[u8; 32], String> {
 /// - `POST /admin/purge-project`
 /// - `POST /admin/rename-project`
 /// - `POST /admin/move-project`
+/// - `POST /admin/move-session`
 /// - `POST /admin/merge-workspace`
 /// - `POST /admin/write-page`
 /// - `POST /admin/delete-page`
@@ -583,6 +586,7 @@ pub fn admin_router_with_decay_breadth(state: AdminState, breadth_weight: f64) -
         .route("/admin/purge-project", post(handle_purge_project))
         .route("/admin/rename-project", post(handle_rename_project))
         .route("/admin/move-project", post(handle_move_project))
+        .route("/admin/move-session", post(handle_move_session))
         .route("/admin/delete-workspace", post(handle_delete_workspace))
         .route("/admin/rename-workspace", post(handle_rename_workspace))
         .route("/admin/merge-workspace", post(handle_merge_workspace))
@@ -4167,6 +4171,669 @@ async fn move_project_core(
         actor,
     )
     .await
+}
+
+// ---------------------------------------------------------------------
+// move-session
+// ---------------------------------------------------------------------
+
+/// JSON request body for `POST /admin/move-session`.
+///
+/// Two shapes share the route: a single move names `session_id`; a batch
+/// names `from_project` (plus optional `from_workspace`) and moves every
+/// session of that scope. Exactly one of the two must be present.
+#[derive(Deserialize)]
+struct MoveSessionRequest {
+    /// The session to move (single form).
+    #[serde(default)]
+    session_id: Option<SessionId>,
+    /// Source workspace of the batch form. Defaults to `default`.
+    #[serde(default)]
+    from_workspace: Option<String>,
+    /// Source project of the batch form: every session in it moves.
+    #[serde(default)]
+    from_project: Option<String>,
+    /// Destination workspace. Defaults to the source workspace.
+    #[serde(default)]
+    workspace: Option<String>,
+    /// Destination project. Must already exist unless `create` is set.
+    project: String,
+    /// What happens to `sessions/<id>.md`: `move` (default) carries the page
+    /// and its history along; `regenerate` retires it in the source so the
+    /// next consolidation writes a fresh one in the destination.
+    #[serde(default)]
+    pages: PagesMode,
+    /// Without `confirm: true` the server runs the move inside a rolled-back
+    /// transaction and reports what would change (`dry_run: true`).
+    #[serde(default)]
+    confirm: bool,
+    /// Skip the live-session guards: an open session (no session end
+    /// recorded), a `pending`/`running` consolidation job, and, for the batch
+    /// form, the hook router's active-project pointer.
+    #[serde(default)]
+    force: bool,
+    /// Create the destination workspace/project when absent instead of 404.
+    #[serde(default)]
+    create: bool,
+}
+
+/// `workspace/project` pair as names, for report labels.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScopeLabel {
+    /// Workspace name.
+    pub workspace: String,
+    /// Project name.
+    pub project: String,
+}
+
+/// Row counts of one session move; identical for the dry run.
+#[derive(Debug, Clone, Serialize)]
+pub struct MoveSessionCounts {
+    /// `observations` rows re-stamped.
+    pub observations: u64,
+    /// `handoffs` rows (produced by the session) re-stamped.
+    pub handoffs: u64,
+    /// `session_consolidation_jobs` rows re-stamped.
+    pub consolidation_jobs: u64,
+    /// `auto_improve_runs` rows re-stamped.
+    pub auto_improve_runs: u64,
+    /// `auto_improve_scheduler_claims` rows re-stamped.
+    pub auto_improve_claims: u64,
+    /// `pages` versions of `sessions/<id>.md` re-stamped (`pages: move`).
+    pub page_versions_moved: u64,
+    /// `pages` rows of `sessions/<id>.md` retired (`pages: regenerate`).
+    pub pages_regenerated: u64,
+}
+
+/// Wire-format report for one session in `POST /admin/move-session`.
+#[derive(Debug, Serialize)]
+pub struct MoveSessionReport {
+    /// The moved session.
+    pub session_id: String,
+    /// `true` when nothing was written (no `confirm`).
+    pub dry_run: bool,
+    /// Scope the session came from.
+    pub from: ScopeLabel,
+    /// Scope the session now belongs to.
+    pub to: ScopeLabel,
+    /// Row counts.
+    pub summary: MoveSessionCounts,
+    /// What happened (or would happen) to `sessions/<id>.md`: `"moved"`,
+    /// `"regenerated"`, or `"none"` when the session has no page.
+    pub page: &'static str,
+    /// The session's recorded working directory, left untouched.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    /// Set when `basename(cwd)` differs from the destination project name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd_warning: Option<String>,
+    /// Pre-move checkpoint, if the tree had uncommitted changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pre_checkpoint: Option<String>,
+    /// Post-move checkpoint, if the move changed the tree.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint: Option<String>,
+}
+
+/// Wire-format report for the batch form of `POST /admin/move-session`.
+#[derive(Debug, Serialize)]
+pub struct MoveSessionBatchReport {
+    /// `true` when nothing was written (no `confirm`).
+    pub dry_run: bool,
+    /// Source scope.
+    pub from: ScopeLabel,
+    /// Destination scope.
+    pub to: ScopeLabel,
+    /// Sessions found in the source scope.
+    pub total: usize,
+    /// Sessions moved (or, for a dry run, that would move).
+    pub moved: usize,
+    /// One report per session, in `started_at` order.
+    pub sessions: Vec<MoveSessionReport>,
+    /// Pre-move checkpoint, if the tree had uncommitted changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pre_checkpoint: Option<String>,
+    /// Post-move checkpoint, if the batch changed the tree.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint: Option<String>,
+}
+
+/// One session move, resolved and validated, before any guard runs.
+struct MoveSessionPlan {
+    session_id: SessionId,
+    from: (WorkspaceId, ProjectId),
+    from_label: ScopeLabel,
+    to: (WorkspaceId, ProjectId),
+    to_label: ScopeLabel,
+    cwd: Option<String>,
+}
+
+async fn handle_move_session(
+    State(state): State<Arc<AdminState>>,
+    actor_ext: Option<axum::Extension<ai_memory_core::ActorContext>>,
+    author_ext: Option<axum::Extension<ai_memory_core::UserId>>,
+    Json(req): Json<MoveSessionRequest>,
+) -> Response {
+    let actor = actor_ext
+        .map(|axum::Extension(a)| a)
+        .unwrap_or_else(ai_memory_core::ActorContext::anonymous);
+    let author_id = author_ext.map(|axum::Extension(u)| u);
+    match (req.session_id, req.from_project.as_deref()) {
+        (Some(session_id), None) => {
+            match move_single_session(&state, &req, session_id, author_id, actor).await {
+                Ok(report) => (StatusCode::OK, Json(json_or_empty(&report))).into_response(),
+                Err(resp) => resp.into_response(),
+            }
+        }
+        (None, Some(from_project)) => {
+            move_session_batch(&state, &req, from_project, author_id, actor).await
+        }
+        _ => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "provide exactly one of session_id (single move) or from_project (batch)"
+            })),
+        )
+            .into_response(),
+    }
+}
+
+fn json_or_empty<T: Serialize>(value: &T) -> serde_json::Value {
+    serde_json::to_value(value).unwrap_or_else(|_| serde_json::json!({}))
+}
+
+/// Best-effort names for a scope; ids stand in when a row vanished
+/// underneath us (a concurrent purge), so a report is still produced.
+async fn scope_label(state: &AdminState, ws: WorkspaceId, proj: ProjectId) -> ScopeLabel {
+    let workspace = state
+        .reader
+        .workspace_name_by_id(ws)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| ws.to_string());
+    let project = state
+        .reader
+        .project_name_by_id(ws, proj)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| proj.to_string());
+    ScopeLabel { workspace, project }
+}
+
+/// Resolve the destination scope: existing only (404) unless `create`.
+async fn resolve_move_session_target(
+    state: &AdminState,
+    workspace: &str,
+    project: &str,
+    create: bool,
+) -> Result<(WorkspaceId, ProjectId), MoveErr> {
+    if create {
+        create_ws_proj(state, workspace, project).await
+    } else {
+        lookup_ws_proj_no_create(state, workspace, project).await
+    }
+}
+
+/// `(session still open, consolidation job pending or running)` for the
+/// live-session guards.
+async fn session_move_blockers(
+    reader: &ReaderPool,
+    session_id: SessionId,
+) -> Result<(bool, bool), StoreError> {
+    reader
+        .with_conn(move |conn| {
+            let open: bool = conn.query_row(
+                "SELECT ended_at IS NULL FROM sessions WHERE id = ?1",
+                [session_id.as_bytes().as_slice()],
+                |row| row.get(0),
+            )?;
+            let pending: bool = conn.query_row(
+                "SELECT EXISTS(SELECT 1 FROM session_consolidation_jobs \
+                 WHERE session_id = ?1 AND state IN ('pending', 'running'))",
+                [session_id.as_bytes().as_slice()],
+                |row| row.get(0),
+            )?;
+            Ok((open, pending))
+        })
+        .await
+}
+
+/// `(session_id, cwd)` of every session in a scope, oldest first.
+async fn list_scope_sessions(
+    reader: &ReaderPool,
+    workspace_id: WorkspaceId,
+    project_id: ProjectId,
+) -> Result<Vec<(SessionId, Option<String>)>, StoreError> {
+    reader
+        .with_conn(move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, cwd FROM sessions \
+                 WHERE workspace_id = ?1 AND project_id = ?2 \
+                 ORDER BY started_at, id",
+            )?;
+            let rows = stmt.query_map(
+                [
+                    workspace_id.as_bytes().as_slice(),
+                    project_id.as_bytes().as_slice(),
+                ],
+                |row| {
+                    let id_bytes: Vec<u8> = row.get(0)?;
+                    let cwd: Option<String> = row.get(1)?;
+                    Ok((id_bytes, cwd))
+                },
+            )?;
+            let mut out = Vec::new();
+            for r in rows {
+                let (id_bytes, cwd) = r?;
+                out.push((
+                    SessionId::from_slice(&id_bytes).map_err(StoreError::Memory)?,
+                    cwd,
+                ));
+            }
+            Ok(out)
+        })
+        .await
+}
+
+fn move_session_store_err(e: StoreError) -> MoveErr {
+    match e {
+        StoreError::NotFound(msg) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": msg })),
+        ),
+        e @ StoreError::PagePathTaken { .. } => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": format!(
+                    "{e}; re-run with pages=regenerate or resolve the destination page first"
+                )
+            })),
+        ),
+        other => internal_err(other.to_string()),
+    }
+}
+
+fn move_session_wiki_err(e: WikiError) -> MoveErr {
+    match e {
+        WikiError::Store(store_err) => move_session_store_err(store_err),
+        e @ WikiError::DestinationPageExists(_) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        ),
+        other => internal_err(format!("move-session aborted: {other}")),
+    }
+}
+
+/// The session's cwd is historical truth and stays put; say so when the
+/// hook router's basename heuristic would not map it to the destination.
+fn move_session_cwd_warning(cwd: Option<&str>, to_project: &str) -> Option<String> {
+    let cwd = cwd?;
+    let base = std::path::Path::new(cwd).file_name()?.to_str()?;
+    if base == to_project {
+        return None;
+    }
+    Some(format!(
+        "session cwd '{cwd}' resolves to project '{base}' by basename, not '{to_project}'; \
+         the cwd was left as recorded. New sessions started there still land in '{base}' \
+         unless a .ai-memory.toml marker pins project = \"{to_project}\"; with \
+         [routing] mid_session = \"sticky\" the remaining events of this session follow it."
+    ))
+}
+
+fn move_session_counts(summary: &ai_memory_store::MoveSessionSummary) -> MoveSessionCounts {
+    MoveSessionCounts {
+        observations: summary.observations,
+        handoffs: summary.handoffs,
+        consolidation_jobs: summary.consolidation_jobs,
+        auto_improve_runs: summary.auto_improve_runs,
+        auto_improve_claims: summary.auto_improve_claims,
+        page_versions_moved: summary.page_versions_moved,
+        pages_regenerated: summary.pages_regenerated,
+    }
+}
+
+fn move_session_page_label(
+    pages: PagesMode,
+    touched_rows: bool,
+    touched_file: bool,
+) -> &'static str {
+    match (pages, touched_rows || touched_file) {
+        (_, false) => "none",
+        (PagesMode::Move, true) => "moved",
+        (PagesMode::Regenerate, true) => "regenerated",
+    }
+}
+
+/// Guards, then the dry run or the real move of one planned session. The
+/// caller wraps the call in the pre/post checkpoints so a batch takes one
+/// pair, not one per session.
+async fn move_planned_session(
+    state: &Arc<AdminState>,
+    req: &MoveSessionRequest,
+    plan: MoveSessionPlan,
+    author_id: Option<ai_memory_core::UserId>,
+    actor: &ai_memory_core::ActorContext,
+) -> Result<MoveSessionReport, MoveErr> {
+    let sid = plan.session_id;
+    if plan.from == plan.to {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(serde_json::json!({
+                "error": format!(
+                    "session {sid} already belongs to {}/{}",
+                    plan.to_label.workspace, plan.to_label.project
+                )
+            })),
+        ));
+    }
+
+    // Live-session guards. An open session may still receive events, and a
+    // queued consolidation would write the page under the old scope; both
+    // are the operator's call with `force`.
+    let (open, pending_job) = session_move_blockers(&state.reader, sid)
+        .await
+        .map_err(|e| internal_err(e.to_string()))?;
+    if !req.force {
+        if open {
+            return Err((
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": format!(
+                        "session {sid} is still open (no session end recorded); \
+                         finish it or re-run with force=true"
+                    )
+                })),
+            ));
+        }
+        if pending_job {
+            return Err((
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": format!(
+                        "session {sid} has a pending or running consolidation job; \
+                         wait for it or re-run with force=true"
+                    )
+                })),
+            ));
+        }
+    }
+
+    // A page file already at the destination blocks a page move; checked here
+    // too so the dry run predicts what the wiki re-checks under its lock.
+    let file_name = format!("{sid}.md");
+    let src_file = state
+        .wiki
+        .project_root(plan.from.0, plan.from.1)
+        .join("sessions")
+        .join(&file_name);
+    let dst_file = state
+        .wiki
+        .project_root(plan.to.0, plan.to.1)
+        .join("sessions")
+        .join(&file_name);
+    if req.pages == PagesMode::Move && src_file.is_file() && dst_file.exists() {
+        return Err(move_session_wiki_err(WikiError::DestinationPageExists(
+            dst_file.display().to_string(),
+        )));
+    }
+
+    let cwd_warning = move_session_cwd_warning(plan.cwd.as_deref(), &plan.to_label.project);
+
+    if !req.confirm {
+        let summary = state
+            .writer
+            .move_session(sid, plan.to.0, plan.to.1, req.pages, author_id, false)
+            .await
+            .map_err(move_session_store_err)?;
+        let touched_rows = summary.page_versions_moved > 0 || summary.pages_regenerated > 0;
+        return Ok(MoveSessionReport {
+            session_id: sid.to_string(),
+            dry_run: true,
+            from: plan.from_label,
+            to: plan.to_label,
+            summary: move_session_counts(&summary),
+            page: move_session_page_label(req.pages, touched_rows, src_file.is_file()),
+            cwd: plan.cwd,
+            cwd_warning,
+            pre_checkpoint: None,
+            checkpoint: None,
+        });
+    }
+
+    let move_ctx = AdmissionContext {
+        workspace: plan.from_label.workspace.clone(),
+        project: plan.from_label.project.clone(),
+        destination_workspace: Some(plan.to_label.workspace.clone()),
+        destination_project: Some(plan.to_label.project.clone()),
+        op: AdmissionOp::MoveSession,
+        actor: actor.clone(),
+        ..Default::default()
+    };
+    // The wiki owns the critical section: admission, file move, SQL
+    // re-stamp, and the file rollback on SQL failure.
+    let outcome = state
+        .wiki
+        .move_session_page(
+            sid,
+            plan.from,
+            plan.to,
+            req.pages,
+            author_id,
+            Some(move_ctx),
+        )
+        .await
+        .map_err(move_session_wiki_err)?;
+    let touched_rows =
+        outcome.summary.page_versions_moved > 0 || outcome.summary.pages_regenerated > 0;
+    Ok(MoveSessionReport {
+        session_id: sid.to_string(),
+        dry_run: false,
+        from: plan.from_label,
+        to: plan.to_label,
+        summary: move_session_counts(&outcome.summary),
+        page: move_session_page_label(
+            req.pages,
+            touched_rows,
+            outcome.file != SessionPageFile::Absent,
+        ),
+        cwd: plan.cwd,
+        cwd_warning,
+        pre_checkpoint: None,
+        checkpoint: None,
+    })
+}
+
+async fn move_single_session(
+    state: &Arc<AdminState>,
+    req: &MoveSessionRequest,
+    session_id: SessionId,
+    author_id: Option<ai_memory_core::UserId>,
+    actor: ai_memory_core::ActorContext,
+) -> Result<MoveSessionReport, MoveErr> {
+    let (from_ws, from_proj, cwd) = state
+        .reader
+        .find_session_scope(session_id)
+        .await
+        .map_err(|e| internal_err(e.to_string()))?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": format!("session {session_id} not found") })),
+            )
+        })?;
+    let from_label = scope_label(state, from_ws, from_proj).await;
+    let to_workspace = req
+        .workspace
+        .clone()
+        .unwrap_or_else(|| from_label.workspace.clone());
+    let to = resolve_move_session_target(state, &to_workspace, &req.project, req.create).await?;
+    let plan = MoveSessionPlan {
+        session_id,
+        from: (from_ws, from_proj),
+        from_label,
+        to,
+        to_label: ScopeLabel {
+            workspace: to_workspace,
+            project: req.project.clone(),
+        },
+        cwd,
+    };
+
+    if !req.confirm {
+        return move_planned_session(state, req, plan, author_id, &actor).await;
+    }
+    let label = format!(
+        "move-session {session_id} {}/{} -> {}/{}",
+        plan.from_label.workspace,
+        plan.from_label.project,
+        plan.to_label.workspace,
+        plan.to_label.project
+    );
+    let pre_checkpoint = checkpoint_or_500(&state.wiki, format!("pre-{label}"))?;
+    let mut report = move_planned_session(state, req, plan, author_id, &actor).await?;
+    if let Err(e) = state.wiki.backfill_scope_manifests().await {
+        warn!(error = %e, "move-session: scope-manifest backfill failed after move");
+    }
+    report.pre_checkpoint = pre_checkpoint;
+    report.checkpoint = checkpoint_or_warn(&state.wiki, label);
+    Ok(report)
+}
+
+async fn move_session_batch(
+    state: &Arc<AdminState>,
+    req: &MoveSessionRequest,
+    from_project: &str,
+    author_id: Option<ai_memory_core::UserId>,
+    actor: ai_memory_core::ActorContext,
+) -> Response {
+    let from_workspace = req
+        .from_workspace
+        .clone()
+        .unwrap_or_else(|| DEFAULT_WORKSPACE_NAME.to_string());
+    let from = match lookup_ws_proj_no_create(state, &from_workspace, from_project).await {
+        Ok(ids) => ids,
+        Err(e) => return e.into_response(),
+    };
+    let to_workspace = req
+        .workspace
+        .clone()
+        .unwrap_or_else(|| from_workspace.clone());
+    let to = match resolve_move_session_target(state, &to_workspace, &req.project, req.create).await
+    {
+        Ok(ids) => ids,
+        Err(e) => return e.into_response(),
+    };
+    let from_label = ScopeLabel {
+        workspace: from_workspace,
+        project: from_project.to_string(),
+    };
+    let to_label = ScopeLabel {
+        workspace: to_workspace,
+        project: req.project.clone(),
+    };
+    if from == to {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(serde_json::json!({
+                "error": "source and destination scopes are identical"
+            })),
+        )
+            .into_response();
+    }
+    // Same guard as move-project: the project the hook router is writing to
+    // is not emptied out from under it without an explicit `force`.
+    if !req.force && state.active_project.contains_project(from.1) {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": format!(
+                    "{}/{} is the active session's project; re-run with force=true to move its \
+                     sessions anyway",
+                    from_label.workspace, from_label.project
+                )
+            })),
+        )
+            .into_response();
+    }
+    let sessions = match list_scope_sessions(&state.reader, from.0, from.1).await {
+        Ok(v) => v,
+        Err(e) => return internal_err(e.to_string()).into_response(),
+    };
+
+    let label = format!(
+        "move-session {}/{} -> {}/{}",
+        from_label.workspace, from_label.project, to_label.workspace, to_label.project
+    );
+    let pre_checkpoint = if req.confirm && !sessions.is_empty() {
+        match checkpoint_or_500(&state.wiki, format!("pre-{label}")) {
+            Ok(oid) => oid,
+            Err(e) => return e.into_response(),
+        }
+    } else {
+        None
+    };
+
+    let total = sessions.len();
+    let mut reports = Vec::with_capacity(total);
+    let mut failure: Option<(SessionId, MoveErr)> = None;
+    for (session_id, cwd) in sessions {
+        let plan = MoveSessionPlan {
+            session_id,
+            from,
+            from_label: from_label.clone(),
+            to,
+            to_label: to_label.clone(),
+            cwd,
+        };
+        match move_planned_session(state, req, plan, author_id, &actor).await {
+            Ok(report) => reports.push(report),
+            Err(e) => {
+                failure = Some((session_id, e));
+                break;
+            }
+        }
+    }
+
+    let checkpoint = if req.confirm && !reports.is_empty() {
+        if let Err(e) = state.wiki.backfill_scope_manifests().await {
+            warn!(error = %e, "move-session: scope-manifest backfill failed after batch");
+        }
+        checkpoint_or_warn(&state.wiki, label)
+    } else {
+        None
+    };
+
+    // Stop at the first error, but say how far the batch got: the sessions
+    // already moved stay moved (each was its own transaction).
+    if let Some((session_id, (status, Json(mut body)))) = failure {
+        if let Some(obj) = body.as_object_mut() {
+            obj.insert(
+                "session_id".into(),
+                serde_json::json!(session_id.to_string()),
+            );
+            obj.insert("dry_run".into(), serde_json::json!(!req.confirm));
+            obj.insert("total".into(), serde_json::json!(total));
+            obj.insert("moved".into(), serde_json::json!(reports.len()));
+            obj.insert("sessions".into(), json_or_empty(&reports));
+            if let Some(oid) = checkpoint {
+                obj.insert("checkpoint".into(), serde_json::json!(oid));
+            }
+        }
+        return (status, Json(body)).into_response();
+    }
+    let report = MoveSessionBatchReport {
+        dry_run: !req.confirm,
+        from: from_label,
+        to: to_label,
+        total,
+        moved: reports.len(),
+        sessions: reports,
+        pre_checkpoint,
+        checkpoint,
+    };
+    (StatusCode::OK, Json(json_or_empty(&report))).into_response()
 }
 
 /// One source page, with everything the copy loop and the block

--- a/crates/ai-memory-mcp/tests/admin_move_session.rs
+++ b/crates/ai-memory-mcp/tests/admin_move_session.rs
@@ -737,6 +737,70 @@ async fn move_session_target_404_unless_create() {
         (1, 2, 1, 1)
     );
 
+    // Dry run with create: the full plan is reported, nothing is created.
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({
+            "session_id": sid.to_string(),
+            "workspace": "fresh-ws",
+            "project": "brand-new",
+            "create": true
+        }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["dry_run"], true, "{body}");
+    assert_eq!(body["would_create_project"], true, "{body}");
+    assert_eq!(body["session_moved"], true, "{body}");
+    assert_eq!(body["summary"]["observations"], 2, "{body}");
+    assert_eq!(body["summary"]["handoffs"], 1, "{body}");
+    assert_eq!(body["summary"]["consolidation_jobs"], 1, "{body}");
+    assert_eq!(body["summary"]["page_versions_moved"], 1, "{body}");
+    assert_eq!(body["page"], "moved", "{body}");
+    assert!(
+        store
+            .reader
+            .find_workspace("fresh-ws".to_string())
+            .await
+            .unwrap()
+            .is_none(),
+        "a dry run must not create the workspace"
+    );
+    let dst_projects: i64 = store
+        .reader
+        .with_conn(|conn| {
+            Ok(conn.query_row(
+                "SELECT COUNT(*) FROM projects WHERE name = 'brand-new'",
+                [],
+                |r| r.get(0),
+            )?)
+        })
+        .await
+        .unwrap();
+    assert_eq!(dst_projects, 0, "a dry run must not create the project row");
+    // Batch dry run with create behaves the same.
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "from_project": "src", "project": "brand-new", "create": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["would_create_project"], true, "{body}");
+    assert_eq!(body["total"], 1, "{body}");
+    assert_eq!(body["sessions"][0]["would_create_project"], true, "{body}");
+    assert!(
+        store
+            .reader
+            .find_project(scopes.ws, "brand-new".to_string())
+            .await
+            .unwrap()
+            .is_none()
+    );
+
     let resp = post(
         &state,
         "/admin/move-session",
@@ -752,6 +816,7 @@ async fn move_session_target_404_unless_create() {
     assert_eq!(resp.status(), StatusCode::OK);
     let body = body_json(resp).await;
     assert_eq!(body["to"]["workspace"], "fresh-ws", "{body}");
+    assert!(body.get("would_create_project").is_none(), "{body}");
     let new_ws = store
         .reader
         .find_workspace("fresh-ws".to_string())
@@ -826,7 +891,7 @@ async fn move_session_rejects_bad_shapes() {
     let body = body_json(resp).await;
     assert_eq!(body["session_moved"], false, "{body}");
     assert_eq!(body["summary"]["observations"], 0, "{body}");
-    assert_eq!(body["page"], "none", "{body}");
+    assert_eq!(body["page"], "already in destination", "{body}");
     assert_eq!(
         rows_in_scope(&store, sid, scopes.ws, scopes.src).await,
         (1, 2, 1, 1)
@@ -905,7 +970,7 @@ async fn move_session_batch_empties_phantom_bucket_with_only_observations() {
     assert_eq!(s["session_moved"], false, "{body}");
     assert_eq!(s["summary"]["observations"], 4, "{body}");
     assert_eq!(s["summary"]["handoffs"], 0, "{body}");
-    assert_eq!(s["page"], "none", "{body}");
+    assert_eq!(s["page"], "already in destination", "{body}");
     assert_eq!(
         rows_in_scope(&store, sid, scopes.ws, scopes.src).await,
         (0, 4, 0, 0)
@@ -988,6 +1053,7 @@ async fn move_session_rehome_of_open_session_needs_no_force() {
     assert_eq!(body["moved"], 1, "{body}");
     assert_eq!(body["sessions"][0]["session_moved"], false, "{body}");
     assert_eq!(body["sessions"][0]["summary"]["observations"], 2, "{body}");
+    assert_eq!(body["sessions"][0]["page"], "none", "{body}");
     assert_eq!(
         rows_in_scope(&store, sid, scopes.ws, scopes.dst).await,
         (1, 2, 0, 0)

--- a/crates/ai-memory-mcp/tests/admin_move_session.rs
+++ b/crates/ai-memory-mcp/tests/admin_move_session.rs
@@ -814,16 +814,192 @@ async fn move_session_rejects_bad_shapes() {
     )
     .await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    // Same scope.
+    // Same scope in the single form is a re-home, not an error: nothing is
+    // stray here, so every count is zero and the row stays.
     let resp = post(
         &state,
         "/admin/move-session",
-        json!({ "session_id": sid.to_string(), "project": "src" }),
+        json!({ "session_id": sid.to_string(), "project": "src", "confirm": true }),
     )
     .await;
-    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["session_moved"], false, "{body}");
+    assert_eq!(body["summary"]["observations"], 0, "{body}");
+    assert_eq!(body["page"], "none", "{body}");
     assert_eq!(
         rows_in_scope(&store, sid, scopes.ws, scopes.src).await,
         (1, 2, 1, 1)
     );
+    // Same scope in the batch form stays a 422.
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "from_project": "src", "project": "src" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+/// Scatter `n` observations of `sid` into `(ws, proj)` the way pre-sticky
+/// mid-session routing did: rows stamped into a project the session row
+/// never belonged to.
+async fn scatter_observations(
+    store: &Store,
+    sid: SessionId,
+    ws: WorkspaceId,
+    proj: ProjectId,
+    n: usize,
+) {
+    for i in 0..n {
+        store
+            .writer
+            .insert_observation(Sanitized::new(
+                NewObservation {
+                    session_id: sid,
+                    workspace_id: ws,
+                    project_id: proj,
+                    kind: ObservationKind::PostToolUse,
+                    extension: None,
+                    source_event: None,
+                    title: format!("stray {i}"),
+                    body: "landed in the wrong bucket".into(),
+                    importance: 5,
+                },
+                &Sanitizer::builtin(),
+            ))
+            .await
+            .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn move_session_batch_empties_phantom_bucket_with_only_observations() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    let scopes = seed_scopes(&store).await;
+    // The session is rooted in `dst` (row, 2 observations, handoff, job,
+    // page all there); 4 of its observations landed in `src`, which has no
+    // `sessions` row at all: the phantom bucket.
+    let sid = seed_session(&store, &state.wiki, scopes.ws, scopes.dst, "/repo/dst").await;
+    scatter_observations(&store, sid, scopes.ws, scopes.src, 4).await;
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.ws, scopes.src).await,
+        (0, 4, 0, 0)
+    );
+
+    // Dry run sees the session through its observations and reports them.
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "from_project": "src", "project": "dst" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["dry_run"], true, "{body}");
+    assert_eq!(body["total"], 1, "{body}");
+    assert_eq!(body["moved"], 1, "{body}");
+    let s = &body["sessions"][0];
+    assert_eq!(s["session_id"], sid.to_string(), "{body}");
+    assert_eq!(s["session_moved"], false, "{body}");
+    assert_eq!(s["summary"]["observations"], 4, "{body}");
+    assert_eq!(s["summary"]["handoffs"], 0, "{body}");
+    assert_eq!(s["page"], "none", "{body}");
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.ws, scopes.src).await,
+        (0, 4, 0, 0)
+    );
+
+    // Confirm: the strays are gathered, the bucket is empty, the row and the
+    // page never moved.
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "from_project": "src", "project": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["dry_run"], false, "{body}");
+    assert_eq!(body["total"], 1, "{body}");
+    assert_eq!(body["moved"], 1, "{body}");
+    assert_eq!(body["sessions"][0]["session_moved"], false, "{body}");
+    assert_eq!(body["sessions"][0]["summary"]["observations"], 4, "{body}");
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.ws, scopes.src).await,
+        (0, 0, 0, 0)
+    );
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.ws, scopes.dst).await,
+        (1, 6, 1, 1)
+    );
+    assert!(
+        state
+            .wiki
+            .abs_path(scopes.ws, scopes.dst, &page_path(sid))
+            .exists()
+    );
+    assert_eq!(
+        read_page(&state, "default", "dst", sid).await,
+        StatusCode::OK
+    );
+    // Nothing left touching the bucket.
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "from_project": "src", "project": "dst" }),
+    )
+    .await;
+    assert_eq!(body_json(resp).await["total"], 0);
+}
+
+/// An open session whose row already sits in the destination is re-homed
+/// without `force`: the row does not move, so the open-session guard does not
+/// apply (a pending job still does).
+#[tokio::test]
+async fn move_session_rehome_of_open_session_needs_no_force() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    let scopes = seed_scopes(&store).await;
+    let sid = SessionId::new();
+    store
+        .writer
+        .begin_session(NewSession {
+            id: sid,
+            workspace_id: scopes.ws,
+            project_id: scopes.dst,
+            agent_kind: AgentKind::ClaudeCode,
+            cwd: Some("/repo/dst".into()),
+            actor_user: None,
+        })
+        .await
+        .unwrap();
+    scatter_observations(&store, sid, scopes.ws, scopes.src, 2).await;
+
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "from_project": "src", "project": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["moved"], 1, "{body}");
+    assert_eq!(body["sessions"][0]["session_moved"], false, "{body}");
+    assert_eq!(body["sessions"][0]["summary"]["observations"], 2, "{body}");
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.ws, scopes.dst).await,
+        (1, 2, 0, 0)
+    );
+
+    // The same open session, batch-moved out of its own scope, still needs
+    // force: the row would move.
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "from_project": "dst", "project": "src", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
 }

--- a/crates/ai-memory-mcp/tests/admin_move_session.rs
+++ b/crates/ai-memory-mcp/tests/admin_move_session.rs
@@ -1,0 +1,829 @@
+//! Integration tests for `POST /admin/move-session` (#402).
+//!
+//! Same harness as `admin_move.rs`: a real [`AdminState`] over a
+//! tmpdir-backed store + wiki, driven through `admin_router` with
+//! `tower::ServiceExt::oneshot`. Two scopes, one session with everything a
+//! move re-stamps (observations, a handoff it produced, a completed
+//! consolidation job) and a `sessions/<id>.md` page written through the wiki
+//! so a real file sits on disk.
+
+use ai_memory_core::{
+    AgentKind, NewHandoff, NewObservation, NewSession, ObservationKind, PagePath, ProjectId,
+    Sanitized, Sanitizer, SessionId, Tier, WorkspaceId,
+};
+use ai_memory_mcp::{AdminState, admin_router};
+use ai_memory_store::{DecayParams, Store};
+use ai_memory_wiki::{Wiki, WritePageRequest};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::json;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
+    let store = Store::open(tmp.path()).unwrap();
+    let wiki = Wiki::new(tmp.path(), store.writer.clone())
+        .unwrap()
+        .with_store_reader(store.reader.clone());
+    let db_path = store.db_path().to_path_buf();
+    let state = AdminState {
+        writer: store.writer.clone(),
+        reader: store.reader.clone(),
+        wiki,
+        llm: None,
+        auto_improve_require_approval: false,
+        auto_improve_review_config: Default::default(),
+        embedder: None,
+        provider_health: ai_memory_llm::ProviderHealth::default(),
+        decay_params: DecayParams::default(),
+        data_dir: tmp.path().to_path_buf(),
+        db_path,
+        bind: "127.0.0.1:0".to_string(),
+        home_dir: None,
+        bootstrap_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
+        token_pepper: None,
+        active_project: ai_memory_core::ActiveProject::new(),
+        scope_invalidator: None,
+        trusted_proxy_identity: false,
+    };
+    (state, store)
+}
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+}
+
+async fn post(state: &AdminState, uri: &str, body: serde_json::Value) -> axum::response::Response {
+    let router = admin_router(state.clone());
+    let req = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    router.oneshot(req).await.unwrap()
+}
+
+async fn get(state: &AdminState, uri: &str) -> axum::response::Response {
+    let router = admin_router(state.clone());
+    let req = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    router.oneshot(req).await.unwrap()
+}
+
+/// Two projects in workspace `default`, `src` and `dst`, plus a workspace
+/// `other` with a project `far` for the cross-workspace case.
+struct Scopes {
+    ws: WorkspaceId,
+    src: ProjectId,
+    dst: ProjectId,
+    other_ws: WorkspaceId,
+    far: ProjectId,
+}
+
+async fn seed_scopes(store: &Store) -> Scopes {
+    let ws = store
+        .writer
+        .get_or_create_workspace("default")
+        .await
+        .unwrap();
+    let src = store
+        .writer
+        .get_or_create_project(ws, "src", None)
+        .await
+        .unwrap();
+    let dst = store
+        .writer
+        .get_or_create_project(ws, "dst", None)
+        .await
+        .unwrap();
+    let other_ws = store.writer.get_or_create_workspace("other").await.unwrap();
+    let far = store
+        .writer
+        .get_or_create_project(other_ws, "far", None)
+        .await
+        .unwrap();
+    Scopes {
+        ws,
+        src,
+        dst,
+        other_ws,
+        far,
+    }
+}
+
+/// One ended session in `(ws, proj)` with two observations, a handoff it
+/// produced, a completed consolidation job and a `sessions/<id>.md` page
+/// written through the wiki (so the file exists on disk).
+async fn seed_session(
+    store: &Store,
+    wiki: &Wiki,
+    ws: WorkspaceId,
+    proj: ProjectId,
+    cwd: &str,
+) -> SessionId {
+    let sid = SessionId::new();
+    store
+        .writer
+        .begin_session(NewSession {
+            id: sid,
+            workspace_id: ws,
+            project_id: proj,
+            agent_kind: AgentKind::ClaudeCode,
+            cwd: Some(cwd.into()),
+            actor_user: None,
+        })
+        .await
+        .unwrap();
+    for n in 0..2 {
+        store
+            .writer
+            .insert_observation(Sanitized::new(
+                NewObservation {
+                    session_id: sid,
+                    workspace_id: ws,
+                    project_id: proj,
+                    kind: ObservationKind::UserPrompt,
+                    extension: None,
+                    source_event: None,
+                    title: format!("prompt {n}"),
+                    body: "do the thing".into(),
+                    importance: 5,
+                },
+                &Sanitizer::builtin(),
+            ))
+            .await
+            .unwrap();
+    }
+    store.writer.end_session(sid, None).await.unwrap();
+    store
+        .writer
+        .insert_handoff(NewHandoff {
+            workspace_id: ws,
+            project_id: proj,
+            from_session_id: Some(sid),
+            from_agent: AgentKind::ClaudeCode,
+            to_agent: None,
+            cwd: None,
+            summary: "handoff from the moved session".into(),
+            open_questions: vec![],
+            next_steps: vec![],
+            files_touched: vec![],
+            owner_user: None,
+        })
+        .await
+        .unwrap();
+    assert!(
+        store
+            .writer
+            .enqueue_session_consolidation(ws, proj, sid)
+            .await
+            .unwrap()
+    );
+    let job = store
+        .writer
+        .claim_session_consolidation(i64::MAX / 2, 0)
+        .await
+        .unwrap()
+        .expect("the queued job must be claimable");
+    assert_eq!(job.session_id(), sid);
+    store
+        .writer
+        .complete_session_consolidation(job)
+        .await
+        .unwrap();
+    wiki.write_page(WritePageRequest {
+        workspace_id: ws,
+        project_id: proj,
+        path: page_path(sid),
+        frontmatter: json!({ "title": "Session summary" }),
+        body: format!("consolidated body of {sid}"),
+        tier: Tier::Episodic,
+        pinned: false,
+        title: Some("Session summary".into()),
+        admission_ctx: None,
+        author_id: None,
+        actor: ai_memory_core::ActorContext::anonymous(),
+    })
+    .await
+    .unwrap();
+    sid
+}
+
+fn page_path(sid: SessionId) -> PagePath {
+    PagePath::new(format!("sessions/{sid}.md")).unwrap()
+}
+
+/// `(sessions, observations, handoffs, consolidation_jobs)` rows of `sid`
+/// sitting in `(ws, proj)`.
+async fn rows_in_scope(
+    store: &Store,
+    sid: SessionId,
+    ws: WorkspaceId,
+    proj: ProjectId,
+) -> (i64, i64, i64, i64) {
+    // The mcp crate does not depend on rusqlite directly: params go in as
+    // plain byte slices and the closure returns the store's error type.
+    store
+        .reader
+        .with_conn(move |conn| {
+            let params = [
+                sid.as_bytes().as_slice(),
+                ws.as_bytes().as_slice(),
+                proj.as_bytes().as_slice(),
+            ];
+            let mut counts = [0i64; 4];
+            for (slot, sql) in counts.iter_mut().zip([
+                "SELECT COUNT(*) FROM sessions \
+                 WHERE id = ?1 AND workspace_id = ?2 AND project_id = ?3",
+                "SELECT COUNT(*) FROM observations \
+                 WHERE session_id = ?1 AND workspace_id = ?2 AND project_id = ?3",
+                "SELECT COUNT(*) FROM handoffs \
+                 WHERE from_session_id = ?1 AND workspace_id = ?2 AND project_id = ?3",
+                "SELECT COUNT(*) FROM session_consolidation_jobs \
+                 WHERE session_id = ?1 AND workspace_id = ?2 AND project_id = ?3",
+            ]) {
+                *slot = conn.query_row(sql, params, |r| r.get(0))?;
+            }
+            Ok((counts[0], counts[1], counts[2], counts[3]))
+        })
+        .await
+        .unwrap()
+}
+
+async fn read_page(state: &AdminState, ws: &str, project: &str, sid: SessionId) -> StatusCode {
+    get(
+        state,
+        &format!("/admin/read-page?workspace={ws}&project={project}&path=sessions/{sid}.md"),
+    )
+    .await
+    .status()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn move_session_dry_run_reports_counts_and_changes_nothing() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    let scopes = seed_scopes(&store).await;
+    let sid = seed_session(&store, &state.wiki, scopes.ws, scopes.src, "/repo/src").await;
+
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "session_id": sid.to_string(), "project": "dst" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["dry_run"], true, "{body}");
+    assert_eq!(body["from"]["project"], "src", "{body}");
+    assert_eq!(body["to"]["workspace"], "default", "{body}");
+    assert_eq!(body["to"]["project"], "dst", "{body}");
+    assert_eq!(body["summary"]["observations"], 2, "{body}");
+    assert_eq!(body["summary"]["handoffs"], 1, "{body}");
+    assert_eq!(body["summary"]["consolidation_jobs"], 1, "{body}");
+    assert_eq!(body["summary"]["page_versions_moved"], 1, "{body}");
+    assert_eq!(body["page"], "moved", "{body}");
+    assert_eq!(body["cwd"], "/repo/src", "{body}");
+    assert!(
+        body["cwd_warning"]
+            .as_str()
+            .is_some_and(|w| w.contains("'src'") && w.contains("'dst'")),
+        "basename(cwd) = src differs from dst: {body}"
+    );
+    assert!(body.get("checkpoint").is_none(), "{body}");
+
+    // Nothing moved: rows and file still in the source scope.
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.ws, scopes.src).await,
+        (1, 2, 1, 1)
+    );
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.ws, scopes.dst).await,
+        (0, 0, 0, 0)
+    );
+    let path = page_path(sid);
+    assert!(state.wiki.abs_path(scopes.ws, scopes.src, &path).exists());
+    assert!(!state.wiki.abs_path(scopes.ws, scopes.dst, &path).exists());
+    assert_eq!(
+        read_page(&state, "default", "src", sid).await,
+        StatusCode::OK
+    );
+}
+
+#[tokio::test]
+async fn move_session_restamps_rows_moves_file_and_checkpoints() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    let scopes = seed_scopes(&store).await;
+    // cwd basename equals the destination: no warning expected.
+    let sid = seed_session(&store, &state.wiki, scopes.ws, scopes.src, "/repo/dst").await;
+
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "session_id": sid.to_string(), "project": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["dry_run"], false, "{body}");
+    assert_eq!(body["summary"]["observations"], 2, "{body}");
+    assert_eq!(body["summary"]["page_versions_moved"], 1, "{body}");
+    assert_eq!(body["page"], "moved", "{body}");
+    assert!(body.get("cwd_warning").is_none(), "{body}");
+    assert!(
+        body["checkpoint"].as_str().is_some(),
+        "a real move must checkpoint the wiki: {body}"
+    );
+
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.ws, scopes.dst).await,
+        (1, 2, 1, 1)
+    );
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.ws, scopes.src).await,
+        (0, 0, 0, 0)
+    );
+    let path = page_path(sid);
+    assert!(!state.wiki.abs_path(scopes.ws, scopes.src, &path).exists());
+    assert!(state.wiki.abs_path(scopes.ws, scopes.dst, &path).exists());
+    assert_eq!(
+        read_page(&state, "default", "dst", sid).await,
+        StatusCode::OK
+    );
+    assert_eq!(
+        read_page(&state, "default", "src", sid).await,
+        StatusCode::NOT_FOUND
+    );
+    // The move landed in git history.
+    let checkpoints = state.wiki.recent_checkpoints(5).unwrap();
+    assert!(
+        checkpoints
+            .iter()
+            .any(|c| c.summary.contains("move-session")),
+        "{checkpoints:?}"
+    );
+}
+
+#[tokio::test]
+async fn move_session_across_workspaces_and_regenerate() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    let scopes = seed_scopes(&store).await;
+    let sid = seed_session(&store, &state.wiki, scopes.ws, scopes.src, "/repo/src").await;
+
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({
+            "session_id": sid.to_string(),
+            "workspace": "other",
+            "project": "far",
+            "pages": "regenerate",
+            "confirm": true
+        }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["to"]["workspace"], "other", "{body}");
+    assert_eq!(body["summary"]["pages_regenerated"], 1, "{body}");
+    assert_eq!(body["summary"]["page_versions_moved"], 0, "{body}");
+    assert_eq!(body["page"], "regenerated", "{body}");
+
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.other_ws, scopes.far).await,
+        (1, 2, 1, 1)
+    );
+    let path = page_path(sid);
+    assert!(
+        !state.wiki.abs_path(scopes.ws, scopes.src, &path).exists(),
+        "retired page file must be removed so the watcher cannot resurrect it"
+    );
+    assert!(
+        !state
+            .wiki
+            .abs_path(scopes.other_ws, scopes.far, &path)
+            .exists()
+    );
+    assert_eq!(
+        read_page(&state, "default", "src", sid).await,
+        StatusCode::NOT_FOUND
+    );
+}
+
+#[tokio::test]
+async fn move_session_page_collision_returns_409_and_leaves_source_intact() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    let scopes = seed_scopes(&store).await;
+    let sid = seed_session(&store, &state.wiki, scopes.ws, scopes.src, "/repo/src").await;
+    // A latest page at the same path in the destination, DB row only, so the
+    // wiki's file step succeeds and the store refuses (PagePathTaken).
+    store
+        .writer
+        .upsert_page(ai_memory_core::NewPage {
+            workspace_id: scopes.ws,
+            project_id: scopes.dst,
+            path: page_path(sid),
+            title: "taken".into(),
+            body: "already here".into(),
+            tier: Tier::Semantic,
+            frontmatter_json: json!({}),
+            pinned: false,
+            links: vec![],
+            author_id: None,
+            expires_at: None,
+            entities: vec![],
+        })
+        .await
+        .unwrap();
+
+    for confirm in [false, true] {
+        let resp = post(
+            &state,
+            "/admin/move-session",
+            json!({ "session_id": sid.to_string(), "project": "dst", "confirm": confirm }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT, "confirm={confirm}");
+        let body = body_json(resp).await;
+        assert!(
+            body["error"]
+                .as_str()
+                .is_some_and(|e| e.contains("regenerate")),
+            "{body}"
+        );
+    }
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.ws, scopes.src).await,
+        (1, 2, 1, 1)
+    );
+    let path = page_path(sid);
+    assert!(
+        state.wiki.abs_path(scopes.ws, scopes.src, &path).exists(),
+        "the file must be back in the source after the store refused"
+    );
+    assert!(!state.wiki.abs_path(scopes.ws, scopes.dst, &path).exists());
+
+    // Regenerate side-steps the collision.
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({
+            "session_id": sid.to_string(),
+            "project": "dst",
+            "pages": "regenerate",
+            "confirm": true
+        }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.ws, scopes.dst).await,
+        (1, 2, 1, 1)
+    );
+}
+
+#[tokio::test]
+async fn move_session_pending_job_or_open_session_needs_force() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    let scopes = seed_scopes(&store).await;
+    let sid = seed_session(&store, &state.wiki, scopes.ws, scopes.src, "/repo/src").await;
+    // A second generation waiting in the queue.
+    store
+        .writer
+        .insert_observation(Sanitized::new(
+            NewObservation {
+                session_id: sid,
+                workspace_id: scopes.ws,
+                project_id: scopes.src,
+                kind: ObservationKind::UserPrompt,
+                extension: None,
+                source_event: None,
+                title: "late prompt".into(),
+                body: "one more".into(),
+                importance: 5,
+            },
+            &Sanitizer::builtin(),
+        ))
+        .await
+        .unwrap();
+    assert!(
+        store
+            .writer
+            .enqueue_session_consolidation(scopes.ws, scopes.src, sid)
+            .await
+            .unwrap()
+    );
+
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "session_id": sid.to_string(), "project": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let body = body_json(resp).await;
+    assert!(
+        body["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("consolidation job")),
+        "{body}"
+    );
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.ws, scopes.src).await,
+        (1, 3, 1, 2)
+    );
+
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "session_id": sid.to_string(), "project": "dst", "confirm": true, "force": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.ws, scopes.dst).await,
+        (1, 3, 1, 2)
+    );
+
+    // An open session (no session end) is refused the same way.
+    let open = SessionId::new();
+    store
+        .writer
+        .begin_session(NewSession {
+            id: open,
+            workspace_id: scopes.ws,
+            project_id: scopes.src,
+            agent_kind: AgentKind::Codex,
+            cwd: None,
+            actor_user: None,
+        })
+        .await
+        .unwrap();
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "session_id": open.to_string(), "project": "dst" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let body = body_json(resp).await;
+    assert!(
+        body["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("still open")),
+        "{body}"
+    );
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "session_id": open.to_string(), "project": "dst", "force": true }),
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "dry run with force passes the guard"
+    );
+}
+
+#[tokio::test]
+async fn move_session_batch_from_project_empties_the_source() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    let scopes = seed_scopes(&store).await;
+    let a = seed_session(&store, &state.wiki, scopes.ws, scopes.src, "/repo/src").await;
+    let b = seed_session(&store, &state.wiki, scopes.ws, scopes.src, "/repo/src").await;
+
+    // Dry run first: counts, nothing written.
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "from_project": "src", "project": "dst" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["dry_run"], true, "{body}");
+    assert_eq!(body["total"], 2, "{body}");
+    assert_eq!(body["moved"], 2, "{body}");
+    assert_eq!(body["sessions"].as_array().map(Vec::len), Some(2), "{body}");
+    assert_eq!(
+        rows_in_scope(&store, a, scopes.ws, scopes.src).await,
+        (1, 2, 1, 1)
+    );
+
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "from_project": "src", "project": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["dry_run"], false, "{body}");
+    assert_eq!(body["moved"], 2, "{body}");
+    assert!(body["checkpoint"].as_str().is_some(), "{body}");
+    for sid in [a, b] {
+        assert_eq!(
+            rows_in_scope(&store, sid, scopes.ws, scopes.dst).await,
+            (1, 2, 1, 1)
+        );
+        assert_eq!(
+            rows_in_scope(&store, sid, scopes.ws, scopes.src).await,
+            (0, 0, 0, 0)
+        );
+        assert!(
+            state
+                .wiki
+                .abs_path(scopes.ws, scopes.dst, &page_path(sid))
+                .exists()
+        );
+        assert_eq!(
+            read_page(&state, "default", "dst", sid).await,
+            StatusCode::OK
+        );
+    }
+    // Source is empty now: a second batch has nothing to do.
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "from_project": "src", "project": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["total"], 0, "{body}");
+}
+
+#[tokio::test]
+async fn move_session_batch_stops_at_first_error_and_reports_progress() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    let scopes = seed_scopes(&store).await;
+    let first = seed_session(&store, &state.wiki, scopes.ws, scopes.src, "/repo/src").await;
+    // Second session is still open: refused without force.
+    let open = SessionId::new();
+    store
+        .writer
+        .begin_session(NewSession {
+            id: open,
+            workspace_id: scopes.ws,
+            project_id: scopes.src,
+            agent_kind: AgentKind::Codex,
+            cwd: None,
+            actor_user: None,
+        })
+        .await
+        .unwrap();
+
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "from_project": "src", "project": "dst", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let body = body_json(resp).await;
+    assert_eq!(body["session_id"], open.to_string(), "{body}");
+    assert_eq!(body["total"], 2, "{body}");
+    assert_eq!(body["moved"], 1, "{body}");
+    assert_eq!(body["sessions"].as_array().map(Vec::len), Some(1), "{body}");
+    // The first session stayed moved (its own transaction), the open one did not.
+    assert_eq!(
+        rows_in_scope(&store, first, scopes.ws, scopes.dst).await,
+        (1, 2, 1, 1)
+    );
+    assert_eq!(
+        rows_in_scope(&store, open, scopes.ws, scopes.src).await.0,
+        1
+    );
+}
+
+#[tokio::test]
+async fn move_session_target_404_unless_create() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    let scopes = seed_scopes(&store).await;
+    let sid = seed_session(&store, &state.wiki, scopes.ws, scopes.src, "/repo/src").await;
+
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "session_id": sid.to_string(), "project": "brand-new", "confirm": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.ws, scopes.src).await,
+        (1, 2, 1, 1)
+    );
+
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({
+            "session_id": sid.to_string(),
+            "workspace": "fresh-ws",
+            "project": "brand-new",
+            "create": true,
+            "confirm": true
+        }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["to"]["workspace"], "fresh-ws", "{body}");
+    let new_ws = store
+        .reader
+        .find_workspace("fresh-ws".to_string())
+        .await
+        .unwrap()
+        .expect("workspace created");
+    let new_proj = store
+        .reader
+        .find_project(new_ws, "brand-new".to_string())
+        .await
+        .unwrap()
+        .expect("project created");
+    assert_eq!(
+        rows_in_scope(&store, sid, new_ws, new_proj).await,
+        (1, 2, 1, 1)
+    );
+    assert!(
+        state
+            .wiki
+            .abs_path(new_ws, new_proj, &page_path(sid))
+            .exists()
+    );
+    // The new project dir got its scope manifest.
+    assert!(
+        state
+            .wiki
+            .project_root(new_ws, new_proj)
+            .join("_meta.md")
+            .exists()
+    );
+    assert_eq!(
+        read_page(&state, "fresh-ws", "brand-new", sid).await,
+        StatusCode::OK
+    );
+}
+
+#[tokio::test]
+async fn move_session_rejects_bad_shapes() {
+    let tmp = TempDir::new().unwrap();
+    let (state, store) = make_state(&tmp).await;
+    let scopes = seed_scopes(&store).await;
+    let sid = seed_session(&store, &state.wiki, scopes.ws, scopes.src, "/repo/src").await;
+
+    // Neither session_id nor from_project.
+    let resp = post(&state, "/admin/move-session", json!({ "project": "dst" })).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    // Both at once.
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "session_id": sid.to_string(), "from_project": "src", "project": "dst" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    // Unknown session.
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "session_id": SessionId::new().to_string(), "project": "dst" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    // Same scope.
+    let resp = post(
+        &state,
+        "/admin/move-session",
+        json!({ "session_id": sid.to_string(), "project": "src" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(
+        rows_in_scope(&store, sid, scopes.ws, scopes.src).await,
+        (1, 2, 1, 1)
+    );
+}

--- a/crates/ai-memory-store/src/error.rs
+++ b/crates/ai-memory-store/src/error.rs
@@ -112,6 +112,16 @@ pub enum StoreError {
     #[error("workspace name '{0}' is already taken")]
     WorkspaceNameTaken(String),
 
+    /// A session move was rejected because the destination scope already has
+    /// a latest page at the session page path (`idx_pages_latest_path`), so
+    /// re-stamping the source versions would collide. The caller retries with
+    /// the regenerate mode or resolves the destination page first.
+    #[error("page path '{path}' already has a latest version in the destination scope")]
+    PagePathTaken {
+        /// The colliding wiki-relative page path.
+        path: String,
+    },
+
     /// The supplied workspace name failed validation (empty, slash, etc.).
     #[error("invalid workspace name: {0}")]
     InvalidWorkspaceName(String),

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -58,8 +58,7 @@ pub use reader::{
     PageHitWithMeta, PageLinks, PageMeta, PageSummary, ProjectSummary, ReaderPool,
     ReindexTargetStatus, RelatedPage, RrfContributions, ScopeRow, SearchExplain,
     SessionDependentRows, SessionEndDisposition, SessionSummary, StatusCounts, StoredEmbedding,
-    StoredPageBody,
-    WorkspaceScopeRow, WorkspaceSummary, f32_vec_to_bytes,
+    StoredPageBody, WorkspaceScopeRow, WorkspaceSummary, f32_vec_to_bytes,
 };
 pub use scope::{
     ResolvedScope, ScopeName, ScopeResolutionError, ScopeResolver, WORKSPACE_PROJECT_PAIR_REQUIRED,

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -46,7 +46,8 @@ pub use error::{StoreError, StoreResult};
 pub use maintenance::MaintenanceJob;
 pub use ops::{
     AdmittedSession, DeleteWorkspaceSummary, EmbeddingWrite, HookSessionAdmission,
-    IngestObservationOutcome, LifecycleOnlyEndOutcome, MoveSummary, PurgeSummary, ReorgSummary,
+    IngestObservationOutcome, LifecycleOnlyEndOutcome, MoveSessionSummary, MoveSummary, PagesMode,
+    PurgeSummary, ReorgSummary,
 };
 pub use reader::{
     ActivityWindow, AgentSessionCount, AutoImproveCandidateSession, BriefPageBody, BriefingPage,

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -56,8 +56,8 @@ pub use reader::{
     FeedbackFinding, GraphVia, HealthDetail, HealthPage, ObservationHit, OpenSession, PageAuthor,
     PageHit, PageHitWithMeta, PageLinks, PageMeta, PageSummary, ProjectSummary, ReaderPool,
     ReindexTargetStatus, RelatedPage, RrfContributions, ScopeRow, SearchExplain,
-    SessionEndDisposition, StatusCounts, StoredEmbedding, StoredPageBody, WorkspaceScopeRow,
-    WorkspaceSummary, f32_vec_to_bytes,
+    SessionDependentRows, SessionEndDisposition, StatusCounts, StoredEmbedding, StoredPageBody,
+    WorkspaceScopeRow, WorkspaceSummary, f32_vec_to_bytes,
 };
 pub use scope::{
     ResolvedScope, ScopeName, ScopeResolutionError, ScopeResolver, WORKSPACE_PROJECT_PAIR_REQUIRED,

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -3056,12 +3056,14 @@ pub fn move_project_workspace(
 
 /// How [`move_session`] treats the session's consolidated wiki page
 /// (`sessions/<session_id>.md`) when the session changes scope.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum PagesMode {
     /// Re-stamp every version of the page into the destination scope so the
     /// curated page and its supersession history follow the session. Fails
     /// with [`StoreError::PagePathTaken`] when the destination already holds
     /// a latest page at that path.
+    #[default]
     Move,
     /// Leave the rows in the source scope but clear `is_latest`, so the next
     /// consolidation of the session writes a fresh page in the destination.
@@ -3117,6 +3119,8 @@ pub struct MoveSessionSummary {
 /// `commit = false` performs the same work and rolls the transaction back
 /// before returning, so the summary is an exact dry run. A target equal to the
 /// source is a no-op that reports zero counts and `session_moved = false`.
+/// `author_id` is the operator recorded on the `audit_log` row, as in
+/// [`rename_project`].
 ///
 /// The `workspace_id`/`project_id` pairing triggers only guard INSERT, so the
 /// target pair is validated against `projects` here before any UPDATE runs.
@@ -3133,6 +3137,7 @@ pub fn move_session(
     target_workspace: WorkspaceId,
     target_project: ProjectId,
     pages: PagesMode,
+    author_id: Option<ai_memory_core::UserId>,
     commit: bool,
 ) -> StoreResult<MoveSessionSummary> {
     let tx = conn.transaction()?;
@@ -3275,7 +3280,7 @@ pub fn move_session(
         Some(to_ws),
         Some(to_proj),
         None,
-        None,
+        author_id.as_ref().map(ai_memory_core::UserId::as_bytes),
         Timestamp::now().as_microsecond(),
     )?;
 
@@ -5377,8 +5382,16 @@ pub(crate) mod tests {
         let dst_proj = get_or_create_project(&mut conn, &dst_ws, "target", None).unwrap();
         let sid = seed_movable_session(&mut conn, src_ws, src_proj);
 
-        let summary =
-            move_session(&mut conn, sid, dst_ws, dst_proj, PagesMode::Move, false).unwrap();
+        let summary = move_session(
+            &mut conn,
+            sid,
+            dst_ws,
+            dst_proj,
+            PagesMode::Move,
+            None,
+            false,
+        )
+        .unwrap();
         assert!(summary.session_moved);
         assert_eq!(summary.observations, 2);
         assert_eq!(summary.handoffs, 1);
@@ -5419,8 +5432,16 @@ pub(crate) mod tests {
         let dst_proj = get_or_create_project(&mut conn, &dst_ws, "target", None).unwrap();
         let sid = seed_movable_session(&mut conn, src_ws, src_proj);
 
-        let summary =
-            move_session(&mut conn, sid, dst_ws, dst_proj, PagesMode::Move, true).unwrap();
+        let summary = move_session(
+            &mut conn,
+            sid,
+            dst_ws,
+            dst_proj,
+            PagesMode::Move,
+            None,
+            true,
+        )
+        .unwrap();
         assert!(summary.session_moved);
         assert_eq!(summary.observations, 2);
         assert_eq!(summary.page_versions_moved, 2);
@@ -5462,8 +5483,16 @@ pub(crate) mod tests {
         let path = format!("sessions/{sid}.md");
         upsert_page(&mut conn, &page(dst_ws, dst_proj, &path, "already here")).unwrap();
 
-        let err = move_session(&mut conn, sid, dst_ws, dst_proj, PagesMode::Move, true)
-            .expect_err("latest page at the same path in the target must block the move");
+        let err = move_session(
+            &mut conn,
+            sid,
+            dst_ws,
+            dst_proj,
+            PagesMode::Move,
+            None,
+            true,
+        )
+        .expect_err("latest page at the same path in the target must block the move");
         assert!(
             matches!(&err, StoreError::PagePathTaken { path: p } if *p == path),
             "unexpected error: {err:?}"
@@ -5491,6 +5520,7 @@ pub(crate) mod tests {
             dst_ws,
             dst_proj,
             PagesMode::Regenerate,
+            None,
             true,
         )
         .unwrap();
@@ -5517,8 +5547,16 @@ pub(crate) mod tests {
         )
         .unwrap();
 
-        let summary =
-            move_session(&mut conn, sid, dst_ws, dst_proj, PagesMode::Move, true).unwrap();
+        let summary = move_session(
+            &mut conn,
+            sid,
+            dst_ws,
+            dst_proj,
+            PagesMode::Move,
+            None,
+            true,
+        )
+        .unwrap();
         assert!(summary.session_moved);
         assert_eq!(summary.page_versions_moved, 0);
         assert_eq!(summary.pages_regenerated, 0);
@@ -5528,8 +5566,16 @@ pub(crate) mod tests {
     #[test]
     fn move_session_unknown_session_is_not_found() {
         let (_tmp, mut conn, ws, proj) = fresh_db();
-        let err = move_session(&mut conn, SessionId::new(), ws, proj, PagesMode::Move, true)
-            .expect_err("unknown session must not succeed");
+        let err = move_session(
+            &mut conn,
+            SessionId::new(),
+            ws,
+            proj,
+            PagesMode::Move,
+            None,
+            true,
+        )
+        .expect_err("unknown session must not succeed");
         assert!(
             matches!(err, StoreError::NotFound(_)),
             "unexpected error: {err:?}"
@@ -5544,8 +5590,16 @@ pub(crate) mod tests {
 
         // A project id that exists, but not in the requested workspace: the
         // pairing triggers only guard INSERT, so the op must refuse it itself.
-        let err = move_session(&mut conn, sid, dst_ws, src_proj, PagesMode::Move, true)
-            .expect_err("target project outside the target workspace must be refused");
+        let err = move_session(
+            &mut conn,
+            sid,
+            dst_ws,
+            src_proj,
+            PagesMode::Move,
+            None,
+            true,
+        )
+        .expect_err("target project outside the target workspace must be refused");
         assert!(
             matches!(err, StoreError::NotFound(_)),
             "unexpected error: {err:?}"
@@ -5558,7 +5612,7 @@ pub(crate) mod tests {
         let (_tmp, mut conn, ws, proj) = fresh_db();
         let sid = seed_movable_session(&mut conn, ws, proj);
 
-        let summary = move_session(&mut conn, sid, ws, proj, PagesMode::Move, true).unwrap();
+        let summary = move_session(&mut conn, sid, ws, proj, PagesMode::Move, None, true).unwrap();
         assert!(!summary.session_moved);
         assert_eq!(summary.observations, 0);
         assert_eq!(summary.handoffs, 0);

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -3054,6 +3054,239 @@ pub fn move_project_workspace(
     })
 }
 
+/// How [`move_session`] treats the session's consolidated wiki page
+/// (`sessions/<session_id>.md`) when the session changes scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PagesMode {
+    /// Re-stamp every version of the page into the destination scope so the
+    /// curated page and its supersession history follow the session. Fails
+    /// with [`StoreError::PagePathTaken`] when the destination already holds
+    /// a latest page at that path.
+    Move,
+    /// Leave the rows in the source scope but clear `is_latest`, so the next
+    /// consolidation of the session writes a fresh page in the destination.
+    Regenerate,
+}
+
+/// Summary returned by [`move_session`] and exposed via
+/// [`crate::writer::WriterHandle::move_session`]. Populated identically for a
+/// dry run (`commit = false`), whose transaction is rolled back after counting.
+#[derive(Debug, Clone)]
+pub struct MoveSessionSummary {
+    /// Whether the `sessions` row changed scope. `false` when the target
+    /// scope equals the source scope (no-op; every count is zero).
+    pub session_moved: bool,
+    /// `observations` rows re-stamped (every row of the session, including
+    /// any that landed outside the session row's own scope).
+    pub observations: u64,
+    /// `handoffs` rows re-stamped (`from_session_id` = the session).
+    pub handoffs: u64,
+    /// `session_consolidation_jobs` rows re-stamped.
+    pub consolidation_jobs: u64,
+    /// `auto_improve_runs` rows re-stamped.
+    pub auto_improve_runs: u64,
+    /// `auto_improve_scheduler_claims` rows re-stamped.
+    pub auto_improve_claims: u64,
+    /// `pages` rows (all versions) re-stamped under [`PagesMode::Move`].
+    pub page_versions_moved: u64,
+    /// `pages` rows whose `is_latest` was cleared under
+    /// [`PagesMode::Regenerate`].
+    pub pages_regenerated: u64,
+    /// The session page path when the source scope held at least one version
+    /// of it, so the caller can move or retire the on-disk file too.
+    pub page_path: Option<String>,
+    /// Scope the session was read from.
+    pub from_workspace: WorkspaceId,
+    /// Scope the session was read from.
+    pub from_project: ProjectId,
+    /// Scope the session now belongs to.
+    pub to_workspace: WorkspaceId,
+    /// Scope the session now belongs to.
+    pub to_project: ProjectId,
+    /// The session's recorded working directory, left untouched by the move
+    /// (historical truth; the caller may warn when it no longer matches the
+    /// destination project).
+    pub cwd: Option<String>,
+}
+
+/// Re-stamp one session and every row that hangs off it (`observations`,
+/// `handoffs` it produced, its consolidation jobs, auto-improve runs and
+/// scheduler claim) into `(target_workspace, target_project)` in ONE
+/// transaction, plus its `sessions/<session_id>.md` page per `pages`.
+///
+/// `commit = false` performs the same work and rolls the transaction back
+/// before returning, so the summary is an exact dry run. A target equal to the
+/// source is a no-op that reports zero counts and `session_moved = false`.
+///
+/// The `workspace_id`/`project_id` pairing triggers only guard INSERT, so the
+/// target pair is validated against `projects` here before any UPDATE runs.
+///
+/// # Errors
+/// - [`StoreError::NotFound`] when the session or the target project (in the
+///   target workspace) does not exist.
+/// - [`StoreError::PagePathTaken`] under [`PagesMode::Move`] when the target
+///   scope already has a latest page at the session page path.
+/// - [`StoreError::Sqlite`] on any other SQL failure.
+pub fn move_session(
+    conn: &mut Connection,
+    session_id: SessionId,
+    target_workspace: WorkspaceId,
+    target_project: ProjectId,
+    pages: PagesMode,
+    commit: bool,
+) -> StoreResult<MoveSessionSummary> {
+    let tx = conn.transaction()?;
+
+    let sid = session_id.as_bytes();
+    let row = tx
+        .query_row(
+            "SELECT workspace_id, project_id, cwd FROM sessions WHERE id = ?1",
+            params![&sid[..]],
+            |row| {
+                Ok((
+                    row.get::<_, Vec<u8>>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((from_ws, from_proj, cwd)) = row else {
+        return Err(StoreError::NotFound(format!(
+            "session {session_id} not found"
+        )));
+    };
+    let from_workspace = WorkspaceId::from_slice(&from_ws)?;
+    let from_project = ProjectId::from_slice(&from_proj)?;
+
+    let mut summary = MoveSessionSummary {
+        session_moved: false,
+        observations: 0,
+        handoffs: 0,
+        consolidation_jobs: 0,
+        auto_improve_runs: 0,
+        auto_improve_claims: 0,
+        page_versions_moved: 0,
+        pages_regenerated: 0,
+        page_path: None,
+        from_workspace,
+        from_project,
+        to_workspace: target_workspace,
+        to_project: target_project,
+        cwd,
+    };
+    if from_workspace == target_workspace && from_project == target_project {
+        return Ok(summary);
+    }
+
+    let to_ws = target_workspace.as_bytes();
+    let to_proj = target_project.as_bytes();
+    let target_exists: Option<i64> = tx
+        .query_row(
+            "SELECT 1 FROM projects WHERE id = ?1 AND workspace_id = ?2",
+            params![&to_proj[..], &to_ws[..]],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if target_exists.is_none() {
+        return Err(StoreError::NotFound(format!(
+            "project {target_project} not found in workspace {target_workspace}"
+        )));
+    }
+
+    let sessions_updated = tx.execute(
+        "UPDATE sessions SET workspace_id = ?1, project_id = ?2 WHERE id = ?3",
+        params![&to_ws[..], &to_proj[..], &sid[..]],
+    )?;
+    summary.session_moved = sessions_updated == 1;
+    // Fires `observations_fts_au` per row (delete + reinsert of the same
+    // text); the FTS index stays consistent inside this transaction.
+    summary.observations = tx.execute(
+        "UPDATE observations SET workspace_id = ?1, project_id = ?2 WHERE session_id = ?3",
+        params![&to_ws[..], &to_proj[..], &sid[..]],
+    )? as u64;
+    summary.handoffs = tx.execute(
+        "UPDATE handoffs SET workspace_id = ?1, project_id = ?2 WHERE from_session_id = ?3",
+        params![&to_ws[..], &to_proj[..], &sid[..]],
+    )? as u64;
+    summary.consolidation_jobs = tx.execute(
+        "UPDATE session_consolidation_jobs SET workspace_id = ?1, project_id = ?2 \
+         WHERE session_id = ?3",
+        params![&to_ws[..], &to_proj[..], &sid[..]],
+    )? as u64;
+    summary.auto_improve_runs = tx.execute(
+        "UPDATE auto_improve_runs SET workspace_id = ?1, project_id = ?2 WHERE session_id = ?3",
+        params![&to_ws[..], &to_proj[..], &sid[..]],
+    )? as u64;
+    summary.auto_improve_claims = tx.execute(
+        "UPDATE auto_improve_scheduler_claims SET workspace_id = ?1, project_id = ?2 \
+         WHERE session_id = ?3",
+        params![&to_ws[..], &to_proj[..], &sid[..]],
+    )? as u64;
+
+    let page_path = format!("sessions/{session_id}.md");
+    let source_versions: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM pages WHERE workspace_id = ?1 AND project_id = ?2 AND path = ?3",
+        params![&from_ws[..], &from_proj[..], page_path.as_str()],
+        |row| row.get(0),
+    )?;
+    if source_versions > 0 {
+        match pages {
+            PagesMode::Move => {
+                let taken: Option<i64> = tx
+                    .query_row(
+                        "SELECT 1 FROM pages \
+                         WHERE workspace_id = ?1 AND project_id = ?2 AND path = ?3 \
+                           AND is_latest = 1",
+                        params![&to_ws[..], &to_proj[..], page_path.as_str()],
+                        |row| row.get(0),
+                    )
+                    .optional()?;
+                if taken.is_some() {
+                    return Err(StoreError::PagePathTaken { path: page_path });
+                }
+                summary.page_versions_moved = tx.execute(
+                    "UPDATE pages SET workspace_id = ?1, project_id = ?2 \
+                     WHERE workspace_id = ?3 AND project_id = ?4 AND path = ?5",
+                    params![
+                        &to_ws[..],
+                        &to_proj[..],
+                        &from_ws[..],
+                        &from_proj[..],
+                        page_path.as_str()
+                    ],
+                )? as u64;
+            }
+            PagesMode::Regenerate => {
+                summary.pages_regenerated = tx.execute(
+                    "UPDATE pages SET is_latest = 0 \
+                     WHERE workspace_id = ?1 AND project_id = ?2 AND path = ?3 \
+                       AND is_latest = 1",
+                    params![&from_ws[..], &from_proj[..], page_path.as_str()],
+                )? as u64;
+            }
+        }
+        summary.page_path = Some(page_path);
+    }
+
+    audit(
+        &tx,
+        "move_session",
+        Some(to_ws),
+        Some(to_proj),
+        None,
+        None,
+        Timestamp::now().as_microsecond(),
+    )?;
+
+    if commit {
+        tx.commit()?;
+    } else {
+        tx.rollback()?;
+    }
+    Ok(summary)
+}
+
 /// Remove embedding rows in a workspace/project scope whose `(provider, model, dim)`
 /// does not match the configured triple, plus rows tied to superseded pages.
 pub fn delete_stale_page_embeddings(
@@ -4952,6 +5185,393 @@ pub(crate) mod tests {
             )
             .unwrap();
         assert_eq!(src_pages, 1, "rollback must preserve source pages");
+    }
+
+    /// Seed one session in `(ws, proj)` with everything `move_session`
+    /// re-stamps: two observations, one handoff it produced, one completed
+    /// consolidation job, one auto-improve run, one scheduler claim, and two
+    /// versions of its `sessions/<id>.md` page. Returns the session id.
+    fn seed_movable_session(conn: &mut Connection, ws: WorkspaceId, proj: ProjectId) -> SessionId {
+        use ai_memory_core::ObservationKind;
+
+        let sid = SessionId::new();
+        begin_session(
+            conn,
+            &NewSession {
+                id: sid,
+                workspace_id: ws,
+                project_id: proj,
+                agent_kind: AgentKind::ClaudeCode,
+                cwd: Some("/repo/src".into()),
+                actor_user: None,
+            },
+        )
+        .unwrap();
+        for n in 0..2 {
+            insert_observation(
+                conn,
+                &NewObservation {
+                    session_id: sid,
+                    workspace_id: ws,
+                    project_id: proj,
+                    kind: ObservationKind::UserPrompt,
+                    extension: None,
+                    source_event: None,
+                    title: format!("movable-obs-{n}"),
+                    body: "zebra token body".into(),
+                    importance: 5,
+                },
+            )
+            .unwrap();
+        }
+        end_session(conn, &sid, None).unwrap();
+        insert_handoff(
+            conn,
+            &NewHandoff {
+                workspace_id: ws,
+                project_id: proj,
+                from_session_id: Some(sid),
+                from_agent: AgentKind::ClaudeCode,
+                to_agent: None,
+                cwd: None,
+                summary: "handoff from the movable session".into(),
+                open_questions: vec![],
+                next_steps: vec![],
+                files_touched: vec![],
+                owner_user: None,
+            },
+        )
+        .unwrap();
+        assert!(crate::session_consolidation::enqueue(conn, ws, proj, sid).unwrap());
+        conn.execute(
+            "UPDATE session_consolidation_jobs SET state = 'completed', completed_at = 1 \
+             WHERE session_id = ?1",
+            params![sid.as_bytes()],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO auto_improve_runs \
+             (id, workspace_id, project_id, session_id, proposal_actor_json, created_at) \
+             VALUES (?1, ?2, ?3, ?4, '{}', 1)",
+            params![
+                uuid::Uuid::new_v4().as_bytes(),
+                ws.as_bytes(),
+                proj.as_bytes(),
+                sid.as_bytes()
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO auto_improve_scheduler_claims \
+             (workspace_id, project_id, session_id, claimed_at) VALUES (?1, ?2, ?3, 1)",
+            params![ws.as_bytes(), proj.as_bytes(), sid.as_bytes()],
+        )
+        .unwrap();
+        let path = format!("sessions/{sid}.md");
+        upsert_page(conn, &page(ws, proj, &path, "first version")).unwrap();
+        upsert_page(conn, &page(ws, proj, &path, "second version")).unwrap();
+        sid
+    }
+
+    /// Rows of `table` keyed to `sid` (via `session_col`) that sit in the
+    /// given scope.
+    fn session_rows_in_scope(
+        conn: &Connection,
+        table: &str,
+        session_col: &str,
+        sid: SessionId,
+        ws: WorkspaceId,
+        proj: ProjectId,
+    ) -> i64 {
+        conn.query_row(
+            &format!(
+                "SELECT COUNT(*) FROM {table} \
+                 WHERE {session_col} = ?1 AND workspace_id = ?2 AND project_id = ?3"
+            ),
+            params![sid.as_bytes(), ws.as_bytes(), proj.as_bytes()],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    /// `(all versions, latest versions)` of the session page in a scope.
+    fn session_page_versions(
+        conn: &Connection,
+        sid: SessionId,
+        ws: WorkspaceId,
+        proj: ProjectId,
+    ) -> (i64, i64) {
+        let path = format!("sessions/{sid}.md");
+        conn.query_row(
+            "SELECT COUNT(*), COALESCE(SUM(is_latest), 0) FROM pages \
+             WHERE workspace_id = ?1 AND project_id = ?2 AND path = ?3",
+            params![ws.as_bytes(), proj.as_bytes(), path],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap()
+    }
+
+    /// Observations of `sid` reachable through FTS in a scope, i.e. what a
+    /// scoped search would return after the move.
+    fn fts_hits_in_scope(
+        conn: &Connection,
+        sid: SessionId,
+        ws: WorkspaceId,
+        proj: ProjectId,
+    ) -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM observations_fts \
+             JOIN observations ON observations.rowid = observations_fts.rowid \
+             WHERE observations_fts MATCH 'zebra' \
+               AND observations.session_id = ?1 \
+               AND observations.workspace_id = ?2 AND observations.project_id = ?3",
+            params![sid.as_bytes(), ws.as_bytes(), proj.as_bytes()],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    /// The `(table, session column)` pairs `move_session` re-stamps besides
+    /// `sessions` and `pages`.
+    const MOVE_SESSION_CHILD_TABLES: [(&str, &str); 5] = [
+        ("observations", "session_id"),
+        ("handoffs", "from_session_id"),
+        ("session_consolidation_jobs", "session_id"),
+        ("auto_improve_runs", "session_id"),
+        ("auto_improve_scheduler_claims", "session_id"),
+    ];
+
+    fn assert_session_bundle_in_scope(
+        conn: &Connection,
+        sid: SessionId,
+        here: (WorkspaceId, ProjectId),
+        gone: (WorkspaceId, ProjectId),
+    ) {
+        assert_eq!(
+            session_rows_in_scope(conn, "sessions", "id", sid, here.0, here.1),
+            1
+        );
+        assert_eq!(
+            session_rows_in_scope(conn, "sessions", "id", sid, gone.0, gone.1),
+            0
+        );
+        for (table, col) in MOVE_SESSION_CHILD_TABLES {
+            let expected = if table == "observations" { 2 } else { 1 };
+            assert_eq!(
+                session_rows_in_scope(conn, table, col, sid, here.0, here.1),
+                expected,
+                "{table} rows must sit in the expected scope"
+            );
+            assert_eq!(
+                session_rows_in_scope(conn, table, col, sid, gone.0, gone.1),
+                0,
+                "{table} rows must not sit in the other scope"
+            );
+        }
+    }
+
+    #[test]
+    fn move_session_dry_run_reports_counts_and_changes_nothing() {
+        let (_tmp, mut conn, src_ws, src_proj) = fresh_db();
+        let dst_ws = get_or_create_workspace(&mut conn, "other").unwrap();
+        let dst_proj = get_or_create_project(&mut conn, &dst_ws, "target", None).unwrap();
+        let sid = seed_movable_session(&mut conn, src_ws, src_proj);
+
+        let summary =
+            move_session(&mut conn, sid, dst_ws, dst_proj, PagesMode::Move, false).unwrap();
+        assert!(summary.session_moved);
+        assert_eq!(summary.observations, 2);
+        assert_eq!(summary.handoffs, 1);
+        assert_eq!(summary.consolidation_jobs, 1);
+        assert_eq!(summary.auto_improve_runs, 1);
+        assert_eq!(summary.auto_improve_claims, 1);
+        assert_eq!(summary.page_versions_moved, 2);
+        assert_eq!(summary.pages_regenerated, 0);
+        assert_eq!(
+            summary.page_path.as_deref(),
+            Some(format!("sessions/{sid}.md").as_str())
+        );
+        assert_eq!(summary.from_workspace, src_ws);
+        assert_eq!(summary.from_project, src_proj);
+        assert_eq!(summary.to_workspace, dst_ws);
+        assert_eq!(summary.to_project, dst_proj);
+        assert_eq!(summary.cwd.as_deref(), Some("/repo/src"));
+
+        // Rolled back: everything still lives in the source scope.
+        assert_session_bundle_in_scope(&conn, sid, (src_ws, src_proj), (dst_ws, dst_proj));
+        assert_eq!(session_page_versions(&conn, sid, src_ws, src_proj), (2, 1));
+        assert_eq!(session_page_versions(&conn, sid, dst_ws, dst_proj), (0, 0));
+        assert_eq!(fts_hits_in_scope(&conn, sid, src_ws, src_proj), 2);
+        let audited: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM audit_log WHERE op = 'move_session'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(audited, 0, "dry run must not leave an audit row");
+    }
+
+    #[test]
+    fn move_session_restamps_dependent_rows_and_page_versions() {
+        let (_tmp, mut conn, src_ws, src_proj) = fresh_db();
+        let dst_ws = get_or_create_workspace(&mut conn, "other").unwrap();
+        let dst_proj = get_or_create_project(&mut conn, &dst_ws, "target", None).unwrap();
+        let sid = seed_movable_session(&mut conn, src_ws, src_proj);
+
+        let summary =
+            move_session(&mut conn, sid, dst_ws, dst_proj, PagesMode::Move, true).unwrap();
+        assert!(summary.session_moved);
+        assert_eq!(summary.observations, 2);
+        assert_eq!(summary.page_versions_moved, 2);
+        assert_eq!(summary.pages_regenerated, 0);
+
+        assert_session_bundle_in_scope(&conn, sid, (dst_ws, dst_proj), (src_ws, src_proj));
+        // Both versions moved and the supersession chain kept exactly one latest.
+        assert_eq!(session_page_versions(&conn, sid, dst_ws, dst_proj), (2, 1));
+        assert_eq!(session_page_versions(&conn, sid, src_ws, src_proj), (0, 0));
+        // The FTS index followed the observations into the new scope.
+        assert_eq!(fts_hits_in_scope(&conn, sid, dst_ws, dst_proj), 2);
+        assert_eq!(fts_hits_in_scope(&conn, sid, src_ws, src_proj), 0);
+        // cwd is historical truth and stays put.
+        let cwd: Option<String> = conn
+            .query_row(
+                "SELECT cwd FROM sessions WHERE id = ?1",
+                params![sid.as_bytes()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(cwd.as_deref(), Some("/repo/src"));
+        let audited: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM audit_log \
+                 WHERE op = 'move_session' AND workspace_id = ?1 AND project_id = ?2",
+                params![dst_ws.as_bytes(), dst_proj.as_bytes()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(audited, 1);
+    }
+
+    #[test]
+    fn move_session_rejects_page_path_taken_in_target_and_rolls_back() {
+        let (_tmp, mut conn, src_ws, src_proj) = fresh_db();
+        let dst_ws = get_or_create_workspace(&mut conn, "other").unwrap();
+        let dst_proj = get_or_create_project(&mut conn, &dst_ws, "target", None).unwrap();
+        let sid = seed_movable_session(&mut conn, src_ws, src_proj);
+        let path = format!("sessions/{sid}.md");
+        upsert_page(&mut conn, &page(dst_ws, dst_proj, &path, "already here")).unwrap();
+
+        let err = move_session(&mut conn, sid, dst_ws, dst_proj, PagesMode::Move, true)
+            .expect_err("latest page at the same path in the target must block the move");
+        assert!(
+            matches!(&err, StoreError::PagePathTaken { path: p } if *p == path),
+            "unexpected error: {err:?}"
+        );
+        // Nothing moved: the session rows were re-stamped inside the same
+        // transaction and must have rolled back with the page check.
+        assert_session_bundle_in_scope(&conn, sid, (src_ws, src_proj), (dst_ws, dst_proj));
+        assert_eq!(session_page_versions(&conn, sid, src_ws, src_proj), (2, 1));
+        assert_eq!(session_page_versions(&conn, sid, dst_ws, dst_proj), (1, 1));
+    }
+
+    #[test]
+    fn move_session_regenerate_retires_source_page_and_moves_rows() {
+        let (_tmp, mut conn, src_ws, src_proj) = fresh_db();
+        let dst_ws = get_or_create_workspace(&mut conn, "other").unwrap();
+        let dst_proj = get_or_create_project(&mut conn, &dst_ws, "target", None).unwrap();
+        let sid = seed_movable_session(&mut conn, src_ws, src_proj);
+        // A latest page at the path in the target is fine under Regenerate.
+        let path = format!("sessions/{sid}.md");
+        upsert_page(&mut conn, &page(dst_ws, dst_proj, &path, "already here")).unwrap();
+
+        let summary = move_session(
+            &mut conn,
+            sid,
+            dst_ws,
+            dst_proj,
+            PagesMode::Regenerate,
+            true,
+        )
+        .unwrap();
+        assert!(summary.session_moved);
+        assert_eq!(summary.page_versions_moved, 0);
+        assert_eq!(summary.pages_regenerated, 1);
+        assert_eq!(summary.page_path.as_deref(), Some(path.as_str()));
+
+        assert_session_bundle_in_scope(&conn, sid, (dst_ws, dst_proj), (src_ws, src_proj));
+        // Source versions stay where they are, none of them latest anymore.
+        assert_eq!(session_page_versions(&conn, sid, src_ws, src_proj), (2, 0));
+        assert_eq!(session_page_versions(&conn, sid, dst_ws, dst_proj), (1, 1));
+    }
+
+    #[test]
+    fn move_session_without_page_reports_no_page_path() {
+        let (_tmp, mut conn, src_ws, src_proj) = fresh_db();
+        let dst_ws = get_or_create_workspace(&mut conn, "other").unwrap();
+        let dst_proj = get_or_create_project(&mut conn, &dst_ws, "target", None).unwrap();
+        let sid = seed_movable_session(&mut conn, src_ws, src_proj);
+        conn.execute(
+            "DELETE FROM pages WHERE workspace_id = ?1 AND project_id = ?2",
+            params![src_ws.as_bytes(), src_proj.as_bytes()],
+        )
+        .unwrap();
+
+        let summary =
+            move_session(&mut conn, sid, dst_ws, dst_proj, PagesMode::Move, true).unwrap();
+        assert!(summary.session_moved);
+        assert_eq!(summary.page_versions_moved, 0);
+        assert_eq!(summary.pages_regenerated, 0);
+        assert_eq!(summary.page_path, None);
+    }
+
+    #[test]
+    fn move_session_unknown_session_is_not_found() {
+        let (_tmp, mut conn, ws, proj) = fresh_db();
+        let err = move_session(&mut conn, SessionId::new(), ws, proj, PagesMode::Move, true)
+            .expect_err("unknown session must not succeed");
+        assert!(
+            matches!(err, StoreError::NotFound(_)),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn move_session_unknown_target_project_is_not_found() {
+        let (_tmp, mut conn, src_ws, src_proj) = fresh_db();
+        let dst_ws = get_or_create_workspace(&mut conn, "other").unwrap();
+        let sid = seed_movable_session(&mut conn, src_ws, src_proj);
+
+        // A project id that exists, but not in the requested workspace: the
+        // pairing triggers only guard INSERT, so the op must refuse it itself.
+        let err = move_session(&mut conn, sid, dst_ws, src_proj, PagesMode::Move, true)
+            .expect_err("target project outside the target workspace must be refused");
+        assert!(
+            matches!(err, StoreError::NotFound(_)),
+            "unexpected error: {err:?}"
+        );
+        assert_session_bundle_in_scope(&conn, sid, (src_ws, src_proj), (dst_ws, src_proj));
+    }
+
+    #[test]
+    fn move_session_same_scope_is_a_noop_summary() {
+        let (_tmp, mut conn, ws, proj) = fresh_db();
+        let sid = seed_movable_session(&mut conn, ws, proj);
+
+        let summary = move_session(&mut conn, sid, ws, proj, PagesMode::Move, true).unwrap();
+        assert!(!summary.session_moved);
+        assert_eq!(summary.observations, 0);
+        assert_eq!(summary.handoffs, 0);
+        assert_eq!(summary.consolidation_jobs, 0);
+        assert_eq!(summary.auto_improve_runs, 0);
+        assert_eq!(summary.auto_improve_claims, 0);
+        assert_eq!(summary.page_versions_moved, 0);
+        assert_eq!(summary.pages_regenerated, 0);
+        assert_eq!(summary.page_path, None);
+        assert_eq!(summary.from_workspace, ws);
+        assert_eq!(summary.to_project, proj);
+        assert_eq!(summary.cwd.as_deref(), Some("/repo/src"));
+        assert_eq!(session_page_versions(&conn, sid, ws, proj), (2, 1));
     }
 
     #[test]

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -3075,11 +3075,14 @@ pub enum PagesMode {
 /// dry run (`commit = false`), whose transaction is rolled back after counting.
 #[derive(Debug, Clone)]
 pub struct MoveSessionSummary {
-    /// Whether the `sessions` row changed scope. `false` when the target
-    /// scope equals the source scope (no-op; every count is zero).
+    /// Whether the `sessions` row changed scope. `false` when the row already
+    /// sat in the target scope: the call is then a "re-home" that only
+    /// re-stamps the session's rows still lying in other scopes, and every
+    /// count says how many of those there were (all zero when none).
     pub session_moved: bool,
-    /// `observations` rows re-stamped (every row of the session, including
-    /// any that landed outside the session row's own scope).
+    /// `observations` rows re-stamped: every row of the session that was
+    /// outside the target scope, including any that landed outside the
+    /// session row's own scope. Rows already in the target are not counted.
     pub observations: u64,
     /// `handoffs` rows re-stamped (`from_session_id` = the session).
     pub handoffs: u64,
@@ -3116,11 +3119,25 @@ pub struct MoveSessionSummary {
 /// scheduler claim) into `(target_workspace, target_project)` in ONE
 /// transaction, plus its `sessions/<session_id>.md` page per `pages`.
 ///
+/// Dependent rows are matched by session id alone, so a hybrid session whose
+/// events were scattered over other scopes (mid-session routing before the
+/// sticky mode) is gathered whole; only rows not already in the target are
+/// touched and counted.
+///
+/// A target equal to the session row's own scope is a **re-home**: the row
+/// stays put (`session_moved = false`) and the same sweep re-stamps every
+/// dependent row still lying in any other scope; a session with nothing
+/// outside the target reports zero counts (not an error). Its page rows are
+/// then handled wherever they sit outside the target: under
+/// [`PagesMode::Move`] they are re-stamped (refused with
+/// [`StoreError::PagePathTaken`] when the target already holds a latest page
+/// or more than one outside scope does), under [`PagesMode::Regenerate`]
+/// their latest rows are retired. In a real move the page rows handled are
+/// those of the source scope, as before.
+///
 /// `commit = false` performs the same work and rolls the transaction back
-/// before returning, so the summary is an exact dry run. A target equal to the
-/// source is a no-op that reports zero counts and `session_moved = false`.
-/// `author_id` is the operator recorded on the `audit_log` row, as in
-/// [`rename_project`].
+/// before returning, so the summary is an exact dry run. `author_id` is the
+/// operator recorded on the `audit_log` row, as in [`rename_project`].
 ///
 /// The `workspace_id`/`project_id` pairing triggers only guard INSERT, so the
 /// target pair is validated against `projects` here before any UPDATE runs.
@@ -3180,9 +3197,7 @@ pub fn move_session(
         to_project: target_project,
         cwd,
     };
-    if from_workspace == target_workspace && from_project == target_project {
-        return Ok(summary);
-    }
+    let rehome = from_workspace == target_workspace && from_project == target_project;
 
     let to_ws = target_workspace.as_bytes();
     let to_proj = target_project.as_bytes();
@@ -3199,43 +3214,55 @@ pub fn move_session(
         )));
     }
 
-    let sessions_updated = tx.execute(
-        "UPDATE sessions SET workspace_id = ?1, project_id = ?2 WHERE id = ?3",
-        params![&to_ws[..], &to_proj[..], &sid[..]],
-    )?;
-    summary.session_moved = sessions_updated == 1;
-    // Fires `observations_fts_au` per row (delete + reinsert of the same
-    // text); the FTS index stays consistent inside this transaction.
-    summary.observations = tx.execute(
-        "UPDATE observations SET workspace_id = ?1, project_id = ?2 WHERE session_id = ?3",
-        params![&to_ws[..], &to_proj[..], &sid[..]],
-    )? as u64;
-    summary.handoffs = tx.execute(
-        "UPDATE handoffs SET workspace_id = ?1, project_id = ?2 WHERE from_session_id = ?3",
-        params![&to_ws[..], &to_proj[..], &sid[..]],
-    )? as u64;
-    summary.consolidation_jobs = tx.execute(
-        "UPDATE session_consolidation_jobs SET workspace_id = ?1, project_id = ?2 \
-         WHERE session_id = ?3",
-        params![&to_ws[..], &to_proj[..], &sid[..]],
-    )? as u64;
-    summary.auto_improve_runs = tx.execute(
-        "UPDATE auto_improve_runs SET workspace_id = ?1, project_id = ?2 WHERE session_id = ?3",
-        params![&to_ws[..], &to_proj[..], &sid[..]],
-    )? as u64;
-    summary.auto_improve_claims = tx.execute(
-        "UPDATE auto_improve_scheduler_claims SET workspace_id = ?1, project_id = ?2 \
-         WHERE session_id = ?3",
-        params![&to_ws[..], &to_proj[..], &sid[..]],
-    )? as u64;
+    if !rehome {
+        let sessions_updated = tx.execute(
+            "UPDATE sessions SET workspace_id = ?1, project_id = ?2 WHERE id = ?3",
+            params![&to_ws[..], &to_proj[..], &sid[..]],
+        )?;
+        summary.session_moved = sessions_updated == 1;
+    }
+    // Every dependent row of the session not already in the target, whatever
+    // scope it lies in. Fires `observations_fts_au` per observation row
+    // (delete + reinsert of the same text); the FTS index stays consistent
+    // inside this transaction.
+    let restamp = |table: &str, session_col: &str| -> StoreResult<u64> {
+        Ok(tx.execute(
+            &format!(
+                "UPDATE {table} SET workspace_id = ?1, project_id = ?2 \
+                 WHERE {session_col} = ?3 \
+                   AND NOT (workspace_id = ?1 AND project_id = ?2)"
+            ),
+            params![&to_ws[..], &to_proj[..], &sid[..]],
+        )? as u64)
+    };
+    summary.observations = restamp("observations", "session_id")?;
+    summary.handoffs = restamp("handoffs", "from_session_id")?;
+    summary.consolidation_jobs = restamp("session_consolidation_jobs", "session_id")?;
+    summary.auto_improve_runs = restamp("auto_improve_runs", "session_id")?;
+    summary.auto_improve_claims = restamp("auto_improve_scheduler_claims", "session_id")?;
 
+    // Page rows to handle: the source scope's in a real move; in a re-home,
+    // any scope other than the target (the source IS the target).
     let page_path = format!("sessions/{session_id}.md");
-    let source_versions: i64 = tx.query_row(
-        "SELECT COUNT(*) FROM pages WHERE workspace_id = ?1 AND project_id = ?2 AND path = ?3",
-        params![&from_ws[..], &from_proj[..], page_path.as_str()],
-        |row| row.get(0),
+    let page_scope_sql = if rehome {
+        "NOT (workspace_id = ?1 AND project_id = ?2)"
+    } else {
+        "workspace_id = ?1 AND project_id = ?2"
+    };
+    let page_scope_params = if rehome {
+        (&to_ws[..], &to_proj[..])
+    } else {
+        (&from_ws[..], &from_proj[..])
+    };
+    let (candidate_versions, candidate_latest): (i64, i64) = tx.query_row(
+        &format!(
+            "SELECT COUNT(*), COALESCE(SUM(is_latest), 0) FROM pages \
+             WHERE {page_scope_sql} AND path = ?3"
+        ),
+        params![page_scope_params.0, page_scope_params.1, page_path.as_str()],
+        |row| Ok((row.get(0)?, row.get(1)?)),
     )?;
-    if source_versions > 0 {
+    if candidate_versions > 0 {
         match pages {
             PagesMode::Move => {
                 let taken: Option<i64> = tx
@@ -3247,27 +3274,33 @@ pub fn move_session(
                         |row| row.get(0),
                     )
                     .optional()?;
-                if taken.is_some() {
+                // Two latest rows cannot share the path in the target
+                // (`idx_pages_latest_path`): a re-home that finds latest
+                // rows in more than one outside scope is a collision too.
+                if taken.is_some() || candidate_latest > 1 {
                     return Err(StoreError::PagePathTaken { path: page_path });
                 }
                 summary.page_versions_moved = tx.execute(
-                    "UPDATE pages SET workspace_id = ?1, project_id = ?2 \
-                     WHERE workspace_id = ?3 AND project_id = ?4 AND path = ?5",
+                    &format!(
+                        "UPDATE pages SET workspace_id = ?4, project_id = ?5 \
+                         WHERE {page_scope_sql} AND path = ?3"
+                    ),
                     params![
+                        page_scope_params.0,
+                        page_scope_params.1,
+                        page_path.as_str(),
                         &to_ws[..],
                         &to_proj[..],
-                        &from_ws[..],
-                        &from_proj[..],
-                        page_path.as_str()
                     ],
                 )? as u64;
             }
             PagesMode::Regenerate => {
                 summary.pages_regenerated = tx.execute(
-                    "UPDATE pages SET is_latest = 0 \
-                     WHERE workspace_id = ?1 AND project_id = ?2 AND path = ?3 \
-                       AND is_latest = 1",
-                    params![&from_ws[..], &from_proj[..], page_path.as_str()],
+                    &format!(
+                        "UPDATE pages SET is_latest = 0 \
+                         WHERE {page_scope_sql} AND path = ?3 AND is_latest = 1"
+                    ),
+                    params![page_scope_params.0, page_scope_params.1, page_path.as_str()],
                 )? as u64;
             }
         }
@@ -5607,8 +5640,10 @@ pub(crate) mod tests {
         assert_session_bundle_in_scope(&conn, sid, (src_ws, src_proj), (dst_ws, src_proj));
     }
 
+    /// Same scope, nothing stray: a re-home with every count at zero, not
+    /// an error (the audit row is still written).
     #[test]
-    fn move_session_same_scope_is_a_noop_summary() {
+    fn move_session_same_scope_with_nothing_stray_reports_zero_counts() {
         let (_tmp, mut conn, ws, proj) = fresh_db();
         let sid = seed_movable_session(&mut conn, ws, proj);
 
@@ -5625,7 +5660,159 @@ pub(crate) mod tests {
         assert_eq!(summary.from_workspace, ws);
         assert_eq!(summary.to_project, proj);
         assert_eq!(summary.cwd.as_deref(), Some("/repo/src"));
+        assert_session_bundle_in_scope(&conn, sid, (ws, proj), (WorkspaceId::new(), proj));
         assert_eq!(session_page_versions(&conn, sid, ws, proj), (2, 1));
+        let audited: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM audit_log WHERE op = 'move_session'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(audited, 1);
+    }
+
+    /// Insert `n` observations of `sid` stamped into `(ws, proj)` directly,
+    /// the way mid-session routing before the sticky mode scattered events
+    /// into phantom projects.
+    fn scatter_observations(
+        conn: &mut Connection,
+        sid: SessionId,
+        ws: WorkspaceId,
+        proj: ProjectId,
+        n: usize,
+    ) {
+        use ai_memory_core::ObservationKind;
+        for i in 0..n {
+            insert_observation(
+                conn,
+                &NewObservation {
+                    session_id: sid,
+                    workspace_id: ws,
+                    project_id: proj,
+                    kind: ObservationKind::PostToolUse,
+                    extension: None,
+                    source_event: None,
+                    title: format!("stray-obs-{i}"),
+                    body: "zebra token body".into(),
+                    importance: 5,
+                },
+            )
+            .unwrap();
+        }
+    }
+
+    /// The phantom-bucket case: the session row already sits in the target,
+    /// some of its observations landed in another scope. Moving the session
+    /// to its own scope re-homes those rows and reports the real counts.
+    #[test]
+    fn move_session_rehomes_stray_rows_when_session_row_already_in_target() {
+        let (_tmp, mut conn, ws, target) = fresh_db();
+        let stray = get_or_create_project(&mut conn, &ws, "tmp", None).unwrap();
+        // Session (row, 2 observations, handoff, job, run, claim, page) in T.
+        let sid = seed_movable_session(&mut conn, ws, target);
+        // 3 observations of the same session stamped into S.
+        scatter_observations(&mut conn, sid, ws, stray, 3);
+        assert_eq!(
+            session_rows_in_scope(&conn, "observations", "session_id", sid, ws, stray),
+            3
+        );
+
+        // Dry run: same counts, nothing changes.
+        let summary =
+            move_session(&mut conn, sid, ws, target, PagesMode::Move, None, false).unwrap();
+        assert!(!summary.session_moved);
+        assert_eq!(summary.observations, 3);
+        assert_eq!(
+            session_rows_in_scope(&conn, "observations", "session_id", sid, ws, stray),
+            3
+        );
+
+        let summary =
+            move_session(&mut conn, sid, ws, target, PagesMode::Move, None, true).unwrap();
+        assert!(!summary.session_moved, "the row was already in the target");
+        assert_eq!(summary.observations, 3, "only the stray rows are counted");
+        assert_eq!(summary.handoffs, 0);
+        assert_eq!(summary.consolidation_jobs, 0);
+        assert_eq!(summary.auto_improve_runs, 0);
+        assert_eq!(summary.auto_improve_claims, 0);
+        assert_eq!(summary.page_versions_moved, 0);
+        assert_eq!(summary.pages_regenerated, 0);
+        assert_eq!(
+            summary.page_path, None,
+            "the page already sits in the target"
+        );
+        assert_eq!(summary.from_project, target);
+        assert_eq!(summary.to_project, target);
+
+        assert_eq!(
+            session_rows_in_scope(&conn, "observations", "session_id", sid, ws, target),
+            5
+        );
+        assert_eq!(
+            session_rows_in_scope(&conn, "observations", "session_id", sid, ws, stray),
+            0
+        );
+        assert_eq!(fts_hits_in_scope(&conn, sid, ws, target), 5);
+        assert_eq!(fts_hits_in_scope(&conn, sid, ws, stray), 0);
+        assert_eq!(
+            session_rows_in_scope(&conn, "sessions", "id", sid, ws, target),
+            1
+        );
+        assert_eq!(session_page_versions(&conn, sid, ws, target), (2, 1));
+    }
+
+    /// A re-home also gathers the session page when its rows lie outside the
+    /// target: moved under `Move` (collision rule against the target),
+    /// retired under `Regenerate`.
+    #[test]
+    fn move_session_rehome_handles_page_rows_outside_target() {
+        let (_tmp, mut conn, ws, target) = fresh_db();
+        let stray = get_or_create_project(&mut conn, &ws, "tmp", None).unwrap();
+        let sid = seed_movable_session(&mut conn, ws, target);
+        let path = format!("sessions/{sid}.md");
+        // Park the page in the stray scope: nothing at the path in T.
+        conn.execute(
+            "UPDATE pages SET workspace_id = ?1, project_id = ?2 WHERE path = ?3",
+            params![ws.as_bytes(), stray.as_bytes(), path],
+        )
+        .unwrap();
+        assert_eq!(session_page_versions(&conn, sid, ws, target), (0, 0));
+        assert_eq!(session_page_versions(&conn, sid, ws, stray), (2, 1));
+
+        let summary =
+            move_session(&mut conn, sid, ws, target, PagesMode::Move, None, true).unwrap();
+        assert!(!summary.session_moved);
+        assert_eq!(summary.observations, 0);
+        assert_eq!(summary.page_versions_moved, 2);
+        assert_eq!(summary.page_path.as_deref(), Some(path.as_str()));
+        assert_eq!(session_page_versions(&conn, sid, ws, target), (2, 1));
+        assert_eq!(session_page_versions(&conn, sid, ws, stray), (0, 0));
+
+        // Stray latest AND a latest in the target: Move collides, Regenerate
+        // retires the stray one and leaves the target's page alone.
+        upsert_page(&mut conn, &page(ws, stray, &path, "stray again")).unwrap();
+        let err = move_session(&mut conn, sid, ws, target, PagesMode::Move, None, true)
+            .expect_err("a latest page at the path in the target must block the page move");
+        assert!(
+            matches!(&err, StoreError::PagePathTaken { path: p } if *p == path),
+            "unexpected error: {err:?}"
+        );
+        assert_eq!(session_page_versions(&conn, sid, ws, stray), (1, 1));
+        let summary = move_session(
+            &mut conn,
+            sid,
+            ws,
+            target,
+            PagesMode::Regenerate,
+            None,
+            true,
+        )
+        .unwrap();
+        assert_eq!(summary.pages_regenerated, 1);
+        assert_eq!(summary.page_versions_moved, 0);
+        assert_eq!(session_page_versions(&conn, sid, ws, stray), (1, 0));
+        assert_eq!(session_page_versions(&conn, sid, ws, target), (2, 1));
     }
 
     #[test]

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -3071,6 +3071,29 @@ pub enum PagesMode {
     Regenerate,
 }
 
+/// One scope a move drained observations out of, and how many.
+///
+/// A move matches dependent rows by session id alone, so it gathers rows from
+/// EVERY scope they landed in — not just the one the caller named as the
+/// source. That is deliberate (it is what repairs a session scattered by
+/// pre-sticky mid-session routing), but it is not cleanly reversible: moving
+/// back sends every row to one scope, and the original per-row attribution is
+/// gone. So the caller is told which scopes it is about to drain, by name,
+/// before it commits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MoveSessionSourceScope {
+    /// Workspace the rows are currently stamped with.
+    pub workspace_id: WorkspaceId,
+    /// Project the rows are currently stamped with.
+    pub project_id: ProjectId,
+    /// Workspace name, resolved for the operator-facing report.
+    pub workspace_name: String,
+    /// Project name, resolved for the operator-facing report.
+    pub project_name: String,
+    /// Observations of this session currently in that scope.
+    pub observations: u64,
+}
+
 /// Summary returned by [`move_session`] and exposed via
 /// [`crate::writer::WriterHandle::move_session`]. Populated identically for a
 /// dry run (`commit = false`), whose transaction is rolled back after counting.
@@ -3117,6 +3140,11 @@ pub struct MoveSessionSummary {
     /// (historical truth; the caller may warn when it no longer matches the
     /// destination project).
     pub cwd: Option<String>,
+    /// Scopes holding observations of this session that are NOT the target,
+    /// with their counts, newest-largest first. More than one entry means the
+    /// move will drain a project the caller did not name; an empty list means
+    /// everything already sits in the target.
+    pub source_scopes: Vec<MoveSessionSourceScope>,
 }
 
 /// Re-stamp one session and every row that hangs off it (`observations`,
@@ -3202,6 +3230,7 @@ pub fn move_session(
         to_workspace: target_workspace,
         to_project: target_project,
         cwd,
+        source_scopes: Vec::new(),
     };
     let rehome = from_workspace == target_workspace && from_project == target_project;
 
@@ -3227,6 +3256,42 @@ pub fn move_session(
         )?;
         summary.session_moved = sessions_updated == 1;
     }
+    // Which scopes this move is about to drain, resolved to names BEFORE the
+    // re-stamp moves the rows. A move gathers by session id alone, so it can
+    // empty a project the caller never named; the operator sees that in the
+    // dry run rather than discovering it afterwards, when the original
+    // attribution is no longer recoverable.
+    {
+        let mut stmt = tx.prepare(
+            "SELECT o.workspace_id, o.project_id, w.name, p.name, COUNT(*) \
+             FROM observations o \
+             JOIN workspaces w ON w.id = o.workspace_id \
+             JOIN projects p ON p.id = o.project_id \
+             WHERE o.session_id = ?1 AND NOT (o.workspace_id = ?2 AND o.project_id = ?3) \
+             GROUP BY o.workspace_id, o.project_id \
+             ORDER BY COUNT(*) DESC",
+        )?;
+        let rows = stmt.query_map(params![&sid[..], &to_ws[..], &to_proj[..]], |row| {
+            Ok((
+                row.get::<_, Vec<u8>>(0)?,
+                row.get::<_, Vec<u8>>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, i64>(4)?,
+            ))
+        })?;
+        for row in rows {
+            let (ws_bytes, proj_bytes, workspace_name, project_name, count) = row?;
+            summary.source_scopes.push(MoveSessionSourceScope {
+                workspace_id: WorkspaceId::from_slice(&ws_bytes)?,
+                project_id: ProjectId::from_slice(&proj_bytes)?,
+                workspace_name,
+                project_name,
+                observations: u64::try_from(count).unwrap_or(0),
+            });
+        }
+    }
+
     // Every dependent row of the session not already in the target, whatever
     // scope it lies in. Fires `observations_fts_au` per observation row
     // (delete + reinsert of the same text); the FTS index stays consistent
@@ -5766,6 +5831,55 @@ pub(crate) mod tests {
             )
             .unwrap();
         }
+    }
+
+    /// A move gathers dependent rows by session id alone, so it drains every
+    /// scope they landed in — including projects the caller never named. That
+    /// is deliberate, but it is not cleanly reversible, so the dry run has to
+    /// say which scopes it is about to empty before anything is committed.
+    #[test]
+    fn move_session_dry_run_names_every_scope_it_will_drain() {
+        let (_tmp, mut conn, ws, target) = fresh_db();
+        let unnamed_a = get_or_create_project(&mut conn, &ws, "scratchpad", None).unwrap();
+        let unnamed_b = get_or_create_project(&mut conn, &ws, "tmp", None).unwrap();
+        let sid = seed_movable_session(&mut conn, ws, target);
+        scatter_observations(&mut conn, sid, ws, unnamed_a, 3);
+        scatter_observations(&mut conn, sid, ws, unnamed_b, 1);
+
+        // Dry run: nothing is written, but the report must already name both
+        // scopes it would empty.
+        let summary =
+            move_session(&mut conn, sid, ws, target, PagesMode::Move, None, false).unwrap();
+
+        let named: Vec<(String, u64)> = summary
+            .source_scopes
+            .iter()
+            .map(|s| (s.project_name.clone(), s.observations))
+            .collect();
+        assert_eq!(
+            named,
+            vec![("scratchpad".to_string(), 3), ("tmp".to_string(), 1)],
+            "both drained scopes must be named, largest first"
+        );
+        assert!(
+            summary.source_scopes.iter().all(|s| s.workspace_id == ws),
+            "each entry carries its resolved scope ids"
+        );
+        // The dry run really was a dry run.
+        assert_eq!(
+            session_rows_in_scope(&conn, "observations", "session_id", sid, ws, unnamed_a),
+            3
+        );
+
+        // The destination itself is never listed as a scope to drain.
+        let confirmed =
+            move_session(&mut conn, sid, ws, target, PagesMode::Move, None, true).unwrap();
+        assert_eq!(confirmed.observations, 4);
+        let after = move_session(&mut conn, sid, ws, target, PagesMode::Move, None, false).unwrap();
+        assert!(
+            after.source_scopes.is_empty(),
+            "with everything in the destination there is nothing left to drain"
+        );
     }
 
     /// The phantom-bucket case: the session row already sits in the target,

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -3065,7 +3065,8 @@ pub enum PagesMode {
     /// a latest page at that path.
     #[default]
     Move,
-    /// Leave the rows in the source scope but clear `is_latest`, so the next
+    /// Leave the rows in the source scope but clear `is_latest` (and the
+    /// session's `summary_page_id` when it pointed at them), so the next
     /// consolidation of the session writes a fresh page in the destination.
     Regenerate,
 }
@@ -3100,6 +3101,10 @@ pub struct MoveSessionSummary {
     /// The session page path when the source scope held at least one version
     /// of it, so the caller can move or retire the on-disk file too.
     pub page_path: Option<String>,
+    /// `pages` versions of `sessions/<id>.md` sitting in the target scope
+    /// once the call is done (moved there now or already there before), so
+    /// a caller can tell "nothing to move" from "no page anywhere".
+    pub page_versions_in_target: u64,
     /// Scope the session was read from.
     pub from_workspace: WorkspaceId,
     /// Scope the session was read from.
@@ -3191,6 +3196,7 @@ pub fn move_session(
         page_versions_moved: 0,
         pages_regenerated: 0,
         page_path: None,
+        page_versions_in_target: 0,
         from_workspace,
         from_project,
         to_workspace: target_workspace,
@@ -3302,10 +3308,30 @@ pub fn move_session(
                     ),
                     params![page_scope_params.0, page_scope_params.1, page_path.as_str()],
                 )? as u64;
+                // The session's summary pointer targeted the page just
+                // retired; the next consolidation sets it again.
+                tx.execute(
+                    &format!(
+                        "UPDATE sessions SET summary_page_id = NULL \
+                         WHERE id = ?4 AND summary_page_id IN ( \
+                             SELECT id FROM pages WHERE {page_scope_sql} AND path = ?3)"
+                    ),
+                    params![
+                        page_scope_params.0,
+                        page_scope_params.1,
+                        page_path.as_str(),
+                        &sid[..],
+                    ],
+                )?;
             }
         }
-        summary.page_path = Some(page_path);
+        summary.page_path = Some(page_path.clone());
     }
+    summary.page_versions_in_target = tx.query_row(
+        "SELECT COUNT(*) FROM pages WHERE workspace_id = ?1 AND project_id = ?2 AND path = ?3",
+        params![&to_ws[..], &to_proj[..], page_path.as_str()],
+        |row| row.get::<_, i64>(0),
+    )? as u64;
 
     audit(
         &tx,
@@ -5464,6 +5490,8 @@ pub(crate) mod tests {
         let dst_ws = get_or_create_workspace(&mut conn, "other").unwrap();
         let dst_proj = get_or_create_project(&mut conn, &dst_ws, "target", None).unwrap();
         let sid = seed_movable_session(&mut conn, src_ws, src_proj);
+        point_summary_at_latest(&mut conn, sid, src_ws, src_proj);
+        let pointer = summary_page_id(&conn, sid);
 
         let summary = move_session(
             &mut conn,
@@ -5479,6 +5507,9 @@ pub(crate) mod tests {
         assert_eq!(summary.observations, 2);
         assert_eq!(summary.page_versions_moved, 2);
         assert_eq!(summary.pages_regenerated, 0);
+        assert_eq!(summary.page_versions_in_target, 2);
+        // The page kept its id, so the pointer is still right.
+        assert_eq!(summary_page_id(&conn, sid), pointer);
 
         assert_session_bundle_in_scope(&conn, sid, (dst_ws, dst_proj), (src_ws, src_proj));
         // Both versions moved and the supersession chain kept exactly one latest.
@@ -5546,6 +5577,9 @@ pub(crate) mod tests {
         // A latest page at the path in the target is fine under Regenerate.
         let path = format!("sessions/{sid}.md");
         upsert_page(&mut conn, &page(dst_ws, dst_proj, &path, "already here")).unwrap();
+        // The session points at its (source) latest page, as consolidation
+        // leaves it.
+        point_summary_at_latest(&mut conn, sid, src_ws, src_proj);
 
         let summary = move_session(
             &mut conn,
@@ -5563,9 +5597,40 @@ pub(crate) mod tests {
         assert_eq!(summary.page_path.as_deref(), Some(path.as_str()));
 
         assert_session_bundle_in_scope(&conn, sid, (dst_ws, dst_proj), (src_ws, src_proj));
-        // Source versions stay where they are, none of them latest anymore.
+        // Source versions stay where they are, none of them latest anymore,
+        // and the session no longer points at the retired page.
         assert_eq!(session_page_versions(&conn, sid, src_ws, src_proj), (2, 0));
         assert_eq!(session_page_versions(&conn, sid, dst_ws, dst_proj), (1, 1));
+        assert_eq!(summary_page_id(&conn, sid), None);
+    }
+
+    /// Point `sessions.summary_page_id` at the session's latest page in a
+    /// scope, the way session consolidation does.
+    fn point_summary_at_latest(
+        conn: &mut Connection,
+        sid: SessionId,
+        ws: WorkspaceId,
+        proj: ProjectId,
+    ) {
+        let path = format!("sessions/{sid}.md");
+        conn.execute(
+            "UPDATE sessions SET summary_page_id = ( \
+                 SELECT id FROM pages \
+                 WHERE workspace_id = ?1 AND project_id = ?2 AND path = ?3 AND is_latest = 1) \
+             WHERE id = ?4",
+            params![ws.as_bytes(), proj.as_bytes(), path, sid.as_bytes()],
+        )
+        .unwrap();
+        assert!(summary_page_id(conn, sid).is_some());
+    }
+
+    fn summary_page_id(conn: &Connection, sid: SessionId) -> Option<Vec<u8>> {
+        conn.query_row(
+            "SELECT summary_page_id FROM sessions WHERE id = ?1",
+            params![sid.as_bytes()],
+            |r| r.get(0),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -5594,6 +5659,7 @@ pub(crate) mod tests {
         assert_eq!(summary.page_versions_moved, 0);
         assert_eq!(summary.pages_regenerated, 0);
         assert_eq!(summary.page_path, None);
+        assert_eq!(summary.page_versions_in_target, 0);
     }
 
     #[test]
@@ -5742,6 +5808,7 @@ pub(crate) mod tests {
             summary.page_path, None,
             "the page already sits in the target"
         );
+        assert_eq!(summary.page_versions_in_target, 2);
         assert_eq!(summary.from_project, target);
         assert_eq!(summary.to_project, target);
 

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -221,6 +221,26 @@ fn rerank_page_hits_with_meta(
     hits
 }
 
+/// Rows keyed to one session (see [`ReaderPool::session_dependent_rows`]).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SessionDependentRows {
+    /// `observations` rows of the session, in any scope.
+    pub observations: u64,
+    /// `handoffs` rows the session produced, in any scope.
+    pub handoffs: u64,
+    /// `session_consolidation_jobs` rows, in any scope.
+    pub consolidation_jobs: u64,
+    /// `auto_improve_runs` rows, in any scope.
+    pub auto_improve_runs: u64,
+    /// `auto_improve_scheduler_claims` rows, in any scope.
+    pub auto_improve_claims: u64,
+    /// Versions of `sessions/<id>.md` in the queried page scope.
+    pub page_versions: u64,
+    /// Latest versions of `sessions/<id>.md` in the queried page scope
+    /// (0 or 1).
+    pub page_latest: u64,
+}
+
 /// One page flagged by `stale`/`wrong` feedback on its current version,
 /// aggregated per (page, kind) for the lint pass.
 #[derive(Debug, Clone, Serialize)]
@@ -2057,6 +2077,52 @@ impl ReaderPool {
                 out.push(SessionId::from_slice(&r?)?);
             }
             Ok(out)
+        })
+        .await
+    }
+
+    /// Rows keyed to a session across every scope, plus its
+    /// `sessions/<id>.md` page rows in one scope: what a `move_session` into
+    /// a scope that holds nothing of the session yet would touch. Used for
+    /// the dry run of a move whose destination does not exist yet.
+    ///
+    /// # Errors
+    /// Propagates any SQL or pool error.
+    pub async fn session_dependent_rows(
+        &self,
+        session_id: SessionId,
+        page_scope: (WorkspaceId, ProjectId),
+    ) -> StoreResult<SessionDependentRows> {
+        self.with_conn(move |conn| {
+            let sid = session_id.as_bytes();
+            let count = |sql: &str| -> StoreResult<u64> {
+                Ok(conn.query_row(sql, [sid.as_slice()], |r| r.get::<_, i64>(0))? as u64)
+            };
+            let (page_versions, page_latest): (i64, i64) = conn.query_row(
+                "SELECT COUNT(*), COALESCE(SUM(is_latest), 0) FROM pages \
+                 WHERE workspace_id = ?1 AND project_id = ?2 AND path = ?3",
+                params![
+                    page_scope.0.as_bytes(),
+                    page_scope.1.as_bytes(),
+                    format!("sessions/{session_id}.md"),
+                ],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )?;
+            Ok(SessionDependentRows {
+                observations: count("SELECT COUNT(*) FROM observations WHERE session_id = ?1")?,
+                handoffs: count("SELECT COUNT(*) FROM handoffs WHERE from_session_id = ?1")?,
+                consolidation_jobs: count(
+                    "SELECT COUNT(*) FROM session_consolidation_jobs WHERE session_id = ?1",
+                )?,
+                auto_improve_runs: count(
+                    "SELECT COUNT(*) FROM auto_improve_runs WHERE session_id = ?1",
+                )?,
+                auto_improve_claims: count(
+                    "SELECT COUNT(*) FROM auto_improve_scheduler_claims WHERE session_id = ?1",
+                )?,
+                page_versions: page_versions as u64,
+                page_latest: page_latest as u64,
+            })
         })
         .await
     }

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -2020,6 +2020,47 @@ impl ReaderPool {
         .await
     }
 
+    /// Ids of every session that touches `(workspace_id, project_id)`: a
+    /// `sessions` row in the scope OR at least one observation stamped into
+    /// it. The second leg catches the phantom projects that mid-session
+    /// routing before the sticky mode filled with observations of sessions
+    /// rooted elsewhere (no `sessions` row of their own), so a batch
+    /// `move-session` can empty such a bucket. Ordered by first touch (the
+    /// row's `started_at` or the earliest observation in the scope), then id.
+    ///
+    /// # Errors
+    /// Propagates any SQL or pool error.
+    pub async fn session_ids_touching_scope(
+        &self,
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+    ) -> StoreResult<Vec<SessionId>> {
+        self.with_conn(move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id FROM ( \
+                     SELECT id, started_at AS first_seen FROM sessions \
+                     WHERE workspace_id = ?1 AND project_id = ?2 \
+                     UNION ALL \
+                     SELECT session_id AS id, MIN(created_at) AS first_seen FROM observations \
+                     WHERE workspace_id = ?1 AND project_id = ?2 \
+                     GROUP BY session_id \
+                 ) \
+                 GROUP BY id \
+                 ORDER BY MIN(first_seen), id",
+            )?;
+            let rows = stmt.query_map(
+                params![workspace_id.as_bytes(), project_id.as_bytes()],
+                |row| row.get::<_, Vec<u8>>(0),
+            )?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(SessionId::from_slice(&r?)?);
+            }
+            Ok(out)
+        })
+        .await
+    }
+
     /// How a `SessionEnd` should treat its target session (issue #152).
     ///
     /// The old boolean ("is the session open?") conflated two very different

--- a/crates/ai-memory-store/src/writer.rs
+++ b/crates/ai-memory-store/src/writer.rs
@@ -317,6 +317,7 @@ pub(crate) enum WriteCmd {
         target_workspace: WorkspaceId,
         target_project: ProjectId,
         pages: PagesMode,
+        author_id: Option<UserId>,
         commit: bool,
         reply: oneshot::Sender<StoreResult<MoveSessionSummary>>,
     },
@@ -1258,7 +1259,8 @@ impl WriterHandle {
     /// `(target_workspace, target_project)` in one transaction. With
     /// `commit = false` the transaction is rolled back after counting, so the
     /// summary is an exact dry run. The target project must already exist;
-    /// the caller moves the on-disk page file afterwards.
+    /// the caller moves the on-disk page file afterwards. `author_id` is the
+    /// operator recorded on the audit row.
     ///
     /// # Errors
     /// Returns [`StoreError::WriterClosed`] if the actor has shut down,
@@ -1272,6 +1274,7 @@ impl WriterHandle {
         target_workspace: WorkspaceId,
         target_project: ProjectId,
         pages: PagesMode,
+        author_id: Option<UserId>,
         commit: bool,
     ) -> StoreResult<MoveSessionSummary> {
         let (tx, rx) = oneshot::channel();
@@ -1280,6 +1283,7 @@ impl WriterHandle {
             target_workspace,
             target_project,
             pages,
+            author_id,
             commit,
             reply: tx,
         })
@@ -2188,6 +2192,7 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
                 target_workspace,
                 target_project,
                 pages,
+                author_id,
                 commit,
                 reply,
             } => {
@@ -2197,6 +2202,7 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
                     target_workspace,
                     target_project,
                     pages,
+                    author_id,
                     commit,
                 );
                 send_or_warn(reply, result, "move_session");
@@ -2627,7 +2633,7 @@ mod tests {
 
         let dry = store
             .writer
-            .move_session(sid, ws, dst, PagesMode::Move, false)
+            .move_session(sid, ws, dst, PagesMode::Move, None, false)
             .await
             .unwrap();
         assert!(dry.session_moved);
@@ -2639,7 +2645,7 @@ mod tests {
 
         let moved = store
             .writer
-            .move_session(sid, ws, dst, PagesMode::Move, true)
+            .move_session(sid, ws, dst, PagesMode::Move, None, true)
             .await
             .unwrap();
         assert!(moved.session_moved);

--- a/crates/ai-memory-store/src/writer.rs
+++ b/crates/ai-memory-store/src/writer.rs
@@ -26,7 +26,8 @@ use crate::auto_improve::{
 use crate::error::{StoreError, StoreResult};
 use crate::ops::{
     self, AdmittedSession, DeleteWorkspaceSummary, EmbeddingWrite, HookSessionAdmission,
-    IngestObservationOutcome, LifecycleOnlyEndOutcome, MoveSummary, PurgeSummary, ReorgSummary,
+    IngestObservationOutcome, LifecycleOnlyEndOutcome, MoveSessionSummary, MoveSummary, PagesMode,
+    PurgeSummary, ReorgSummary,
 };
 use crate::session_consolidation::SessionConsolidationJob;
 use crate::users::{self, TOKEN_HASH_LEN};
@@ -306,6 +307,18 @@ pub(crate) enum WriteCmd {
         from_workspace: WorkspaceId,
         to_workspace: WorkspaceId,
         reply: oneshot::Sender<StoreResult<MoveSummary>>,
+    },
+    /// Re-stamp one session and its dependent rows (observations, handoffs,
+    /// consolidation jobs, auto-improve runs and claim, session page) into
+    /// another scope in one transaction. `commit = false` rolls back after
+    /// counting so the reply is an exact dry run.
+    MoveSession {
+        session_id: SessionId,
+        target_workspace: WorkspaceId,
+        target_project: ProjectId,
+        pages: PagesMode,
+        commit: bool,
+        reply: oneshot::Sender<StoreResult<MoveSessionSummary>>,
     },
     /// Rename a project's `name` column without moving any files (the wiki
     /// is flat on disk). Fails with [`crate::error::StoreError::ProjectNameTaken`]
@@ -1239,6 +1252,41 @@ impl WriterHandle {
         rx.await.map_err(|_| StoreError::WriterClosed)?
     }
 
+    /// Re-stamp one session, its observations, the handoffs it produced, its
+    /// consolidation jobs, auto-improve runs and scheduler claim, and its
+    /// `sessions/<id>.md` page (per `pages`) into
+    /// `(target_workspace, target_project)` in one transaction. With
+    /// `commit = false` the transaction is rolled back after counting, so the
+    /// summary is an exact dry run. The target project must already exist;
+    /// the caller moves the on-disk page file afterwards.
+    ///
+    /// # Errors
+    /// Returns [`StoreError::WriterClosed`] if the actor has shut down,
+    /// [`StoreError::NotFound`] if the session or the target project is
+    /// absent, [`StoreError::PagePathTaken`] when [`PagesMode::Move`] would
+    /// collide with a latest page in the target scope, or propagates the SQL
+    /// error.
+    pub async fn move_session(
+        &self,
+        session_id: SessionId,
+        target_workspace: WorkspaceId,
+        target_project: ProjectId,
+        pages: PagesMode,
+        commit: bool,
+    ) -> StoreResult<MoveSessionSummary> {
+        let (tx, rx) = oneshot::channel();
+        self.send(WriteCmd::MoveSession {
+            session_id,
+            target_workspace,
+            target_project,
+            pages,
+            commit,
+            reply: tx,
+        })
+        .await?;
+        rx.await.map_err(|_| StoreError::WriterClosed)?
+    }
+
     /// Rename a project within its workspace (column-only; no file moves).
     ///
     /// # Errors
@@ -2135,6 +2183,24 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
                 );
                 send_or_warn(reply, result, "move_project_workspace");
             }
+            WriteCmd::MoveSession {
+                session_id,
+                target_workspace,
+                target_project,
+                pages,
+                commit,
+                reply,
+            } => {
+                let result = ops::move_session(
+                    &mut conn,
+                    session_id,
+                    target_workspace,
+                    target_project,
+                    pages,
+                    commit,
+                );
+                send_or_warn(reply, result, "move_session");
+            }
             WriteCmd::RenameProject {
                 workspace_id,
                 project_id,
@@ -2522,6 +2588,65 @@ mod tests {
                 .unwrap();
             assert_eq!(count, 1, "pending command must have committed");
         }
+    }
+
+    /// The dry run and the real move both go through the actor; only the
+    /// latter changes the session row a reader sees.
+    #[tokio::test]
+    async fn move_session_dry_run_then_commit_through_writer() {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let ws = store
+            .writer
+            .get_or_create_workspace("default")
+            .await
+            .unwrap();
+        let src = store
+            .writer
+            .get_or_create_project(ws, "src", None)
+            .await
+            .unwrap();
+        let dst = store
+            .writer
+            .get_or_create_project(ws, "dst", None)
+            .await
+            .unwrap();
+        let sid = SessionId::new();
+        store
+            .writer
+            .begin_session(NewSession {
+                id: sid,
+                workspace_id: ws,
+                project_id: src,
+                agent_kind: AgentKind::Codex,
+                cwd: None,
+                actor_user: None,
+            })
+            .await
+            .unwrap();
+
+        let dry = store
+            .writer
+            .move_session(sid, ws, dst, PagesMode::Move, false)
+            .await
+            .unwrap();
+        assert!(dry.session_moved);
+        assert_eq!(
+            store.reader.session_project_ids(sid).await.unwrap(),
+            Some((ws, src)),
+            "dry run must roll back"
+        );
+
+        let moved = store
+            .writer
+            .move_session(sid, ws, dst, PagesMode::Move, true)
+            .await
+            .unwrap();
+        assert!(moved.session_moved);
+        assert_eq!(
+            store.reader.session_project_ids(sid).await.unwrap(),
+            Some((ws, dst))
+        );
     }
 
     /// Once the actor has stopped, calls fail fast with

--- a/crates/ai-memory-store/src/writer.rs
+++ b/crates/ai-memory-store/src/writer.rs
@@ -1260,7 +1260,9 @@ impl WriterHandle {
     /// `commit = false` the transaction is rolled back after counting, so the
     /// summary is an exact dry run. The target project must already exist;
     /// the caller moves the on-disk page file afterwards. `author_id` is the
-    /// operator recorded on the audit row.
+    /// operator recorded on the audit row. A target equal to the session
+    /// row's own scope re-homes only the rows still lying elsewhere
+    /// (`session_moved = false`); see [`ops::move_session`].
     ///
     /// # Errors
     /// Returns [`StoreError::WriterClosed`] if the actor has shut down,

--- a/crates/ai-memory-store/tests/session_ids_touching_scope.rs
+++ b/crates/ai-memory-store/tests/session_ids_touching_scope.rs
@@ -1,0 +1,113 @@
+//! Integration tests for `ReaderPool::session_ids_touching_scope` (#402).
+//!
+//! A phantom project filled by pre-sticky mid-session routing holds
+//! observations of sessions rooted elsewhere and no `sessions` row of its
+//! own. The batch `move-session` must see those sessions, so "touching a
+//! scope" is: a `sessions` row in it OR at least one observation in it.
+
+use ai_memory_core::{ProjectId, SessionId, WorkspaceId};
+use ai_memory_store::Store;
+use rusqlite::{Connection, params};
+
+fn id(n: u8) -> [u8; 16] {
+    let mut b = [0u8; 16];
+    b[15] = n;
+    b
+}
+
+/// Workspace `w` with projects `a` and `b`; session 10 rooted in `b` with 3
+/// observations in `a` and 1 in `b`; session 11 rooted in `a` (started later)
+/// with 1 observation in `a`; session 12 rooted in `b` with no observations.
+fn seed(db_path: &std::path::Path) {
+    let conn = Connection::open(db_path).unwrap();
+    let now = 1_700_000_000_000_i64;
+    let (ws, a, b) = (id(1), id(2), id(3));
+
+    conn.execute(
+        "INSERT INTO workspaces (id, name, created_at) VALUES (?1, 'w', ?2)",
+        params![&ws[..], now],
+    )
+    .unwrap();
+    for (pid, name, rp) in [(&a, "proj-a", "/w/a"), (&b, "proj-b", "/w/b")] {
+        conn.execute(
+            "INSERT INTO projects (id, workspace_id, name, repo_path, created_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![&pid[..], &ws[..], name, rp, now],
+        )
+        .unwrap();
+    }
+    for (sid, proj, started) in [(10u8, &b, now), (11, &a, now + 10), (12, &b, now + 20)] {
+        conn.execute(
+            "INSERT INTO sessions (id, workspace_id, project_id, agent_kind, cwd, started_at) \
+             VALUES (?1, ?2, ?3, 'claude-code', '/w', ?4)",
+            params![&id(sid)[..], &ws[..], &proj[..], started],
+        )
+        .unwrap();
+    }
+    for (n, sid, proj, ts) in [
+        (20u8, 10u8, &a, now + 1),
+        (21, 10, &a, now + 2),
+        (22, 10, &a, now + 3),
+        (23, 10, &b, now + 4),
+        (24, 11, &a, now + 11),
+    ] {
+        conn.execute(
+            "INSERT INTO observations \
+             (id, session_id, workspace_id, project_id, kind, title, body, created_at) \
+             VALUES (?1, ?2, ?3, ?4, 'note', 't', 'x', ?5)",
+            params![&id(n)[..], &id(sid)[..], &ws[..], &proj[..], ts],
+        )
+        .unwrap();
+    }
+}
+
+fn sid(n: u8) -> SessionId {
+    SessionId::from_slice(&id(n)).unwrap()
+}
+
+#[tokio::test]
+async fn lists_sessions_with_a_row_or_an_observation_in_the_scope_oldest_first() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    seed(store.db_path());
+    let ws = WorkspaceId::from_slice(&id(1)).unwrap();
+    let a = ProjectId::from_slice(&id(2)).unwrap();
+    let b = ProjectId::from_slice(&id(3)).unwrap();
+
+    // `a`: session 10 through its observations (first at now+1), session 11
+    // through its row (now+10). Session 12 never touched `a`.
+    assert_eq!(
+        store
+            .reader
+            .session_ids_touching_scope(ws, a)
+            .await
+            .unwrap(),
+        vec![sid(10), sid(11)]
+    );
+    // `b`: session 10 through its row (now) and its late observation,
+    // session 12 through its row alone; each id once.
+    assert_eq!(
+        store
+            .reader
+            .session_ids_touching_scope(ws, b)
+            .await
+            .unwrap(),
+        vec![sid(10), sid(12)]
+    );
+}
+
+#[tokio::test]
+async fn empty_scope_lists_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    seed(store.db_path());
+    let ws = WorkspaceId::from_slice(&id(1)).unwrap();
+    assert!(
+        store
+            .reader
+            .session_ids_touching_scope(ws, ProjectId::from_slice(&id(9)).unwrap())
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}

--- a/crates/ai-memory-wiki/src/admission.rs
+++ b/crates/ai-memory-wiki/src/admission.rs
@@ -63,6 +63,12 @@ pub enum AdmissionOp {
     /// project id. Carries source names in `workspace`/`project` and
     /// destination names in `destination_workspace`/`destination_project`.
     MoveProject,
+    /// One session (its rows and its `sessions/<id>.md` page) is being moved
+    /// to another project. Carries the source names in `workspace`/`project`
+    /// and the destination names in `destination_workspace`/
+    /// `destination_project`; no page path. Lets a mirror move or drop the
+    /// session page file.
+    MoveSession,
     /// A handoff is being created. Carries the workspace/project; no page path,
     /// since handoffs live in their own table rather than the wiki tree.
     ///
@@ -88,6 +94,7 @@ impl AdmissionOp {
             AdmissionOp::PurgeProject => "purge_project",
             AdmissionOp::PurgeWorkspace => "purge_workspace",
             AdmissionOp::MoveProject => "move_project",
+            AdmissionOp::MoveSession => "move_session",
             AdmissionOp::HandoffBegin => "handoff_begin",
             AdmissionOp::HandoffAccept => "handoff_accept",
             AdmissionOp::HandoffCancel => "handoff_cancel",
@@ -782,6 +789,7 @@ mod tests {
         assert_eq!(AdmissionOp::WritePage.as_header_value(), "write_page");
         assert_eq!(AdmissionOp::Consolidate.as_header_value(), "consolidate");
         assert_eq!(AdmissionOp::MoveProject.as_header_value(), "move_project");
+        assert_eq!(AdmissionOp::MoveSession.as_header_value(), "move_session");
     }
 
     #[tokio::test]

--- a/crates/ai-memory-wiki/src/error.rs
+++ b/crates/ai-memory-wiki/src/error.rs
@@ -42,6 +42,12 @@ pub enum WikiError {
     /// already exists.
     #[error("destination dir already exists: {0}")]
     DestinationExists(String),
+
+    /// A move-session refused to overwrite an existing page file at the
+    /// destination (`<wiki_root>/<ws>/<proj>/sessions/<id>.md`). Surfaced as
+    /// `409 Conflict` at the admin layer.
+    #[error("destination page file already exists: {0}")]
+    DestinationPageExists(String),
 }
 
 impl From<serde_yaml::Error> for WikiError {

--- a/crates/ai-memory-wiki/src/lib.rs
+++ b/crates/ai-memory-wiki/src/lib.rs
@@ -24,4 +24,4 @@ pub use git::{COMMIT_AUTHOR_EMAIL, COMMIT_AUTHOR_NAME, GitAdapter};
 pub use markdown::{Markdown, derive_title, emit, parse};
 pub use migrations::run_pending as run_wiki_migrations;
 pub use watcher::{DEBOUNCE_WINDOW, RECONCILE_INTERVAL, WatcherHandle};
-pub use wiki::{Wiki, WritePageRequest};
+pub use wiki::{MoveSessionOutcome, SessionPageFile, Wiki, WritePageRequest};

--- a/crates/ai-memory-wiki/src/wiki.rs
+++ b/crates/ai-memory-wiki/src/wiki.rs
@@ -4,14 +4,14 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use ai_memory_core::{
-    ActorContext, AutoImproveProposalId, NewPage, PageId, PagePath, ProjectId, Sanitizer, Tier,
-    UserId, WorkspaceId,
+    ActorContext, AutoImproveProposalId, NewPage, PageId, PagePath, ProjectId, Sanitizer,
+    SessionId, Tier, UserId, WorkspaceId,
 };
 use ai_memory_llm::Embedder;
 use ai_memory_store::{
     ApproveAutoImproveProposal, ApproveAutoImproveProposalResult, AutoImproveProposalDetail,
-    FailAutoImproveProposal, MoveSummary, ReaderPool, WriterHandle, artifact_path_for,
-    f32_vec_to_bytes,
+    FailAutoImproveProposal, MoveSessionSummary, MoveSummary, PagesMode, ReaderPool, WriterHandle,
+    artifact_path_for, f32_vec_to_bytes,
 };
 use tokio::sync::RwLock;
 
@@ -41,6 +41,31 @@ enum PageStoreRemoval {
     Decay {
         expected_latest_id: PageId,
     },
+}
+
+/// What [`Wiki::move_session_page`] did with the on-disk
+/// `sessions/<session_id>.md` file of the moved session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionPageFile {
+    /// Renamed from the source project directory into the destination one
+    /// ([`PagesMode::Move`]).
+    Moved,
+    /// Removed from the source project directory ([`PagesMode::Regenerate`]),
+    /// so the watcher cannot re-index it as a live page after its rows were
+    /// retired; the next consolidation writes a fresh page in the destination.
+    Removed,
+    /// No file existed in the source project directory.
+    Absent,
+}
+
+/// Result of [`Wiki::move_session_page`]: the store summary plus what
+/// happened to the page file.
+#[derive(Debug, Clone)]
+pub struct MoveSessionOutcome {
+    /// Row counts and scopes as reported by the store re-stamp.
+    pub summary: MoveSessionSummary,
+    /// Disposition of the on-disk session page file.
+    pub file: SessionPageFile,
 }
 
 /// Wiki filesystem handle.
@@ -318,6 +343,120 @@ impl Wiki {
                             src.display()
                         ))));
                     }
+                }
+                Err(e.into())
+            }
+        }
+    }
+
+    /// Move one session to another project: relocate its `sessions/<id>.md`
+    /// file on disk and re-stamp its store rows in one transaction
+    /// ([`WriterHandle::move_session`]).
+    ///
+    /// Same critical section and ordering as [`Self::move_project_workspace`]:
+    /// the exclusive mutation guard is held across the admission chain, the
+    /// file step and the store step; disk goes first and SQL last, so the DB
+    /// is never ahead of disk. Under [`PagesMode::Move`] the file is renamed
+    /// into the destination project directory (refused when a file already
+    /// sits there). Under [`PagesMode::Regenerate`] the file is first parked
+    /// under the watcher-ignored `.ai-memory-tmp.` prefix and deleted once the
+    /// rows are retired: left in place, the next reconciliation pass would
+    /// re-index it as a fresh latest page in the source scope. A store failure
+    /// puts the file back where it was in both modes.
+    ///
+    /// # Errors
+    /// Returns [`WikiError::DestinationPageExists`] when the destination
+    /// already holds a page file at that path, [`WikiError::Store`] for store
+    /// refusals (`NotFound`, `PagePathTaken`), or an I/O error when the file
+    /// step or its rollback fails.
+    pub async fn move_session_page(
+        &self,
+        session_id: SessionId,
+        from: (WorkspaceId, ProjectId),
+        to: (WorkspaceId, ProjectId),
+        pages: PagesMode,
+        author_id: Option<UserId>,
+        admission_ctx: Option<AdmissionContext>,
+    ) -> WikiResult<MoveSessionOutcome> {
+        let _guard = self.mutation_lock.write().await;
+        let resolved_ctx = if let Some(chain) = &self.admission_chain {
+            let mut ctx = admission_ctx.unwrap_or_default();
+            ctx.op = AdmissionOp::MoveSession;
+            self.resolve_admission_names(from.0, from.1, &mut ctx).await;
+            chain.notify(None, &ctx).await?;
+            Some(ctx)
+        } else {
+            None
+        };
+
+        let file_name = format!("{session_id}.md");
+        let src = self
+            .project_root(from.0, from.1)
+            .join("sessions")
+            .join(&file_name);
+        let parked = if src.is_file() {
+            let target = match pages {
+                PagesMode::Move => {
+                    let dst = self
+                        .project_root(to.0, to.1)
+                        .join("sessions")
+                        .join(&file_name);
+                    if dst.exists() {
+                        return Err(WikiError::DestinationPageExists(dst.display().to_string()));
+                    }
+                    dst
+                }
+                // Same directory, watcher-ignored name: invisible to
+                // reindex/reconcile, trivially renamed back on failure.
+                PagesMode::Regenerate => {
+                    src.with_file_name(format!(".ai-memory-tmp.move-session.{file_name}"))
+                }
+            };
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::rename(&src, &target)?;
+            Some(target)
+        } else {
+            None
+        };
+
+        match self
+            .writer
+            .move_session(session_id, to.0, to.1, pages, author_id, true)
+            .await
+        {
+            Ok(summary) => {
+                let file = match (&parked, pages) {
+                    (None, _) => SessionPageFile::Absent,
+                    (Some(_), PagesMode::Move) => SessionPageFile::Moved,
+                    (Some(tmp), PagesMode::Regenerate) => {
+                        // The rows are retired; a leftover temp file is
+                        // ignored by the watcher, so this is best-effort.
+                        if let Err(e) = std::fs::remove_file(tmp) {
+                            tracing::warn!(
+                                error = %e,
+                                path = %tmp.display(),
+                                "move-session: could not remove parked session page file"
+                            );
+                        }
+                        SessionPageFile::Removed
+                    }
+                };
+                if let (Some(chain), Some(ctx)) = (&self.admission_chain, &resolved_ctx) {
+                    chain.dispatch_async(None, &serde_json::Value::Null, "", ctx);
+                }
+                Ok(MoveSessionOutcome { summary, file })
+            }
+            Err(e) => {
+                if let Some(target) = parked
+                    && let Err(rollback_err) = std::fs::rename(&target, &src)
+                {
+                    return Err(WikiError::Io(std::io::Error::other(format!(
+                        "INCONSISTENT STATE: session page file moved but DB re-stamp failed ({e}) and moving it back also failed ({rollback_err}); manually move {} -> {}",
+                        target.display(),
+                        src.display()
+                    ))));
                 }
                 Err(e.into())
             }
@@ -4027,5 +4166,247 @@ mod tests {
         let err = parse_entities(&path, &serde_json::json!({"entities": "sqlite"}))
             .expect_err("a string instead of a list is a structural error");
         assert!(err.to_string().contains("non-array entities"), "{err}");
+    }
+
+    /// Two projects in one workspace, one ended session in the first with a
+    /// consolidated `sessions/<id>.md` page written through the wiki.
+    async fn session_with_page(
+        tmp: &TempDir,
+    ) -> (
+        Store,
+        Wiki,
+        WorkspaceId,
+        ProjectId,
+        ProjectId,
+        SessionId,
+        PagePath,
+    ) {
+        let (store, wiki, ws, src) = scoped(tmp).await;
+        let dst = store
+            .writer
+            .get_or_create_project(ws, "target", None)
+            .await
+            .unwrap();
+        let sid = SessionId::new();
+        store
+            .writer
+            .begin_session(ai_memory_core::NewSession {
+                id: sid,
+                workspace_id: ws,
+                project_id: src,
+                agent_kind: ai_memory_core::AgentKind::ClaudeCode,
+                cwd: Some("/repo/src".into()),
+                actor_user: None,
+            })
+            .await
+            .unwrap();
+        store.writer.end_session(sid, None).await.unwrap();
+        let path = PagePath::new(format!("sessions/{sid}.md")).unwrap();
+        wiki.write_page(req(
+            ws,
+            src,
+            path.as_str(),
+            "consolidated session body",
+            serde_json::json!({ "title": "Session" }),
+        ))
+        .await
+        .unwrap();
+        (store, wiki, ws, src, dst, sid, path)
+    }
+
+    fn leftover_tempfiles(dir: &Path) -> Vec<String> {
+        std::fs::read_dir(dir)
+            .map(|rd| {
+                rd.filter_map(Result::ok)
+                    .map(|e| e.file_name().to_string_lossy().into_owned())
+                    .filter(|n| n.starts_with(".ai-memory-tmp."))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    #[tokio::test]
+    async fn move_session_page_moves_file_and_rows() {
+        let tmp = TempDir::new().unwrap();
+        let (store, wiki, ws, src, dst, sid, path) = session_with_page(&tmp).await;
+
+        let outcome = wiki
+            .move_session_page(sid, (ws, src), (ws, dst), PagesMode::Move, None, None)
+            .await
+            .unwrap();
+        assert_eq!(outcome.file, SessionPageFile::Moved);
+        assert!(outcome.summary.session_moved);
+        assert_eq!(outcome.summary.page_versions_moved, 1);
+
+        assert!(
+            !wiki.abs_path(ws, src, &path).exists(),
+            "source file must be gone"
+        );
+        let moved = std::fs::read_to_string(wiki.abs_path(ws, dst, &path)).unwrap();
+        assert!(moved.contains("consolidated session body"));
+        assert_eq!(
+            store.reader.session_project_ids(sid).await.unwrap(),
+            Some((ws, dst))
+        );
+        assert!(
+            store
+                .reader
+                .page_body_by_ids(ws, dst, path.as_str())
+                .await
+                .unwrap()
+                .is_some(),
+            "latest page row must now sit in the destination"
+        );
+        assert!(
+            store
+                .reader
+                .page_body_by_ids(ws, src, path.as_str())
+                .await
+                .unwrap()
+                .is_none()
+        );
+        // The moved file is byte-identical to what the store indexed, so the
+        // watcher's follow-up reindex in the destination is a no-op.
+        wiki.reindex_page(ws, dst, path.clone()).await.unwrap();
+        assert_eq!(
+            store
+                .reader
+                .page_body_by_ids(ws, dst, path.as_str())
+                .await
+                .unwrap()
+                .unwrap()
+                .body,
+            "consolidated session body"
+        );
+    }
+
+    #[tokio::test]
+    async fn move_session_page_regenerate_removes_source_file() {
+        let tmp = TempDir::new().unwrap();
+        let (store, wiki, ws, src, dst, sid, path) = session_with_page(&tmp).await;
+
+        let outcome = wiki
+            .move_session_page(sid, (ws, src), (ws, dst), PagesMode::Regenerate, None, None)
+            .await
+            .unwrap();
+        assert_eq!(outcome.file, SessionPageFile::Removed);
+        assert_eq!(outcome.summary.pages_regenerated, 1);
+
+        let src_abs = wiki.abs_path(ws, src, &path);
+        assert!(!src_abs.exists(), "retired page file must not linger");
+        assert!(!wiki.abs_path(ws, dst, &path).exists());
+        assert!(
+            leftover_tempfiles(src_abs.parent().unwrap()).is_empty(),
+            "parked copy must be deleted after the store commit"
+        );
+        assert!(
+            store
+                .reader
+                .page_body_by_ids(ws, src, path.as_str())
+                .await
+                .unwrap()
+                .is_none(),
+            "no latest version left in the source"
+        );
+        assert_eq!(
+            store.reader.session_project_ids(sid).await.unwrap(),
+            Some((ws, dst))
+        );
+    }
+
+    #[tokio::test]
+    async fn move_session_page_puts_file_back_when_store_refuses() {
+        let tmp = TempDir::new().unwrap();
+        let (store, wiki, ws, src, dst, sid, path) = session_with_page(&tmp).await;
+        // A latest page row at the same path in the destination, without a
+        // file, so the disk step succeeds and only the SQL step refuses.
+        store
+            .writer
+            .upsert_page(NewPage {
+                workspace_id: ws,
+                project_id: dst,
+                path: path.clone(),
+                title: "taken".into(),
+                body: "already here".into(),
+                tier: Tier::Semantic,
+                frontmatter_json: serde_json::json!({}),
+                pinned: false,
+                links: vec![],
+                author_id: None,
+                expires_at: None,
+                entities: vec![],
+            })
+            .await
+            .unwrap();
+
+        let err = wiki
+            .move_session_page(sid, (ws, src), (ws, dst), PagesMode::Move, None, None)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                WikiError::Store(ai_memory_store::StoreError::PagePathTaken { .. })
+            ),
+            "unexpected error: {err}"
+        );
+        assert!(
+            wiki.abs_path(ws, src, &path).exists(),
+            "source file must be back after the store refused"
+        );
+        assert!(!wiki.abs_path(ws, dst, &path).exists());
+        assert_eq!(
+            store.reader.session_project_ids(sid).await.unwrap(),
+            Some((ws, src))
+        );
+    }
+
+    #[tokio::test]
+    async fn move_session_page_refuses_existing_destination_file() {
+        let tmp = TempDir::new().unwrap();
+        let (store, wiki, ws, src, dst, sid, path) = session_with_page(&tmp).await;
+        wiki.write_page(req(
+            ws,
+            dst,
+            path.as_str(),
+            "destination already has this page",
+            serde_json::json!({}),
+        ))
+        .await
+        .unwrap();
+
+        let err = wiki
+            .move_session_page(sid, (ws, src), (ws, dst), PagesMode::Move, None, None)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, WikiError::DestinationPageExists(_)),
+            "unexpected error: {err}"
+        );
+        assert!(wiki.abs_path(ws, src, &path).exists());
+        assert_eq!(
+            store.reader.session_project_ids(sid).await.unwrap(),
+            Some((ws, src)),
+            "nothing may move when the destination file exists"
+        );
+    }
+
+    #[tokio::test]
+    async fn move_session_page_without_file_reports_absent() {
+        let tmp = TempDir::new().unwrap();
+        let (store, wiki, ws, src, dst, sid, path) = session_with_page(&tmp).await;
+        std::fs::remove_file(wiki.abs_path(ws, src, &path)).unwrap();
+
+        let outcome = wiki
+            .move_session_page(sid, (ws, src), (ws, dst), PagesMode::Move, None, None)
+            .await
+            .unwrap();
+        assert_eq!(outcome.file, SessionPageFile::Absent);
+        // The rows still move even though the file was already gone.
+        assert_eq!(outcome.summary.page_versions_moved, 1);
+        assert_eq!(
+            store.reader.session_project_ids(sid).await.unwrap(),
+            Some((ws, dst))
+        );
     }
 }

--- a/crates/ai-memory-wiki/src/wiki.rs
+++ b/crates/ai-memory-wiki/src/wiki.rs
@@ -362,7 +362,10 @@ impl Wiki {
     /// under the watcher-ignored `.ai-memory-tmp.` prefix and deleted once the
     /// rows are retired: left in place, the next reconciliation pass would
     /// re-index it as a fresh latest page in the source scope. A store failure
-    /// puts the file back where it was in both modes.
+    /// puts the file back where it was in both modes. When `from == to` (a
+    /// re-home of a session already rooted in the destination) there is no
+    /// file to relocate: the file step is skipped and only the store sweep
+    /// runs.
     ///
     /// # Errors
     /// Returns [`WikiError::DestinationPageExists`] when the destination
@@ -394,7 +397,7 @@ impl Wiki {
             .project_root(from.0, from.1)
             .join("sessions")
             .join(&file_name);
-        let parked = if src.is_file() {
+        let parked = if from != to && src.is_file() {
             let target = match pages {
                 PagesMode::Move => {
                     let dst = self

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -426,8 +426,8 @@ auto-improve         finalize-session     pending-writes
 embed                generate-auth-token  setup-agent
 bootstrap            install-instructions install-skills
 reorg                purge-project        rename-project
-move-project         uninstall            auth
-user                 completions
+move-project         move-session         uninstall
+auth                 user                 completions
 ```
 
 Run `ai-memory --help` for the full tree.

--- a/docs/admission-webhooks.md
+++ b/docs/admission-webhooks.md
@@ -72,6 +72,12 @@ Webhooks fire on these `op` values today (extensible enum):
   `ctx.destination_workspace` / `ctx.destination_project`, and no page path;
   fired before the directory rename + DB re-stamp so a mirror can rename or
   reject the project move.
+- `move_session` — one session (its rows and its `sessions/<id>.md` page)
+  is moved to another project (`/admin/move-session`). Carries the source
+  project in `ctx.workspace` / `ctx.project`, destination names in
+  `ctx.destination_workspace` / `ctx.destination_project`, and no page path;
+  fired before the page file moves and the DB re-stamps so a mirror can move
+  or reject it.
 - `handoff_begin` / `handoff_accept` / `handoff_cancel` — a handoff is created,
   consumed, or discarded. Carries the workspace / project and the acting
   operator, no page path (handoffs live in their own table, not the wiki tree).
@@ -121,7 +127,7 @@ within 750 ms is treated as a refusal and the baton remains open. Configure
 smaller per-webhook values when you need logs to identify which decider timed
 out rather than the aggregate deadline firing first.
 
-`delete` / `purge_project` / `purge_workspace` / `move_project` are notifications — there is no
+`delete` / `purge_project` / `purge_workspace` / `move_project` / `move_session` are notifications — there is no
 body to mutate; a `Reject`-policy webhook still aborts the operation
 (admission fires BEFORE the SQL destruction in both the `/admin/purge-project`
 and `/admin/delete-workspace` paths, and before source teardown in
@@ -184,10 +190,10 @@ terminal `purge_project` notification is unchanged.
 POST <webhook.url>
 Content-Type: application/json
 X-Memory-Op: write_page | consolidate | delete | purge_project | purge_workspace | move_project
-             | handoff_begin | handoff_accept | handoff_cancel
+             | move_session | handoff_begin | handoff_accept | handoff_cancel
 ```
 
-(The header is one of those nine values; the second line is a continuation of
+(The header is one of those ten values; the second line is a continuation of
 the list, not a second header.)
 
 ```jsonc
@@ -200,8 +206,8 @@ the list, not a second header.)
   "ctx": {
     "workspace": "default",                  // resolved name (see §5)
     "project": "ai-memory-ops",              // resolved name
-    "destination_workspace": "archive",       // move_project only; omitted otherwise
-    "destination_project": "ai-memory-ops",   // move_project only; omitted otherwise
+    "destination_workspace": "archive",       // move_project / move_session only; omitted otherwise
+    "destination_project": "ai-memory-ops",   // move_project / move_session only; omitted otherwise
     "actor": {                               // request-layer identity
       "agent": "claude-code",                // claude-code | codex | opencode | hook | cli | …
       "user": "djalmajr",                    // null when unauthenticated
@@ -209,7 +215,7 @@ the list, not a second header.)
       "client": "72836f52-...",              // DCR client UUID
       "session_id": "019e6d-..."
     },
-    "op": "write_page",                      // write_page | consolidate | delete | purge_project | purge_workspace | move_project
+    "op": "write_page",                      // write_page | consolidate | delete | purge_project | purge_workspace | move_project | move_session
     "partial_failure": true                  // purge_project/purge_workspace only, and ONLY when set
                                              //   (skipped on the wire when false).
                                              //   true → the DB rows were purged but

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -402,9 +402,10 @@ scope), the `handoffs` it produced (`from_session_id`), its
   session. Refused with `409` when the destination already has a latest page
   (or a page file) at that path; retry with `--pages regenerate` or resolve
   the destination page first.
-- `--pages regenerate`: the source versions are retired (`is_latest = 0`)
-  and the file is removed, so the next consolidation of the session writes a
-  fresh page in the destination. The file has to go: a page file left on
+- `--pages regenerate`: the source versions are retired (`is_latest = 0`),
+  the session's `summary_page_id` is cleared when it pointed at them, and the
+  file is removed, so the next consolidation of the session writes a fresh
+  page in the destination. The file has to go: a page file left on
   disk with no latest row is re-indexed as a new latest page by the next
   reconciliation pass.
 
@@ -435,13 +436,18 @@ the whole run.
 **Dry run by default.** Without `--confirm` the server runs the same
 transaction and rolls it back, so the counts in the response are exact
 (`dry_run: true`), and the CLI prints the exact command to apply. Nothing
-is written and no audit row is left.
+is written and no audit row is left; with `--create` against a destination
+that does not exist yet the dry run does not create it either: it reports
+`would_create_project: true` with the counts of what would move (the CLI
+says "would create project"), and only the `--confirm` run creates it.
 
 **Guards (409 unless `--force`).** A session that is still open (no session
 end recorded) may still receive events; a `pending`/`running` consolidation
 job would write the page under the old scope; the batch form also refuses
 the project the hook router has published as active, like `move-project`.
-`--force` proceeds. Note that forcing an open session leaves the hook
+`--force` proceeds. A re-home (the session row already sits in the
+destination) skips the open-session guard: the row does not move, so an
+open session only has its stray rows gathered; the job guard still applies. Note that forcing an open session leaves the hook
 router's per-session active pointer on the old scope until it expires;
 sticky routing then keeps following the session row, which is now the
 destination.
@@ -456,9 +462,13 @@ Response (`MoveSessionReport`): `session_id`, `dry_run`, `session_moved`
 (`{workspace, project}`), `summary` (`observations`, `handoffs`,
 `consolidation_jobs`, `auto_improve_runs`, `auto_improve_claims`,
 `page_versions_moved`, `pages_regenerated`), `page` (`moved` |
-`regenerated` | `none`), `cwd`, `cwd_warning`, `pre_checkpoint`,
-`checkpoint`. The batch wraps them in `{dry_run, from, to, total, moved,
-sessions: [...]}`.
+`regenerated` | `already in destination` for a re-home whose page rows all
+sit in the destination | `none` when the session has no page anywhere),
+`cwd`, `cwd_warning`, `would_create_project` (dry run with `create` only),
+`pre_checkpoint` (only when the wiki tree had uncommitted changes before the
+move), `checkpoint` (only when the move changed the tree). The batch wraps
+them in `{dry_run, would_create_project?, from, to, total, moved, sessions:
+[...]}`.
 
 Failure modes:
 

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -13,6 +13,7 @@ on a homelab box where mistakes are harder to undo.
 | `/admin/rename-workspace` | ✅ yes | no | yes (rename back) | Column-only update on `workspaces.name`; refreshes `_meta.md` scope manifests and checkpoints the wiki tree. |
 | `/admin/delete-workspace` | ✅ yes | the workspace and every child project | no | Runs `purge_workspace` admission first, deletes SQLite rows in one cascade, removes the UUID-keyed workspace directory and managed-workstream raw segments, reports filesystem partial failures, and dispatches mirror notification after durable work. |
 | `move-project --confirm` | ✅ yes | source only in the merge case (a `Reject`-policy `purge_project` webhook can still abort the source teardown leaving everything intact) | no | Fresh destination → lossless **true move** (re-stamp `workspace_id`, keep `project_id`, rename the dir): sessions/observations/handoffs + history all survive. Destination with a same-named project → **copy+purge merge**: only latest pages migrate. |
+| `move-session <id> --to --confirm` | ✅ yes | no | yes (move it back) | Re-stamps one session (or every session of `--from-project`) into another project: `sessions`, `observations`, its `handoffs`, consolidation jobs, auto-improve runs/claims and its `sessions/<id>.md` page, one transaction per session; the page file moves with it (`--pages move`, default) or is retired for regeneration. Without `--confirm` it is a real dry run (rolled back). Refuses with `409` an open session or a pending consolidation job unless `--force`. |
 | `backup --output-path` | ✅ yes | no | n/a | Streams a gzipped tarball from the server's online `sqlite3 .backup` plus the wiki tree. Safe alongside the live writer. |
 | `checkpoints` | ✅ yes | no | n/a | Lists recent wiki git checkpoints. Read-only. |
 | `restore-page --path --from` | ✅ yes | overwrites one markdown page version | yes (restore another checkpoint) | Restores one page from wiki git history, reindexes it into SQLite, and writes a post-restore checkpoint. Does not restore DB-only state. |
@@ -353,6 +354,115 @@ Failure modes:
   directory moved but before SQL committed, the error includes the
   exact manual repair.
 
+### `move-session`
+
+```bash
+# One session, page and history included (dry run: no --confirm)
+ai-memory move-session 0192b6a1-4c2e-7d3f-8a5b-1234567890ab --to NAS_general
+# Apply
+ai-memory move-session 0192b6a1-4c2e-7d3f-8a5b-1234567890ab --to NAS_general --confirm
+# Every session of a stray project, into another workspace, page regenerated later
+ai-memory move-session --from-project tmp --to NAS_general --to-workspace home \
+  --pages regenerate --confirm
+```
+
+Moves one session, or every session of `--from-project`, into another
+project, in the same or another workspace. Use it when a session was
+captured under the wrong project (a `cd` into `/tmp` before sticky routing,
+a subagent started in a scratch directory, a repo cloned under a temporary
+name) and its observations should live with the project they are about.
+Unlike `reorg`, which re-derives every session's project from its `cwd`,
+this names the destination explicitly and leaves the rest of the store
+alone.
+
+**Request.** `POST /admin/move-session` takes either
+`{"session_id": "<uuid>", "workspace"?, "project", "pages"?, "confirm"?,
+"force"?, "create"?}` or the batch form `{"from_workspace"?, "from_project",
+"workspace"?, "project", "pages"?, "confirm"?, "force"?, "create"?}`.
+`workspace` (the destination) defaults to the source workspace;
+`from_workspace` defaults to `default`. The CLI resolves `--from-project`
+like every other scope argument (marker, else literal); `--to` and
+`--to-workspace` stay literal.
+
+**What moves, per session, in ONE transaction:** the `sessions` row, every
+`observations` row of the session (including any that landed in another
+scope), the `handoffs` it produced (`from_session_id`), its
+`session_consolidation_jobs`, `auto_improve_runs` and
+`auto_improve_scheduler_claims`, and its `sessions/<id>.md` page:
+
+- `--pages move` (default): every version of the page is re-stamped into the
+  destination and the file is renamed into the destination project
+  directory, so the curated page and its supersession history follow the
+  session. Refused with `409` when the destination already has a latest page
+  (or a page file) at that path; retry with `--pages regenerate` or resolve
+  the destination page first.
+- `--pages regenerate`: the source versions are retired (`is_latest = 0`)
+  and the file is removed, so the next consolidation of the session writes a
+  fresh page in the destination. The file has to go: a page file left on
+  disk with no latest row is re-indexed as a new latest page by the next
+  reconciliation pass.
+
+The audit row (`op = move_session`) carries the operator when the request
+was attributed. What does NOT move: `sessions.cwd` (historical truth; the
+response carries `cwd_warning` when its basename is not the destination
+project, since new sessions started there still resolve by basename unless a
+`.ai-memory.toml` marker pins the project), other pages written during the
+session (decisions, gotchas: pages are not tracked per session), handoffs the
+session *accepted*, and `auto_improve_proposals` (they have no `session_id`;
+they target pages in the scope they were staged in). `entities` and
+`page_feedback` are not re-stamped either, the same gap `move-project` has.
+
+**Order of operations (per session):** validate the destination (404 unless
+`create`), reject a same-scope target (422), run the guards, then, under the
+wiki's exclusive mutation gate, fire `op=move_session` admission webhooks
+(source names in `ctx.workspace`/`ctx.project`, destination names in
+`ctx.destination_*`), move the file, and re-stamp SQLite. Disk goes first
+and SQL last, as in `move-project`: a store failure renames the file back,
+so the move is all-or-nothing unless the filesystem also refuses the
+rollback, in which case the error names the manual repair. A `--confirm`
+run takes a wiki checkpoint before and after; a batch takes one pair for
+the whole run.
+
+**Dry run by default.** Without `--confirm` the server runs the same
+transaction and rolls it back, so the counts in the response are exact
+(`dry_run: true`), and the CLI prints the exact command to apply. Nothing
+is written and no audit row is left.
+
+**Guards (409 unless `--force`).** A session that is still open (no session
+end recorded) may still receive events; a `pending`/`running` consolidation
+job would write the page under the old scope; the batch form also refuses
+the project the hook router has published as active, like `move-project`.
+`--force` proceeds. Note that forcing an open session leaves the hook
+router's per-session active pointer on the old scope until it expires;
+sticky routing then keeps following the session row, which is now the
+destination.
+
+**Batch form.** Every session of the source scope moves one at a time, each
+in its own transaction. The batch stops at the first refusal and the error
+body reports `moved`/`total` and the sessions already moved (they stay
+moved). A dry run of the batch shows the whole plan first.
+
+Response (`MoveSessionReport`): `session_id`, `dry_run`, `from`/`to`
+(`{workspace, project}`), `summary` (`observations`, `handoffs`,
+`consolidation_jobs`, `auto_improve_runs`, `auto_improve_claims`,
+`page_versions_moved`, `pages_regenerated`), `page` (`moved` |
+`regenerated` | `none`), `cwd`, `cwd_warning`, `pre_checkpoint`,
+`checkpoint`. The batch wraps them in `{dry_run, from, to, total, moved,
+sessions: [...]}`.
+
+Failure modes:
+
+- **Neither `session_id` nor `from_project`, or both** → 400.
+- **Session or destination not found** → 404 (pass `create` / `--create`
+  to create the destination).
+- **Destination equals the source scope** → 422.
+- **Open session, pending consolidation job, or active source project
+  (batch)** → 409 without `force`.
+- **Latest page or page file already at `sessions/<id>.md` in the
+  destination** (`--pages move`) → 409; nothing moved.
+- **Store failure after the file moved** → 500, file renamed back; the
+  error names the manual repair if that rollback also fails.
+
 ### `checkpoints`
 
 ```bash
@@ -566,6 +676,16 @@ ai-memory rename-project --from old --to new
 # (the hook router stamps by basename(cwd) = "new"); past
 # observations stay under that project too because the project_id
 # is stable.
+```
+
+### "Reattach a session captured under the wrong project"
+
+```bash
+ai-memory move-session <session-id> --to my-project          # dry run
+ai-memory move-session <session-id> --to my-project --confirm
+# Or empty a stray project into the right one, then drop the husk:
+ai-memory move-session --from-project tmp --to my-project --confirm
+ai-memory purge-project --project tmp --confirm
 ```
 
 ## Why this matters: the flat-wiki incident

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -13,7 +13,7 @@ on a homelab box where mistakes are harder to undo.
 | `/admin/rename-workspace` | ✅ yes | no | yes (rename back) | Column-only update on `workspaces.name`; refreshes `_meta.md` scope manifests and checkpoints the wiki tree. |
 | `/admin/delete-workspace` | ✅ yes | the workspace and every child project | no | Runs `purge_workspace` admission first, deletes SQLite rows in one cascade, removes the UUID-keyed workspace directory and managed-workstream raw segments, reports filesystem partial failures, and dispatches mirror notification after durable work. |
 | `move-project --confirm` | ✅ yes | source only in the merge case (a `Reject`-policy `purge_project` webhook can still abort the source teardown leaving everything intact) | no | Fresh destination → lossless **true move** (re-stamp `workspace_id`, keep `project_id`, rename the dir): sessions/observations/handoffs + history all survive. Destination with a same-named project → **copy+purge merge**: only latest pages migrate. |
-| `move-session <id> --to --confirm` | ✅ yes | no | yes (move it back) | Re-stamps one session (or every session of `--from-project`) into another project: `sessions`, `observations`, its `handoffs`, consolidation jobs, auto-improve runs/claims and its `sessions/<id>.md` page, one transaction per session; the page file moves with it (`--pages move`, default) or is retired for regeneration. Without `--confirm` it is a real dry run (rolled back). Refuses with `409` an open session or a pending consolidation job unless `--force`. |
+| `move-session <id> --to --confirm` | ✅ yes | no | yes (move it back) | Re-stamps one session (or every session touching `--from-project`) into another project: `sessions`, `observations`, its `handoffs`, consolidation jobs, auto-improve runs/claims and its `sessions/<id>.md` page, one transaction per session; the page file moves with it (`--pages move`, default) or is retired for regeneration. Without `--confirm` it is a real dry run (rolled back). Refuses with `409` an open session or a pending consolidation job unless `--force`. |
 | `backup --output-path` | ✅ yes | no | n/a | Streams a gzipped tarball from the server's online `sqlite3 .backup` plus the wiki tree. Safe alongside the live writer. |
 | `checkpoints` | ✅ yes | no | n/a | Lists recent wiki git checkpoints. Read-only. |
 | `restore-page --path --from` | ✅ yes | overwrites one markdown page version | yes (restore another checkpoint) | Restores one page from wiki git history, reindexes it into SQLite, and writes a post-restore checkpoint. Does not restore DB-only state. |
@@ -366,14 +366,20 @@ ai-memory move-session --from-project tmp --to NAS_general --to-workspace home \
   --pages regenerate --confirm
 ```
 
-Moves one session, or every session of `--from-project`, into another
+Moves one session, or every session touching `--from-project`, into another
 project, in the same or another workspace. Use it when a session was
 captured under the wrong project (a `cd` into `/tmp` before sticky routing,
 a subagent started in a scratch directory, a repo cloned under a temporary
 name) and its observations should live with the project they are about.
 Unlike `reorg`, which re-derives every session's project from its `cwd`,
 this names the destination explicitly and leaves the rest of the store
-alone.
+alone. Sessions already rooted in the destination only get their stray rows
+re-homed: the `sessions` row stays, every row of theirs still lying in
+another scope is gathered into the destination, and the report says
+`session_moved: false` with the counts. The batch form therefore sees a
+session through a `sessions` row in the source OR observations stamped into
+it, which is what empties a phantom bucket that holds only observations of
+sessions rooted elsewhere (mid-session routing before sticky).
 
 **Request.** `POST /admin/move-session` takes either
 `{"session_id": "<uuid>", "workspace"?, "project", "pages"?, "confirm"?,
@@ -413,7 +419,10 @@ they target pages in the scope they were staged in). `entities` and
 `page_feedback` are not re-stamped either, the same gap `move-project` has.
 
 **Order of operations (per session):** validate the destination (404 unless
-`create`), reject a same-scope target (422), run the guards, then, under the
+`create`), reject a batch whose source is the destination (422; the single
+form with the session's own project is a re-home), run the guards (the
+open-session guard does not apply to a re-home, whose row does not move),
+then, under the
 wiki's exclusive mutation gate, fire `op=move_session` admission webhooks
 (source names in `ctx.workspace`/`ctx.project`, destination names in
 `ctx.destination_*`), move the file, and re-stamp SQLite. Disk goes first
@@ -442,7 +451,8 @@ in its own transaction. The batch stops at the first refusal and the error
 body reports `moved`/`total` and the sessions already moved (they stay
 moved). A dry run of the batch shows the whole plan first.
 
-Response (`MoveSessionReport`): `session_id`, `dry_run`, `from`/`to`
+Response (`MoveSessionReport`): `session_id`, `dry_run`, `session_moved`
+(`false` for a re-home), `from`/`to`
 (`{workspace, project}`), `summary` (`observations`, `handoffs`,
 `consolidation_jobs`, `auto_improve_runs`, `auto_improve_claims`,
 `page_versions_moved`, `pages_regenerated`), `page` (`moved` |
@@ -455,9 +465,11 @@ Failure modes:
 - **Neither `session_id` nor `from_project`, or both** → 400.
 - **Session or destination not found** → 404 (pass `create` / `--create`
   to create the destination).
-- **Destination equals the source scope** → 422.
-- **Open session, pending consolidation job, or active source project
-  (batch)** → 409 without `force`.
+- **Batch source equals the destination** → 422 (the single form with the
+  session's own project is a re-home, 200 with `session_moved: false`).
+- **Open session (unless the row already sits in the destination), pending
+  consolidation job, or active source project (batch)** → 409 without
+  `force`.
 - **Latest page or page file already at `sessions/<id>.md` in the
   destination** (`--pages move`) → 409; nothing moved.
 - **Store failure after the file moved** → 500, file renamed back; the

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -485,6 +485,28 @@ Failure modes:
 - **Store failure after the file moved** → 500, file renamed back; the
   error names the manual repair if that rollback also fails.
 
+**It drains every scope, not just the one you named.** Dependent rows are
+matched by session id alone, so a session whose observations were scattered
+across projects (pre-`sticky` mid-session routing, for instance) is gathered
+whole. That is the point of the command — but it means a move can empty a
+project you did not mention, and it is **not cleanly reversible**: moving the
+session back later returns every row to a single project, and the original
+per-row split is gone.
+
+The dry run therefore names each scope it would drain, with counts:
+
+```text
+  gathering observations out of 2 scopes into default/acme-api:
+    default/scratchpad: 3 observation(s)
+    default/tmp: 1 observation(s)
+  Note: this empties every scope listed above, not only the one named as the
+  source. Moving the session back later returns all rows to a single project —
+  the split shown here is not restored.
+```
+
+`POST /admin/move-session` reports the same list as `source_scopes`. Read it
+before confirming.
+
 ### `checkpoints`
 
 ```bash

--- a/docs/marker-file.md
+++ b/docs/marker-file.md
@@ -392,7 +392,7 @@ Both entry points, as of v1.20:
   calling the server — `run`, `bootstrap`, `search`, `read-page`,
   `write-page`, `lint`, `curator`, `embed`, `pending-writes`,
   `forget-sweep`, `auto-improve`, `purge-project`, `rename-project`,
-  `move-project` (source side), and friends.
+  `move-project` and `move-session --from-project` (source side), and friends.
 
 Before v1.20 only the hooks read it. A checkout declaring
 `workspace = "acme"` therefore had its captures land in `acme` while every

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -399,6 +399,23 @@ docker cp ai-memory:/data/wiki ./my-ai-memory-wiki
 docker exec ai-memory git -C /data/wiki log --oneline
 ```
 
+## Move a session to another project
+
+A session captured under the wrong project (a `cd` into a scratch
+directory, a subagent started elsewhere) can be reattached without a
+reorg of the whole store:
+
+```bash
+ai-memory move-session <session-id> --to my-project            # dry run
+ai-memory move-session <session-id> --to my-project --confirm  # apply
+ai-memory move-session --from-project tmp --to my-project --confirm
+```
+
+The session, its observations, handoffs, consolidation jobs and its
+`sessions/<id>.md` page move together; see
+[`docs/lifecycle-ops.md`](lifecycle-ops.md#move-session) for the page modes,
+guards, and what stays behind.
+
 ## Project consolidation preferences
 
 Create `_prompts/consolidation.md` in a project's wiki when its compiled pages


### PR DESCRIPTION
## What changed

Adds an operator command to move a session (and everything keyed to it) to another project, mirroring `move-project` in shape and safety:

- **CLI** `ai-memory move-session <session-id> --to <project> [--to-workspace <ws>] [--pages move|regenerate] [--confirm] [--force] [--create]` and the batch form `ai-memory move-session --from-project <p> [--from-workspace <ws>] --to <project> ...`. Without `--confirm` it prints the dry-run summary and the exact command to apply; `--force` skips the guards; `--create` creates the destination (only on confirm; a dry run reports `would create project` and writes nothing).
- **Admin route** `POST /admin/move-session` (single or batch body), root bearer like its siblings. Guards: 404 unknown session/target, 422 same scope in the batch form, 409 for an open session or a `pending`/`running` consolidation job unless `force`, 409 on a page-path collision in the destination.
- **Store** `ops::move_session` (+ `WriteCmd::MoveSession` / `WriterHandle::move_session`): one transaction re-stamping `sessions`, `observations` (FTS trigger fires as intended), `handoffs` (`from_session_id`), `session_consolidation_jobs`, `auto_improve_runs`, `auto_improve_scheduler_claims`, and the session page `sessions/<id>.md`: `--pages move` moves every version (refusing with `PagePathTaken` if the destination already has a latest page at that path); `--pages regenerate` retires the source latest row (and clears `sessions.summary_page_id`) so the next consolidation rewrites it. `commit=false` runs the same transaction and rolls it back (real dry run). Audit row `op=move_session` with the operator when known.
- **Re-home**: a session whose row already sits in the destination is not a no-op; its stray rows in other scopes (the phantom-bucket case that motivated the issue) are gathered into the destination, and the batch form enumerates sessions that have a row **or** any observation in the source, so an observation-only bucket can be emptied.
- **Wiki** `Wiki::move_session_page` (new `AdmissionOp::MoveSession`): under the mutation lock, file first, SQL last, file put back on store error, like `move_project_workspace`; `regenerate` parks the source file under a watcher-ignored name before the SQL and removes it after commit, because the watcher would otherwise re-index the file as a fresh page. Checkpoint pair (`pre-move-session` / `move-session`) when the tree changes.
- Docs: `docs/lifecycle-ops.md` (`### move-session`, safety matrix), `docs/usage.md`, `docs/admission-webhooks.md`.

No defaults change; no existing command changes behaviour.

## Why

Closes #402. Sessions land in the wrong project (phantom buckets before #395, wrong marker, wrong folder) and the only fix today is SQL with the server stopped; `rename-project` refuses an existing target, `move-project` moves whole projects, `reorg` re-splits by cwd. This gives operators a transactional, dry-run-first, admission-checked way to relocate one session or empty a bucket.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `TAILWIND_SKIP=1 cargo test --workspace` passes (33 new tests across store, wiki, mcp admin, cli)
- [x] Manual test on a copy of a production store, local server: batch `--from-project tmp --to NAS_general` emptied a real phantom bucket (10 observations, 0 session rows) in 117 ms and a re-run reports 0 of 0; a 362-observation session with a two-version page moved to its real project in 61 ms end to end (file, rows, handoff, git checkpoint), `read-page` finds it in the destination; 404/409 guards, `--create --pages regenerate`, and the dry-run-writes-nothing invariant verified against the database.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected any unintended identity before requesting merge.

## CHANGELOG (merge gate)

- [x] I added a `CHANGELOG.md` `[Unreleased]` entry under Added.
- [x] No changed defaults.

## Notes for reviewers

- `auto_improve_proposals` is deliberately not re-stamped: it has no `session_id`, hangs off `run_id`, and points at source pages through `target_latest_page_id_at_stage`; documented. `entities` and `page_feedback` are not touched either, matching `move-project` today.
- `sessions.cwd` is left as recorded; the report warns when its basename differs from the destination project and points at the `.ai-memory.toml` marker / `[routing] mid_session = sticky`.
- Implementation drafted with Claude Code and reviewed, tested and validated by the author.
