### PR TITLE
docs(auto-improve): mark phase 5 report-only step as implemented

### DIFF
--- a/docs/auto-improve-skillopt-roadmap.md
+++ b/docs/auto-improve-skillopt-roadmap.md
@@ -268,16 +268,28 @@ Required tests:
 
 ## Phase 5 — Slow / Meta Update Later
 
-Defer this until patch proposals, edit budgets, rejections, and optional evals
-produce enough data.
+Status: report-only step implemented; `_meta` update and cross-project
+optimizer memory not started.
 
-First version should be report-only. Later, a protected `_meta` section can be
-updated through a normal pending proposal, never directly by a per-session review.
-Cross-project optimizer memory is explicitly out of scope until there is evidence
-it helps ai-memory users.
+Defer the rest until patch proposals, edit budgets, rejections, and optional
+evals produce enough data.
+
+First version should be report-only. `auto_improve_telemetry.rs` ships this:
+a structured `AutoImproveTelemetryReport` (terminal rates, bounded findings,
+blind spots) built from persisted proposal outcomes, staged and approved like
+any other report — approval writes the report page only and performs no
+learning-memory changes, and it explicitly does not edit rules, procedures,
+notes, or `_meta` pages.
+
+Later, a protected `_meta` section can be updated through a normal pending
+proposal, never directly by a per-session review. Cross-project optimizer
+memory is explicitly out of scope until there is evidence it helps ai-memory
+users. Neither has been started.
 
 ## Completion Criteria
 
 This roadmap is complete when phases 1–4 are implemented with docs, migrations,
 tests, and changelog entries, and phase 5 has either a report-only design or a
-documented deferral with evidence requirements.
+documented deferral with evidence requirements. Phases 1–4 and phase 5's
+report-only step are done; the `_meta` update and cross-project optimizer
+memory remain deferred pending evidence.


### PR DESCRIPTION
## Summary
- The `auto-improve-skillopt-roadmap.md` tracked phase 5 ("Slow / Meta Update Later") as pure future work, but `auto_improve_telemetry.rs` already ships the report-only first version it calls for: a structured `AutoImproveTelemetryReport` (terminal rates, bounded findings, blind spots) staged and approved like any other report, writing only the report page and never touching rules, procedures, notes, or `_meta` pages.
- Adds a `Status:` line consistent with phases 3-4's existing convention, and updates Completion Criteria to reflect what's actually left: the protected `_meta` update path and cross-project optimizer memory, both still unstarted.

## Test plan
- [x] Docs-only change; no code, tests, or CHANGELOG entry required (not user-facing behavior).