### PR TITLE
test(packaging): run the PowerShell wrapper under -ExecutionPolicy Bypass

### DIFF
--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -1462,7 +1462,19 @@ fn powershell_wrapper_forwards_subscription_oauth_tokens_without_putting_values_
     ];
     let mut command = Command::new("powershell.exe");
     command
-        .args(["-NoLogo", "-NoProfile", "-NonInteractive", "-File"])
+        // -ExecutionPolicy Bypass: bin/ai-memory.ps1 is an unsigned local script, so a machine
+        // left on the Windows client default of `Restricted` refuses to load it and the wrapper
+        // never runs (`UnauthorizedAccess`), failing this test for a reason unrelated to what it
+        // checks. Every other PowerShell invocation in the repo already passes Bypass; this one
+        // did not.
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+        ])
         .arg(repo_root().join("bin/ai-memory.ps1"))
         .args(["llm-test", "--provider", "anthropic-oauth"])
         .env("AI_MEMORY_DOCKER", &docker)


### PR DESCRIPTION
## What

`powershell_wrapper_forwards_subscription_oauth_tokens_without_putting_values_in_argv` launches `bin/ai-memory.ps1` with `powershell.exe -File`, but without an execution policy. Add `-ExecutionPolicy Bypass` to that invocation.

## Why

`bin/ai-memory.ps1` is an unsigned local script. On a machine left at the Windows **client default** of `Restricted`, PowerShell refuses to load it:

```
... ai-memory.ps1 cannot be loaded because running scripts is disabled on this system.
    + FullyQualifiedErrorId : UnauthorizedAccess
```

The wrapper never runs, `output.status.success()` is `false`, and the test panics at the `assert!` — for a reason unrelated to what it checks. On a stock Windows checkout this is the **only** failing test in `cargo test --workspace`, so it lands as exactly the kind of "genuine Windows break shows as a failed run on `main`" that moving Windows off the PR critical path was meant to surface (CHANGELOG, Unreleased).

Every other PowerShell invocation in the repo already passes `Bypass`, so the test was simply inconsistent with them:

- `crates/ai-memory-cli/src/commands/render_shared.rs` (`-ExecutionPolicy Bypass -EncodedCommand`)
- `crates/ai-memory-web/build.rs` (`-ExecutionPolicy Bypass -Command`)
- `tests/hooks/test_lib.sh` (`-ExecutionPolicy Bypass -Command`)

The test still runs the real wrapper against a fake `docker.cmd` and still asserts the OAuth token *values* never reach Docker argv (only `-e NAME` forwarding). It just no longer depends on the developer's machine execution policy.

## Proof (Windows 11, toolchain 1.95)

- Before: `test result: FAILED. 12 passed; 1 failed` (this test) — the workspace's only failure.
- After: `cargo test -p ai-memory-cli --test packaging` → `13 passed; 0 failed`.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (0 warnings).

Test-only change (a test's own process invocation), so no `CHANGELOG.md` entry per CONTRIBUTING, and no dependency change, so `cargo deny check` is unaffected.
