### PR TITLE
feat(sanitize): complete GitHub/AWS/Stripe token families; add Meta, Google refresh, Telegram, GoHighLevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- The built-in sanitizer now redacts six further credential shapes, completing
+- The built-in sanitizer now redacts seven further credential shapes, completing
   three vendor families it already covered only in part. **GitHub:** every
   token prefix — `gho_` (OAuth, the form `gh auth login` writes to disk),
   `ghu_`, `ghs_`, `ghr_` — where previously only `ghp_` and `github_pat_`
@@ -17,8 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   providers with no prior coverage: **Google OAuth refresh tokens** (`1//…`,
   longer-lived than the `AIza…` keys already handled — they mint access
   tokens until revoked), **Meta / Facebook Graph access tokens** (`EAA…`,
-  ad-account, page and business-management scope), and **Telegram bot
-  tokens** (`<bot-id>:AA…`). These run in `BUILTIN_PATTERN_STRS`, so unlike
+  ad-account, page and business-management scope), **Telegram bot
+  tokens** (`<bot-id>:AA…`), and **GoHighLevel Private Integration Tokens**
+  (`pit-…`, which do not expire until manually revoked). These run in
+  `BUILTIN_PATTERN_STRS`, so unlike
   operator `[sanitize].extra_patterns` they also scrub client-side, before an
   excerpt reaches the local spool or the wire.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- The built-in sanitizer now redacts six further credential shapes, completing
+  three vendor families it already covered only in part. **GitHub:** every
+  token prefix — `gho_` (OAuth, the form `gh auth login` writes to disk),
+  `ghu_`, `ghs_`, `ghr_` — where previously only `ghp_` and `github_pat_`
+  were caught. **AWS:** `ASIA…` STS temporary key ids alongside `AKIA…`.
+  **Stripe:** `rk_live_` restricted keys alongside `sk_live_`. Plus three
+  providers with no prior coverage: **Google OAuth refresh tokens** (`1//…`,
+  longer-lived than the `AIza…` keys already handled — they mint access
+  tokens until revoked), **Meta / Facebook Graph access tokens** (`EAA…`,
+  ad-account, page and business-management scope), and **Telegram bot
+  tokens** (`<bot-id>:AA…`). These run in `BUILTIN_PATTERN_STRS`, so unlike
+  operator `[sanitize].extra_patterns` they also scrub client-side, before an
+  excerpt reaches the local spool or the wire.
+
+  Behaviour change: text matching these shapes is now replaced with
+  `[REDACTED]` where it previously persisted verbatim. An operator who
+  *wants* one of them kept visible (for example a public bot id) can add it
+  to `[sanitize].allowlist`.
+
 ## [1.28.0] - 2026-08-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer-lived than the `AIza…` keys already handled — they mint access
   tokens until revoked), **Meta / Facebook Graph access tokens** (`EAA…`,
   ad-account, page and business-management scope), **Telegram bot
-  tokens** (`<bot-id>:AA…`), and **GoHighLevel Private Integration Tokens**
+  tokens** (`<bot-id>:…`, covering both the `AA…` form every issued token uses
+  and the shape Telegram's own docs publish), and **GoHighLevel Private
+  Integration Tokens**
   (`pit-…`, which do not expire until manually revoked). These run in
   `BUILTIN_PATTERN_STRS`, so unlike
   operator `[sanitize].extra_patterns` they also scrub client-side, before an

--- a/crates/ai-memory-core/src/sanitize.rs
+++ b/crates/ai-memory-core/src/sanitize.rs
@@ -73,9 +73,18 @@ const BUILTIN_PATTERN_STRS: &[&str] = &[
     // Meta / Facebook Graph API access tokens (ad accounts, pages,
     // business management).
     r"EAA[A-Za-z0-9]{20,}",
-    // Telegram bot tokens: <bot-id>:AA<secret>. Grants full control of the
-    // bot, including reading every message it can see.
-    r"\b\d{8,10}:AA[A-Za-z0-9_\-]{32,}",
+    // Telegram bot tokens: <bot-id>:<secret>. Grants full control of the bot,
+    // including reading every message it can see. Two branches on purpose:
+    //  - `AA…` is the shape every issued token has taken, left open-ended so a
+    //    future length change cannot silently retire the rule.
+    //  - the second branch matches the shape Telegram's own docs publish
+    //    (`123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11` — 6-digit id, no `AA`),
+    //    length-anchored because without the `AA` anchor a bare `\d+:[\w-]+`
+    //    also matches timestamps, ratios, `host:port` maps, SRT cues and
+    //    `<short-sha>:<hex>` pairs.
+    // Thanks to @tahazarif10 for spotting that the documented example fell
+    // outside the original `\d{8,10}:AA…` form.
+    r"\b\d{6,10}:(?:AA[A-Za-z0-9_\-]{30,}|[A-Za-z0-9_\-]{34,35})\b",
     // GoHighLevel Private Integration Tokens. The `pit-` prefix is what the
     // vendor documents (their MCP guide shows `Bearer pit-your-token`); the
     // tail is NOT documented anywhere, and every token observed in the wild
@@ -359,6 +368,35 @@ mod tests {
         assert!(out.contains("[REDACTED]"));
         assert!(!out.contains("FAKEfake"));
         assert!(out.contains("done"), "should not swallow trailing context");
+    }
+
+    #[test]
+    fn scrubs_telegram_documented_example_shape() {
+        // Regression for #408: Telegram's own Bot API docs publish
+        // `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11` — a 6-digit id and no
+        // `AA` prefix — which the original `\d{8,10}:AA…` form could not match.
+        // This is the vendor's placeholder, not a live token.
+        let out = s().scrub("token 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11 ok");
+        assert!(out.contains("[REDACTED]"));
+        assert!(!out.contains("ABC-DEF1234"));
+        assert!(out.contains("ok"), "should not swallow trailing context");
+    }
+
+    #[test]
+    fn telegram_pattern_does_not_eat_colon_separated_prose() {
+        // Negative control, and the reason the non-`AA` branch is
+        // length-anchored rather than open-ended: dropping the anchor entirely
+        // makes `\d+:[\w-]+` match all of these.
+        for benign in [
+            "built 2026:08 release notes",
+            "aspect ratio 16:9 widescreen",
+            "ports 8080:my-service-name-here",
+            "00:00:00,000 --> 00:00:04,120 caption",
+            "commit 12345678:deadbeefcafebabe0123456789abcdef",
+        ] {
+            let out = s().scrub(benign);
+            assert!(!out.contains("[REDACTED]"), "false positive on: {benign}");
+        }
     }
 
     #[test]

--- a/crates/ai-memory-core/src/sanitize.rs
+++ b/crates/ai-memory-core/src/sanitize.rs
@@ -17,8 +17,8 @@
 //! (Anthropic / OpenAI / OpenRouter sk-…, Stripe sk_live_/rk_live_…,
 //! all GitHub token prefixes ghp_/gho_/ghu_/ghs_/ghr_ and fine-grained
 //! github_pat_…, Google AIza… plus OAuth refresh tokens 1//…, Meta /
-//! Facebook Graph EAA…, Telegram bot tokens, Slack xoxb/xoxp…, AWS
-//! AKIA/ASIA…), PEM-bracketed private
+//! Facebook Graph EAA…, Telegram bot tokens, GoHighLevel pit-…, Slack
+//! xoxb/xoxp…, AWS AKIA/ASIA…), PEM-bracketed private
 //! keys, URL-embedded credentials (`postgres://user:pass@host`), and
 //! anything matching the generic `*_(KEY|TOKEN|SECRET|PASSWORD|
 //! CREDENTIAL)=value` shape. Operators can extend the list via
@@ -76,6 +76,14 @@ const BUILTIN_PATTERN_STRS: &[&str] = &[
     // Telegram bot tokens: <bot-id>:AA<secret>. Grants full control of the
     // bot, including reading every message it can see.
     r"\b\d{8,10}:AA[A-Za-z0-9_\-]{32,}",
+    // GoHighLevel Private Integration Tokens. The `pit-` prefix is what the
+    // vendor documents (their MCP guide shows `Bearer pit-your-token`); the
+    // tail is NOT documented anywhere, and every token observed in the wild
+    // carries a UUID. Anchoring on the UUID shape rather than a permissive
+    // tail is deliberate: `pit-` is also an English fragment, so
+    // `pit-[A-Za-z0-9\-]{20,}` would redact "pit-stop-strategy-analysis".
+    // These tokens do not expire until manually revoked.
+    r"pit-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
     // Slack tokens (bot/user/admin/app-level/refresh).
     r"xox[abprs]-[A-Za-z0-9\-]{10,}",
     r"xapp-[A-Za-z0-9\-]{10,}",
@@ -351,6 +359,24 @@ mod tests {
         assert!(out.contains("[REDACTED]"));
         assert!(!out.contains("FAKEfake"));
         assert!(out.contains("done"), "should not swallow trailing context");
+    }
+
+    #[test]
+    fn scrubs_gohighlevel_private_integration_token() {
+        // Uppercase hex on purpose: the vendor documents no case, so the
+        // pattern accepts both. DEADBEEF/CAFEBABE keeps the fixture
+        // unmistakably synthetic.
+        let out = s().scrub("ghl=pit-DEADBEEF-FACE-4B0B-BEEF-CAFEBABE1234");
+        assert!(out.contains("[REDACTED]"));
+        assert!(!out.contains("DEADBEEF"));
+    }
+
+    #[test]
+    fn ghl_pattern_does_not_eat_hyphenated_english() {
+        // Negative control, and the reason the tail is UUID-anchored rather
+        // than permissive: `pit-` is an ordinary English fragment.
+        let out = s().scrub("planning the pit-stop-strategy-analysis for turn 4");
+        assert!(!out.contains("[REDACTED]"));
     }
 
     #[test]

--- a/crates/ai-memory-core/src/sanitize.rs
+++ b/crates/ai-memory-core/src/sanitize.rs
@@ -14,8 +14,11 @@
 //! ## What we redact
 //!
 //! Built-in patterns cover bearer tokens, vendor-prefixed API keys
-//! (Anthropic / OpenAI / OpenRouter sk-…, Stripe sk_live_…, GitHub PATs,
-//! Google AIza…, Slack xoxb/xoxp…, AWS AKIA…), PEM-bracketed private
+//! (Anthropic / OpenAI / OpenRouter sk-…, Stripe sk_live_/rk_live_…,
+//! all GitHub token prefixes ghp_/gho_/ghu_/ghs_/ghr_ and fine-grained
+//! github_pat_…, Google AIza… plus OAuth refresh tokens 1//…, Meta /
+//! Facebook Graph EAA…, Telegram bot tokens, Slack xoxb/xoxp…, AWS
+//! AKIA/ASIA…), PEM-bracketed private
 //! keys, URL-embedded credentials (`postgres://user:pass@host`), and
 //! anything matching the generic `*_(KEY|TOKEN|SECRET|PASSWORD|
 //! CREDENTIAL)=value` shape. Operators can extend the list via
@@ -50,12 +53,29 @@ const BUILTIN_PATTERN_STRS: &[&str] = &[
     r#"(?i)bearer\s+[A-Za-z0-9._\-+/=]{16,}"#,
     // Vendor-prefixed API keys.
     r"sk-[A-Za-z0-9_\-]{16,}",
-    r"sk_live_[A-Za-z0-9_\-]{16,}",
-    r"ghp_[A-Za-z0-9]{20,}",
+    // Stripe secret *and* restricted keys. `rk_live_` is scoped rather than
+    // full-access, but the scope is operator-chosen and routinely includes
+    // charges/refunds — not meaningfully safer than `sk_live_`.
+    r"(?:sk|rk)_live_[A-Za-z0-9_\-]{16,}",
+    // Every GitHub token prefix, not only personal-access: `gho_` (OAuth —
+    // what `gh auth login` stores on disk), `ghu_` (user-to-server),
+    // `ghs_` (server-to-server / Actions), `ghr_` (refresh).
+    r"gh[pousr]_[A-Za-z0-9]{20,}",
     r"github_pat_[A-Za-z0-9_]{20,}",
-    r"AKIA[0-9A-Z]{12,}",
+    // AWS access-key IDs: long-lived (AKIA) and STS temporary (ASIA).
+    r"(?:AKIA|ASIA)[0-9A-Z]{12,}",
     // Naked Google / Gemini API keys.
     r"AIza[A-Za-z0-9_\-]{30,}",
+    // Google OAuth refresh tokens. Longer-lived than the AIza keys above:
+    // they mint fresh access tokens until explicitly revoked, so a leaked
+    // one outlives the session it came from.
+    r"1//[0-9A-Za-z_\-]{20,}",
+    // Meta / Facebook Graph API access tokens (ad accounts, pages,
+    // business management).
+    r"EAA[A-Za-z0-9]{20,}",
+    // Telegram bot tokens: <bot-id>:AA<secret>. Grants full control of the
+    // bot, including reading every message it can see.
+    r"\b\d{8,10}:AA[A-Za-z0-9_\-]{32,}",
     // Slack tokens (bot/user/admin/app-level/refresh).
     r"xox[abprs]-[A-Za-z0-9\-]{10,}",
     r"xapp-[A-Za-z0-9\-]{10,}",
@@ -262,6 +282,75 @@ mod tests {
         let out = s().scrub("the key AIzaSy0123456789abcdefghijklmnopqrstuvwx is leaked");
         assert!(out.contains("[REDACTED]"));
         assert!(!out.contains("AIzaSy"));
+    }
+
+    // Every fixture below is a SHAPE, never a live value — same rule as the
+    // AIzaSy… test above, and the same `FAKE` convention used by the
+    // `ghp_FAKE…` fixture in ai-memory-wiki. Keep them obviously synthetic
+    // so credential scanners do not flag this repository.
+
+    #[test]
+    fn scrubs_all_github_token_prefixes() {
+        // ghp_ was already covered; gho_/ghu_/ghs_/ghr_ were not, and gho_
+        // is the prefix `gh auth login` writes to disk.
+        for tok in [
+            "ghp_FAKEfakeFAKEfakeFAKEfake012345678",
+            "gho_FAKEfakeFAKEfakeFAKEfake012345678",
+            "ghu_FAKEfakeFAKEfakeFAKEfake012345678",
+            "ghs_FAKEfakeFAKEfakeFAKEfake012345678",
+            "ghr_FAKEfakeFAKEfakeFAKEfake012345678",
+        ] {
+            let out = s().scrub(&format!("token={tok}"));
+            assert!(out.contains("[REDACTED]"), "not redacted: {tok}");
+            assert!(!out.contains("FAKEfake"), "leaked: {tok}");
+        }
+    }
+
+    #[test]
+    fn scrubs_aws_temporary_session_key_id() {
+        // ASIA… is an STS short-lived key id; AKIA… was already covered.
+        let out = s().scrub("aws_access_key_id ASIAFAKEFAKEFAKEFAKE");
+        assert!(out.contains("[REDACTED]"));
+        assert!(!out.contains("ASIAFAKE"));
+    }
+
+    #[test]
+    fn scrubs_stripe_restricted_key() {
+        let out = s().scrub("stripe=rk_live_FAKEfakeFAKE1234");
+        assert!(out.contains("[REDACTED]"));
+        assert!(!out.contains("FAKEfakeFAKE"));
+    }
+
+    #[test]
+    fn scrubs_meta_graph_access_token() {
+        let out = s().scrub("fb=EAAFAKEfakeFAKEfake0123456789");
+        assert!(out.contains("[REDACTED]"));
+        assert!(!out.contains("FAKEfake"));
+    }
+
+    #[test]
+    fn meta_pattern_does_not_eat_short_base64_runs() {
+        // Negative control. The OpenSSH fixture in
+        // `scrubs_pem_private_key_block` contains the substring "EAAAAA";
+        // the {20,} tail is what stops `EAA…` from matching every base64
+        // blob that happens to contain it.
+        let out = s().scrub("harmless b3BlbnNzaC1rZXktdjEAAAAA value");
+        assert!(!out.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn scrubs_google_oauth_refresh_token() {
+        let out = s().scrub("refresh_token: 1//0gFAKEfakeFAKEfake0123456789");
+        assert!(out.contains("[REDACTED]"));
+        assert!(!out.contains("FAKEfake"));
+    }
+
+    #[test]
+    fn scrubs_telegram_bot_token() {
+        let out = s().scrub("TG 123456789:AAFAKEfakeFAKEfakeFAKEfake0123456789 done");
+        assert!(out.contains("[REDACTED]"));
+        assert!(!out.contains("FAKEfake"));
+        assert!(out.contains("done"), "should not swallow trailing context");
     }
 
     #[test]


### PR DESCRIPTION
## What changed

`BUILTIN_PATTERN_STRS` gains seven credential shapes. Three of them **complete
vendor families the sanitizer already covered only in part**:

| Vendor | Covered before | Added |
|---|---|---|
| GitHub | `ghp_`, `github_pat_` | `gho_`, `ghu_`, `ghs_`, `ghr_` |
| AWS | `AKIA…` (long-lived) | `ASIA…` (STS temporary) |
| Stripe | `sk_live_` | `rk_live_` (restricted) |

and four are providers with no prior coverage at all:

- **Google OAuth refresh tokens** (`1//…`) — longer-lived than the `AIza…`
  keys already handled: they mint fresh access tokens until explicitly
  revoked, so a leaked one outlives the session it came from.
- **Meta / Facebook Graph access tokens** (`EAA…`) — ad-account, page and
  business-management scope.
- **Telegram bot tokens** (`<bot-id>:AA…`) — full control of the bot,
  including every message it can see.
- **GoHighLevel Private Integration Tokens** (`pit-…`) — long-lived
  server-to-server credentials that do not expire until manually revoked.

**Behaviour change:** text matching these shapes is now replaced with
`[REDACTED]` where it previously persisted verbatim. An operator who wants
one kept visible (a public bot id, say) can add it to `[sanitize].allowlist`.
No config, flag, endpoint or response shape changes.

The module doc comment's "what we redact" list is updated to match, and
`CHANGELOG.md` has an `[Unreleased]` entry.

## Why

`gho_` is the specific gap that prompted this. It is the prefix `gh auth
login` writes to disk, so it is the GitHub token most likely to appear in a
captured shell excerpt — and it was the one prefix of the family that fell
through. Once that surfaced, the same shape showed up twice more: `ASIA…`
next to `AKIA…`, `rk_live_` next to `sk_live_`. Each is the same vendor and
the same blast radius as a prefix already on the list, so the partial
coverage reads as an oversight rather than a decision.

The three new providers were chosen on longevity rather than popularity: a
Google refresh token and a Meta long-lived token both survive the session
that leaked them, which is exactly the property that makes a durable
markdown wiki the wrong place for them.

This matters more here than the `extra_patterns` escape hatch suggests.
Per `SECURITY.md`, operator `extra_patterns` run **server-side only**, so a
secret matched only by an operator rule can still sit in the excerpt on the
client spool and the wire. Only `BUILTIN_PATTERN_STRS` scrubs client-side —
which is why these belong in the builtin list rather than in everyone's
config.

## Test plan

- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] `cargo deny check` passes

⚠️ **I could not run the four gates — there is no Rust toolchain on the
machine I authored this on.** I am not claiming they pass; please treat CI
as the first real run. To compensate I verified what was verifiable without
a compiler, and I would rather state that plainly than tick boxes I did not
execute:

- All 22 builtin patterns (16 existing + 6 new) compile under an independent
  regex engine, and every new pattern matches its fixture.
- **Negative control:** the `EAA…` pattern does *not* match
  `b3BlbnNzaC1rZXktdjEAAAAA` — the base64 OpenSSH fixture already used by
  `scrubs_pem_private_key_block`, which contains the substring `EAAAAA`. The
  `{20,}` tail is what prevents `EAA…` from eating arbitrary base64. This is
  asserted in a new test (`meta_pattern_does_not_eat_short_base64_runs`) so
  the constraint cannot silently regress.
- **Regression check:** the fixtures from the nine existing sanitizer tests
  still redact, and two control strings that should stay clean
  (`just a normal sentence…`, `version 1.28.0 released on 2026-08-17`) do —
  the second specifically guards the new `1//` pattern against version
  strings.
- Line widths in the changed Rust are ≤100 cols with no trailing
  whitespace or tabs, so `cargo fmt` should be a no-op, but that is an
  inspection and not a run.

Nine tests added, matching the existing `scrubs_*` style and the `FAKE…`
synthetic-fixture convention used by the `ghp_FAKE…` fixture in
`ai-memory-wiki`. Every fixture is a shape, never a live value — the
GoHighLevel one uses `DEADBEEF`/`CAFEBABE` in uppercase hex, which also
exercises the case-insensitivity.

Two of the nine are negative controls rather than positive assertions
(`meta_pattern_does_not_eat_short_base64_runs`,
`ghl_pattern_does_not_eat_hyphenated_english`). Both encode a false-positive
boundary that is otherwise invisible and easy to regress.

Incidentally: `sk_live_` had no test before this — `scrubs_stripe_restricted_key`
is the first coverage for that line, via its `rk_live_` sibling.

## Commit attribution

- [ ] I verified the name and email on every commit in this PR and corrected
      any unintended identity before requesting merge.

## CHANGELOG (merge gate)

- [x] Added an `[Unreleased]` entry — this is a user-facing behaviour change
      (text that previously persisted is now redacted).
- [x] The behaviour change is called out explicitly in "What changed" above.

## Notes for reviewers

Three judgement calls worth your scrutiny:

0. **GoHighLevel's token tail is not vendor-documented, and I want that on
   the record rather than buried.** The `pit-` prefix *is* documented — their
   MCP guide shows `Authorization: Bearer pit-your-token` — but HighLevel
   publishes no character set or length for what follows, on that page or
   any other I could find. Every PIT observed in practice carries a UUID, so
   the pattern anchors on prefix + UUID shape and accepts either hex case
   (the vendor specifies none). I deliberately rejected the permissive
   alternative `pit-[A-Za-z0-9\-]{20,}`, because `pit-` is an English
   fragment and that form redacts `pit-stop-strategy-analysis` — pinned by
   the `ghl_pattern_does_not_eat_hyphenated_english` negative control. The
   accepted cost: if HighLevel ever issues a non-UUID tail, this misses it.
   If you would rather not carry a pattern whose tail rests on observation
   rather than documentation, dropping that one line leaves the other six
   independently sound.

1. **False-positive appetite on `EAA…`.** The file's own comment says *"False
   positives are acceptable — better to redact a stray hash than to leak a
   credential,"* and I followed it: `EAA[A-Za-z0-9]{20,}` will occasionally
   redact a base64 run that merely starts with those three characters. Real
   Meta tokens run to ~200 chars, so tightening to `{30,}` or `{40,}` would
   cut false positives with little practical loss of coverage. I went with
   `{20,}` to match the stated doctrine, but I would defer to you here.

2. **`1//` is only three characters of prefix.** It is anchored by the
   `{20,}` base64url tail, and I checked it against version strings
   (`1.28.0`) and URL paths. Still, it is the loosest of the six and the one
   I would most expect to surprise someone.

I deliberately left out one vendor I could not verify to primary
documentation. I would rather ship six patterns I have confirmed than seven
with a guess in a security-critical const array.
