### PR TITLE
docs: correct Pi/OMP extension filenames and document profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Corrected the Pi/OMP extension filenames in `README.md`, `docs/install.md`,
+  and `docs/mcp-install.md`, which still described the pre-rename
+  `ai-memory.ts` after the agent-distinct `ai-memory-pi.ts` /
+  `ai-memory-omp.ts` split. Following those instructions by hand created the
+  very duplicate-load the split exists to prevent, since each agent loads
+  every `*.ts` in its extensions directory. Documented `--profile` /
+  `OMP_PROFILE` and the `PI_CODING_AGENT_DIR` precedence alongside them.
+
 ### Added
 - New `llm_timeout_secs` config key (env `AI_MEMORY_LLM_TIMEOUT_SECS`, or
   `llm_timeout_secs = 900` in config.toml) overrides the per-request timeout

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 | Cursor | Supported | MCP config + lifecycle hooks. |
 | Gemini CLI | Supported | MCP config + lifecycle hooks. |
 | Oh My Pi / OMP | Supported | Use `--client omp` / `--agent omp` (or `oh-my-pi`) for native `.omp` MCP config + TypeScript extension; generated extension enforces capture exclusions. |
-| Pi | Supported | Generated `~/.pi/agent/extensions/ai-memory.ts` extension provides lifecycle capture and an HTTP MCP bridge; generated extension enforces capture exclusions. |
+| Pi | Supported | Generated `~/.pi/agent/extensions/ai-memory-pi.ts` extension provides lifecycle capture and an HTTP MCP bridge; generated extension enforces capture exclusions. |
 | Crush | Managed-only | `ai-memory run crush` resumes its project-local session database and supplies portable context through a temporary supported global-context file; no lifecycle-hook installer is provided. |
 | Managed workstreams | Opt-in | `ai-memory run` provides transparent cross-harness continuity for Claude Code, Codex, OpenCode, Pi, Crush, Kimi Code, Command Code, both incompatible Kiro CLI engines, OMP, Grok Build CLI, and Antigravity CLI. Direct launches remain unchanged. See [`docs/managed-workstreams.md`](docs/managed-workstreams.md). |
 | Claude Desktop | MCP-only | Uses `mcp-remote`; no lifecycle hooks. |

--- a/docs/install.md
+++ b/docs/install.md
@@ -937,7 +937,7 @@ docker run --rm akitaonrails/ai-memory:latest \
     --server-url "http://homelab:49374/mcp" \
     --auth-token "$TOKEN"
 
-# Extension — write to ~/.omp/agent/extensions/ai-memory.ts.
+# Extension — write to ~/.omp/agent/extensions/ai-memory-omp.ts.
 # If you have the local wrapper installed, prefer `--apply`:
 ai-memory install-hooks --agent omp --apply \
     --server-url "http://homelab:49374" \
@@ -952,11 +952,32 @@ for hooks; both target OMP's native `.omp` integration surface.
 ### Pi
 
 Pi does not read a native `mcp.json`. ai-memory supports Pi through one
-generated TypeScript extension at `~/.pi/agent/extensions/ai-memory.ts`; the
+generated TypeScript extension at `~/.pi/agent/extensions/ai-memory-pi.ts`; the
 same file captures lifecycle events and bridges ai-memory's HTTP MCP tools into
 Pi with `pi.registerTool`. When `PI_CODING_AGENT_DIR` is set (it relocates
 Pi's whole `~/.pi/agent` home), the extension is written to
-`$PI_CODING_AGENT_DIR/extensions/ai-memory.ts` instead.
+`$PI_CODING_AGENT_DIR/extensions/ai-memory-pi.ts` instead.
+
+The Pi and OMP extensions use distinct filenames (`ai-memory-pi.ts` and
+`ai-memory-omp.ts`) so installing one never overwrites the other. They are
+not interchangeable — only Pi's bridges MCP tools.
+
+#### OMP profiles
+
+`omp --profile <name>` relocates OMP's agent home to
+`~/.omp/profiles/<name>/agent`. Point the installer at the same profile so
+the extension lands where that profile loads it:
+
+```bash
+ai-memory install-hooks --agent omp --profile work --apply
+# or set it once for the shell:
+OMP_PROFILE=work ai-memory install-hooks --agent omp --apply
+```
+
+`--profile` takes precedence over `OMP_PROFILE`, and `uninstall --profile
+<name>` removes the same file. `PI_CODING_AGENT_DIR` overrides **both** —
+when it is set it names the agent directory outright, so no profile
+subdirectory is derived from it.
 
 ```bash
 ai-memory install-hooks --agent pi --apply \

--- a/docs/mcp-install.md
+++ b/docs/mcp-install.md
@@ -1039,11 +1039,22 @@ ai-memory install-hooks --agent omp --apply
 # or: ai-memory install-hooks --agent oh-my-pi --apply
 ```
 
-This writes `~/.omp/agent/extensions/ai-memory.ts`, which OMP discovers
+This writes `~/.omp/agent/extensions/ai-memory-omp.ts`, which OMP discovers
 as a direct TypeScript extension on startup. Restart `omp` after
 installing or changing the file. When `PI_CODING_AGENT_DIR` is set
 (it relocates OMP's whole `~/.omp/agent` home), the extension is written
-to `$PI_CODING_AGENT_DIR/extensions/ai-memory.ts` instead.
+to `$PI_CODING_AGENT_DIR/extensions/ai-memory-omp.ts` instead, and
+`--profile <name>` (or `OMP_PROFILE`) targets
+`~/.omp/profiles/<name>/agent/extensions/` — note `PI_CODING_AGENT_DIR`
+takes precedence over a profile, since it names the agent directory
+outright.
+
+Pi and OMP honour the *same* `PI_CODING_AGENT_DIR`, and each agent loads
+every direct `*.ts` in its extensions directory. Pointing both at one
+directory therefore makes each load both extensions and capture every
+event twice, once under each agent identity. `install-hooks` warns when it
+detects this; give the two agents separate homes, or scope OMP to a
+profile.
 
 **Gotchas:**
 - OMP extensions are TypeScript modules, not shell hooks; stdout is not
@@ -1055,9 +1066,9 @@ to `$PI_CODING_AGENT_DIR/extensions/ai-memory.ts` instead.
 
 **Status:** ✅ MCP and lifecycle capture supported via generated bridge
 extension. Pi has no native `mcp.json`; use `install-hooks --agent pi --apply`
-to write `~/.pi/agent/extensions/ai-memory.ts`. When `PI_CODING_AGENT_DIR`
+to write `~/.pi/agent/extensions/ai-memory-pi.ts`. When `PI_CODING_AGENT_DIR`
 is set (it relocates Pi's whole `~/.pi/agent` home), the extension is
-written to `$PI_CODING_AGENT_DIR/extensions/ai-memory.ts` instead.
+written to `$PI_CODING_AGENT_DIR/extensions/ai-memory-pi.ts` instead.
 
 ```bash
 ai-memory install-hooks --agent pi --apply


### PR DESCRIPTION
Found by `pr-post-audit` on the 1.29.0 range (v1.28.1..de918a79), before tagging.

## The finding

Eight references to `extensions/ai-memory.ts` survived the rename to agent-distinct filenames (#433), across three files including the **top-level README support table**:

| file | refs |
|---|---|
| `docs/mcp-install.md` | 4 |
| `docs/install.md` | 3 |
| `README.md` | 1 |

The code writes `ai-memory-pi.ts` / `ai-memory-omp.ts`; every one of those docs still named the old path.

**Why this is more than a typo.** Each agent loads *every* direct `*.ts` in its extensions directory. An operator following the old instructions by hand would create a second ai-memory extension next to the installed one — and capture every event twice, once per agent identity. That is precisely the duplicate-load the rename and the new collision warning exist to prevent, reintroduced through the docs.

## Also fixed

`--profile` and `OMP_PROFILE` shipped in #433 with no documentation outside the changelog. Both are now covered in `docs/install.md` where the other `install-hooks` flags live, together with the `PI_CODING_AGENT_DIR` precedence rule.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)