### PR TITLE
fix(packaging): bump stale AUR PKGBUILD pkgver to 1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   *wants* one of them kept visible (for example a public bot id) can add it
   to `[sanitize].allowlist`.
 
+### Fixed
+- The AUR `PKGBUILD` (`packaging/aur/PKGBUILD`) still declared `pkgver=0.3.2`,
+  roughly a hundred releases behind the `1.28.0` that `Cargo.toml` and the
+  latest tag actually ship. Anyone building the AUR package as published
+  would fetch the `v0.3.2` source tarball instead of current `main`,
+  silently missing every feature and fix since. Bumped `pkgver` to `1.28.0`
+  to match the current release; `pkgrel` stays at `1` since this is a fresh
+  version bump, not a rebuild of the same upstream version.
+
 ## [1.28.0] - 2026-08-17
 
 ### Fixed

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: AkitaOnRails <boss@akitaonrails.com>
 
 pkgname=ai-memory
-pkgver=0.3.2
+pkgver=1.28.0
 pkgrel=1
 pkgdesc="Local-first long-term memory MCP server for AI coding agents"
 arch=('x86_64' 'aarch64')


### PR DESCRIPTION
## What
The AUR `PKGBUILD` (`packaging/aur/PKGBUILD`) still declared `pkgver=0.3.2`, roughly a hundred releases behind the `1.28.0` that `Cargo.toml`, `CHANGELOG.md`, and the latest git tag actually ship.

## Why it matters
Anyone building the AUR package as currently published would fetch the `v0.3.2` source tarball instead of anything close to current `main`, silently missing every feature and fix shipped since — including behavior, security, and dependency changes.

## Change
- Bump `pkgver` 0.3.2 → 1.28.0 in `packaging/aur/PKGBUILD` (`pkgrel` stays at `1` since this is a version bump, not a rebuild of the same upstream release).
- Add a `### Fixed` entry under `[Unreleased]` in `CHANGELOG.md`, per CONTRIBUTING.md's merge-gate requirement for user-facing/observable fixes.

## Checks
This only touches packaging metadata and the changelog, no Rust source, so `cargo fmt`, `cargo clippy`, and `cargo test` are unaffected.
