### PR TITLE
ci: move Windows tests off the pull-request critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,24 +50,14 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo test --workspace --all-targets
 
-  # Native Windows is where the `#[cfg(windows)]` regression tests (drain
-  # lock ERROR_LOCK_VIOLATION, libgit2 path-resolution fallback, verbatim
-  # path handling) actually run — the test matrix above never compiles
-  # them. Observability only for now (`continue-on-error`): a Windows
-  # runner-environment quirk must not block Linux/macOS merges, but the
-  # results are visible on every push so Windows-only breakage is caught
-  # in review instead of by end users.
-  test-windows:
-    name: test (windows-latest, non-gating)
-    runs-on: windows-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - run: cargo test --workspace --all-targets
-        env:
-          TAILWIND_SKIP: "1"
+  # Native Windows coverage lives in `.github/workflows/windows.yml`: it
+  # runs on every push to main, nightly, on demand, and on any pull request
+  # carrying the `windows` label. It was ~1000s here against ~250s for the
+  # same tests on Linux, which meant every pull request waited roughly
+  # seventeen minutes when every gating job below finishes in about eight —
+  # and it was `continue-on-error`, so those extra minutes gated nothing.
+  # Add the `windows` label to a pull request that touches path handling,
+  # file locking, or git plumbing.
 
   # The companion importer is deliberately outside the root workspace
   # (its own [workspace] in companions/ai-memory-importer/Cargo.toml), so

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,71 @@
+name: windows
+
+# Native Windows is where the `#[cfg(windows)]` regression tests actually
+# run — drain-lock ERROR_LOCK_VIOLATION, the libgit2 path-resolution
+# fallback, verbatim path handling. The Linux/macOS matrix in `ci.yml`
+# never compiles them, so this coverage is not optional.
+#
+# It lives outside `ci.yml` because of what it costs there, not because it
+# matters less. A Windows run takes ~1000s against ~250s for the same tests
+# on Linux (slower linking, and a cache restore that is ~10x slower over
+# many small files). Every gating job in `ci.yml` finishes in about eight
+# minutes; leaving Windows in that workflow made every pull request wait
+# roughly seventeen, with the last eight spent on a job that was marked
+# `continue-on-error` and therefore blocked nothing. Linux and macOS are
+# the priority platforms and now set the pull-request feedback time.
+#
+# Moving it here makes the coverage *stronger*, not weaker:
+#
+#   * it runs on every push to `main`, so every merge is checked;
+#   * it no longer carries `continue-on-error`, so a real Windows break is
+#     a red run instead of a yellow one nobody reads. It cannot block a
+#     Linux/macOS merge from here, which was the original reason for the
+#     override;
+#   * a nightly run catches toolchain and dependency drift that no code
+#     change would trigger;
+#   * `workflow_dispatch` and the `windows` label give a pull request that
+#     touches platform-sensitive code — path handling, file locking, git
+#     plumbing — a way to opt in *before* merging.
+#
+# If you are changing any of those areas, add the `windows` label to the
+# pull request rather than finding out after the merge.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  schedule:
+    # 04:23 UTC daily. Off the hour, and away from nix.yml's Monday slot.
+    - cron: '23 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # A newer push supersedes an in-flight run for the same ref. Nothing
+  # downstream consumes this job's result, so cancelling is safe and keeps
+  # the Windows runner queue short.
+  group: windows-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  test:
+    name: test (windows-latest)
+    # On a pull request, only when explicitly opted in. Pushes to main,
+    # the schedule, and manual dispatch always run.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'windows')
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - run: cargo test --workspace --all-targets
+        env:
+          TAILWIND_SKIP: "1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,9 +221,17 @@ cargo deny check                                          # dependency policy (i
   `tests/e2e/handoff_smoke.sh`, `scripts/check-native-packaging.sh`.
 - CI additionally runs `cargo build --release --bin ai-memory` on
   Linux/macOS, a Docker image smoke test, `cargo audit` (with the ignores
-  listed in `ci.yml`), differential gitleaks scanning, and a non-gating
-  Windows test job. `.github/workflows/secret-scan.yml` runs the separate
-  weekly/manual full-history gitleaks scan.
+  listed in `ci.yml`), and differential gitleaks scanning.
+  `.github/workflows/secret-scan.yml` runs the separate weekly/manual
+  full-history gitleaks scan.
+- **Windows runs in its own workflow** (`.github/workflows/windows.yml`):
+  every push to `main`, nightly, on demand, and on any PR labelled
+  `windows`. It is the only place `#[cfg(windows)]` tests compile, and it
+  is ~4x slower than the same tests on Linux — keeping it out of `ci.yml`
+  is what holds PR feedback near the eight minutes the gating jobs take.
+  **Add the `windows` label** to a PR touching path handling, file
+  locking, or git plumbing, so the check runs before the merge rather
+  than after it.
 
 ## Code style guidelines
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Windows tests moved to their own workflow
+  (`.github/workflows/windows.yml`), running on every push to `main`,
+  nightly, on demand, and on any PR labelled `windows`. They were the
+  slowest job in `ci.yml` by a wide margin (~1000s against ~250s for the
+  same tests on Linux) while carrying `continue-on-error`, so every pull
+  request waited roughly seventeen minutes for a job that gated nothing
+  when all gating jobs finished in about eight. Coverage is now stronger,
+  not weaker: `continue-on-error` is gone, so a genuine Windows break shows
+  as a failed run on `main` instead of a yellow mark on a PR, and the
+  nightly run catches toolchain or dependency drift that no code change
+  would trigger.
 - `ai-memory status` now reports local hook-spool health: pending event
   count, age of the oldest queued event, and total failed-delivery attempts.
   This makes "memory capture is delayed, not broken" visible to an operator


### PR DESCRIPTION
Measured from real runs on `main`, not estimated.

## The problem

Recent `ci.yml` runs took **15–17 minutes**. Here is where that went on run `32302601048`:

| job | time | gating? |
|---|---|---|
| **test (windows, non-gating)** | **1002s** | **no** |
| cargo build --release (macos-x86_64) | 486s | yes |
| test (macos) | 370s | yes |
| cargo build --release (macos-aarch64) | 310s | yes |
| test (ubuntu) | 268s | yes |
| cargo build --release (linux-x86_64) | 259s | yes |
| the other 9 jobs | 4–70s each | — |

The run took 1008s; Windows took 1002s. **Every gating job finished in about eight minutes, and the wall clock was set by a job marked `continue-on-error`.**

Step breakdown on Windows: 830s in `cargo test`, 153s restoring the cache — against 246s and 15s for the same steps on Linux. Slower linking, and a cache restore across many small files. Caching is already correct everywhere (`Swatinem/rust-cache` on all seven Rust-building jobs; the uncached ones are 4–20s and build no Rust), so this was never a cache problem — it was a scheduling one.

## The change

Windows moves to `.github/workflows/windows.yml`, running on:

- every **push to `main`** — every merge is still checked
- **nightly** — catches toolchain and dependency drift no code change would trigger
- **`workflow_dispatch`** — on demand
- any PR carrying the **`windows` label** — opt in before merging a platform-sensitive change

**`continue-on-error` is removed.** It existed so a Windows runner quirk could not block a Linux/macOS merge; from a main-and-schedule workflow it cannot block one regardless, so a genuine break now shows as a failed run rather than a yellow mark nobody reads. That is stricter than before, not looser.

Expected effect: PR feedback drops from ~17 minutes to ~8, bounded now by the macOS release build. No test is removed and no platform loses coverage.

## Checked before removing the job

`main` has **no branch protection and no rulesets** (`required_status_checks` → 404, `rulesets` → `[]`), so dropping the `test (windows-latest, non-gating)` context strands no required check and cannot leave PRs waiting on a status that will never report.

## Not included

I left the three `cargo build --release` jobs on pull requests. They are 1055s of runner time and deferring them would save another ~2 minutes, but the Linux and macOS binaries are the priority platforms here and that trade is not obviously worth it. The big win is above; this one can be revisited if eight minutes still feels long.

`AGENTS.md` documents the label so the check is requested deliberately rather than remembered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)