### PR TITLE
test(packaging): run the PowerShell wrapper under -ExecutionPolicy Bypass (#449)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The Windows packaging test for the PowerShell wrapper now runs it with
+  `-ExecutionPolicy Bypass`. `-File` loads a script from disk and execution
+  policy governs script files, so on a machine at the Windows client default
+  of `Restricted` the unsigned wrapper was refused and the test failed for a
+  reason unrelated to what it asserts. Test-only; no shipped behaviour
+  changes. (#449)
+
 ### Added
 - Windows tests moved to their own workflow
   (`.github/workflows/windows.yml`), running on every push to `main`,

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -1462,11 +1462,14 @@ fn powershell_wrapper_forwards_subscription_oauth_tokens_without_putting_values_
     ];
     let mut command = Command::new("powershell.exe");
     command
-        // -ExecutionPolicy Bypass: bin/ai-memory.ps1 is an unsigned local script, so a machine
-        // left on the Windows client default of `Restricted` refuses to load it and the wrapper
-        // never runs (`UnauthorizedAccess`), failing this test for a reason unrelated to what it
-        // checks. Every other PowerShell invocation in the repo already passes Bypass; this one
-        // did not.
+        // -ExecutionPolicy Bypass: `-File` loads a script from disk, and execution policy
+        // governs script *files*, so on a machine left at the Windows client default of
+        // `Restricted` the unsigned bin/ai-memory.ps1 is refused (`UnauthorizedAccess`) and
+        // the wrapper never runs — failing this test for a reason unrelated to what it
+        // checks. The other in-repo invocation (render_shared.rs) uses `-Command`, which is
+        // not policy-gated and therefore needs no override; the generated hook commands pass
+        // Bypass defensively. GitHub's runner is permissive enough that this passes there
+        // today, so the fix is for running the suite on a stock Windows install.
         .args([
             "-NoLogo",
             "-NoProfile",

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -1462,7 +1462,19 @@ fn powershell_wrapper_forwards_subscription_oauth_tokens_without_putting_values_
     ];
     let mut command = Command::new("powershell.exe");
     command
-        .args(["-NoLogo", "-NoProfile", "-NonInteractive", "-File"])
+        // -ExecutionPolicy Bypass: bin/ai-memory.ps1 is an unsigned local script, so a machine
+        // left on the Windows client default of `Restricted` refuses to load it and the wrapper
+        // never runs (`UnauthorizedAccess`), failing this test for a reason unrelated to what it
+        // checks. Every other PowerShell invocation in the repo already passes Bypass; this one
+        // did not.
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+        ])
         .arg(repo_root().join("bin/ai-memory.ps1"))
         .args(["llm-test", "--provider", "anthropic-oauth"])
         .env("AI_MEMORY_DOCKER", &docker)


### PR DESCRIPTION
Carries kevin9327's commit from #449 verbatim, plus one maintainer commit correcting the rationale.

## The fix is right

`-File` loads a script from disk, and PowerShell's execution policy governs script *files*. On a machine left at the Windows client default of `Restricted`, the unsigned `bin/ai-memory.ps1` is refused with `UnauthorizedAccess` and the wrapper never runs — so the test fails for a reason unrelated to what it asserts.

## The stated reason was not

The comment claimed *"Every other PowerShell invocation in the repo already passes Bypass; this one did not."* Checking each one:

| site | mode | Bypass? | needs it? |
|---|---|---|---|
| `packaging.rs:1463` | `-File` | was missing | **yes** — policy-gated |
| `render_shared.rs:2494` | `-Command` | no | no — not policy-gated |
| `render_shared.rs:1269/2394` | `-EncodedCommand` (generated) | yes | defensive |

So the pattern does not hold. Left as written, it invites someone to "restore consistency" by adding Bypass where it does nothing, or to delete it here on the grounds that the neighbour manages without.

Also worth recording: this **passes on GitHub's runner today** — the Windows job went green on #442 before this change. The fix serves anyone running the suite on a stock Windows install, rather than repairing a red CI job.

## Note on where this now runs

Windows tests moved to `.github/workflows/windows.yml` in #442, so this test executes on pushes to `main`, nightly, on demand, and on PRs labelled `windows` — not on every PR.

## Verification
`cargo fmt --check`, `cargo test --workspace` → **2498 passed, 0 failed**. The changed test is `#[cfg(windows)]` and does not compile on this host; its correctness rests on the PowerShell semantics above and on the Windows workflow run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)