### PR TITLE
feat(llm): allow overriding Gemini provider base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- The `gemini` LLM provider now respects the `LLM_BASE_URL` configuration value.
+  Previously, the base URL was hardcoded to `generativelanguage.googleapis.com`.
+  This allows using self-hosted, local Gemini-compatible models (like Gemma 3 hosted via Litert) that expect the native `/v1beta/models/...:generateContent` payload shape.
+
 ## [1.30.0] - 2026-08-21
 
 ### Fixed

--- a/crates/ai-memory-cli/src/config.rs
+++ b/crates/ai-memory-cli/src/config.rs
@@ -2038,3 +2038,35 @@ mod tests {
         assert_eq!(provider.provider, ProviderChoice::AnthropicOAuth);
     }
 }
+
+#[test]
+fn llm_provider_config_passes_base_url_to_gemini() {
+    let cfg = Config {
+        llm_provider: Some("gemini".into()),
+        llm_base_url: Some("http://localhost:9379".into()),
+        runtime_env: RuntimeEnv {
+            gemini_api_key: Some(SecretString::from("dummy")),
+            ..RuntimeEnv::default()
+        },
+        ..Config::default()
+    };
+    let provider = cfg.llm_provider_config().unwrap().unwrap();
+    assert_eq!(provider.provider, ProviderChoice::Gemini);
+    assert_eq!(provider.base_url.as_deref(), Some("http://localhost:9379"));
+}
+
+#[test]
+fn llm_provider_config_gemini_uses_default_base_url_when_none_provided() {
+    let cfg = Config {
+        llm_provider: Some("gemini".into()),
+        llm_base_url: None, // Explicitly None
+        runtime_env: RuntimeEnv {
+            gemini_api_key: Some(SecretString::from("dummy")),
+            ..RuntimeEnv::default()
+        },
+        ..Config::default()
+    };
+    let provider = cfg.llm_provider_config().unwrap().unwrap();
+    assert_eq!(provider.provider, ProviderChoice::Gemini);
+    assert_eq!(provider.base_url, None);
+}

--- a/crates/ai-memory-llm/src/factory.rs
+++ b/crates/ai-memory-llm/src/factory.rs
@@ -247,9 +247,11 @@ pub fn build_provider(config: ProviderConfig) -> LlmResult<Arc<dyn LlmProvider>>
         }
         ProviderChoice::Gemini => {
             let key = config.auth.require_api_key()?;
-            Ok(Arc::new(
-                GeminiProvider::new(key, config.model)?.with_timeout_secs(timeout),
-            ))
+            let mut provider = GeminiProvider::new(key, config.model)?;
+            if let Some(url) = config.base_url {
+                provider = provider.with_base_url(url);
+            }
+            Ok(Arc::new(provider.with_timeout_secs(timeout)))
         }
         ProviderChoice::OpenAiCompat => {
             let base = config


### PR DESCRIPTION
## What changed

* **Before:** `AI_MEMORY_LLM_PROVIDER=gemini` ignored the `LLM_BASE_URL` environment variable (or `llm_base_url` config parameter) and always strictly connected to `generativelanguage.googleapis.com`.
* **After:** `GeminiProvider::new` is dynamically extended via `.with_base_url()` if a custom base URL is supplied in the config.

## Why

To support self-hosted, local Gemini-compatible models. Users hosting models like Gemma 3 offline often have endpoints that strictly speak the Google Generative Language API dialect (e.g. `/v1beta/models/...:generateContent`). Because they do not speak OpenAI's `/v1/chat/completions` dialect, these users cannot use `openai-compat` as a workaround and must use the native `gemini` provider pointing to localhost.

This is especially critical for local setups where Gemma runs with a command like `gemini gemma start`, since `gemini-cli` is still actively maintained and deployed under enterprise plans.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Manual test: Set `AI_MEMORY_LLM_PROVIDER=gemini`, `AI_MEMORY_LLM_MODEL=gemma3-1b-gpu-custom`, and `LLM_BASE_URL=http://localhost:9379`. Verified via server logs and local endpoint that the request is successfully routed to the local server instead of Google's public endpoint.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected
      any unintended identity before requesting merge. See
      [commit attribution guidance](https://github.com/akitaonrails/ai-memory/blob/main/CONTRIBUTING.md#commit-attribution).

## CHANGELOG (merge gate)

- [x] I added a `CHANGELOG.md` `[Unreleased]` entry — **required** for any
      user-facing change: new flag / env var / endpoint / MCP tool / marker
      key, changed behaviour, or an observable bug fix. (Exempt only for
      internal refactors, dead-code removal, and test-only churn.)
- [x] Any changed **default** (flag behaviour, config default, env var,
      response shape) is called out explicitly in "What changed" above.

## Notes for reviewers

I've added two unit tests in `crates/ai-memory-cli/src/config.rs` inside the `mod tests` block:
1. `llm_provider_config_passes_base_url_to_gemini` to ensure that the custom base URL is correctly parsed and passed to the Gemini provider configuration.
2. `llm_provider_config_gemini_uses_default_base_url_when_none_provided` to ensure that omitting `LLM_BASE_URL` leaves the base URL as `None` (falling back to the standard Google API endpoint).