### PR TITLE
docs(deploy): document the status hook-spool section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Documented the `ai-memory status` hook-spool section in
+  `docs/deploy.md`. It shipped with no operator-facing description, in the
+  one document whose troubleshooting list is where someone looks when
+  capture seems delayed. (#428)
 - The Windows packaging test for the PowerShell wrapper now runs it with
   `-ExecutionPolicy Bypass`. `-File` loads a script from disk and execution
   policy governs script files, so on a machine at the Windows client default

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -253,6 +253,30 @@ ssh "$SERVER" "tail -100 $DEPLOY_DIR/data/logs/ai-memory.log.$(date +%F)"
   every project in the workspace, or add `--project <name>` to scope
   the rebuild. Scheduled embedding backfill can also fill missing
   rows when enabled.
+- **Capture looks delayed, or observations are missing**: `ai-memory
+  status` reports local hook-spool health — how many events are queued
+  client-side, the age of the oldest one, and the total failed-delivery
+  attempts:
+
+  ```
+    spool:
+      pending:    2
+      oldest:     15m 0s
+      retries:    4
+  ```
+
+  A non-empty spool with an aging oldest entry means hooks are reaching
+  the local queue but not the server; events are not lost, they drain
+  once it is reachable. `pending: 0` means capture is keeping up.
+
+  The spool is **client-side**, so this section reflects the machine you
+  run the command on, not the server — it is the local data dir even when
+  `AI_MEMORY_SERVER_URL` points at a homelab. It is also printed when the
+  server cannot be reached at all (to stderr, so `--json` consumers still
+  get a single object on stdout), which is precisely when a backlog is
+  worth seeing. `--json` carries the same numbers under a `spool` object
+  (`pending`, `oldest_age_ms`, `retries_total`).
+
 - **Provider failures**: `ai-memory status` reports passive LLM and
   embedding health from the last real provider call. A fresh process
   reports `unknown` until the server actually uses that role; it does


### PR DESCRIPTION
Found by `pr-post-audit` on the v1.29.0..b02703c range, before tagging.

## The gap

#441 added a user-visible section to `ai-memory status` and a matching `spool` object to `--json`, and **documented neither**. `AGENTS.md` requires docs to move with a user-facing surface, and I missed it when merging.

It matters because of *where* it is missing. `docs/deploy.md` has the troubleshooting list an operator actually reads, and it already covers provider health, embedding mismatches, permission failures and restart loops — but not the one signal that answers "are my hook events reaching the server". Someone whose capture looks delayed would find every neighbouring problem documented and not this one.

## What it now says

The output shape, plus the three things that are not obvious from reading it:

- a non-empty spool means events are **delayed, not lost** — they drain when the server is reachable
- the numbers are **client-side**, so they describe the machine running the command, not the server, even when `AI_MEMORY_SERVER_URL` points at a homelab
- it is printed **when the server is unreachable too** (on stderr, so `--json` still yields one object on stdout), which is exactly when a backlog is worth seeing

## Sample output is real

Taken from an actual run against a seeded spool rather than written by hand:

```
local spool (server unreachable):
  pending:    2
  oldest:     15m 0s
  retries:    4
```

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)