### PR TITLE
feat(cli): show local hook-spool backlog in status

### DIFF
--- a/crates/ai-memory-cli/src/commands/hook_spool.rs
+++ b/crates/ai-memory-cli/src/commands/hook_spool.rs
@@ -103,6 +103,37 @@ pub fn spool_len(spool: &Path) -> usize {
     list_entries(spool).map_or(0, |f| f.len())
 }
 
+/// Enqueue time of the oldest queued spool entry, or `None` when the spool is
+/// missing/empty. Derived solely from the Unix-ms prefix baked into each file
+/// name at [`enqueue`] time — the same zero-padded ordering key [`drain`] sorts
+/// on — so it never opens a spool file. That keeps status telemetry off the
+/// captured payload entirely (a spool body must never surface in status output)
+/// and makes the scan pure metadata: one `read_dir`, no deserialization.
+///
+/// A `.json` file whose name has no parseable millisecond prefix (i.e. one
+/// [`enqueue`] never wrote) has no usable age, so it is skipped here even though
+/// [`spool_len`] still counts it — an unrelated file can make `pending` and the
+/// oldest age disagree, matching `spool_len`'s existing count-every-`*.json`
+/// policy rather than inventing a stricter one.
+#[must_use]
+pub fn oldest_spool_entry_time(spool: &Path) -> Option<SystemTime> {
+    let oldest_ms = list_entries(spool)?
+        .iter()
+        .filter_map(|path| entry_created_ms_from_name(path))
+        .min()?;
+    Some(UNIX_EPOCH + Duration::from_millis(oldest_ms))
+}
+
+/// Parse the leading Unix-ms `created_ms` field from a spool file name
+/// (`<ms>-<pid>-<seq>.json`). Returns `None` for any name that field is absent
+/// or non-numeric in, so a stray file can never poison the oldest-age scan.
+fn entry_created_ms_from_name(path: &Path) -> Option<u64> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.split('-').next())
+        .and_then(|prefix| prefix.parse::<u64>().ok())
+}
+
 fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -865,6 +896,70 @@ mod tests {
 
         assert_eq!(static_bearer.as_deref(), Some("static-token"));
         assert!(absent_bearer.is_none());
+    }
+
+    /// Enqueue an entry whose `created_ms` (and therefore file-name prefix) is
+    /// fixed, so oldest-selection tests are deterministic without sleeps.
+    fn enqueue_at(spool: &Path, created_ms: u64) {
+        let mut entry = entry_for("https://x/hook?event=stop".into(), "{}".into(), None, false);
+        entry.created_ms = created_ms;
+        enqueue(spool, &entry).unwrap();
+    }
+
+    #[test]
+    fn oldest_spool_entry_time_none_when_empty_or_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Directory never created — behaves like an empty spool, no error.
+        assert!(oldest_spool_entry_time(&spool_dir(tmp.path())).is_none());
+
+        let spool = spool_dir(tmp.path());
+        create_spool_dir(&spool).unwrap();
+        assert!(oldest_spool_entry_time(&spool).is_none());
+    }
+
+    #[test]
+    fn oldest_spool_entry_time_matches_single_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        enqueue_at(&spool, 1_700_000_000_000);
+
+        assert_eq!(spool_len(&spool), 1);
+        assert_eq!(
+            oldest_spool_entry_time(&spool),
+            Some(UNIX_EPOCH + Duration::from_millis(1_700_000_000_000)),
+        );
+    }
+
+    #[test]
+    fn oldest_spool_entry_time_selects_earliest_regardless_of_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        // Enqueued newest-first so the answer can't come from enumeration order.
+        enqueue_at(&spool, 3_000);
+        enqueue_at(&spool, 1_000); // oldest
+        enqueue_at(&spool, 2_000);
+
+        assert_eq!(spool_len(&spool), 3);
+        assert_eq!(
+            oldest_spool_entry_time(&spool),
+            Some(UNIX_EPOCH + Duration::from_millis(1_000)),
+        );
+    }
+
+    #[test]
+    fn oldest_spool_entry_time_skips_unparseable_name_without_panicking() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spool = spool_dir(tmp.path());
+        enqueue_at(&spool, 5_000);
+        // A stray `.json` with no numeric prefix: counted by spool_len, but it
+        // has no usable timestamp, so the oldest age still reflects the real entry.
+        std::fs::write(spool.join("not-a-spool-entry.json"), b"{}").unwrap();
+
+        assert_eq!(spool_len(&spool), 2);
+        assert_eq!(
+            oldest_spool_entry_time(&spool),
+            Some(UNIX_EPOCH + Duration::from_millis(5_000)),
+        );
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/status.rs
+++ b/crates/ai-memory-cli/src/commands/status.rs
@@ -4,10 +4,14 @@
 //! server; renders the response as human text or JSON. Never opens
 //! the store directly — the server is the source of truth.
 
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
 use ai_memory_llm::{ProviderHealthSnapshot, ProviderHealthStatus, ProviderRoleHealthSnapshot};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
+use super::hook_spool;
 use crate::cli::StatusArgs;
 use crate::config::Config;
 use crate::http_client::{ServerEndpoint, get_json};
@@ -72,6 +76,10 @@ pub async fn run(config: &Config, args: StatusArgs) -> Result<()> {
     let ep = ServerEndpoint::from_config_resolving_auth(config).await;
     let report: Report = get_json(&ep, "/admin/status", &[]).await?;
 
+    // Local hook-spool health is read from the client-side data dir (the spool
+    // is always local, unlike the server-reported paths above). Metadata only.
+    let spool = SpoolHealth::gather(&config.data_dir);
+
     if args.json {
         println!(
             "{}",
@@ -88,6 +96,10 @@ pub async fn run(config: &Config, args: StatusArgs) -> Result<()> {
                 },
                 "derived": report.derived,
                 "providers": report.providers,
+                "hook_spool": {
+                    "pending": spool.pending,
+                    "oldest_age_secs": spool.oldest_age.map(|age| age.as_secs()),
+                },
                 "client": { "server_url": ep.url, "auth": ep.auth_token.is_some() },
             }))?
         );
@@ -134,8 +146,65 @@ pub async fn run(config: &Config, args: StatusArgs) -> Result<()> {
         {
             println!("    retry:     {hint}");
         }
+        println!("  hook spool:");
+        println!("    pending:        {}", spool.pending);
+        println!("    oldest pending: {}", spool.oldest_display());
     }
     Ok(())
+}
+
+/// Local hook-spool backlog for status output: how many captured events are
+/// still queued on this machine and how long the oldest has waited. Only the
+/// count and age are ever exposed — the spool bodies (prompts, tool payloads,
+/// captured observations) are never opened, per the status privacy rule.
+struct SpoolHealth {
+    /// Events currently queued in the local spool.
+    pending: usize,
+    /// Wall-clock age of the oldest queued event, or `None` when the spool is
+    /// empty. Saturates to zero if the entry's timestamp is in the future
+    /// (clock skew), so status never reports a negative age.
+    oldest_age: Option<Duration>,
+}
+
+impl SpoolHealth {
+    /// Read the local spool metadata. Degrades to an empty backlog when the
+    /// spool directory is missing/unreadable — status must stay useful (and
+    /// never panic) when one component can't be read.
+    fn gather(data_dir: &Path) -> Self {
+        let spool = hook_spool::spool_dir(data_dir);
+        let pending = hook_spool::spool_len(&spool);
+        let oldest_age = hook_spool::oldest_spool_entry_time(&spool).map(|created| {
+            SystemTime::now()
+                .duration_since(created)
+                .unwrap_or_default()
+        });
+        Self {
+            pending,
+            oldest_age,
+        }
+    }
+
+    /// Human-readable oldest-pending age, or `none` when the spool is empty.
+    fn oldest_display(&self) -> String {
+        self.oldest_age
+            .map_or_else(|| "none".to_string(), format_age)
+    }
+}
+
+/// Render a backlog age as a compact `3s` / `2m` / `1h` / `4d` string, matching
+/// the terse style of the surrounding status lines. Coarsens to the largest
+/// whole unit; sub-second ages read as `0s`.
+fn format_age(age: Duration) -> String {
+    let secs = age.as_secs();
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 60 * 60 {
+        format!("{}m", secs / 60)
+    } else if secs < 24 * 60 * 60 {
+        format!("{}h", secs / (60 * 60))
+    } else {
+        format!("{}d", secs / (24 * 60 * 60))
+    }
 }
 
 fn provider_health_line(role: &ProviderRoleHealthSnapshot) -> String {
@@ -192,6 +261,76 @@ fn error_detail(role: &ProviderRoleHealthSnapshot) -> String {
 mod tests {
     use super::*;
     use jiff::Timestamp;
+
+    fn enqueue_at(data_dir: &Path, created_ms: u64) {
+        let spool = hook_spool::spool_dir(data_dir);
+        let mut entry =
+            hook_spool::entry_for("https://x/hook?event=stop".into(), "{}".into(), None, false);
+        entry.created_ms = created_ms;
+        hook_spool::enqueue(&spool, &entry).unwrap();
+    }
+
+    #[test]
+    fn format_age_coarsens_to_largest_whole_unit() {
+        assert_eq!(format_age(Duration::from_millis(400)), "0s");
+        assert_eq!(format_age(Duration::from_secs(8)), "8s");
+        assert_eq!(format_age(Duration::from_secs(59)), "59s");
+        assert_eq!(format_age(Duration::from_secs(60)), "1m");
+        assert_eq!(format_age(Duration::from_secs(3599)), "59m");
+        assert_eq!(format_age(Duration::from_secs(3600)), "1h");
+        assert_eq!(format_age(Duration::from_secs(24 * 3600)), "1d");
+    }
+
+    #[test]
+    fn spool_health_empty_spool_reports_zero_and_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let health = SpoolHealth::gather(tmp.path());
+        assert_eq!(health.pending, 0);
+        assert!(health.oldest_age.is_none());
+        assert_eq!(health.oldest_display(), "none");
+    }
+
+    #[test]
+    fn spool_health_counts_pending_and_ages_oldest() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Two entries; the older is well in the past so its age is non-trivial
+        // and its display is a real duration rather than `none`.
+        let now_ms = u64::try_from(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+        enqueue_at(tmp.path(), now_ms - 5_000);
+        enqueue_at(tmp.path(), now_ms - 90_000); // oldest → ~90s
+
+        let health = SpoolHealth::gather(tmp.path());
+        assert_eq!(health.pending, 2);
+        let age = health.oldest_age.expect("oldest age present");
+        assert!(age.as_secs() >= 90, "age tracks the oldest entry: {age:?}");
+        assert_eq!(health.oldest_display(), format_age(age));
+    }
+
+    #[test]
+    fn spool_health_future_timestamp_saturates_to_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        let now_ms = u64::try_from(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+        // Clock skew: a timestamp far in the future must not yield a negative
+        // age or panic.
+        enqueue_at(tmp.path(), now_ms + 10 * 60 * 1000);
+
+        let health = SpoolHealth::gather(tmp.path());
+        assert_eq!(health.pending, 1);
+        assert_eq!(health.oldest_age, Some(Duration::ZERO));
+        assert_eq!(health.oldest_display(), "0s");
+    }
 
     #[test]
     fn provider_health_line_renders_unknown_and_disabled() {


### PR DESCRIPTION
## Summary

Adds local hook-spool health information to `ai-memory status`.

The status command can now answer two useful questions:

* How many hook events are waiting in the local spool?
* How old is the oldest pending event?

This makes it easier to tell when capture is falling behind locally, even when the server itself still appears healthy.

## Output

Text output now includes a `hook spool` section:

```text
hook spool:
  pending:        12
  oldest pending: 8s
```

For an empty spool:

```text
hook spool:
  pending:        0
  oldest pending: none
```

JSON output also includes:

```json
{
  "hook_spool": {
    "pending": 12,
    "oldest_age_secs": 8
  }
}
```

`oldest_age_secs` is `null` when the spool is empty.

## Why

Before this change, `ai-memory status` mainly reported server-side state.

That meant the server could look healthy while hook events were accumulating in the local spool because of a slow or temporarily unreachable server.

There was no simple operator-visible signal showing that local capture was delayed.

This PR implements the spool-side part of the observability work discussed in the issue. Server-side ingestion and writer metrics are intentionally left for a separate design pass.

## Implementation

The implementation stays within the existing spool architecture:

* Reuses `hook_spool::spool_len()` for the pending event count.
* Adds `oldest_spool_entry_time()` to determine the oldest queued entry.
* Uses the timestamp already encoded in spool filenames rather than reading or deserializing event payloads.
* Computes and formats the age in the CLI as compact values such as `8s`, `2m`, `1h`, or `4d`.

The oldest entry is selected using the minimum timestamp, so filesystem enumeration order does not matter.

## Privacy

The new status information does not inspect or expose captured content.

It only uses:

* event count
* timestamp metadata
* calculated age

It does not read or print prompts, tool payloads, observations, spool contents, or spool filenames.

## Edge cases

The implementation handles:

* missing or empty spool directories as `pending: 0`
* no oldest entry as `oldest pending: none`
* multiple entries regardless of filesystem ordering
* malformed `.json` filenames without panicking
* timestamps in the future by saturating the reported age to `0s`

Malformed `.json` entries remain included in `spool_len()`, preserving its existing counting behavior, but are ignored when determining the oldest timestamp.

## Compatibility

This is observability-only.

It does not change:

* hook behavior
* spool format
* retry behavior
* server behavior
* ingestion backpressure
* SQLite writer behavior

## Tests

Added coverage for:

### `hook_spool.rs`

* empty/missing spool
* single entry
* oldest entry across multiple files
* malformed filename handling

### `status.rs`

* duration formatting boundaries
* empty spool output
* pending count and oldest age
* future timestamp handling

Tests use the existing production spool APIs with deterministic timestamps, so no sleeps are required.

## Files changed

* `crates/ai-memory-cli/src/commands/hook_spool.rs`
* `crates/ai-memory-cli/src/commands/status.rs`

## Out of scope

As discussed in the issue, this PR intentionally does not add server-side telemetry such as:

* accepted/rejected hook counters
* saturation counters
* writer queue depth
* retry metrics
* Prometheus/OpenTelemetry support
* new health endpoints

Those require a separate design pass.

Related #428 