### PR TITLE
docs(aur): mark pkgver/sha256sums as release-time placeholders

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,5 +1,18 @@
 # Maintainer: AkitaOnRails <boss@akitaonrails.com>
 
+# NOTE: pkgver/pkgrel and the sha256sums below are PLACEHOLDERS.
+# `.github/workflows/release.yml` copies this file at publish time and
+# rewrites all of them from the release tag before pushing to the AUR:
+#
+#     sed -i -e "s/^pkgver=.*/pkgver=${version}/" \
+#            -e "s/^pkgrel=.*/pkgrel=1/" ...
+#
+# So the value here never reaches a user, and bumping it by hand fixes
+# nothing while going stale again at the next release. Check the published
+# package instead:
+#
+#     curl -s 'https://aur.archlinux.org/rpc/v5/info?arg[]=ai-memory'
+#
 pkgname=ai-memory
 pkgver=0.3.2
 pkgrel=1

--- a/packaging/aur/PKGBUILD-bin
+++ b/packaging/aur/PKGBUILD-bin
@@ -1,5 +1,18 @@
 # Maintainer: AkitaOnRails <boss@akitaonrails.com>
 
+# NOTE: pkgver/pkgrel and the sha256sums below are PLACEHOLDERS.
+# `.github/workflows/release.yml` copies this file at publish time and
+# rewrites all of them from the release tag before pushing to the AUR:
+#
+#     sed -i -e "s/^pkgver=.*/pkgver=${version}/" \
+#            -e "s/^pkgrel=.*/pkgrel=1/" ...
+#
+# So the value here never reaches a user, and bumping it by hand fixes
+# nothing while going stale again at the next release. Check the published
+# package instead:
+#
+#     curl -s 'https://aur.archlinux.org/rpc/v5/info?arg[]=ai-memory'
+#
 pkgname=ai-memory-bin
 _pkgname=ai-memory
 pkgver=0.3.2


### PR DESCRIPTION
Follow-up to #444, which I am closing rather than merging.

## Why #444 is declined

`release.yml` rewrites these values at publish time:

```
sed -i -e "s/^pkgver=.*/pkgver=${version}/" \
       -e "s/^pkgrel=.*/pkgrel=1/" \
       -e "s/^sha256sums=('.*')/sha256sums=('${source_sha}')/" \
       "$source_pkgbuild"
```

So the in-repo `pkgver=0.3.2` never reaches a user. The live AUR packages confirm it:

```
ai-memory        1.29.0-1
ai-memory-bin    1.29.0-1
```

Merging #444 would have written `1.28.0` — already two releases behind when it was opened — and it would go stale again at the next release.

## But the confusion was legitimate

A file reading `0.3.2` in a repo shipping 1.29.0 looks like neglect, and nothing said otherwise. This adds a comment at the top of **both** PKGBUILDs explaining the placeholder and pointing at the AUR RPC as the way to check what is actually published, so the next person does not spend their time on the same non-bug.

## Verified the annotation is inert

- `^pkgver=` still matches only the real assignment (the comment's example is indented, so it never starts at column 0)
- a simulated release `sed` produces `pkgver=1.29.0` correctly
- both files still parse as shell

Comment-only; no behaviour change, so no changelog entry per the internal-churn exemption in `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)