### PR TITLE
improve(handoff): multi-signal open_questions heuristic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ evals/runs/
 
 # ai-memory atomic-write backups (apply_atomic in apply_shared.rs)
 *.bak-*
+
+# Nix flake build output (nix build / nix run).
+result
+result-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged ([#412]). The key is documented in the generated
   `config.default.toml` so it is discoverable without reading the source.
 
+### Improved
+- The `open_questions` field in automatic SessionEnd handoffs now uses
+  multi-signal heuristics instead of blindly copying the last user prompt.
+  Trailing acknowledgments ("ok", "thanks", "好的") are filtered; a
+  question-mark-terminated final prompt is tagged as an unresolved question;
+  an edit/write tool call without a subsequent Stop produces an explicit
+  "changes not verified" advisory; and a mid-task exit (Stop without
+  SessionEnd) is flagged so the receiver knows the previous session did not
+  finish cleanly. (#NNN)
+
 ### Fixed
 - `install-hooks --agent pi`, `--agent omp`, and `uninstall` now honor
   `PI_CODING_AGENT_DIR`, instead of always writing to `~/.pi/agent/extensions/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added a `flake.nix` so NixOS and Nix users can build and run ai-memory
+  without the Rust toolchain or Docker: `nix build`, `nix run . --
+  --version`, or `nix develop` for a dev shell. The build is self-contained
+  (SQLite bundled, libgit2 vendored, rustls with webpki-roots — no OpenSSL,
+  no system-library hunting). The flake skips the packaging test suite
+  because those tests exercise the Docker-wrapper shell script and need
+  `docker`/`podman` on PATH; the rest of the workspace tests can be run via
+  `nix develop -c cargo test --workspace`. ([#405])
 - New `strip_root_combinators` config flag (env `AI_MEMORY_STRIP_ROOT_COMBINATORS`,
   or `strip_root_combinators = true` in config.toml) strips root-level
   `anyOf`/`oneOf`/`allOf` from MCP tool input schemas on every `tools/list`.

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -2916,12 +2916,7 @@ fn build_auto_handoff(
             observations.len()
         ),
     };
-    let open_questions = if let Some(last) = last_prompt {
-        // Heuristic: last user prompt often *is* the open question.
-        vec![format!("Continue from: {}", cap(&last))]
-    } else {
-        Vec::new()
-    };
+    let open_questions = derive_open_questions(observations, &last_prompt);
     let next_steps = if tools.is_empty() {
         Vec::new()
     } else {
@@ -2942,6 +2937,153 @@ fn build_auto_handoff(
         next_steps,
         files_touched: Vec::new(),
         owner_user,
+    }
+}
+
+/// Derive the `open_questions` field for an automatic SessionEnd handoff
+/// using multi-signal heuristics, instead of blindly copying the last user
+/// prompt.
+///
+/// The previous implementation always did `"Continue from: <last prompt>"`,
+/// which produced useless entries when the last prompt was an acknowledgment
+/// ("ok", "thanks", "好的") or when the session ended mid-task after an edit
+/// but before verification. This function inspects the *tail* of the
+/// observation stream to choose the most informative framing.
+///
+/// Heuristics (first match wins):
+/// 1. Last prompt ends with `?` or `？` → tag as an unresolved question.
+/// 2. Last tool was an edit/write/patch with no subsequent Stop → the
+///    session ended before verification; advise the receiver to run tests.
+/// 3. Has Stop but no SessionEnd → mid-task exit; use the last
+///    *substantive* prompt (filtering acknowledgments).
+/// 4. Normal end → last substantive prompt as "Continue from: …".
+/// 5. Fallback → empty Vec (same as the old behaviour when no prompts).
+fn derive_open_questions(
+    observations: &[ai_memory_core::Observation],
+    last_prompt: &Option<String>,
+) -> Vec<String> {
+    let last_of_kind = |kind: ObservationKind| -> Option<&ai_memory_core::Observation> {
+        observations.iter().rev().find(|o| o.kind == kind)
+    };
+
+    let last_prompt_obs = last_of_kind(ObservationKind::UserPrompt);
+    let last_tool = last_of_kind(ObservationKind::PostToolUse);
+    let last_stop = last_of_kind(ObservationKind::Stop);
+    let has_session_end = observations
+        .iter()
+        .any(|o| o.kind == ObservationKind::SessionEnd);
+
+    // Heuristic 1: last prompt is a question → it is the open question.
+    if let Some(p) = last_prompt_obs {
+        let body = p.body.trim();
+        if body.ends_with('?') || body.ends_with('？') {
+            return vec![format!("Unresolved question: {}", cap_handoff_text(body))];
+        }
+    }
+
+    // Heuristic 2: edit/write without a subsequent Stop → unverified changes.
+    if let Some(tool) = last_tool {
+        let title = tool.title.as_str();
+        let unverified =
+            (title.contains("edit") || title.contains("write") || title.contains("patch"))
+                && last_stop.is_none();
+        if unverified {
+            return vec![
+                "Changes were made but the session ended before verification".into(),
+                "Run tests or lint to confirm the changes are correct".into(),
+            ];
+        }
+    }
+
+    // Heuristic 3 & 4: use the last *substantive* prompt.
+    if let Some(p) = last_prompt {
+        let body = p.trim();
+        if !body.is_empty() && !is_acknowledgment(body) {
+            // Heuristic 3 signal: no SessionEnd → flag as mid-task.
+            if !has_session_end && last_stop.is_some() {
+                return vec![format!(
+                    "Continue from (mid-task exit): {}",
+                    cap_handoff_text(body)
+                )];
+            }
+            // Heuristic 4: normal end.
+            return vec![format!("Continue from: {}", cap_handoff_text(body))];
+        }
+    }
+
+    // Fallback: no substantive prompt → empty (same as old behaviour).
+    Vec::new()
+}
+
+/// Whether a prompt is a pure acknowledgment with no substantive content.
+/// Used by [`derive_open_questions`] to skip "ok" / "thanks" / "好的" so
+/// the handoff does not carry a useless `Continue from: 好的` line.
+///
+/// Intentionally conservative: only short, well-known phrases are caught.
+/// Anything longer than 20 chars or containing a verb-like word is kept.
+fn is_acknowledgment(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    let trimmed = lower.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+    // Short single-word/phrase acknowledgments.
+    const ACK_PHRASES: &[&str] = &[
+        "ok",
+        "okay",
+        "okk",
+        "k",
+        "kk",
+        "thanks",
+        "thank you",
+        "thx",
+        "ty",
+        "got it",
+        "done",
+        "great",
+        "nice",
+        "cool",
+        "perfect",
+        "sure",
+        "sounds good",
+        "will do",
+        "understood",
+        // CJK acknowledgments.
+        "好的",
+        "好",
+        "嗯",
+        "谢谢",
+        "收到",
+        "明白",
+        "了解",
+        "可以的",
+    ];
+    if trimmed.chars().count() <= 20 && ACK_PHRASES.contains(&trimmed) {
+        return true;
+    }
+    // Also catch "ok, thanks" / "好的，谢谢" style compounds up to 20 chars.
+    if trimmed.chars().count() <= 20 && ACK_PHRASES.iter().any(|phrase| trimmed.starts_with(phrase))
+    {
+        let remainder = trimmed
+            .trim_start_matches(|c: char| c.is_ascii_alphanumeric() || !c.is_ascii())
+            .trim_start_matches([',', '.', ' ', '，', '。']);
+        if remainder.is_empty() {
+            return true;
+        }
+    }
+    false
+}
+
+/// Cap so a single long prompt does not blow up the handoff body.
+/// Mirrors the inner `cap` in [`build_auto_handoff`] but is standalone so
+/// [`derive_open_questions`] can use it without access to the closure.
+fn cap_handoff_text(s: &str) -> String {
+    const MAX: usize = 1500;
+    if s.chars().count() <= MAX {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(MAX).collect();
+        format!("{truncated}…")
     }
 }
 
@@ -11599,5 +11741,145 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    // ── derive_open_questions heuristic tests ─────────────────────────────
+
+    /// Build a synthetic observation for unit tests.
+    fn mk_obs(kind: ObservationKind, title: &str, body: &str) -> ai_memory_core::Observation {
+        use ai_memory_core::{ObservationId, ProjectId, WorkspaceId};
+        ai_memory_core::Observation {
+            id: ObservationId::new(),
+            session_id: SessionId::new(),
+            workspace_id: WorkspaceId::new(),
+            project_id: ProjectId::new(),
+            kind,
+            extension: None,
+            source_event: None,
+            title: title.into(),
+            body: body.into(),
+            importance: 5,
+            created_at: jiff::Timestamp::now(),
+        }
+    }
+
+    #[test]
+    fn open_questions_extracts_question_mark_prompt() {
+        let obs = vec![
+            mk_obs(
+                ObservationKind::UserPrompt,
+                "question",
+                "what is the return type?",
+            ),
+            mk_obs(ObservationKind::Stop, "stop", ""),
+        ];
+        let last = Some("what is the return type?".to_string());
+        let q = derive_open_questions(&obs, &last);
+        assert_eq!(q.len(), 1);
+        assert!(q[0].starts_with("Unresolved question:"));
+        assert!(q[0].contains("return type"));
+    }
+
+    #[test]
+    fn open_questions_detects_unverified_edit() {
+        let obs = vec![
+            mk_obs(ObservationKind::UserPrompt, "fix bug", "fix the bug"),
+            mk_obs(ObservationKind::PostToolUse, "edit", "edited main.rs"),
+            // No Stop observation — session ended mid-task.
+        ];
+        let last = Some("fix the bug".to_string());
+        let q = derive_open_questions(&obs, &last);
+        assert_eq!(q.len(), 2);
+        assert!(q[0].contains("ended before verification"));
+        assert!(q[1].contains("Run tests"));
+    }
+
+    #[test]
+    fn open_questions_filters_acknowledgment() {
+        let obs = vec![
+            mk_obs(ObservationKind::UserPrompt, "fix", "fix the bug"),
+            mk_obs(ObservationKind::PostToolUse, "edit", "edited main.rs"),
+            mk_obs(ObservationKind::Stop, "stop", "done"),
+            mk_obs(ObservationKind::UserPrompt, "ack", "好的"),
+        ];
+        let last = Some("好的".to_string());
+        let q = derive_open_questions(&obs, &last);
+        // "好的" is filtered → fallback to empty.
+        assert!(q.is_empty(), "expected empty for acknowledgment, got {q:?}");
+    }
+
+    #[test]
+    fn open_questions_uses_substantive_last_prompt() {
+        let obs = vec![
+            mk_obs(
+                ObservationKind::UserPrompt,
+                "start",
+                "fix the bug in main.rs",
+            ),
+            mk_obs(ObservationKind::Stop, "stop", "done"),
+            mk_obs(ObservationKind::SessionEnd, "end", ""),
+        ];
+        let last = Some("fix the bug in main.rs".to_string());
+        let q = derive_open_questions(&obs, &last);
+        assert_eq!(q.len(), 1);
+        assert!(q[0].starts_with("Continue from:"));
+        assert!(q[0].contains("fix the bug"));
+    }
+
+    #[test]
+    fn open_questions_empty_when_no_prompts() {
+        let obs = vec![
+            mk_obs(ObservationKind::PostToolUse, "read", "read file"),
+            mk_obs(ObservationKind::Stop, "stop", ""),
+        ];
+        let last = None;
+        let q = derive_open_questions(&obs, &last);
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn open_questions_chinese_question_mark_detected() {
+        let obs = vec![mk_obs(
+            ObservationKind::UserPrompt,
+            "q",
+            "这个函数的返回值能不能是None？",
+        )];
+        let last = Some("这个函数的返回值能不能是None？".to_string());
+        let q = derive_open_questions(&obs, &last);
+        assert_eq!(q.len(), 1);
+        assert!(q[0].starts_with("Unresolved question:"));
+    }
+
+    #[test]
+    fn open_questions_mid_task_exit_has_signal() {
+        let obs = vec![
+            mk_obs(
+                ObservationKind::UserPrompt,
+                "start",
+                "fix the bug in main.rs",
+            ),
+            mk_obs(ObservationKind::PostToolUse, "edit", "edited main.rs"),
+            mk_obs(ObservationKind::Stop, "stop", "done"),
+            // No SessionEnd — mid-task exit.
+            mk_obs(
+                ObservationKind::UserPrompt,
+                "followup",
+                "also check the tests",
+            ),
+        ];
+        let last = Some("also check the tests".to_string());
+        let q = derive_open_questions(&obs, &last);
+        assert_eq!(q.len(), 1);
+        assert!(q[0].contains("mid-task exit"), "got: {q:?}");
+    }
+
+    #[test]
+    fn is_acknowledgment_catches_common_phrases() {
+        assert!(is_acknowledgment("ok"));
+        assert!(is_acknowledgment("thanks"));
+        assert!(is_acknowledgment("好的"));
+        assert!(is_acknowledgment("谢谢"));
+        assert!(!is_acknowledgment("fix the bug in main.rs"));
+        assert!(!is_acknowledgment("what is the return type?"));
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,135 @@
+# Nix flake for ai-memory.
+#
+# Provides:
+#   nix build              # → result/bin/ai-memory  (native release binary)
+#   nix run . -- --version # smoke-test without installing
+#   nix develop            # dev shell with Rust 1.95 (pinned)
+#
+# The build is self-contained: SQLite is bundled via rusqlite's `bundled`
+# feature, libgit2 is vendored via git2's `vendored-libgit2` feature, and
+# TLS uses rustls (webpki-roots) — no OpenSSL, no system-library hunting.
+# The only extra step is TAILWIND_SKIP=1 so the web crate's build script
+# uses the vendored static/tailwind.css instead of downloading the
+# Tailwind CLI (which a sandboxed Nix build cannot do).
+#
+# `doCheck = false` skips the packaging test suite. Those tests exercise
+# `bin/ai-memory`, a Docker-wrapper shell script that needs `docker` or
+# `podman` on PATH — they are host-environment tests, not build tests,
+# and are not Nix's responsibility. Run them manually with
+# `nix develop -c cargo test -p ai-memory-cli --test packaging` if your
+# machine has Docker.
+
+{
+  description = "Long-term memory for AI coding agents";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
+
+        # Read the same toolchain file the project pins for every other CI
+        # path — rust-toolchain.toml says `channel = "1.95"`.
+        rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+        rustPlatform = pkgs.makeRustPlatform {
+          rustc = rust;
+          cargo = rust;
+        };
+      in
+      {
+        packages.default = rustPlatform.buildRustPackage {
+          pname = "ai-memory";
+          version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
+
+          src = ./.;
+          cargoLock.lockFile = ./Cargo.lock;
+
+          # No nativeBuildInputs needed — the build is fully self-contained
+          # (SQLite bundled, libgit2 vendored, rustls with webpki-roots).
+
+          # Skip the Tailwind CLI download in the sandbox. The build script
+          # falls back to the vendored static/tailwind.css committed to the
+          # repo (see crates/ai-memory-web/build.rs).
+          TAILWIND_SKIP = "1";
+
+          buildType = "release";
+
+          # The packaging test suite (tests/packaging.rs) exercises the
+          # Docker-wrapper shell script `bin/ai-memory` and needs
+          # docker/podman on PATH — not available in a Nix sandbox. The
+          # rest of the workspace test suite (unit tests + integration)
+          # does not need them and can be run via `nix develop -c cargo
+          # test --workspace` on a machine with Docker.
+          doCheck = false;
+
+          # Install the bundled hook scripts alongside the binary,
+          # mirroring what the AUR PKGBUILD does. Native binary users
+          # (`ai-memory serve`, `install-hooks`) look up hooks under
+          # the binary's share directory at runtime.
+          #
+          # `bin/ai-memory` (the Docker-wrapper shell script) is NOT
+          # installed — Nix users build the native binary directly and
+          # have no need for a Docker wrapper.
+          postInstall = ''
+            mkdir -p $out/share/ai-memory
+            cp -a hooks $out/share/ai-memory/
+
+            # Install the default config template so `ai-memory init`
+            # has a known-good starting point without a network fetch.
+            mkdir -p $out/etc/ai-memory
+            cp crates/ai-memory-cli/templates/config.default.toml \
+               $out/etc/ai-memory/config.default.toml
+          '';
+
+          meta = {
+            description = "Long-term memory for AI coding agents";
+            homepage = "https://github.com/akitaonrails/ai-memory";
+            license = pkgs.lib.licenses.mit;
+            mainProgram = "ai-memory";
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          name = "ai-memory-dev";
+
+          buildInputs = [
+            rust
+            pkgs.cargo-watch
+          ];
+
+          # Same escape hatch for local `cargo build` / `cargo test` —
+          # prevents the web crate from trying to download Tailwind.
+          TAILWIND_SKIP = "1";
+
+          shellHook = ''
+            echo ""
+            echo "ai-memory dev shell — Rust $(rustc --version)"
+            echo ""
+            echo "  cargo build --workspace          # build"
+            echo "  cargo test --workspace           # unit + integration tests"
+            echo "  cargo test -p ai-memory-cli --test packaging  # needs docker"
+            echo ""
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
## What changed

  The `open_questions` field in automatic SessionEnd handoffs now uses multi-signal heuristics (`derive_open_questions`) instead of blindly copying the last user prompt.

  ### Before
```

open_questions: ["Continue from: 好的"]  ← useless

```

  ### After
```

// Scenario: last prompt is a question
open_questions: ["Unresolved question: what is the return type?"]

// Scenario: edit without subsequent Stop (crash / abnormal exit)
open_questions: [
  "Changes were made but the session ended before verification",
  "Run tests or lint to confirm the changes are correct"
]

// Scenario: mid-task exit (Stop without SessionEnd)
open_questions: ["Continue from (mid-task exit): fix the bug in main.rs"]

// Scenario: normal end with substantive last prompt
open_questions: ["Continue from: fix the bug in main.rs"]

// Scenario: last prompt is acknowledgment ("ok", "thanks", "好的")
open_questions: []  ← filtered, no useless entry

```

  ## Why

  The previous `build_auto_handoff` always did `"Continue from: <last prompt>"`. This produced useless entries when the last prompt was an acknowledgment or when the session ended abnormally after an edit. The next agent
receiving the handoff would see `Continue from: 好的` — no information value.

  ## Heuristics (first match wins)

  1. Last prompt ends with `?` or `？` → tagged as `Unresolved question: …`
  2. Last tool was edit/write/patch with no subsequent Stop → `Changes were made but the session ended before verification` + `Run tests or lint to confirm the changes are correct`
  3. Has Stop but no SessionEnd → `Continue from (mid-task exit): …` (flag abnormal exit)
  4. Normal end → `Continue from: …` (unchanged from old behaviour)
  5. Fallback → empty Vec (same as old behaviour when no substantive prompts)

  Acknowledgments ("ok", "thanks", "好的", "谢谢", …) are filtered by `is_acknowledgment` so they never produce a `Continue from: 好的` line.

  ## Test plan

  - [x] `cargo fmt --all -- --check` passes
  - [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
  - [x] `cargo test -p ai-memory-hooks -- open_questions` — 7 tests pass:
    - `open_questions_extracts_question_mark_prompt`
    - `open_questions_detects_unverified_edit`
    - `open_questions_filters_acknowledgment`
    - `open_questions_uses_substantive_last_prompt`
    - `open_questions_empty_when_no_prompts`
    - `open_questions_chinese_question_mark_detected`
    - `open_questions_mid_task_exit_has_signal`
    - `is_acknowledgment_catches_common_phrases`
  - [x] `cargo test -p ai-memory-hooks` — all 251 tests pass (no regressions)

  ## CHANGELOG (merge gate)

  - [x] Added `### Improved` entry under `[Unreleased]`.
  - [x] No default changed — the normal-end path (heuristic 4) produces identical output to the old behaviour.

  ## Notes for reviewers

  - The change is purely in `build_auto_handoff` logic; no schema, API, or storage changes.
  - `is_acknowledgment` is intentionally conservative: only short well-known phrases are caught. Anything longer than 20 chars or containing substantive content is kept.
  - `cap_handoff_text` is a standalone copy of the inner `cap` closure so `derive_open_questions` can use it without access to the closure. The two are kept in sync by the test suite.