### PR TITLE
feat(mcp): configurable strict (combinator-stripped) tool schemas

### DIFF
--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -485,7 +485,8 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
         .with_active_project(active_project.clone())
         .with_sanitizer(sanitizer.clone())
         .with_trusted_proxy_identity(trusted_proxy_identity_enabled(&config.auth))
-        .with_per_user_slots(config.slots.per_user);
+        .with_per_user_slots(config.slots.per_user)
+        .with_strict_schema(config.strict_schema);
     if let Some(e) = embedder.clone() {
         server = server.with_embedder(e);
     }

--- a/crates/ai-memory-cli/src/config.rs
+++ b/crates/ai-memory-cli/src/config.rs
@@ -140,6 +140,12 @@ pub struct Config {
     /// already supplies its own schema. Set
     /// `AI_MEMORY_LLM_COMPAT_STRICT=false` for an incompatible endpoint.
     pub llm_compat_strict: bool,
+    /// Serve restricted (combinator-stripped) tool schemas on every
+    /// `tools/list`, even when the client sends no `?flavor=` marker, for
+    /// strict upstream validators that forward tool schemas verbatim
+    /// (Moonshot/Bedrock dialect) from generic MCP clients (issue #412).
+    /// Set with `AI_MEMORY_STRICT_SCHEMA=true`.
+    pub strict_schema: bool,
     /// Opt-in: run LLM consolidation on SessionEnd (in addition to the
     /// always-written heuristic session page), when an LLM provider is
     /// configured. Off by default. Provider work is durably queued after the
@@ -543,6 +549,7 @@ impl Default for Config {
             llm_compat_strict: true,
             consolidate_on_session_end: false,
             capture_assistant: false,
+            strict_schema: false,
             reranker: None,
             embedding_provider: None,
             embedding_model: None,

--- a/crates/ai-memory-cli/templates/config.default.toml
+++ b/crates/ai-memory-cli/templates/config.default.toml
@@ -35,6 +35,13 @@ log_level = "info"
 # --capture-assistant`. Env equivalent: `AI_MEMORY_CAPTURE_ASSISTANT=true`.
 # capture_assistant = false
 
+# Serve restricted tool schemas on every tools/list (strips root-level
+# anyOf/oneOf/allOf) even without a `?flavor=moonshot`/`?flavor=bedrock`
+# marker. For strict upstream validators (Moonshot/Bedrock dialect) reached
+# through generic MCP clients that forward schemas verbatim. Env:
+# `AI_MEMORY_STRICT_SCHEMA=true`
+# strict_schema = false
+
 # Optional final LLM relevance pass for project/scopes memory_query calls.
 # Requires an LLM provider and adds at most one provider call per eligible
 # query. The bounded query, page titles, and search snippets are sent to that

--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -401,6 +401,12 @@ pub struct AiMemoryServer {
     /// otherwise it immediately approves validated proposals through the normal
     /// wiki write path.
     auto_improve_require_approval: bool,
+    /// Force restricted tool schemas on every `tools/list`, regardless of
+    /// the client's `?flavor=` marker (issue #412). Generic MCP clients
+    /// (OpenCode, Cursor, …) never send the marker, yet forward tool
+    /// schemas verbatim to strict validators (Moonshot/Bedrock dialect)
+    /// that reject root-level combinators.
+    strict_schema: bool,
     /// Server-configured defaults used by manual MCP auto-improvement. This
     /// keeps manual runs at least as strict as the operator's configured
     /// Phase 1/2 budgets instead of falling back to compiled defaults.
@@ -1247,6 +1253,7 @@ impl AiMemoryServer {
             wiki: None,
             decay_params: DecayParams::default(),
             decay_breadth_weight: 0.0,
+            strict_schema: false,
             embedder: None,
             reranker: None,
             client_activity: Arc::new(std::sync::Mutex::new(ClientActivityBuffer::new())),
@@ -1277,6 +1284,14 @@ impl AiMemoryServer {
     #[must_use]
     pub fn with_per_user_slots(mut self, enabled: bool) -> Self {
         self.per_user_slots = enabled;
+        self
+    }
+
+    /// Force restricted tool schemas on every `tools/list` (issue #412);
+    /// see [`Self::strict_schema`].
+    #[must_use]
+    pub fn with_strict_schema(mut self, enabled: bool) -> Self {
+        self.strict_schema = enabled;
         self
     }
 
@@ -3853,12 +3868,15 @@ impl ServerHandler for AiMemoryServer {
         let tools = self.tool_router.list_all();
         // rmcp injects `http::request::Parts` into request extensions in
         // both stateless and stateful modes, so the flavor marker is
-        // available even without peer clientInfo.
-        let restricted_schema = context
-            .extensions
-            .get::<http::request::Parts>()
-            .and_then(|parts| parts.uri.query())
-            .is_some_and(has_restricted_schema_flavor);
+        // available even without peer clientInfo. `strict_schema` forces
+        // the restricted form for every client, not just flavored ones
+        // (issue #412).
+        let restricted_schema = self.strict_schema
+            || context
+                .extensions
+                .get::<http::request::Parts>()
+                .and_then(|parts| parts.uri.query())
+                .is_some_and(has_restricted_schema_flavor);
         if restricted_schema {
             Ok(ListToolsResult::with_all_items(
                 restricted_schema_tool_list(tools),

--- a/crates/ai-memory-mcp/tests/mcp_stateless_http.rs
+++ b/crates/ai-memory-mcp/tests/mcp_stateless_http.rs
@@ -251,3 +251,46 @@ async fn stateless_tools_list_without_flavor_keeps_root_any_of() {
         "unflavored tools/list must keep the upstream root anyOf: {schema}"
     );
 }
+
+/// `strict_schema=true` serves the restricted tool list to every client —
+/// including generic ones that never send `?flavor=` (issue #412: OpenCode,
+/// Cursor etc. forward schemas verbatim to strict validators).
+#[tokio::test]
+async fn stateless_strict_schema_strips_root_any_of_without_flavor() {
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let ws = store
+        .writer
+        .get_or_create_workspace("default".to_string())
+        .await
+        .unwrap();
+    let proj = store
+        .writer
+        .get_or_create_project(ws, "scratch".to_string(), None)
+        .await
+        .unwrap();
+    let server = AiMemoryServer::new(store.reader.clone(), store.writer.clone(), ws, proj)
+        .with_strict_schema(true);
+    let svc = StreamableHttpService::new(
+        move || Ok(server.clone()),
+        LocalSessionManager::default().into(),
+        StreamableHttpServerConfig::default()
+            .with_stateful_mode(false)
+            .with_json_response(true),
+    );
+    let router = Router::new().nest_service("/mcp", svc);
+
+    let resp = router.clone().oneshot(post(TOOLS_LIST)).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let schema = read_page_input_schema(&body_string(resp).await);
+    for key in ["anyOf", "oneOf", "allOf"] {
+        assert!(
+            schema.get(key).is_none(),
+            "strict schema must strip root `{key}` with no flavor marker: {schema}"
+        );
+    }
+    assert!(
+        schema.get("properties").is_some(),
+        "the flat schema must keep describing the args: {schema}"
+    );
+}


### PR DESCRIPTION
Fixes #412

## Problem

`restricted_schema_tool_list()` (strips root-level `anyOf`/`oneOf`/`allOf` from tool input schemas) activates **only** for requests carrying `?flavor=moonshot` or `?flavor=bedrock`. Generic MCP clients — OpenCode, Cursor, and others — never send that marker, yet they forward tool schemas verbatim to strict upstream validators (Moonshot's "moonshot flavored json schema" dialect). Result: any Moonshot-routed session calling `memory_read_page` fails hard with HTTP 400 at `tools/list` and no fallback.

## Change

New opt-in config `AI_MEMORY_STRICT_SCHEMA=true` (config.toml: `strict_schema = true`, default `false`) forces the restricted (combinator-stripped) tool list for **every** client, regardless of flavor marker. Operators behind any strict upstream can enable it without per-client detection heuristics.

- `config.rs`: `Config::strict_schema` (env `AI_MEMORY_STRICT_SCHEMA`)
- `serve.rs`: wired into `AiMemoryServer` via `.with_strict_schema()`
- `server.rs`: `AiMemoryServer::strict_schema` field + builder; `list_tools` serves the restricted list when `self.strict_schema ||` flavor marker present
- `config.default.toml`: documented commented option

Root combinators only are stripped; nested combinators and runtime "exactly one of" validation are unchanged (the #155 contract stays).

## Verification

- New integration test `stateless_strict_schema_strips_root_any_of_without_flavor` — `tools/list` with no `?flavor=` returns `memory_read_page` without root combinators, `properties` intact.
- Existing flavor tests (`stateless_moonshot_flavor_strips_root_any_of`, `stateless_bedrock_flavor_strips_root_any_of`, control `stateless_tools_list_without_flavor_keeps_root_any_of`) all still pass — strict mode is opt-in, default behavior unchanged.
- `cargo check -p ai-memory-cli` + `cargo fmt --check` clean.