### PR TITLE
fix(install-hooks): honor PI_CODING_AGENT_DIR for Pi/OMP extension paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `install-hooks --agent pi`, `--agent omp`, and `uninstall` now honor
+  `PI_CODING_AGENT_DIR`, instead of always writing to `~/.pi/agent/extensions/`
+  and `~/.omp/agent/extensions/`. Both agents relocate their whole agent
+  config home (`~/.pi/agent` / `~/.omp/agent`) through that variable, so on an
+  install with it set the extensions landed where the agent never loads them:
+  the install reported success and capture silently did nothing. ai-memory
+  already honored the variable when resolving Pi/OMP transcripts, so the two
+  halves of one install disagreed about where that home was. Installs without
+  `PI_CODING_AGENT_DIR` set are unaffected.
+
 ### Added
 - The built-in sanitizer now redacts seven further credential shapes, completing
   three vendor families it already covered only in part. **GitHub:** every

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -162,8 +162,28 @@ pub(crate) fn opencode_plugin_path() -> anyhow::Result<std::path::PathBuf> {
         .join("ai-memory.ts"))
 }
 
+/// `$PI_CODING_AGENT_DIR/extensions/ai-memory.ts` when the var is set, else
 /// `~/.omp/agent/extensions/ai-memory.ts` — OMP lifecycle extension.
+///
+/// `PI_CODING_AGENT_DIR` relocates OMP's whole agent config home
+/// (`~/.omp/agent`), so extensions written to the default path are never
+/// loaded by an OMP configured that way: capture silently does nothing, with
+/// a successful-looking install. ai-memory already honors the variable when
+/// it resolves OMP transcripts (`ManagedHarness::Omp` in
+/// `ai-memory-workstream`), so ignoring it here left one half of the same
+/// install pointing somewhere the other half did not.
 pub(crate) fn omp_extension_path() -> anyhow::Result<std::path::PathBuf> {
+    omp_extension_path_in(std::env::var_os("PI_CODING_AGENT_DIR"))
+}
+
+/// The env value comes in as a parameter so tests can exercise both branches
+/// without mutating process env (mirrors [`codex_hooks_path_in`]).
+fn omp_extension_path_in(
+    env_override: Option<std::ffi::OsString>,
+) -> anyhow::Result<std::path::PathBuf> {
+    if let Some(dir) = crate::commands::path_util::agent_config_home(env_override) {
+        return Ok(dir.join("extensions").join("ai-memory.ts"));
+    }
     Ok(home_dir()
         .context("could not locate $HOME for ~/.omp/agent/extensions")?
         .join(".omp")
@@ -172,8 +192,28 @@ pub(crate) fn omp_extension_path() -> anyhow::Result<std::path::PathBuf> {
         .join("ai-memory.ts"))
 }
 
+/// `$PI_CODING_AGENT_DIR/extensions/ai-memory.ts` when the var is set, else
 /// `~/.pi/agent/extensions/ai-memory.ts` — Pi lifecycle + MCP bridge extension.
+///
+/// `PI_CODING_AGENT_DIR` relocates Pi's whole agent config home
+/// (`~/.pi/agent`), so extensions written to the default path are never
+/// loaded by a Pi configured that way: capture silently does nothing, with a
+/// successful-looking install. ai-memory already honors the variable when it
+/// resolves Pi transcripts (`ManagedHarness::Pi` in `ai-memory-workstream`),
+/// so ignoring it here left one half of the same install pointing somewhere
+/// the other half did not.
 pub(crate) fn pi_extension_path() -> anyhow::Result<std::path::PathBuf> {
+    pi_extension_path_in(std::env::var_os("PI_CODING_AGENT_DIR"))
+}
+
+/// The env value comes in as a parameter so tests can exercise both branches
+/// without mutating process env (mirrors [`codex_hooks_path_in`]).
+fn pi_extension_path_in(
+    env_override: Option<std::ffi::OsString>,
+) -> anyhow::Result<std::path::PathBuf> {
+    if let Some(dir) = crate::commands::path_util::agent_config_home(env_override) {
+        return Ok(dir.join("extensions").join("ai-memory.ts"));
+    }
     Ok(home_dir()
         .context("could not locate $HOME for ~/.pi/agent/extensions")?
         .join(".pi")
@@ -5910,6 +5950,73 @@ model = "gpt-5"
         let extension = build_omp_extension("http://127.0.0.1:49374", Some("tok"), None);
 
         assert_generated_ts_uses_bounded_hook_queue(&extension);
+    }
+
+    /// `PI_CODING_AGENT_DIR` relocates Pi's whole agent config home
+    /// (`~/.pi/agent`), not just session storage, so the extension must follow
+    /// the variable or Pi never loads it — the install reports success and
+    /// capture silently does nothing.
+    #[test]
+    fn pi_extension_path_honours_pi_coding_agent_dir() {
+        let custom = if cfg!(windows) {
+            r"C:\custom\pi-agent"
+        } else {
+            "/custom/pi-agent"
+        };
+        let path = pi_extension_path_in(Some(std::ffi::OsString::from(custom))).unwrap();
+        assert_eq!(
+            path,
+            Path::new(custom).join("extensions").join("ai-memory.ts")
+        );
+
+        // Unset and blank both fall back to ~/.pi/agent/extensions/ai-memory.ts.
+        // Blank counts as unset because an exported-but-empty variable is nearly
+        // always a failed shell expansion, not a request to install into the
+        // filesystem root.
+        for env in [None, Some(std::ffi::OsString::new())] {
+            let path = pi_extension_path_in(env).unwrap();
+            assert!(
+                path.ends_with(
+                    Path::new(".pi")
+                        .join("agent")
+                        .join("extensions")
+                        .join("ai-memory.ts")
+                ),
+                "default must be ~/.pi/agent/extensions/ai-memory.ts, got {}",
+                path.display()
+            );
+        }
+    }
+
+    /// Same relocation contract as Pi: OMP honors `PI_CODING_AGENT_DIR` for
+    /// the default profile and moves `~/.omp/agent` wholesale, extensions
+    /// included.
+    #[test]
+    fn omp_extension_path_honours_pi_coding_agent_dir() {
+        let custom = if cfg!(windows) {
+            r"C:\custom\omp-agent"
+        } else {
+            "/custom/omp-agent"
+        };
+        let path = omp_extension_path_in(Some(std::ffi::OsString::from(custom))).unwrap();
+        assert_eq!(
+            path,
+            Path::new(custom).join("extensions").join("ai-memory.ts")
+        );
+
+        for env in [None, Some(std::ffi::OsString::new())] {
+            let path = omp_extension_path_in(env).unwrap();
+            assert!(
+                path.ends_with(
+                    Path::new(".omp")
+                        .join("agent")
+                        .join("extensions")
+                        .join("ai-memory.ts")
+                ),
+                "default must be ~/.omp/agent/extensions/ai-memory.ts, got {}",
+                path.display()
+            );
+        }
     }
 
     #[test]

--- a/docs/install.md
+++ b/docs/install.md
@@ -954,7 +954,9 @@ for hooks; both target OMP's native `.omp` integration surface.
 Pi does not read a native `mcp.json`. ai-memory supports Pi through one
 generated TypeScript extension at `~/.pi/agent/extensions/ai-memory.ts`; the
 same file captures lifecycle events and bridges ai-memory's HTTP MCP tools into
-Pi with `pi.registerTool`.
+Pi with `pi.registerTool`. When `PI_CODING_AGENT_DIR` is set (it relocates
+Pi's whole `~/.pi/agent` home), the extension is written to
+`$PI_CODING_AGENT_DIR/extensions/ai-memory.ts` instead.
 
 ```bash
 ai-memory install-hooks --agent pi --apply \

--- a/docs/mcp-install.md
+++ b/docs/mcp-install.md
@@ -1041,7 +1041,9 @@ ai-memory install-hooks --agent omp --apply
 
 This writes `~/.omp/agent/extensions/ai-memory.ts`, which OMP discovers
 as a direct TypeScript extension on startup. Restart `omp` after
-installing or changing the file.
+installing or changing the file. When `PI_CODING_AGENT_DIR` is set
+(it relocates OMP's whole `~/.omp/agent` home), the extension is written
+to `$PI_CODING_AGENT_DIR/extensions/ai-memory.ts` instead.
 
 **Gotchas:**
 - OMP extensions are TypeScript modules, not shell hooks; stdout is not
@@ -1053,7 +1055,9 @@ installing or changing the file.
 
 **Status:** ✅ MCP and lifecycle capture supported via generated bridge
 extension. Pi has no native `mcp.json`; use `install-hooks --agent pi --apply`
-to write `~/.pi/agent/extensions/ai-memory.ts`.
+to write `~/.pi/agent/extensions/ai-memory.ts`. When `PI_CODING_AGENT_DIR`
+is set (it relocates Pi's whole `~/.pi/agent` home), the extension is
+written to `$PI_CODING_AGENT_DIR/extensions/ai-memory.ts` instead.
 
 ```bash
 ai-memory install-hooks --agent pi --apply


### PR DESCRIPTION
## What changed

`install-hooks --agent pi`, `install-hooks --agent omp`, and `uninstall` now honor `PI_CODING_AGENT_DIR` when resolving the generated extension path, instead of always writing to `~/.pi/agent/extensions/ai-memory.ts` and `~/.omp/agent/extensions/ai-memory.ts`.

- When `PI_CODING_AGENT_DIR` is set (non-empty, non-whitespace): extension goes to `$PI_CODING_AGENT_DIR/extensions/ai-memory.ts`.
- When unset or blank: behavior is unchanged (default `~/.pi/agent/...` / `~/.omp/agent/...`).
- `uninstall` picks this up for free because it delegates to the same resolvers.

## Why

Fixes #406. Both Pi and OMP use `PI_CODING_AGENT_DIR` to relocate their **whole** agent config home (`~/.pi/agent` / `~/.omp/agent` — not just session storage; per [Pi's environment-variable docs](https://pi.dev/docs/latest/environment-variables) and [OMP's docs](https://github.com/can1357/oh-my-pi/blob/main/docs/extension-loading.md), extensions live under that home in `extensions/`). With the variable set, the old code wrote the extension where the agent never loads it: the install reported success and capture silently did nothing.

`ai-memory-workstream`'s harness adapter already honored the variable when resolving Pi/OMP transcripts (`ManagedHarness::Pi` / `ManagedHarness::Omp`), so this closes the gap where one half of the same install disagreed with the other — the same shape as the `CODEX_HOME` fix in #379/1.28.0.

Note: the issue's working hypothesis ("if `PI_CODING_AGENT_DIR` relocates `~/.pi`, the extension path becomes `$PI_CODING_AGENT_DIR/agent/extensions`") is incorrect per upstream docs — the variable relocates the agent dir itself, so the extension resolves to `$PI_CODING_AGENT_DIR/extensions`. This mirrors the harness's existing `$PI_CODING_AGENT_DIR/sessions` shape exactly.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `cargo deny check` passes
- [x] New tests `pi_extension_path_honours_pi_coding_agent_dir` and `omp_extension_path_honours_pi_coding_agent_dir` cover the env-set branch, the unset branch, and the blank-as-unset branch (env value injected as a parameter — the workspace forbids `unsafe`, so `std::env::set_var` is not an option).

## Commit attribution

- [x] I verified the name and email on every commit in this PR.

## CHANGELOG (merge gate)

- [x] Added `CHANGELOG.md` entry under `## [Unreleased]` → `### Fixed`.

## Notes for reviewers

- The `--config-file` override path is untouched and still wins when provided.
- Named OMP profiles (`omp --profile X`) intentionally ignore `PI_CODING_AGENT_DIR` upstream; this fix honors the variable exactly where OMP itself honors it (default profile). `PI_CONFIG_DIR` handling for OMP's config root was deliberately left out of scope, matching the harness adapter's current behavior.
- README support-matrix lines still describe the default path; the variable note lives in `docs/install.md` and `docs/mcp-install.md` where the env behavior matters.
