### PR TITLE
docs: document OrcaRouter as an openai-compat provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Documented OrcaRouter through the existing `openai-compat` provider instead
   of adding a redundant provider type, including the endpoint, model, and API
-  key mapping needed for deployment. (#NNN)
+  key mapping needed for deployment. (#410)
 
 ## [1.28.0] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   *wants* one of them kept visible (for example a public bot id) can add it
   to `[sanitize].allowlist`.
 
+### Changed
+- Documented OrcaRouter through the existing `openai-compat` provider instead
+  of adding a redundant provider type, including the endpoint, model, and API
+  key mapping needed for deployment. (#NNN)
+
 ## [1.28.0] - 2026-08-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -900,7 +900,7 @@ Recommended defaults:
 | `openai-oauth` | `gpt-5.5` | ChatGPT Pro/Plus/Codex backend via `ai-memory auth login openai-oauth`; no Platform API key. |
 | `copilot` | `gpt-5.5` | GitHub Copilot Chat backend via `ai-memory auth login copilot` or `COPILOT_GITHUB_TOKEN`; requires a Copilot subscription. |
 | `gemini` | `gemini-2.5-flash` | Google-hosted option with a generous free tier. |
-| `openai-compat` | no default | OpenRouter, Atlas Cloud, Ollama, vLLM, LM Studio, and other compatible endpoints. |
+| `openai-compat` | no default | OpenRouter, Atlas Cloud, OrcaRouter, Ollama, vLLM, LM Studio, and other compatible endpoints. |
 
 `openai-oauth` stores a refresh token in `<data_dir>/auth.json` and talks to
 the ChatGPT/Codex Responses backend, not `api.openai.com`. For Docker quick
@@ -989,7 +989,7 @@ bounded page-authority adjustment after candidate generation; embeddings
 improve relevance recall but do not decide which source is canonical.
 
 See [`docs/install.md#llm-provider-tiers`](docs/install.md#llm-provider-tiers)
-for env vars and Ollama/OpenRouter/Atlas Cloud examples, and
+for env vars and Ollama/OpenRouter/Atlas Cloud/OrcaRouter examples, and
 [`docs/llm-provider-comparison.md`](docs/llm-provider-comparison.md)
 for the empirical model comparison.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1232,6 +1232,7 @@ If you set only the provider, ai-memory picks a sensible default:
 | `AI_MEMORY_LLM_PROVIDER=opencode` | `claude-sonnet-4-6` | [OpenCode Zen/Go](https://opencode.ai) cloud API — OpenAI-compatible endpoint at `opencode.ai/zen/go/v1`. Set `OPENCODE_API_KEY` (key from `opencode.ai/auth`). Alias: `opencode-zen`. |
 | `AI_MEMORY_EMBEDDING_PROVIDER=openai` | `text-embedding-3-small` (1536-dim) | 5× cheaper than `-3-large` with marginal recall loss. |
 | `AI_MEMORY_EMBEDDING_PROVIDER=openai` + `AI_MEMORY_EMBEDDING_BASE_URL=https://openrouter.ai/api/v1` | `openai/text-embedding-3-small` via [OpenRouter](https://openrouter.ai) | Reuses `LLM_API_KEY` or `OPENAI_API_KEY` with the OpenAI-compatible embedding client. |
+| `AI_MEMORY_EMBEDDING_PROVIDER=openai` + `AI_MEMORY_EMBEDDING_BASE_URL=https://api.orcarouter.ai/v1` | `openai/text-embedding-3-small` via [OrcaRouter](https://www.orcarouter.ai) | Reuses `LLM_API_KEY` with the OpenAI-compatible embedding client. |
 | `AI_MEMORY_EMBEDDING_PROVIDER=voyage` | `voyage-3` (1024-dim) | Voyage's current general-purpose recommendation. |
 | `AI_MEMORY_EMBEDDING_PROVIDER=google` / `gemini` | `gemini-embedding-001` (768-dim) | Google-hosted embeddings via `embedContent`. Set `GEMINI_API_KEY` (or `GOOGLE_API_KEY`). |
 | `AI_MEMORY_EMBEDDING_PROVIDER=openai-compat` | no default — set model, dim, and base URL explicitly | Self-hosted engines (Ollama, LM Studio, vLLM). Keyless by default; `LLM_API_KEY` is sent as a bearer token when present (gateways). Example: `AI_MEMORY_EMBEDDING_BASE_URL=http://localhost:11434/v1`, `AI_MEMORY_EMBEDDING_MODEL=nomic-embed-text`, `AI_MEMORY_EMBEDDING_DIM=768`. Switching an existing `openai`+base-URL setup to `openai-compat` changes the stored `{provider, model, dim}` triple — run `ai-memory embed --force` to re-embed. |
@@ -1408,6 +1409,21 @@ through the generic compatibility credential:
 
 Replace the model with another current Atlas model id when needed. ai-memory
 does not select a default for hosted compatibility endpoints.
+
+[OrcaRouter](https://www.orcarouter.ai) uses the same provider; no
+OrcaRouter-specific ai-memory provider is needed. Pass its API key through the
+generic compatibility credential:
+
+```bash
+-e AI_MEMORY_LLM_PROVIDER=openai-compat
+-e AI_MEMORY_LLM_BASE_URL=https://api.orcarouter.ai/v1
+-e AI_MEMORY_LLM_MODEL=openai/gpt-4o
+-e LLM_API_KEY=sk-orca-...
+```
+
+Replace the model with another current OrcaRouter model id (same
+`provider/model` format as OpenRouter, e.g. `anthropic/claude-sonnet-4.6` or
+`deepseek/deepseek-v4-flash`) when needed.
 
 OpenAI-compatible structured calls use the operation's JSON Schema by default:
 


### PR DESCRIPTION
## What changed

Documents [OrcaRouter](https://www.orcarouter.ai) as a drop-in
`openai-compat` provider. OrcaRouter is an OpenAI-compatible router
(200+ models — OpenAI, Anthropic, Google, DeepSeek, ...) behind a single
API key, and it accepts the same `provider/model` id format as OpenRouter,
so ai-memory needs **no new provider type** — it works through the existing
`openai-compat` provider.

- **README.md**: added OrcaRouter to the `openai-compat` provider table row
  and to the "Ollama/OpenRouter/Atlas Cloud" example list.
- **docs/install.md**: added a named OrcaRouter example mirroring the
  existing OpenRouter/Atlas Cloud examples (`AI_MEMORY_LLM_BASE_URL=
  https://api.orcarouter.ai/v1` + `LLM_API_KEY=sk-orca-...`), and an
  embeddings row mirroring the OpenRouter one.
- **CHANGELOG.md**: `[Unreleased]` → `Changed` entry.

I'm an engineer on the OrcaRouter team.

## Why

ai-memory already routes `openai-compat` LLM and embedding calls through a
configurable base URL, and the install guide names OpenRouter and Atlas
Cloud as hosted compatibility endpoints. OrcaRouter fits the same slot with
no code change; this PR makes it discoverable the same way, with the exact
env vars a deployment needs.

## Test plan

This is a docs-only change — no Rust code or config behaviour was touched,
so the `cargo fmt` / `cargo clippy` / `cargo test` workspace gates are not
affected by this diff. What I did run:

- [x] `git diff --check` passes (no whitespace errors)
- [x] **Live API (real OrcaRouter key):** the exact `openai-compat` wire
      path (`POST {base}/chat/completions` with a Bearer token and
      `max_tokens`) against `https://api.orcarouter.ai/v1` returns HTTP 200
      with a valid completion for `openai/gpt-4o` and for
      `deepseek/deepseek-v4-flash`.
- [x] **Live API:** `POST {base}/embeddings` with
      `openai/text-embedding-3-small` returns HTTP 200 with an embedding
      vector, so the documented embeddings row works.
- [x] Manual test: `grep`-verified the anchor `#llm-provider-tiers` that
      README links to still resolves.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected
      any unintended identity before requesting merge. See
      [commit attribution guidance](https://github.com/akitaonrails/ai-memory/blob/main/CONTRIBUTING.md#commit-attribution).

## CHANGELOG (merge gate)

- [x] I added a `CHANGELOG.md` `[Unreleased]` entry — **required** for any
      user-facing change: new flag / env var / endpoint / MCP tool / marker
      key, changed behaviour, or an observable bug fix. (Exempt only for
      internal refactors, dead-code removal, and test-only churn.)
- [ ] Any changed **default** (flag behaviour, config default, env var,
      response shape) is called out explicitly in "What changed" above.
      (No defaults changed — docs only.)

## Notes for reviewers

- No secrets are committed: the example uses the placeholder key
  `sk-orca-...` (matching how the OpenRouter example uses `sk-or-v1-...`).
- The CHANGELOG entry's `(#NNN)` trailing reference is finalized to
  `(#410)` in the follow-up commit `18d551f`.
