### PR TITLE
fix: container bind guard and non-compose upgrade path (#407)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.28.0] - 2026-08-17
 
 ### Fixed
+- Docker containers no longer refuse to start unauthenticated, which had left
+  every container from the README Quick start crash-looping since v1.27.0
+  (#407). The v1.27.0 bind guard reads a non-loopback bind as evidence of
+  network exposure and refuses without a token. That inference holds on a
+  host, but not inside a container: publishing a port with `-p` *requires*
+  binding `0.0.0.0` in the namespace, and whether that port reaches the
+  network is decided by the host-side publish spec — `-p 127.0.0.1:49374:49374`
+  versus `-p 0.0.0.0:49374:49374` — which the process cannot observe. The
+  documented Quick start passes no token and published to loopback, so it was
+  safe and refused anyway; with the documented `--restart unless-stopped` that
+  became a restart loop. Containers now log a loud warning naming the publish
+  spec as the thing to check, instead of refusing. **The host rule is
+  unchanged** — an unauthenticated non-loopback bind outside a container is
+  still refused. Containers are detected via `/.dockerenv` (Docker),
+  `/run/.containerenv` (Podman), or `AI_MEMORY_IN_CONTAINER`, which the
+  official image now sets.
+
+  Note the `Host` allowlist does not substitute for a token here: it defends
+  against DNS rebinding, where a *browser* sets the header. A client that can
+  route to the port sets `Host` freely. If you publish ai-memory beyond
+  loopback, set `AI_MEMORY_AUTH_TOKEN`.
+- `ai-memory upgrade` no longer tells non-compose Docker users to delete their
+  container and rebuild the `docker run` from memory (#407). It now reconstructs
+  that container's own stop/remove/run — name, restart policy, published ports,
+  mounts, operator-set environment, and an overridden command — and writes it to
+  `${XDG_CACHE_HOME:-~/.cache}/ai-memory/recreate-ai-memory.sh` for review before
+  you run it. The script is written mode 0600 and never echoed, because a real
+  install's environment carries provider API keys and `AI_MEMORY_AUTH_TOKEN`.
+  Environment already baked into the image is deliberately omitted, so the new
+  image's own defaults are not frozen to the old ones. Compose-based installs
+  are unaffected and still upgrade via `docker compose up -d`.
 - `install-hooks --agent codex` and `uninstall` now honor `CODEX_HOME`, instead
   of always writing to `~/.codex/hooks.json`. Codex loads hooks from its
   configured home, so on an install with `CODEX_HOME` set the hooks landed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,17 @@ what the project is and is not designed to defend against.
 
   The server fails closed before serving unauthenticated non-loopback HTTP.
   `--allow-insecure-no-auth` is a deliberate dangerous override for an
-  intentional plain-HTTP LAN deployment. Authentication does not encrypt
+  intentional plain-HTTP LAN deployment.
+
+  **Inside a container this check warns instead of refusing.** Publishing a
+  port with `-p` requires binding `0.0.0.0` in the namespace, so the bind
+  address says nothing about reachability there — that is decided by the
+  host-side publish spec, which the process cannot see. In a container the
+  thing to check is your own `-p`: `-p 127.0.0.1:49374:49374` is loopback-only
+  and safe without a token; anything broader needs `AI_MEMORY_AUTH_TOKEN`.
+  Note the `Host` allowlist is not a substitute — it defends against DNS
+  rebinding, where a browser sets the header, and a client that can route to
+  the port sets `Host` freely. Authentication does not encrypt
   bearer tokens, so use a TLS reverse proxy for traffic beyond loopback; see
   [`docs/https-via-proxy.md`](docs/https-via-proxy.md).
 

--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -139,6 +139,91 @@ self_upgrade_script() {
   AI_MEMORY_SKIP_SELF_UPGRADE=1 exec "${script_path}" upgrade
 }
 
+
+# Reconstruct the `docker run` that created a running container, so a
+# non-compose install can be recreated on the freshly pulled image without
+# the operator having to remember their original flags (issue #407).
+#
+# Written to a 0600 file rather than echoed: the environment of a real
+# install carries provider API keys and AI_MEMORY_AUTH_TOKEN, and printing
+# those into terminal scrollback — or into a piped install log — is exactly
+# the kind of leak this project exists to prevent.
+#
+# Reconstructs the flags that matter for an ai-memory container: name,
+# restart policy, published ports, mounts, operator-supplied environment,
+# and an overridden command. It does NOT reproduce every possible `docker
+# run` flag (networks, capabilities, resource limits, devices); the script
+# says so in its own header so a reader can add anything exotic back.
+emit_docker_run_script() {
+  local container="$1" out="$2" image
+  image="$("${DOCKER}" inspect "${container}" --format '{{.Config.Image}}' 2>/dev/null)" || return 1
+  [ -n "${image}" ] || return 1
+
+  local ports volumes restart cmd
+  ports="$("${DOCKER}" inspect "${container}" --format \
+    '{{range $p, $bindings := .HostConfig.PortBindings}}{{range $bindings}}-p {{if .HostIp}}{{.HostIp}}:{{end}}{{.HostPort}}:{{$p}} {{end}}{{end}}' 2>/dev/null)"
+  volumes="$("${DOCKER}" inspect "${container}" --format \
+    '{{range .Mounts}}{{if eq .Type "volume"}}-v {{.Name}}:{{.Destination}} {{else}}-v {{.Source}}:{{.Destination}} {{end}}{{end}}' 2>/dev/null)"
+  restart="$("${DOCKER}" inspect "${container}" --format \
+    '{{with .HostConfig.RestartPolicy.Name}}{{if ne . "no"}}--restart {{.}}{{end}}{{end}}' 2>/dev/null)"
+
+  # Only the command if the operator overrode the image default; otherwise
+  # let the new image supply its own (that is the point of upgrading).
+  local image_cmd container_cmd
+  image_cmd="$("${DOCKER}" inspect "${image}" --format '{{json .Config.Cmd}}' 2>/dev/null)"
+  container_cmd="$("${DOCKER}" inspect "${container}" --format '{{json .Config.Cmd}}' 2>/dev/null)"
+  cmd=""
+  if [ "${image_cmd}" != "${container_cmd}" ]; then
+    cmd="$("${DOCKER}" inspect "${container}" --format \
+      '{{range .Config.Cmd}}{{printf "%q " .}}{{end}}' 2>/dev/null)"
+  fi
+
+  # Likewise, carry only environment the operator actually passed. Anything
+  # baked into the image is re-applied by the new image anyway, and pinning
+  # it here would freeze a value this upgrade is meant to move forward.
+  local image_env container_env env_flags=""
+  image_env="$("${DOCKER}" inspect "${image}" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null)"
+  container_env="$("${DOCKER}" inspect "${container}" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null)"
+  local kv
+  while IFS= read -r kv; do
+    [ -n "${kv}" ] || continue
+    if printf '%s\n' "${image_env}" | grep -qxF -- "${kv}"; then
+      continue
+    fi
+    env_flags="${env_flags} -e $(printf '%q' "${kv}")"
+  done <<ENVEOF
+${container_env}
+ENVEOF
+
+  ( umask 077 && : > "${out}" ) || return 1
+  {
+    echo "#!/usr/bin/env bash"
+    echo "# Reconstructed by \`ai-memory upgrade\` from the running '${container}'"
+    echo "# container, before it was removed. Review it, then run it."
+    echo "#"
+    echo "# Contains this install's environment (API keys, auth token) — it is"
+    echo "# mode 0600 for that reason. Delete it once the container is back up."
+    echo "#"
+    echo "# Covers name, restart policy, ports, mounts, operator-set environment"
+    echo "# and an overridden command. If your original command used anything"
+    echo "# else (custom network, capabilities, resource limits), re-add it."
+    echo "set -euo pipefail"
+    echo
+    echo "docker stop ${container}"
+    echo "docker rm ${container}"
+    printf 'docker run -d --name %s' "${container}"
+    [ -n "${restart}" ] && printf ' %s' "${restart}"
+    [ -n "${ports}" ] && printf ' %s' "${ports% }"
+    [ -n "${volumes}" ] && printf ' %s' "${volumes% }"
+    [ -n "${env_flags}" ] && printf '%s' "${env_flags}"
+    printf ' %s' "${image}"
+    [ -n "${cmd}" ] && printf ' %s' "${cmd% }"
+    printf '\n'
+  } >> "${out}"
+  chmod 600 "${out}" 2>/dev/null || true
+  return 0
+}
+
 cmd_upgrade() {
   if [ -z "${AI_MEMORY_SKIP_SELF_UPGRADE:-}" ]; then
     self_upgrade_script
@@ -206,10 +291,22 @@ cmd_upgrade() {
     else
       echo "→ a local ai-memory container is running but no compose file"
       echo "  was found in \$PWD/docker-compose.yml, ./docker/docker-compose.yml,"
-      echo "  or ~/deploy/ai-memory/docker-compose.yml. Restart it manually so"
-      echo "  the new image takes effect:"
-      echo "      docker stop ai-memory && docker rm ai-memory"
-      echo "      # then re-run your docker-run command from the README Quick start"
+      echo "  or ~/deploy/ai-memory/docker-compose.yml."
+      local recreate_script="${CACHE_DIR}/recreate-ai-memory.sh"
+      mkdir -p "${CACHE_DIR}" 2>/dev/null || true
+      if emit_docker_run_script "ai-memory" "${recreate_script}"; then
+        echo "  Wrote the equivalent stop/remove/run for THIS container to:"
+        echo "      ${recreate_script}"
+        echo "  Review it and run it so the new image takes effect:"
+        echo "      less ${recreate_script} && bash ${recreate_script}"
+        echo "  (mode 0600 — it carries the environment of this install, including"
+        echo "  any API keys and AI_MEMORY_AUTH_TOKEN. Delete it once you are up.)"
+      else
+        echo "  Could not inspect the running container to reconstruct its"
+        echo "  command. Restart it manually so the new image takes effect:"
+        echo "      docker stop ai-memory && docker rm ai-memory"
+        echo "      # then re-run your docker-run command from the README Quick start"
+      fi
     fi
   fi
 

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -94,15 +94,62 @@ fn configured(value: Option<&String>) -> bool {
     value.is_some_and(|v| !v.trim().is_empty())
 }
 
+/// What the bound address tells us about network exposure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HttpExposure {
+    /// Loopback-only, or authenticated. Nothing to warn about.
+    Safe,
+    /// Unauthenticated on a non-loopback address, allowed because the
+    /// operator passed `--allow-insecure-no-auth`.
+    InsecureByOverride,
+    /// Unauthenticated on a non-loopback address inside a container, where
+    /// the bind address is not evidence either way. See
+    /// [`validate_http_exposure`].
+    UndeterminedInContainer,
+}
+
+/// Detect that this process is running inside a container.
+///
+/// `/.dockerenv` is created by Docker, `/run/.containerenv` by Podman. The
+/// official image also sets `AI_MEMORY_IN_CONTAINER`, so the signal survives
+/// runtimes that create neither file.
+fn running_in_container() -> bool {
+    if std::env::var("AI_MEMORY_IN_CONTAINER").is_ok_and(|v| !v.trim().is_empty()) {
+        return true;
+    }
+    Path::new("/.dockerenv").exists() || Path::new("/run/.containerenv").exists()
+}
+
 /// Refuse accidental unauthenticated network exposure after the listener has
 /// selected its actual local address (which may differ from the bind input).
+///
+/// The check reads the bind address as evidence of reachability. That
+/// inference holds on a host, but **not** inside a container: publishing a
+/// port with `-p` requires binding `0.0.0.0` inside the namespace, and
+/// whether that port reaches the network is decided by the host-side publish
+/// spec — `-p 127.0.0.1:49374:49374` versus `-p 0.0.0.0:49374:49374` — which
+/// the process cannot observe. Refusing there is a false positive that took
+/// down the documented Quick Start container (#407), so containers get a
+/// loud warning instead.
+///
+/// Note this is deliberately not backstopped by the `Host` allowlist: that
+/// allowlist defends against DNS rebinding, where a browser sets the header.
+/// A client that can route to the port sets `Host` freely, so it is not an
+/// access control and cannot substitute for a token here.
 fn validate_http_exposure(
     local_addr: SocketAddr,
     auth_enabled: bool,
     allow_insecure_no_auth: bool,
-) -> Result<()> {
-    if local_addr.ip().is_loopback() || auth_enabled || allow_insecure_no_auth {
-        return Ok(());
+    containerized: bool,
+) -> Result<HttpExposure> {
+    if local_addr.ip().is_loopback() || auth_enabled {
+        return Ok(HttpExposure::Safe);
+    }
+    if allow_insecure_no_auth {
+        return Ok(HttpExposure::InsecureByOverride);
+    }
+    if containerized {
+        return Ok(HttpExposure::UndeterminedInContainer);
     }
 
     anyhow::bail!(
@@ -787,19 +834,34 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
             let local_addr = listener
                 .local_addr()
                 .context("reading bound HTTP listener address")?;
-            validate_http_exposure(local_addr, auth_enabled, args.allow_insecure_no_auth)?;
+            let exposure = validate_http_exposure(
+                local_addr,
+                auth_enabled,
+                args.allow_insecure_no_auth,
+                running_in_container(),
+            )?;
             info!(
                 %local_addr,
                 auth = auth_enabled,
                 body_limit_mb = MAX_BODY_BYTES / 1024 / 1024,
                 "MCP HTTP server ready (POST /mcp, POST /hook, Ctrl-C to stop)",
             );
-            if !auth_enabled && !local_addr.ip().is_loopback() {
+            if exposure == HttpExposure::InsecureByOverride {
                 tracing::warn!(
                     %local_addr,
                     "starting unauthenticated plain HTTP on a non-loopback address because \
                      --allow-insecure-no-auth was supplied — anyone on the network can call \
                      destructive MCP tools"
+                );
+            } else if exposure == HttpExposure::UndeterminedInContainer {
+                tracing::warn!(
+                    %local_addr,
+                    "no AI_MEMORY_AUTH_TOKEN configured. Inside a container the bind address \
+                     cannot show whether this port reaches the network — that is decided by \
+                     the host publish spec. If you published it with `-p 127.0.0.1:49374:49374` \
+                     you are fine; if you published it on 0.0.0.0 or to a LAN address, anyone \
+                     on the network can call destructive MCP tools. Generate a token with \
+                     `ai-memory generate-auth-token` and set AI_MEMORY_AUTH_TOKEN"
                 );
             } else if auth_enabled && !local_addr.ip().is_loopback() {
                 // Auth IS configured but the server is reachable from
@@ -1656,15 +1718,59 @@ mod tests {
             let local_addr: SocketAddr = address.parse().expect("valid test address");
             for auth_enabled in [false, true] {
                 for allow_override in [false, true] {
+                    // On a host, the bind address IS the evidence: an
+                    // unauthenticated non-loopback bind is refused unless
+                    // the operator overrode it.
                     let allowed = loopback || auth_enabled || allow_override;
                     assert_eq!(
-                        validate_http_exposure(local_addr, auth_enabled, allow_override).is_ok(),
+                        validate_http_exposure(local_addr, auth_enabled, allow_override, false)
+                            .is_ok(),
                         allowed,
                         "address={address}, auth={auth_enabled}, override={allow_override}"
                     );
                 }
             }
         }
+    }
+
+    /// Regression for #407. The published image binds `0.0.0.0` because that
+    /// is the only way `-p` publishing works, so the host-side rule above
+    /// refused every container started from the documented Quick Start and
+    /// left it crash-looping under `--restart unless-stopped`.
+    #[test]
+    fn containers_warn_instead_of_refusing_because_the_bind_proves_nothing() {
+        let quick_start: SocketAddr = "0.0.0.0:49374".parse().expect("valid test address");
+
+        // The exact Quick Start shape: no token, no override, in a container.
+        assert_eq!(
+            validate_http_exposure(quick_start, false, false, true).expect("must not refuse"),
+            HttpExposure::UndeterminedInContainer,
+        );
+
+        // Identical inputs on a host still refuse — the carve-out is scoped
+        // to the container case and does not soften the host rule.
+        assert!(validate_http_exposure(quick_start, false, false, false).is_err());
+
+        // A container is not a blanket downgrade: with auth configured the
+        // verdict is Safe, so the operator gets no spurious warning.
+        assert_eq!(
+            validate_http_exposure(quick_start, true, false, true).expect("auth is fine"),
+            HttpExposure::Safe,
+        );
+
+        // An explicit override still reports as an override, not as the
+        // container case, so the startup log keeps naming the real reason.
+        assert_eq!(
+            validate_http_exposure(quick_start, false, true, true).expect("override is fine"),
+            HttpExposure::InsecureByOverride,
+        );
+
+        // Loopback inside a container is plain Safe.
+        let loopback: SocketAddr = "127.0.0.1:49374".parse().expect("valid test address");
+        assert_eq!(
+            validate_http_exposure(loopback, false, false, true).expect("loopback is fine"),
+            HttpExposure::Safe,
+        );
     }
 
     #[test]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,12 @@ ENV AI_MEMORY_DATA_DIR=/data
 # exposed/homelab deployments still set their own `AI_MEMORY_ALLOWED_HOSTS`,
 # which replaces this value entirely.
 ENV AI_MEMORY_ALLOWED_HOSTS="localhost,127.0.0.1,::1,host.docker.internal"
+# Tell the server it is containerised, so the unauthenticated-bind guard in
+# `serve` knows the `0.0.0.0` bind below is a namespace requirement rather
+# than evidence of network exposure (issue #407). `/.dockerenv` covers Docker
+# and `/run/.containerenv` covers Podman; this makes the signal explicit and
+# runtime-independent.
+ENV AI_MEMORY_IN_CONTAINER=1
 WORKDIR /data
 EXPOSE 49374
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \

--- a/docs/install.md
+++ b/docs/install.md
@@ -1715,6 +1715,12 @@ accepts requests. `--allow-insecure-no-auth` can override that refusal only
 for an intentional dangerous plain-HTTP deployment; prefer
 `AI_MEMORY_AUTH_TOKEN` or loopback instead.
 
+In a *container* that refusal becomes a warning, because the container must
+bind `0.0.0.0` internally for `-p` to work at all and cannot see which host
+address you published to. The `-p` above is therefore doing the real work: it
+is what keeps this container loopback-only. If you change it to publish on a
+LAN address, set `AI_MEMORY_AUTH_TOKEN` as well.
+
 Then wire up the agent CLI. Both commands default to no auth and
 `http://127.0.0.1:49374` - no extra flags needed for the local case:
 


### PR DESCRIPTION
Closes #407.

Two independent bugs reported together. Both reproduced against the published `akitaonrails/ai-memory:latest` image before fixing.

## 1. Every Quick start container crash-loops since v1.27.0

The bind guard added in v1.27.0 reads a non-loopback bind as evidence of network exposure and refuses without a token. That inference holds on a host — but not inside a container. Publishing a port with `-p` **requires** binding `0.0.0.0` in the namespace, and whether that port reaches the network is decided by the host-side publish spec (`-p 127.0.0.1:49374:49374` vs `-p 0.0.0.0:49374:49374`), which the process cannot observe.

So the README Quick start — which publishes to loopback and is therefore safe — was refused, and with its documented `--restart unless-stopped` that became the reporter's restart loop.

Reproduced on the real image:

| image | command | result |
|---|---|---|
| 1.28.0 | README Quick start verbatim | `Exited (1)`, `refusing unauthenticated plain HTTP` |
| 1.28.0 | same + `AI_MEMORY_AUTH_TOKEN` | `Up (healthy)` |
| 1.26.1 | README Quick start verbatim | `Up (healthy)` — predates the guard |

Containers now warn instead, naming the publish spec as the thing to check. **The host rule is unchanged**: an unauthenticated non-loopback bind outside a container is still refused, and a test asserts identical inputs refuse on a host and warn in a container. Detection is `/.dockerenv` (Docker), `/run/.containerenv` (Podman), or `AI_MEMORY_IN_CONTAINER`, which the image now sets.

### Why the Host allowlist does not cover this

I checked whether the image's loopback-only `AI_MEMORY_ALLOWED_HOSTS` default could serve as the real fail-closed guard. It cannot. It defends against DNS rebinding, where a *browser* sets the header. Reaching a container's IP directly with a forged `Host: localhost` returned a full `tools/list`. It is not an access control, and the docs now say so.

## 2. `upgrade` could not recreate non-compose containers

It told operators to `docker stop && docker rm` and rebuild the run command from memory. The old comment claimed the original args were unknowable; `docker inspect` has them.

Now reconstructs the container's own stop/remove/run — name, restart policy, ports, mounts, operator-set env, overridden command — into `${XDG_CACHE_HOME:-~/.cache}/ai-memory/recreate-ai-memory.sh` for review before running.

Written to a **0600 file rather than echoed**: a real install's env carries provider API keys and `AI_MEMORY_AUTH_TOKEN`, and printing those into terminal scrollback or a piped install log is exactly the leak this project exists to prevent. Image-baked env is omitted so the new image's defaults are not frozen to the old ones.

Round-trip verified against live containers: the generated command recreates an identical container, including an env value containing a space, a double quote and a `$`.

## Verification

- Full gate: `cargo fmt --check`, `cargo clippy --all-targets --all-features`, `cargo test --workspace` → **2455 passed, 0 failed**
- Binary-level: host + no auth + `0.0.0.0` still refuses; `AI_MEMORY_IN_CONTAINER=1` + same inputs starts with the new warning
- Compose-based installs are untouched and still upgrade via `docker compose up -d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)