### PR TITLE
feat(install-hooks): add Claude prompt capture opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `install-hooks --agent claude-code --no-capture-prompts` can now omit
+  ai-memory's `UserPromptSubmit` hook, preventing prompt text from entering the
+  local spool or wire while leaving session, tool, compaction, and handoff
+  capture active. Re-applying or upgrading preserves the opt-out, third-party
+  hooks under the same event survive, and `--capture-prompts` explicitly
+  enables prompt capture again. Other agents reject both flags because some
+  depend on their prompt hook to inject handoff context. (#446)
 - Windows tests moved to their own workflow
   (`.github/workflows/windows.yml`), running on every push to `main`,
   nightly, on demand, and on any PR labelled `windows`. They were the

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -1629,6 +1629,16 @@ pub struct InstallHooksArgs {
     /// without this flag removes it (idempotent). Default off.
     #[arg(long)]
     pub capture_assistant: bool,
+    /// Do not install Claude Code's `UserPromptSubmit` capture hook. Prompt
+    /// text is then excluded before it can enter the local spool or wire.
+    /// A bare `--apply` re-run preserves an existing opt-out; use
+    /// `--capture-prompts` to enable prompt capture again explicitly.
+    #[arg(long, conflicts_with = "capture_prompts")]
+    pub no_capture_prompts: bool,
+    /// Explicitly enable Claude Code prompt capture after an earlier
+    /// `--no-capture-prompts` install. Only valid for Claude Code.
+    #[arg(long, conflicts_with = "no_capture_prompts")]
+    pub capture_prompts: bool,
     /// Profile to use for OMP extensions, which relocates the path to
     /// `~/.omp/profiles/<profile>/agent/extensions/`.
     #[arg(long)]
@@ -2417,6 +2427,48 @@ mod tests {
         assert_eq!(
             args.project_strategy.and_then(ProjectStrategyArg::baked),
             Some("repo-root")
+        );
+    }
+
+    #[test]
+    fn install_hooks_prompt_capture_flags_parse_and_conflict() {
+        let disabled = Cli::try_parse_from([
+            "ai-memory",
+            "install-hooks",
+            "--agent",
+            "claude-code",
+            "--no-capture-prompts",
+        ])
+        .expect("--no-capture-prompts parses");
+        let Command::InstallHooks(disabled) = disabled.command else {
+            panic!("expected install-hooks command");
+        };
+        assert!(disabled.no_capture_prompts);
+        assert!(!disabled.capture_prompts);
+
+        let enabled = Cli::try_parse_from([
+            "ai-memory",
+            "install-hooks",
+            "--agent",
+            "claude-code",
+            "--capture-prompts",
+        ])
+        .expect("--capture-prompts parses");
+        let Command::InstallHooks(enabled) = enabled.command else {
+            panic!("expected install-hooks command");
+        };
+        assert!(!enabled.no_capture_prompts);
+        assert!(enabled.capture_prompts);
+
+        assert!(
+            Cli::try_parse_from([
+                "ai-memory",
+                "install-hooks",
+                "--no-capture-prompts",
+                "--capture-prompts",
+            ])
+            .is_err(),
+            "the two prompt-capture choices must conflict"
         );
     }
 

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -35,6 +35,8 @@ use crate::commands::render_shared::{
 };
 use crate::config::{Config, DEFAULT_SERVER_URL};
 
+const CLAUDE_PROMPT_EVENT: &str = "UserPromptSubmit";
+
 /// Claude Code's settings file — hooks live under `hooks`.
 /// `$CLAUDE_CONFIG_DIR/settings.json` when the var is set, else
 /// `~/.claude/settings.json`.
@@ -355,6 +357,15 @@ pub fn run(config: &Config, mut args: InstallHooksArgs) -> Result<()> {
              switch to a native Claude Code install."
         );
     }
+    if (args.no_capture_prompts || args.capture_prompts)
+        && !prompt_capture_options_allowed(args.agent)
+    {
+        anyhow::bail!(
+            "--no-capture-prompts and --capture-prompts require --agent claude-code. Other \
+             agents may use their prompt hook to deliver handoff context, so removing it could \
+             break cross-agent continuity."
+        );
+    }
     if args.apply {
         // Preserve a project-strategy an earlier `--apply` baked when this run
         // did not pass `--project-strategy`. Without this, a bare re-apply —
@@ -462,6 +473,7 @@ pub fn run(config: &Config, mut args: InstallHooksArgs) -> Result<()> {
                 strategy,
                 &settings_path,
                 args.capture_assistant,
+                install_claude_prompt_capture(&args),
             )
         }
         AgentChoice::Codex => {
@@ -570,6 +582,43 @@ fn install_project_strategy(args: &InstallHooksArgs) -> Option<ProjectStrategyAr
     existing_agent_config(args)
         .as_deref()
         .and_then(|existing| baked_project_strategy(args.agent, existing))
+}
+
+/// Whether the Claude Code install should include its prompt-capture hook.
+/// Explicit flags win. A bare apply preserves the state of an existing
+/// ai-memory install so `upgrade` cannot silently restore a privacy opt-out.
+fn install_claude_prompt_capture(args: &InstallHooksArgs) -> bool {
+    if args.no_capture_prompts {
+        return false;
+    }
+    if args.capture_prompts || !args.apply {
+        return true;
+    }
+    existing_agent_config(args)
+        .as_deref()
+        .and_then(baked_claude_prompt_capture)
+        .unwrap_or(true)
+}
+
+/// Recover prompt-capture state only from hook entries owned by ai-memory.
+/// `None` means this is not an existing ai-memory Claude Code install.
+fn baked_claude_prompt_capture(existing: &str) -> Option<bool> {
+    let document: serde_json::Value = serde_json::from_str(existing).ok()?;
+    let hooks = document.get("hooks")?.as_object()?;
+    let has_ai_memory_hooks = hooks.values().any(|value| {
+        value
+            .as_array()
+            .is_some_and(|entries| entries.iter().any(is_ai_memory_hook_entry))
+    });
+    if !has_ai_memory_hooks {
+        return None;
+    }
+    Some(
+        hooks
+            .get(CLAUDE_PROMPT_EVENT)
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|entries| entries.iter().any(is_ai_memory_hook_entry)),
+    )
 }
 
 /// Read the config file `--apply` will update for the selected agent.
@@ -1178,6 +1227,19 @@ fn overlay_event_hooks(
     map.insert(event.to_string(), serde_json::Value::Array(entries));
 }
 
+/// Remove only ai-memory's entries for one event. Delete the event key when
+/// no third-party hooks remain so a rendered opt-out stays minimal.
+fn remove_ai_memory_event_hooks(map: &mut serde_json::Map<String, serde_json::Value>, event: &str) {
+    overlay_event_hooks(map, event, &serde_json::Value::Array(Vec::new()));
+    if map
+        .get(event)
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(Vec::is_empty)
+    {
+        map.remove(event);
+    }
+}
+
 fn overlay_kiro_cli_event_hooks(
     map: &mut serde_json::Map<String, serde_json::Value>,
     event: &str,
@@ -1216,6 +1278,24 @@ fn capture_assistant_allowed(agent: AgentChoice) -> bool {
     matches!(agent, AgentChoice::ClaudeCode) && local_hook_policy_v1_supported()
 }
 
+fn prompt_capture_options_allowed(agent: AgentChoice) -> bool {
+    agent == AgentChoice::ClaudeCode
+}
+
+fn configure_claude_prompt_capture(
+    mut payload: serde_json::Value,
+    capture_prompts: bool,
+) -> serde_json::Value {
+    if !capture_prompts
+        && let Some(hooks) = payload
+            .get_mut("hooks")
+            .and_then(serde_json::Value::as_object_mut)
+    {
+        hooks.remove(CLAUDE_PROMPT_EVENT);
+    }
+    payload
+}
+
 fn apply_to_claude_code_settings(
     hooks_dir: &Path,
     server_url: &str,
@@ -1238,15 +1318,19 @@ fn apply_to_claude_code_settings_in(
 ) -> Result<()> {
     let staged = stage_hook_scripts_in(hooks_dir, "claude-code", staging_data_local)?;
     let command_dir = staged_command_dir(&staged, "claude-code");
-    let payload = crate::commands::render_shared::build_claude_code_script_payload_for_test(
-        &command_dir,
-        server_url,
-        auth_token,
-        Some(data_dir),
-        args.project_strategy.and_then(ProjectStrategyArg::baked),
-        args.capture_assistant,
+    let capture_prompts = install_claude_prompt_capture(args);
+    let payload = configure_claude_prompt_capture(
+        crate::commands::render_shared::build_claude_code_script_payload_for_test(
+            &command_dir,
+            server_url,
+            auth_token,
+            Some(data_dir),
+            args.project_strategy.and_then(ProjectStrategyArg::baked),
+            args.capture_assistant,
+        ),
+        capture_prompts,
     );
-    apply_to_claude_code_settings_with_payload(payload, args)
+    apply_to_claude_code_settings_with_payload(payload, args, capture_prompts)
 }
 
 fn apply_to_claude_code_settings_with_staged(
@@ -1257,20 +1341,25 @@ fn apply_to_claude_code_settings_with_staged(
     args: &InstallHooksArgs,
 ) -> Result<()> {
     let command_dir = staged_command_dir(staged, "claude-code");
-    let payload = build_claude_code_payload_with_data_dir(
-        &command_dir,
-        server_url,
-        auth_token,
-        Some(data_dir),
-        args.project_strategy.and_then(ProjectStrategyArg::baked),
-        args.capture_assistant,
+    let capture_prompts = install_claude_prompt_capture(args);
+    let payload = configure_claude_prompt_capture(
+        build_claude_code_payload_with_data_dir(
+            &command_dir,
+            server_url,
+            auth_token,
+            Some(data_dir),
+            args.project_strategy.and_then(ProjectStrategyArg::baked),
+            args.capture_assistant,
+        ),
+        capture_prompts,
     );
-    apply_to_claude_code_settings_with_payload(payload, args)
+    apply_to_claude_code_settings_with_payload(payload, args, capture_prompts)
 }
 
 fn apply_to_claude_code_settings_with_payload(
     payload: serde_json::Value,
     args: &InstallHooksArgs,
+    capture_prompts: bool,
 ) -> Result<()> {
     let path = match &args.config_file {
         Some(p) => p.clone(),
@@ -1295,6 +1384,9 @@ fn apply_to_claude_code_settings_with_payload(
                 .context("`hooks` is present in settings.json but not an object")?;
             for (event, value) in &our_hooks {
                 overlay_event_hooks(hooks, event, value);
+            }
+            if !capture_prompts {
+                remove_ai_memory_event_hooks(hooks, CLAUDE_PROMPT_EVENT);
             }
             Ok(())
         })
@@ -4064,12 +4156,16 @@ fn render_claude_code(
     project_strategy: Option<&str>,
     settings_path: &Path,
     capture_assistant: bool,
+    capture_prompts: bool,
 ) -> Result<()> {
     // Soft check: warn (don't bail) if a script is missing. The user
     // may be running this command inside docker against a host path
     // that exists only on the host's filesystem — bailing would
     // sabotage the docker-only flow `setup-agent` enables.
-    for (_, script) in super::render_shared::CLAUDE_CODE_EVENTS {
+    for (event, script) in super::render_shared::CLAUDE_CODE_EVENTS {
+        if !capture_prompts && event == CLAUDE_PROMPT_EVENT {
+            continue;
+        }
         let script = hook_script_for_claude_code(script);
         let abs = hooks_dir.join(script.as_ref());
         if !abs.exists() {
@@ -4082,13 +4178,16 @@ fn render_claude_code(
             );
         }
     }
-    let payload = build_claude_code_payload_with_data_dir(
-        hooks_dir,
-        server_url,
-        auth_token,
-        Some(data_dir),
-        project_strategy,
-        capture_assistant,
+    let payload = configure_claude_prompt_capture(
+        build_claude_code_payload_with_data_dir(
+            hooks_dir,
+            server_url,
+            auth_token,
+            Some(data_dir),
+            project_strategy,
+            capture_assistant,
+        ),
+        capture_prompts,
     );
     let serialized =
         serde_json::to_string_pretty(&payload).context("serializing claude code hook config")?;
@@ -4508,6 +4607,63 @@ mod tests {
         );
     }
 
+    #[test]
+    fn prompt_capture_options_are_claude_code_only() {
+        use crate::cli::AgentChoice::*;
+        assert!(prompt_capture_options_allowed(ClaudeCode));
+        for agent in [
+            Codex,
+            CommandCode,
+            Cursor,
+            GeminiCli,
+            OpenCode,
+            Pi,
+            Omp,
+            Openclaw,
+            AntigravityCli,
+            Grok,
+            Zero,
+            Devin,
+            KimiCode,
+            KiroCli,
+            KiroCliV3,
+        ] {
+            assert!(!prompt_capture_options_allowed(agent), "{agent:?}");
+        }
+    }
+
+    #[test]
+    fn baked_prompt_capture_reads_only_owned_claude_hooks() {
+        let enabled = serde_json::json!({
+            "hooks": {
+                "SessionStart": [{ "hooks": [{ "command": "ai-memory hook --event session-start" }] }],
+                "UserPromptSubmit": [{ "hooks": [{ "command": "ai-memory hook --event user-prompt" }] }]
+            }
+        });
+        assert_eq!(
+            baked_claude_prompt_capture(&enabled.to_string()),
+            Some(true)
+        );
+
+        let disabled = serde_json::json!({
+            "hooks": {
+                "SessionStart": [{ "hooks": [{ "command": "ai-memory hook --event session-start" }] }],
+                "UserPromptSubmit": [{ "hooks": [{ "command": "third-party prompt guard" }] }]
+            }
+        });
+        assert_eq!(
+            baked_claude_prompt_capture(&disabled.to_string()),
+            Some(false)
+        );
+
+        let unrelated = serde_json::json!({
+            "hooks": {
+                "UserPromptSubmit": [{ "hooks": [{ "command": "third-party prompt guard" }] }]
+            }
+        });
+        assert_eq!(baked_claude_prompt_capture(&unrelated.to_string()), None);
+    }
+
     #[cfg(unix)]
     fn bash_program_for_installer_test() -> Option<std::path::PathBuf> {
         Some(std::path::PathBuf::from("bash"))
@@ -4730,6 +4886,8 @@ mod tests {
             profile: None,
             agent: AgentChoice::OpenCode,
             capture_assistant: false,
+            no_capture_prompts: false,
+            capture_prompts: false,
             hooks_dir: None,
             server_url: None,
             auth_token: None,
@@ -6355,6 +6513,8 @@ model = "gpt-5"
         let args = InstallHooksArgs {
             agent: AgentChoice::Omp,
             capture_assistant: false,
+            no_capture_prompts: false,
+            capture_prompts: false,
             hooks_dir: None,
             server_url: Some("http://127.0.0.1:49374".into()),
             auth_token: None,
@@ -6385,6 +6545,8 @@ model = "gpt-5"
         let args = InstallHooksArgs {
             agent: AgentChoice::Pi,
             capture_assistant: false,
+            no_capture_prompts: false,
+            capture_prompts: false,
             hooks_dir: None,
             server_url: Some("http://127.0.0.1:49374".into()),
             auth_token: None,
@@ -6749,6 +6911,8 @@ model = "gpt-5"
                 profile: None,
                 agent: AgentChoice::Codex,
                 capture_assistant: false,
+                no_capture_prompts: false,
+                capture_prompts: false,
                 hooks_dir: Some(hooks_tmp.path().to_path_buf()),
                 server_url: Some("http://127.0.0.1:49374".to_string()),
                 auth_token: None,
@@ -7233,6 +7397,8 @@ command = "AI_MEMORY_HOOK_URL=http://old:1 /old/ai-memory/hooks/kimi-code/sessio
                 profile: None,
                 agent: AgentChoice::ClaudeCode,
                 capture_assistant: false,
+                no_capture_prompts: false,
+                capture_prompts: false,
                 hooks_dir: Some(hooks_tmp.path().to_path_buf()),
                 server_url: Some("http://127.0.0.1:49374".to_string()),
                 auth_token: None,
@@ -7266,6 +7432,116 @@ command = "AI_MEMORY_HOOK_URL=http://old:1 /old/ai-memory/hooks/kimi-code/sessio
             command.contains(&staged_script.to_string_lossy().into_owned()),
             "generated command must reference staged script {}: {command}",
             staged_script.display()
+        );
+    }
+
+    #[test]
+    fn claude_prompt_opt_out_survives_reapply_and_preserves_third_party_hook() {
+        let hooks_tmp = TempDir::new().unwrap();
+        stub_scripts(
+            hooks_tmp.path(),
+            &[
+                "session-start.sh",
+                "session-end.sh",
+                "user-prompt-submit.sh",
+                "pre-tool-use.sh",
+                "post-tool-use.sh",
+                "pre-compact.sh",
+                "stop.sh",
+            ],
+        );
+
+        let config_tmp = TempDir::new().unwrap();
+        let config_path = config_tmp.path().join("settings.json");
+        let staging_tmp = TempDir::new().unwrap();
+        fs::write(
+            &config_path,
+            serde_json::json!({
+                "hooks": {
+                    "UserPromptSubmit": [
+                        { "hooks": [{ "command": "third-party prompt guard" }] },
+                        { "hooks": [{ "command": "/old/ai-memory hook --event user-prompt" }] }
+                    ]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let disabled = InstallHooksArgs {
+            agent: AgentChoice::ClaudeCode,
+            config_file: Some(config_path.clone()),
+            no_capture_prompts: true,
+            ..default_hook_args()
+        };
+        apply_to_claude_code_settings_in(
+            hooks_tmp.path(),
+            "http://127.0.0.1:49374",
+            None,
+            config_tmp.path(),
+            staging_tmp.path(),
+            &disabled,
+        )
+        .unwrap();
+
+        let assert_disabled = || {
+            let parsed: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+            let prompts = parsed["hooks"][CLAUDE_PROMPT_EVENT]
+                .as_array()
+                .expect("third-party prompt hook keeps the event present");
+            assert_eq!(prompts.len(), 1);
+            assert!(
+                serde_json::to_string(prompts)
+                    .unwrap()
+                    .contains("third-party prompt guard")
+            );
+            assert!(!prompts.iter().any(is_ai_memory_hook_entry));
+        };
+        assert_disabled();
+
+        let bare_reapply = InstallHooksArgs {
+            agent: AgentChoice::ClaudeCode,
+            config_file: Some(config_path.clone()),
+            ..default_hook_args()
+        };
+        apply_to_claude_code_settings_in(
+            hooks_tmp.path(),
+            "http://127.0.0.1:49374",
+            None,
+            config_tmp.path(),
+            staging_tmp.path(),
+            &bare_reapply,
+        )
+        .unwrap();
+        assert_disabled();
+
+        let enabled = InstallHooksArgs {
+            agent: AgentChoice::ClaudeCode,
+            config_file: Some(config_path.clone()),
+            capture_prompts: true,
+            ..default_hook_args()
+        };
+        apply_to_claude_code_settings_in(
+            hooks_tmp.path(),
+            "http://127.0.0.1:49374",
+            None,
+            config_tmp.path(),
+            staging_tmp.path(),
+            &enabled,
+        )
+        .unwrap();
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+        let prompts = parsed["hooks"][CLAUDE_PROMPT_EVENT].as_array().unwrap();
+        assert_eq!(prompts.len(), 2, "third-party + one ai-memory hook");
+        assert_eq!(
+            prompts
+                .iter()
+                .filter(|entry| is_ai_memory_hook_entry(entry))
+                .count(),
+            1
         );
     }
 
@@ -7680,6 +7956,8 @@ command = "AI_MEMORY_HOOK_URL=http://old:1 /old/ai-memory/hooks/kimi-code/sessio
                 profile: None,
                 agent: AgentChoice::Devin,
                 capture_assistant: false,
+                no_capture_prompts: false,
+                capture_prompts: false,
                 hooks_dir: Some(hooks_tmp.path().to_path_buf()),
                 server_url: Some("http://127.0.0.1:49374".to_string()),
                 auth_token: None,
@@ -7744,6 +8022,8 @@ command = "AI_MEMORY_HOOK_URL=http://old:1 /old/ai-memory/hooks/kimi-code/sessio
                 profile: None,
                 agent: AgentChoice::Devin,
                 capture_assistant: false,
+                no_capture_prompts: false,
+                capture_prompts: false,
                 hooks_dir: Some(hooks_tmp.path().to_path_buf()),
                 server_url: Some("http://127.0.0.1:49374".to_string()),
                 auth_token: None,
@@ -7797,6 +8077,8 @@ command = "AI_MEMORY_HOOK_URL=http://old:1 /old/ai-memory/hooks/kimi-code/sessio
             profile: None,
             agent: AgentChoice::Devin,
             capture_assistant: false,
+            no_capture_prompts: false,
+            capture_prompts: false,
             hooks_dir: Some(hooks_tmp.path().to_path_buf()),
             server_url: Some("http://127.0.0.1:49374".to_string()),
             auth_token: None,
@@ -7843,6 +8125,8 @@ command = "AI_MEMORY_HOOK_URL=http://old:1 /old/ai-memory/hooks/kimi-code/sessio
             profile: None,
             agent: AgentChoice::Devin,
             capture_assistant: false,
+            no_capture_prompts: false,
+            capture_prompts: false,
             hooks_dir: Some(hooks_tmp.path().to_path_buf()),
             server_url: Some("http://127.0.0.1:49374".to_string()),
             auth_token: None,
@@ -7914,6 +8198,8 @@ command = "AI_MEMORY_HOOK_URL=http://old:1 /old/ai-memory/hooks/kimi-code/sessio
                 profile: None,
                 agent: AgentChoice::Devin,
                 capture_assistant: false,
+                no_capture_prompts: false,
+                capture_prompts: false,
                 hooks_dir: Some(hooks_tmp.path().to_path_buf()),
                 server_url: Some("http://127.0.0.1:49374".to_string()),
                 auth_token: None,

--- a/docs/install.md
+++ b/docs/install.md
@@ -441,6 +441,23 @@ sanitization before any observation reaches SQLite or FTS. Native hook commands
 invoke the installed binary directly, so upgrading that binary is enough to
 receive the client-side cap.
 
+**Disable Claude Code prompt capture.** Regulated or mixed-trust machines can
+leave the rest of Claude Code's lifecycle capture enabled while preventing
+`UserPromptSubmit` text from entering the local spool or wire:
+
+```bash
+ai-memory install-hooks --agent claude-code --no-capture-prompts --apply
+```
+
+The installer removes only ai-memory's prompt hook and preserves third-party
+hooks registered under the same event. A later bare `install-hooks --apply`
+(including an upgrade refresh) inherits the disabled state. Re-enable prompt
+capture explicitly with `--capture-prompts`. These options are Claude Code-only:
+some other agents use their prompt hook to inject handoff context, so removing
+it would break continuity. Disabling prompt capture reduces session summaries
+and recall quality because user intent is no longer part of the observation
+stream; tool and session-boundary capture continues unchanged.
+
 Some agent harnesses attach the assistant's final turn to their `Stop` event —
 Claude Code sends it as a raw `last_assistant_message`. By default that text is
 never persisted: the native hook binary strips the raw field before it can reach

--- a/docs/marker-file.md
+++ b/docs/marker-file.md
@@ -213,7 +213,8 @@ instead. The fallback is Antigravity-only and is discarded with any event
 rejected by capture exclusions.
 Unsupported tool envelopes do not gain a PreToolUse
 body, and association is only by matching agent-provided call IDs. User-prompt stores its prompt
-text, notification stores its message/text, and post-compaction stores its
+text unless Claude Code hooks were installed with `--no-capture-prompts`;
+notification stores its message/text, and post-compaction stores its
 summary; other event bodies are currently empty unless explicitly supported.
 Stop/assistant-message capture is disabled by default and never persisted; it is
 available only through the explicit double opt-in described in the install guide


### PR DESCRIPTION
## What changed

- Added `install-hooks --agent claude-code --no-capture-prompts` to omit ai-memory's `UserPromptSubmit` hook before prompt text can enter the local spool or wire.
- Added `--capture-prompts` as an explicit way to re-enable prompt capture.
- Preserved the opt-out across bare `--apply` runs and upgrade refreshes by recovering state only from ai-memory-owned hooks.
- Preserved third-party hooks registered under `UserPromptSubmit`.
- Limited both flags to Claude Code because other agents may use their prompt hook to inject handoff context.
- Added CLI parsing, ownership/state recovery, apply/re-apply/re-enable regression coverage, documentation, and a CHANGELOG entry.

The default is unchanged: fresh Claude Code installs still capture user prompts.

## Why

This implements the smaller install-time prompt-capture opt-out requested in #446. Removing the hook client-side provides the structural privacy property described there: sensitive prompt text is never spooled, transported, or stored. Keeping the first version Claude Code-only avoids breaking handoff delivery in clients such as Kimi Code.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes — local Windows host lacks the MSVC `link.exe`; CI should run this in the maintained build environment
- [ ] `cargo test --workspace` passes — a targeted CLI test build was attempted but stopped before project-code compilation because `link.exe` is unavailable
- [x] `cargo metadata --no-deps --format-version 1` passes
- [ ] Manual test: local binary build is blocked by the same missing MSVC linker; the new apply/re-apply/re-enable behavior is covered by focused filesystem tests

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected the commit to the authenticated GitHub account's noreply address.

## CHANGELOG (merge gate)

- [x] I added a `CHANGELOG.md` `[Unreleased]` entry.
- [x] The default is unchanged and is called out explicitly above.

## Notes for reviewers

The benefit of this shape is that the privacy boundary sits before local spooling and transport, and upgrade refreshes cannot silently undo the opt-out. The tradeoff is intentionally visible: without prompt observations, session summaries and recall quality lose direct user-intent evidence. The PR does not attempt the broader allowlist-mode half of #446.