### PR TITLE
docs: document OrcaRouter as an openai-compat provider (#410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Documented OrcaRouter through the existing `openai-compat` provider instead
   of adding a redundant provider type, including the endpoint, model, and API
-  key mapping needed for deployment. (#NNN)
+  key mapping needed for deployment. (#410)
 
 ## [1.28.0] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   *wants* one of them kept visible (for example a public bot id) can add it
   to `[sanitize].allowlist`.
 
+### Changed
+- Documented OrcaRouter through the existing `openai-compat` provider instead
+  of adding a redundant provider type, including the endpoint, model, and API
+  key mapping needed for deployment. (#NNN)
+
 ## [1.28.0] - 2026-08-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Documented OrcaRouter through the existing `openai-compat` provider instead
+  of adding a redundant provider type, including the endpoint, model, and API
+  key mapping needed for deployment. (#410)
+
 ## [1.28.1] - 2026-08-18
 
 ### Security
@@ -42,11 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `[REDACTED]` where it previously persisted verbatim. An operator who
   *wants* one of them kept visible (for example a public bot id) can add it
   to `[sanitize].allowlist`.
-
-### Changed
-- Documented OrcaRouter through the existing `openai-compat` provider instead
-  of adding a redundant provider type, including the endpoint, model, and API
-  key mapping needed for deployment. (#410)
 
 ## [1.28.0] - 2026-08-17
 

--- a/README.md
+++ b/README.md
@@ -900,7 +900,7 @@ Recommended defaults:
 | `openai-oauth` | `gpt-5.5` | ChatGPT Pro/Plus/Codex backend via `ai-memory auth login openai-oauth`; no Platform API key. |
 | `copilot` | `gpt-5.5` | GitHub Copilot Chat backend via `ai-memory auth login copilot` or `COPILOT_GITHUB_TOKEN`; requires a Copilot subscription. |
 | `gemini` | `gemini-2.5-flash` | Google-hosted option with a generous free tier. |
-| `openai-compat` | no default | OpenRouter, Atlas Cloud, Ollama, vLLM, LM Studio, and other compatible endpoints. |
+| `openai-compat` | no default | OpenRouter, Atlas Cloud, OrcaRouter, Ollama, vLLM, LM Studio, and other compatible endpoints. |
 
 `openai-oauth` stores a refresh token in `<data_dir>/auth.json` and talks to
 the ChatGPT/Codex Responses backend, not `api.openai.com`. For Docker quick
@@ -989,7 +989,7 @@ bounded page-authority adjustment after candidate generation; embeddings
 improve relevance recall but do not decide which source is canonical.
 
 See [`docs/install.md#llm-provider-tiers`](docs/install.md#llm-provider-tiers)
-for env vars and Ollama/OpenRouter/Atlas Cloud examples, and
+for env vars and Ollama/OpenRouter/Atlas Cloud/OrcaRouter examples, and
 [`docs/llm-provider-comparison.md`](docs/llm-provider-comparison.md)
 for the empirical model comparison.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1232,6 +1232,7 @@ If you set only the provider, ai-memory picks a sensible default:
 | `AI_MEMORY_LLM_PROVIDER=opencode` | `claude-sonnet-4-6` | [OpenCode Zen/Go](https://opencode.ai) cloud API — OpenAI-compatible endpoint at `opencode.ai/zen/go/v1`. Set `OPENCODE_API_KEY` (key from `opencode.ai/auth`). Alias: `opencode-zen`. |
 | `AI_MEMORY_EMBEDDING_PROVIDER=openai` | `text-embedding-3-small` (1536-dim) | 5× cheaper than `-3-large` with marginal recall loss. |
 | `AI_MEMORY_EMBEDDING_PROVIDER=openai` + `AI_MEMORY_EMBEDDING_BASE_URL=https://openrouter.ai/api/v1` | `openai/text-embedding-3-small` via [OpenRouter](https://openrouter.ai) | Reuses `LLM_API_KEY` or `OPENAI_API_KEY` with the OpenAI-compatible embedding client. |
+| `AI_MEMORY_EMBEDDING_PROVIDER=openai` + `AI_MEMORY_EMBEDDING_BASE_URL=https://api.orcarouter.ai/v1` | `openai/text-embedding-3-small` via [OrcaRouter](https://www.orcarouter.ai) | Reuses `LLM_API_KEY` with the OpenAI-compatible embedding client. |
 | `AI_MEMORY_EMBEDDING_PROVIDER=voyage` | `voyage-3` (1024-dim) | Voyage's current general-purpose recommendation. |
 | `AI_MEMORY_EMBEDDING_PROVIDER=google` / `gemini` | `gemini-embedding-001` (768-dim) | Google-hosted embeddings via `embedContent`. Set `GEMINI_API_KEY` (or `GOOGLE_API_KEY`). |
 | `AI_MEMORY_EMBEDDING_PROVIDER=openai-compat` | no default — set model, dim, and base URL explicitly | Self-hosted engines (Ollama, LM Studio, vLLM). Keyless by default; `LLM_API_KEY` is sent as a bearer token when present (gateways). Example: `AI_MEMORY_EMBEDDING_BASE_URL=http://localhost:11434/v1`, `AI_MEMORY_EMBEDDING_MODEL=nomic-embed-text`, `AI_MEMORY_EMBEDDING_DIM=768`. Switching an existing `openai`+base-URL setup to `openai-compat` changes the stored `{provider, model, dim}` triple — run `ai-memory embed --force` to re-embed. |
@@ -1408,6 +1409,21 @@ through the generic compatibility credential:
 
 Replace the model with another current Atlas model id when needed. ai-memory
 does not select a default for hosted compatibility endpoints.
+
+[OrcaRouter](https://www.orcarouter.ai) uses the same provider; no
+OrcaRouter-specific ai-memory provider is needed. Pass its API key through the
+generic compatibility credential:
+
+```bash
+-e AI_MEMORY_LLM_PROVIDER=openai-compat
+-e AI_MEMORY_LLM_BASE_URL=https://api.orcarouter.ai/v1
+-e AI_MEMORY_LLM_MODEL=openai/gpt-4o
+-e LLM_API_KEY=sk-orca-...
+```
+
+Replace the model with another current OrcaRouter model id (same
+`provider/model` format as OpenRouter, e.g. `anthropic/claude-sonnet-4.6` or
+`deepseek/deepseek-v4-flash`) when needed.
 
 OpenAI-compatible structured calls use the operation's JSON Schema by default:
 


### PR DESCRIPTION
Carries XiaoHuo888-hue's commits from #410 verbatim, plus one maintainer commit relocating the CHANGELOG entry (their PR predates v1.28.1, so git auto-merged the entry *inside* the now-frozen `[1.28.1]` section without raising a conflict).

Docs-only. No code, no new provider type — OrcaRouter is reached through the existing `openai-compat` provider.

## Claims verified independently against the live API

The author disclosed they work on OrcaRouter, so I checked every factual claim against the service rather than the PR body:

- `api.orcarouter.ai` and `www.orcarouter.ai` resolve
- `GET https://api.orcarouter.ai/v1/models` → **HTTP 200**, an OpenAI-compatible listing
- 191 models returned, **189 use the `provider/model` id format** — matching the claim that it takes the same form as OpenRouter
- every model id cited in the docs exists: `openai/gpt-4o`, `anthropic/claude-sonnet-4.6`, `deepseek/deepseek-v4-flash`, and `openai/text-embedding-3-small` for the embeddings row

The documented base URL, id format, and key mapping are therefore accurate. Nothing in the diff asserts a model count, so the PR body's "200+" (vs 191 live) does not reach the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)