### PR TITLE
fix(install-hooks): honor PI_CODING_AGENT_DIR for Pi/OMP extension paths (#411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the install reported success and capture silently did nothing. ai-memory
   already honored the variable when resolving Pi/OMP transcripts, so the two
   halves of one install disagreed about where that home was. Installs without
-  `PI_CODING_AGENT_DIR` set are unaffected.
+  `PI_CODING_AGENT_DIR` set are unaffected. The manual (non-`--apply`)
+  instructions now name the resolved path too, instead of always printing the
+  `~/.pi/agent` / `~/.omp/agent` default. (#411)
 
 ## [1.28.1] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `install-hooks --agent pi`, `--agent omp`, and `uninstall` now honor
+  `PI_CODING_AGENT_DIR`, instead of always writing to `~/.pi/agent/extensions/`
+  and `~/.omp/agent/extensions/`. Both agents relocate their whole agent
+  config home (`~/.pi/agent` / `~/.omp/agent`) through that variable, so on an
+  install with it set the extensions landed where the agent never loads them:
+  the install reported success and capture silently did nothing. ai-memory
+  already honored the variable when resolving Pi/OMP transcripts, so the two
+  halves of one install disagreed about where that home was. Installs without
+  `PI_CODING_AGENT_DIR` set are unaffected.
+
 ### Added
 - The built-in sanitizer now redacts seven further credential shapes, completing
   three vendor families it already covered only in part. **GitHub:** every

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -162,8 +162,28 @@ pub(crate) fn opencode_plugin_path() -> anyhow::Result<std::path::PathBuf> {
         .join("ai-memory.ts"))
 }
 
+/// `$PI_CODING_AGENT_DIR/extensions/ai-memory.ts` when the var is set, else
 /// `~/.omp/agent/extensions/ai-memory.ts` — OMP lifecycle extension.
+///
+/// `PI_CODING_AGENT_DIR` relocates OMP's whole agent config home
+/// (`~/.omp/agent`), so extensions written to the default path are never
+/// loaded by an OMP configured that way: capture silently does nothing, with
+/// a successful-looking install. ai-memory already honors the variable when
+/// it resolves OMP transcripts (`ManagedHarness::Omp` in
+/// `ai-memory-workstream`), so ignoring it here left one half of the same
+/// install pointing somewhere the other half did not.
 pub(crate) fn omp_extension_path() -> anyhow::Result<std::path::PathBuf> {
+    omp_extension_path_in(std::env::var_os("PI_CODING_AGENT_DIR"))
+}
+
+/// The env value comes in as a parameter so tests can exercise both branches
+/// without mutating process env (mirrors [`codex_hooks_path_in`]).
+fn omp_extension_path_in(
+    env_override: Option<std::ffi::OsString>,
+) -> anyhow::Result<std::path::PathBuf> {
+    if let Some(dir) = crate::commands::path_util::agent_config_home(env_override) {
+        return Ok(dir.join("extensions").join("ai-memory.ts"));
+    }
     Ok(home_dir()
         .context("could not locate $HOME for ~/.omp/agent/extensions")?
         .join(".omp")
@@ -172,8 +192,28 @@ pub(crate) fn omp_extension_path() -> anyhow::Result<std::path::PathBuf> {
         .join("ai-memory.ts"))
 }
 
+/// `$PI_CODING_AGENT_DIR/extensions/ai-memory.ts` when the var is set, else
 /// `~/.pi/agent/extensions/ai-memory.ts` — Pi lifecycle + MCP bridge extension.
+///
+/// `PI_CODING_AGENT_DIR` relocates Pi's whole agent config home
+/// (`~/.pi/agent`), so extensions written to the default path are never
+/// loaded by a Pi configured that way: capture silently does nothing, with a
+/// successful-looking install. ai-memory already honors the variable when it
+/// resolves Pi transcripts (`ManagedHarness::Pi` in `ai-memory-workstream`),
+/// so ignoring it here left one half of the same install pointing somewhere
+/// the other half did not.
 pub(crate) fn pi_extension_path() -> anyhow::Result<std::path::PathBuf> {
+    pi_extension_path_in(std::env::var_os("PI_CODING_AGENT_DIR"))
+}
+
+/// The env value comes in as a parameter so tests can exercise both branches
+/// without mutating process env (mirrors [`codex_hooks_path_in`]).
+fn pi_extension_path_in(
+    env_override: Option<std::ffi::OsString>,
+) -> anyhow::Result<std::path::PathBuf> {
+    if let Some(dir) = crate::commands::path_util::agent_config_home(env_override) {
+        return Ok(dir.join("extensions").join("ai-memory.ts"));
+    }
     Ok(home_dir()
         .context("could not locate $HOME for ~/.pi/agent/extensions")?
         .join(".pi")
@@ -5910,6 +5950,73 @@ model = "gpt-5"
         let extension = build_omp_extension("http://127.0.0.1:49374", Some("tok"), None);
 
         assert_generated_ts_uses_bounded_hook_queue(&extension);
+    }
+
+    /// `PI_CODING_AGENT_DIR` relocates Pi's whole agent config home
+    /// (`~/.pi/agent`), not just session storage, so the extension must follow
+    /// the variable or Pi never loads it — the install reports success and
+    /// capture silently does nothing.
+    #[test]
+    fn pi_extension_path_honours_pi_coding_agent_dir() {
+        let custom = if cfg!(windows) {
+            r"C:\custom\pi-agent"
+        } else {
+            "/custom/pi-agent"
+        };
+        let path = pi_extension_path_in(Some(std::ffi::OsString::from(custom))).unwrap();
+        assert_eq!(
+            path,
+            Path::new(custom).join("extensions").join("ai-memory.ts")
+        );
+
+        // Unset and blank both fall back to ~/.pi/agent/extensions/ai-memory.ts.
+        // Blank counts as unset because an exported-but-empty variable is nearly
+        // always a failed shell expansion, not a request to install into the
+        // filesystem root.
+        for env in [None, Some(std::ffi::OsString::new())] {
+            let path = pi_extension_path_in(env).unwrap();
+            assert!(
+                path.ends_with(
+                    Path::new(".pi")
+                        .join("agent")
+                        .join("extensions")
+                        .join("ai-memory.ts")
+                ),
+                "default must be ~/.pi/agent/extensions/ai-memory.ts, got {}",
+                path.display()
+            );
+        }
+    }
+
+    /// Same relocation contract as Pi: OMP honors `PI_CODING_AGENT_DIR` for
+    /// the default profile and moves `~/.omp/agent` wholesale, extensions
+    /// included.
+    #[test]
+    fn omp_extension_path_honours_pi_coding_agent_dir() {
+        let custom = if cfg!(windows) {
+            r"C:\custom\omp-agent"
+        } else {
+            "/custom/omp-agent"
+        };
+        let path = omp_extension_path_in(Some(std::ffi::OsString::from(custom))).unwrap();
+        assert_eq!(
+            path,
+            Path::new(custom).join("extensions").join("ai-memory.ts")
+        );
+
+        for env in [None, Some(std::ffi::OsString::new())] {
+            let path = omp_extension_path_in(env).unwrap();
+            assert!(
+                path.ends_with(
+                    Path::new(".omp")
+                        .join("agent")
+                        .join("extensions")
+                        .join("ai-memory.ts")
+                ),
+                "default must be ~/.omp/agent/extensions/ai-memory.ts, got {}",
+                path.display()
+            );
+        }
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -6006,9 +6006,22 @@ model = "gpt-5"
             );
         }
 
-        // Unset: the hints keep naming the documented defaults.
-        assert!(omp_extension_hint_in(None).ends_with(".omp/agent/extensions/ai-memory.ts"));
-        assert!(pi_extension_hint_in(None).ends_with(".pi/agent/extensions/ai-memory.ts"));
+        // Unset: the hints keep naming the documented defaults. Build the
+        // expected tail from path components rather than hardcoding `/` —
+        // `Path::display` renders `\` on Windows, so a slash-literal suffix
+        // asserts a path shape that platform never produces.
+        for (agent_home, hint) in [
+            (".omp", omp_extension_hint_in(None)),
+            (".pi", pi_extension_hint_in(None)),
+        ] {
+            let tail: PathBuf = [agent_home, "agent", "extensions", "ai-memory.ts"]
+                .iter()
+                .collect();
+            assert!(
+                hint.ends_with(&tail.display().to_string()),
+                "unset must keep the documented default, got: {hint}"
+            );
+        }
     }
 
     /// `PI_CODING_AGENT_DIR` relocates Pi's whole agent config home

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -3030,12 +3030,38 @@ fn apply_to_omp_extension(
     Ok(())
 }
 
+/// The path shown in the manual (non-`--apply`) instructions.
+///
+/// This must name the path the install actually resolves to. Printing the
+/// `~/.omp/agent/...` default to an operator with `PI_CODING_AGENT_DIR` set
+/// would hand them the exact wrong location that `--apply` now avoids — a
+/// hand-copied extension that OMP never loads, with capture silently doing
+/// nothing. Falls back to the documented default only when `$HOME` itself
+/// cannot be resolved and there is no better string to show.
+fn omp_extension_hint_in(env_override: Option<std::ffi::OsString>) -> String {
+    omp_extension_path_in(env_override).map_or_else(
+        |_| "~/.omp/agent/extensions/ai-memory.ts".to_string(),
+        |p| p.display().to_string(),
+    )
+}
+
+/// See [`omp_extension_hint_in`]; same reasoning for Pi.
+fn pi_extension_hint_in(env_override: Option<std::ffi::OsString>) -> String {
+    pi_extension_path_in(env_override).map_or_else(
+        |_| "~/.pi/agent/extensions/ai-memory.ts".to_string(),
+        |p| p.display().to_string(),
+    )
+}
+
 fn render_omp_extension(
     server_url: &str,
     auth_token: Option<&str>,
     project_strategy: Option<&str>,
 ) -> Result<()> {
-    println!("// Oh My Pi / OMP extension — write to ~/.omp/agent/extensions/ai-memory.ts");
+    println!(
+        "// Oh My Pi / OMP extension — write to {}",
+        omp_extension_hint_in(std::env::var_os("PI_CODING_AGENT_DIR"))
+    );
     println!("// Or re-run with `--apply` to install it automatically.");
     println!("// Restart OMP after changing extensions; config is loaded at startup.");
     println!();
@@ -3086,7 +3112,10 @@ fn render_pi_extension(
     auth_token: Option<&str>,
     project_strategy: Option<&str>,
 ) -> Result<()> {
-    println!("// Pi extension — write to ~/.pi/agent/extensions/ai-memory.ts");
+    println!(
+        "// Pi extension — write to {}",
+        pi_extension_hint_in(std::env::var_os("PI_CODING_AGENT_DIR"))
+    );
     println!("// Or re-run with `--apply` to install it automatically.");
     println!("// Restart Pi after changing extensions; MCP tools are bridged by this file.");
     println!();
@@ -5950,6 +5979,36 @@ model = "gpt-5"
         let extension = build_omp_extension("http://127.0.0.1:49374", Some("tok"), None);
 
         assert_generated_ts_uses_bounded_hook_queue(&extension);
+    }
+
+    /// The manual (non-`--apply`) instructions must name the same path
+    /// `--apply` would write to. Printing the `~/.pi/agent` default to an
+    /// operator who set `PI_CODING_AGENT_DIR` would tell them to hand-copy the
+    /// extension exactly where the agent never loads it — reintroducing, in
+    /// the manual path, the silent no-capture this change fixes.
+    #[test]
+    fn extension_hints_follow_pi_coding_agent_dir() {
+        let custom = if cfg!(windows) {
+            r"C:\custom\pi-agent"
+        } else {
+            "/custom/pi-agent"
+        };
+        let env = || Some(std::ffi::OsString::from(custom));
+
+        for hint in [omp_extension_hint_in(env()), pi_extension_hint_in(env())] {
+            assert!(
+                hint.contains("custom") && hint.ends_with("ai-memory.ts"),
+                "hint must point at the relocated agent home, got: {hint}"
+            );
+            assert!(
+                !hint.contains(".pi/agent") && !hint.contains(".omp/agent"),
+                "hint must not advertise the default home when the var is set: {hint}"
+            );
+        }
+
+        // Unset: the hints keep naming the documented defaults.
+        assert!(omp_extension_hint_in(None).ends_with(".omp/agent/extensions/ai-memory.ts"));
+        assert!(pi_extension_hint_in(None).ends_with(".pi/agent/extensions/ai-memory.ts"));
     }
 
     /// `PI_CODING_AGENT_DIR` relocates Pi's whole agent config home

--- a/docs/install.md
+++ b/docs/install.md
@@ -954,7 +954,9 @@ for hooks; both target OMP's native `.omp` integration surface.
 Pi does not read a native `mcp.json`. ai-memory supports Pi through one
 generated TypeScript extension at `~/.pi/agent/extensions/ai-memory.ts`; the
 same file captures lifecycle events and bridges ai-memory's HTTP MCP tools into
-Pi with `pi.registerTool`.
+Pi with `pi.registerTool`. When `PI_CODING_AGENT_DIR` is set (it relocates
+Pi's whole `~/.pi/agent` home), the extension is written to
+`$PI_CODING_AGENT_DIR/extensions/ai-memory.ts` instead.
 
 ```bash
 ai-memory install-hooks --agent pi --apply \

--- a/docs/mcp-install.md
+++ b/docs/mcp-install.md
@@ -1041,7 +1041,9 @@ ai-memory install-hooks --agent omp --apply
 
 This writes `~/.omp/agent/extensions/ai-memory.ts`, which OMP discovers
 as a direct TypeScript extension on startup. Restart `omp` after
-installing or changing the file.
+installing or changing the file. When `PI_CODING_AGENT_DIR` is set
+(it relocates OMP's whole `~/.omp/agent` home), the extension is written
+to `$PI_CODING_AGENT_DIR/extensions/ai-memory.ts` instead.
 
 **Gotchas:**
 - OMP extensions are TypeScript modules, not shell hooks; stdout is not
@@ -1053,7 +1055,9 @@ installing or changing the file.
 
 **Status:** ✅ MCP and lifecycle capture supported via generated bridge
 extension. Pi has no native `mcp.json`; use `install-hooks --agent pi --apply`
-to write `~/.pi/agent/extensions/ai-memory.ts`.
+to write `~/.pi/agent/extensions/ai-memory.ts`. When `PI_CODING_AGENT_DIR`
+is set (it relocates Pi's whole `~/.pi/agent` home), the extension is
+written to `$PI_CODING_AGENT_DIR/extensions/ai-memory.ts` instead.
 
 ```bash
 ai-memory install-hooks --agent pi --apply


### PR DESCRIPTION
Closes #406. Carries rekcilyssup's commits from #411 verbatim, plus one maintainer commit.

## Their change

`install-hooks --agent pi`, `--agent omp`, and `uninstall` now honor `PI_CODING_AGENT_DIR` when resolving the extension path. Reuses the existing `path_util::agent_config_home` helper and the `*_in(env_override)` parameter-injection pattern from the `CODEX_HOME` fix, so both branches are testable without mutating process env (`unsafe_code = "forbid"` rules out `set_var`). Same failure shape as #379: the install reported success and capture silently did nothing.

## Verified independently

#406 was opened to *verify whether* Pi/OMP extension paths should follow this variable, so I checked the vendor docs rather than the PR body. OMP's `docs/extension-loading.md` confirms it:

> "the active agent directory's `extensions/` (default `~/.omp/agent/extensions`)" … "`PI_CODING_AGENT_DIR` can override the agent directory"

So extensions load from `$PI_CODING_AGENT_DIR/extensions/` when set. The premise holds and #406's open question is answered.

## Maintainer commit: the manual path had the same bug

The env-aware resolution landed on `--apply` only. The instructions printed *without* `--apply` still hardcoded `~/.pi/agent/extensions/ai-memory.ts` and `~/.omp/agent/extensions/ai-memory.ts`, so an operator with the variable set who installs by hand was told to copy the extension exactly where the agent never loads it — the same silent no-capture, surviving in the flow this output exists to serve. Both hints now route through the same resolvers, with a test covering set and unset.

## Known limitation (not blocking)

Pi and OMP read the *same* variable and both load from `$DIR/extensions/`, while ai-memory writes the same filename with different content for each (Pi's bridges MCP tools; OMP's does not). Someone running both agents with the variable set gets last-install-wins. That is inherent to upstream sharing one variable — and strictly better than the previous behavior, where the variable was ignored and neither worked. OMP's docs also describe per-profile homes (`~/.omp/profiles/<name>/agent/extensions`), which neither this PR nor the base handles. Worth a follow-up issue rather than a blocker here.

## Verification
`cargo fmt --check`, `cargo clippy --all-targets --all-features`, `cargo test --workspace` → **2458 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)