### PR TITLE
feat(status): report local hook-spool health (#428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   means hook events are queued locally instead of reaching the server. The
   spool is client-side, so the section reflects the local data-dir even when
   the server is remote. The JSON form gains a matching `spool` object
-  (`pending`, `oldest_age_ms`, `retries_total`). (#428)
+  (`pending`, `oldest_age_ms`, `retries_total`). Only files matching the
+  spool's own naming convention are counted, so a foreign `.json` in that
+  directory cannot inflate the pending count or be reported as an
+  epoch-aged entry. (#428)
 
 ## [1.29.0] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`pending`, `oldest_age_ms`, `retries_total`). Only files matching the
   spool's own naming convention are counted, so a foreign `.json` in that
   directory cannot inflate the pending count or be reported as an
-  epoch-aged entry. (#428)
+  epoch-aged entry. The section is also reported when the server cannot be
+  reached — the spool exists to buffer events while the server is down, so
+  that is precisely when its depth is worth seeing; it goes to stderr, so
+  `--json` consumers still get a single object on stdout. (#428)
 
 ## [1.29.0] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `ai-memory status` now reports local hook-spool health: pending event
+  count, age of the oldest queued event, and total failed-delivery attempts.
+  This makes "memory capture is delayed, not broken" visible to an operator
+  without digging through logs: a non-empty spool or an aging oldest event
+  means hook events are queued locally instead of reaching the server. The
+  spool is client-side, so the section reflects the local data-dir even when
+  the server is remote. The JSON form gains a matching `spool` object
+  (`pending`, `oldest_age_ms`, `retries_total`). (#428)
 - New `strip_root_combinators` config flag (env `AI_MEMORY_STRIP_ROOT_COMBINATORS`,
   or `strip_root_combinators = true` in config.toml) strips root-level
   `anyOf`/`oneOf`/`allOf` from MCP tool input schemas on every `tools/list`.

--- a/crates/ai-memory-cli/src/commands/hook_spool.rs
+++ b/crates/ai-memory-cli/src/commands/hook_spool.rs
@@ -103,6 +103,68 @@ pub fn spool_len(spool: &Path) -> usize {
     list_entries(spool).map_or(0, |f| f.len())
 }
 
+/// Snapshot of local hook-spool health for operator status reporting.
+///
+/// Deliberately content-free: counts, ages, and attempt sums only — never
+/// payload excerpts, URLs, or token material (the spool holds private capture
+/// until it drains).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct SpoolHealth {
+    /// Events queued locally awaiting delivery.
+    pub pending: usize,
+    /// Age (ms) of the oldest queued event, or `None` when the spool is empty.
+    pub oldest_age_ms: Option<u64>,
+    /// Sum of failed-delivery attempts across all queued events.
+    pub retries_total: u64,
+}
+
+/// Snapshot local spool health: queued count and oldest-event age from the
+/// timestamp-embedded file names (no file reads), plus total retry attempts
+/// (one bounded read per queued entry — fine for an operator-invoked status
+/// command, never on the hook hot path).
+#[must_use]
+pub fn spool_health(spool: &Path) -> SpoolHealth {
+    let Some(mut files) = list_entries(spool) else {
+        return SpoolHealth::default();
+    };
+    if files.is_empty() {
+        return SpoolHealth::default();
+    }
+    files.sort();
+    let now = now_ms();
+    let oldest_created = files[0]
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(created_ms_from_name)
+        .unwrap_or(0);
+    let mut health = SpoolHealth {
+        pending: files.len(),
+        oldest_age_ms: Some(now.saturating_sub(oldest_created)),
+        retries_total: 0,
+    };
+    for path in &files {
+        if let Ok(bytes) = std::fs::read(path)
+            && let Ok(entry) = serde_json::from_slice::<SpoolEntry>(&bytes)
+        {
+            health.retries_total += u64::from(entry.attempts);
+        }
+    }
+    health
+}
+
+/// Extract the enqueue timestamp embedded in a spool file name
+/// (`{created_ms:013}-{pid}-{seq:016x}.json`), 0 when unparseable. Filenames
+/// are the only place `created_ms` is readable without opening the file, so
+/// oldest-age reporting never pays a read per queued event.
+fn created_ms_from_name(file_name: &str) -> u64 {
+    file_name
+        .split('-')
+        .next()
+        .unwrap_or(file_name)
+        .parse()
+        .unwrap_or(0)
+}
+
 fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -2065,5 +2127,80 @@ mod tests {
             1,
             "the spool entry survives a failed rewrite"
         );
+    }
+
+    #[test]
+    fn spool_health_is_default_when_dir_missing_or_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("no-spool");
+        assert_eq!(spool_health(&missing), SpoolHealth::default());
+
+        let empty = spool_dir(tmp.path());
+        std::fs::create_dir_all(&empty).unwrap();
+        assert_eq!(spool_health(&empty), SpoolHealth::default());
+    }
+
+    #[test]
+    fn spool_health_reports_pending_oldest_age_and_retries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        // Two events with distinct enqueue times; the second carries two failed
+        // attempts. Names embed `created_ms`, so oldest-age comes from the name.
+        let mut old = entry_for("https://x/hook?event=old".into(), "{}".into(), None, false);
+        old.created_ms = now_ms().saturating_sub(5 * 60 * 1000);
+        let mut new = entry_for("https://x/hook?event=new".into(), "{}".into(), None, false);
+        new.created_ms = now_ms().saturating_sub(60 * 1000);
+        new.attempts = 2;
+        enqueue(&spool, &old).unwrap();
+        enqueue(&spool, &new).unwrap();
+
+        let before = now_ms();
+        let health = spool_health(&spool);
+        assert_eq!(health.pending, 2);
+        assert_eq!(health.retries_total, 2);
+        let oldest = health
+            .oldest_age_ms
+            .expect("non-empty spool reports an age");
+        assert!(
+            (5 * 60 * 1000..=5 * 60 * 1000 + 1_000).contains(&oldest),
+            "oldest age ~5m, got {oldest}ms (measured at {before})"
+        );
+    }
+
+    #[test]
+    fn spool_health_ignores_unparseable_entries_for_retries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        write_spool_entry(
+            &spool,
+            "0000000000042-1-0000000000000001.json",
+            "https://x/hook".into(),
+        );
+        std::fs::write(
+            spool.join("0000000000043-1-0000000000000002.json"),
+            b"not a spool entry",
+        )
+        .unwrap();
+
+        let before = now_ms();
+        let health = spool_health(&spool);
+        assert_eq!(health.pending, 2);
+        assert_eq!(health.retries_total, 0);
+        let oldest = health
+            .oldest_age_ms
+            .expect("non-empty spool reports an age");
+        assert!(
+            oldest >= before.saturating_sub(42),
+            "oldest name parses to 42ms, age {oldest}ms"
+        );
+    }
+
+    #[test]
+    fn created_ms_from_name_handles_malformed_names() {
+        assert_eq!(
+            created_ms_from_name("0000000000042-1-0000000000000001.json"),
+            42
+        );
+        assert_eq!(created_ms_from_name("garbage.json"), 0);
     }
 }

--- a/crates/ai-memory-cli/src/commands/hook_spool.rs
+++ b/crates/ai-memory-cli/src/commands/hook_spool.rs
@@ -124,25 +124,44 @@ pub struct SpoolHealth {
 /// command, never on the hook hot path).
 #[must_use]
 pub fn spool_health(spool: &Path) -> SpoolHealth {
-    let Some(mut files) = list_entries(spool) else {
+    let Some(files) = list_entries(spool) else {
         return SpoolHealth::default();
     };
     if files.is_empty() {
         return SpoolHealth::default();
     }
+    // Keep only files whose *names* follow the spool convention. A stray
+    // `.json` that this queue did not write is not a pending hook event, and
+    // letting one drive the age is actively misleading: an unparseable name
+    // reads as `created_ms = 0`, so the oldest age becomes the whole Unix
+    // epoch — roughly 56 years of phantom backlog on a status screen whose
+    // entire job is telling an operator whether capture is keeping up.
+    //
+    // Not hypothetical on macOS: writing to a filesystem without extended
+    // attributes (FAT, SMB, some NFS) leaves AppleDouble sidecars named
+    // `._<original>`, which end in `.json` and sort before any digit.
+    let mut files: Vec<(u64, PathBuf)> = files
+        .into_iter()
+        .filter_map(|path| {
+            let created = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .and_then(created_ms_from_name)?;
+            Some((created, path))
+        })
+        .collect();
+    if files.is_empty() {
+        return SpoolHealth::default();
+    }
     files.sort();
     let now = now_ms();
-    let oldest_created = files[0]
-        .file_name()
-        .and_then(|name| name.to_str())
-        .map(created_ms_from_name)
-        .unwrap_or(0);
+    let oldest_created = files[0].0;
     let mut health = SpoolHealth {
         pending: files.len(),
         oldest_age_ms: Some(now.saturating_sub(oldest_created)),
         retries_total: 0,
     };
-    for path in &files {
+    for (_, path) in &files {
         if let Ok(bytes) = std::fs::read(path)
             && let Ok(entry) = serde_json::from_slice::<SpoolEntry>(&bytes)
         {
@@ -153,16 +172,25 @@ pub fn spool_health(spool: &Path) -> SpoolHealth {
 }
 
 /// Extract the enqueue timestamp embedded in a spool file name
-/// (`{created_ms:013}-{pid}-{seq:016x}.json`), 0 when unparseable. Filenames
-/// are the only place `created_ms` is readable without opening the file, so
-/// oldest-age reporting never pays a read per queued event.
-fn created_ms_from_name(file_name: &str) -> u64 {
-    file_name
-        .split('-')
-        .next()
-        .unwrap_or(file_name)
-        .parse()
-        .unwrap_or(0)
+/// (`{created_ms:013}-{pid}-{seq:016x}.json`), `None` when the name does not
+/// follow that convention. Filenames are the only place `created_ms` is
+/// readable without opening the file, so oldest-age reporting never pays a
+/// read per queued event.
+///
+/// Returns `None` rather than `0` so a foreign file cannot be mistaken for an
+/// entry enqueued at the Unix epoch — see [`spool_health`].
+fn created_ms_from_name(file_name: &str) -> Option<u64> {
+    let (stamp, rest) = file_name.split_once('-')?;
+    // Require the full zero-padded width the writer emits, so a name that
+    // merely *starts* with digits is not accepted.
+    if stamp.len() != 13 || !stamp.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    // And require the remainder to look like `{pid}-{seq}.json`.
+    if !rest.ends_with(".json") || !rest.contains('-') {
+        return None;
+    }
+    stamp.parse().ok()
 }
 
 fn now_ms() -> u64 {
@@ -2199,8 +2227,51 @@ mod tests {
     fn created_ms_from_name_handles_malformed_names() {
         assert_eq!(
             created_ms_from_name("0000000000042-1-0000000000000001.json"),
-            42
+            Some(42)
         );
-        assert_eq!(created_ms_from_name("garbage.json"), 0);
+        assert_eq!(created_ms_from_name("garbage.json"), None);
+        // A macOS AppleDouble sidecar: ends in `.json`, sorts before any
+        // digit, and must never be read as an epoch-0 entry.
+        assert_eq!(created_ms_from_name("._0000000000042-1-0002.json"), None);
+        // Digits alone are not enough — the writer zero-pads to 13.
+        assert_eq!(created_ms_from_name("42-1-0002.json"), None);
+        assert_eq!(created_ms_from_name("0000000000042-1-0002.txt"), None);
+    }
+
+    /// Regression: a foreign `.json` in the spool directory must not be
+    /// counted as a pending event, and must never drive the oldest age.
+    /// Before this guard an AppleDouble sidecar parsed as `created_ms = 0`
+    /// and reported roughly 56 years of backlog that did not exist.
+    #[test]
+    fn spool_health_ignores_files_this_queue_did_not_write() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        std::fs::create_dir_all(&spool).unwrap();
+
+        let mut real = entry_for("https://x/hook".into(), "{}".into(), None, false);
+        real.created_ms = now_ms().saturating_sub(1_000);
+        enqueue(&spool, &real).unwrap();
+
+        // Sorts before any digit and still ends in `.json`.
+        std::fs::write(spool.join("._sidecar.json"), b"\x00\x05").unwrap();
+        std::fs::write(spool.join("notes.json"), b"{}").unwrap();
+
+        let health = spool_health(&spool);
+        assert_eq!(health.pending, 1, "only the real entry is pending");
+        let age = health.oldest_age_ms.expect("one real entry");
+        assert!(
+            age < 60_000,
+            "age must come from the real entry (~1s), got {age}ms"
+        );
+    }
+
+    /// A directory holding only foreign files reports empty, not epoch-aged.
+    #[test]
+    fn spool_health_is_default_when_only_foreign_files_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        std::fs::create_dir_all(&spool).unwrap();
+        std::fs::write(spool.join("._only.json"), b"x").unwrap();
+        assert_eq!(spool_health(&spool), SpoolHealth::default());
     }
 }

--- a/crates/ai-memory-cli/src/commands/status.rs
+++ b/crates/ai-memory-cli/src/commands/status.rs
@@ -8,7 +8,7 @@ use ai_memory_llm::{ProviderHealthSnapshot, ProviderHealthStatus, ProviderRoleHe
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use super::hook_spool::{spool_dir, spool_health};
+use super::hook_spool::{SpoolHealth, spool_dir, spool_health};
 use crate::cli::StatusArgs;
 use crate::config::Config;
 use crate::http_client::{ServerEndpoint, get_json};
@@ -67,12 +67,54 @@ struct EmbeddingTriple {
 /// Run the `status` subcommand.
 ///
 /// # Errors
+/// Print local spool state when the server could not be reached.
+///
+/// Goes to stderr so it cannot corrupt `--json` consumers, which expect a
+/// single object on stdout and get a non-zero exit here anyway. The
+/// unreachable-server error still propagates unchanged; this only adds the
+/// local half of the picture that the caller can actually act on.
+fn report_offline_spool(spool: &SpoolHealth, json: bool) {
+    if json {
+        if let Ok(rendered) = serde_json::to_string(spool) {
+            eprintln!("local spool (server unreachable): {rendered}");
+        }
+        return;
+    }
+    eprintln!("local spool (server unreachable):");
+    eprintln!("  pending:    {}", spool.pending);
+    eprintln!("  oldest:     {}", spool_age_line(spool.oldest_age_ms));
+    eprintln!("  retries:    {}", spool.retries_total);
+    if spool.pending > 0 {
+        eprintln!(
+            "  {} event(s) are queued locally and will be delivered once the \
+             server is reachable again.",
+            spool.pending
+        );
+    }
+}
+
 /// Returns an error if the server is unreachable, returns non-2xx, or
 /// the response can't be parsed.
 pub async fn run(config: &Config, args: StatusArgs) -> Result<()> {
     let ep = ServerEndpoint::from_config_resolving_auth(config).await;
-    let report: Report = get_json(&ep, "/admin/status", &[]).await?;
+
+    // Read the spool BEFORE contacting the server, and surface it even when
+    // that call fails.
+    //
+    // The spool exists to buffer hook events while the server is
+    // unreachable, so "how much is queued locally?" is most worth answering
+    // precisely when the server is down. Computing it after `get_json` meant
+    // the one question this section exists for could not be asked in the one
+    // situation that prompts it.
     let spool = spool_health(&spool_dir(&config.data_dir));
+
+    let report: Report = match get_json::<Report>(&ep, "/admin/status", &[]).await {
+        Ok(report) => report,
+        Err(err) => {
+            report_offline_spool(&spool, args.json);
+            return Err(err);
+        }
+    };
 
     if args.json {
         println!(
@@ -218,6 +260,34 @@ fn error_detail(role: &ProviderRoleHealthSnapshot) -> String {
 mod tests {
     use super::*;
     use jiff::Timestamp;
+
+    /// The offline path must be readable and, critically, must not write the
+    /// spool object to stdout in `--json` mode: consumers there expect one
+    /// object and this call exits non-zero anyway.
+    #[test]
+    fn offline_spool_report_is_content_free_and_serialises() {
+        let spool = SpoolHealth {
+            pending: 2,
+            oldest_age_ms: Some(900_000),
+            retries_total: 4,
+        };
+        let rendered = serde_json::to_string(&spool).expect("SpoolHealth serialises");
+        assert_eq!(
+            rendered,
+            r#"{"pending":2,"oldest_age_ms":900000,"retries_total":4}"#
+        );
+        // The shape is the contract: counts and ages only. If a field
+        // carrying captured text is ever added, this fails loudly.
+        let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        let keys: Vec<_> = value.as_object().unwrap().keys().cloned().collect();
+        assert_eq!(keys, vec!["pending", "oldest_age_ms", "retries_total"]);
+
+        // Both render paths must tolerate an empty spool.
+        report_offline_spool(&SpoolHealth::default(), false);
+        report_offline_spool(&SpoolHealth::default(), true);
+        report_offline_spool(&spool, false);
+        report_offline_spool(&spool, true);
+    }
 
     #[test]
     fn provider_health_line_renders_unknown_and_disabled() {

--- a/crates/ai-memory-cli/src/commands/status.rs
+++ b/crates/ai-memory-cli/src/commands/status.rs
@@ -8,6 +8,7 @@ use ai_memory_llm::{ProviderHealthSnapshot, ProviderHealthStatus, ProviderRoleHe
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
+use super::hook_spool::{spool_dir, spool_health};
 use crate::cli::StatusArgs;
 use crate::config::Config;
 use crate::http_client::{ServerEndpoint, get_json};
@@ -71,6 +72,7 @@ struct EmbeddingTriple {
 pub async fn run(config: &Config, args: StatusArgs) -> Result<()> {
     let ep = ServerEndpoint::from_config_resolving_auth(config).await;
     let report: Report = get_json(&ep, "/admin/status", &[]).await?;
+    let spool = spool_health(&spool_dir(&config.data_dir));
 
     if args.json {
         println!(
@@ -88,6 +90,7 @@ pub async fn run(config: &Config, args: StatusArgs) -> Result<()> {
                 },
                 "derived": report.derived,
                 "providers": report.providers,
+                "spool": spool,
                 "client": { "server_url": ep.url, "auth": ep.auth_token.is_some() },
             }))?
         );
@@ -120,6 +123,10 @@ pub async fn run(config: &Config, args: StatusArgs) -> Result<()> {
             report.derived.unresolved_links_from_latest_pages,
             report.derived.stale_links_from_latest_pages
         );
+        println!("  spool:");
+        println!("    pending:    {}", spool.pending);
+        println!("    oldest:     {}", spool_age_line(spool.oldest_age_ms));
+        println!("    retries:    {}", spool.retries_total);
         println!("  providers:");
         println!(
             "    llm:       {}",
@@ -136,6 +143,25 @@ pub async fn run(config: &Config, args: StatusArgs) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Render a spool age (ms) as a compact human duration, or `-` when the spool
+/// holds no events. Allowed to saturate: an operator reading a stuck-spool
+/// diagnosis wants the magnitude, not sub-second precision.
+fn spool_age_line(age_ms: Option<u64>) -> String {
+    let Some(ms) = age_ms else {
+        return "-".to_string();
+    };
+    let secs = ms / 1000;
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m {}s", secs / 60, secs % 60)
+    } else if secs < 86_400 {
+        format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+    } else {
+        format!("{}d {}h", secs / 86_400, (secs % 86_400) / 3600)
+    }
 }
 
 fn provider_health_line(role: &ProviderRoleHealthSnapshot) -> String {
@@ -228,5 +254,15 @@ mod tests {
         assert!(provider_health_line(&role).contains("anthropic-oauth/claude-sonnet-4-6 error"));
         assert!(provider_health_line(&role).contains("status 401"));
         assert!(provider_health_line(&role).contains("bad token"));
+    }
+
+    #[test]
+    fn spool_age_line_renders_durations_and_empty() {
+        assert_eq!(spool_age_line(None), "-");
+        assert_eq!(spool_age_line(Some(0)), "0s");
+        assert_eq!(spool_age_line(Some(59_999)), "59s");
+        assert_eq!(spool_age_line(Some(60_000)), "1m 0s");
+        assert_eq!(spool_age_line(Some(3_661_000)), "1h 1m");
+        assert_eq!(spool_age_line(Some(172_800_000)), "2d 0h");
     }
 }


### PR DESCRIPTION
Carries rekcilyssup's commit from #438 verbatim, plus two maintainer commits. Implements the spool-side half of #428.

## Their change
`ai-memory status` gains a spool section: pending count, oldest queued age, and total failed attempts — so "capture is delayed, not broken" is visible without reading logs.

Three things verified and clean:
- **Content-free by construction.** `SpoolHealth` holds `pending: usize`, `oldest_age_ms: Option<u64>`, `retries_total: u64` — it cannot carry payloads, and a doc comment says so.
- **Off the hot path.** Called only from `status.rs`; age comes from filenames, so no read per event just to report age.
- **Reuses `spool_dir` / `list_entries`** rather than inventing path logic.

## Maintainer fix 1: foreign files skewed the numbers

`created_ms_from_name` returned `0` for any unparseable name, fed straight into `now - created`. A `.json` the spool did not write counted as pending and, if it sorted first, reported the entire Unix epoch.

Not hypothetical: macOS writes AppleDouble sidecars (`._<original>`) on filesystems without extended attributes (FAT, SMB, some NFS) — they end in `.json` and sort before any digit. Measured before the fix, a one-second-old real entry plus one sidecar gave:

```
pending=2  oldest_age_ms=1787181461533   (20,684 days ≈ 56 years)
```

On a screen whose only job is telling an operator whether capture is keeping up, that reads as catastrophic backlog that does not exist. Entries are now filtered by the writer's own naming convention and the parser returns `Option`.

## Maintainer fix 2: it was silent exactly when it mattered

`run` fetched `/admin/status` before computing spool health, so an unreachable server returned early and the section never printed. The spool exists to buffer while the server is down — so the one question it answers could not be asked in the one situation that prompts it.

Now read before the server call and printed on the error path, with the original error propagating unchanged. Output goes to stderr so `--json` consumers still get a single object on stdout.

Verified with no server listening, two queued events and one foreign file:

```
local spool (server unreachable):
  pending:    2
  oldest:     15m 0s
  retries:    4
  2 event(s) are queued locally and will be delivered once the server is reachable again.
```

## Verification
Both new spool tests fail against the original parser and pass here; the contributor's three original tests are unchanged and still pass. `cargo fmt --check`, `cargo clippy --all-targets --all-features` under `-D warnings`, `cargo test --workspace` → **2494 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)