### PR TITLE
docs(install): document mise github backend, unblock cargo install status

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -13,7 +13,7 @@ path (docker + Claude Code). This page covers everything else:
 - [Installing hooks without docker](#installing-hooks-without-docker)
   (curl-based installer)
 - [Running ai-memory without docker](#running-ai-memory-without-docker)
-  (cargo install, building from source)
+  (mise, building from source)
 - [Managed cross-harness workstreams](managed-workstreams.md)
   (`ai-memory run`, transparent native resume, and argument forwarding)
 - [LLM provider tiers + self-hosted Ollama](#llm-provider-tiers)
@@ -1205,11 +1205,37 @@ automatically; you only set it by hand for custom container setups.
 
 ## Running ai-memory without docker
 
-Most users should stick to the docker wrapper from the Quick start. On macOS,
-tagged releases also publish native `ai-memory-macos-aarch64.tar.gz` and
-`ai-memory-macos-x86_64.tar.gz` archives when you only need the client CLI.
-Build from source only when hacking on ai-memory itself or running on a platform
-docker doesn't support.
+Most users should stick to the docker wrapper from the Quick start. Arch
+Linux users have the [AUR packages](#arch-linux-native-packages-aur). For any
+other host, `mise` installs a tagged release binary directly from GitHub —
+no Rust toolchain needed:
+
+```bash
+mise use -g github:akitaonrails/ai-memory
+```
+
+This uses [mise's GitHub backend](https://mise.jdx.dev/dev-tools/backends/github.html),
+which downloads the release archive matching your OS/arch
+(`ai-memory-linux-x86_64.tar.gz`, `ai-memory-macos-aarch64.tar.gz`, etc.),
+verifies its checksum, GitHub artifact attestation, and SLSA provenance, then
+extracts it and puts `ai-memory` on `PATH`. No dedicated mise plugin or
+registry entry is required — the backend works against any repo whose
+release assets follow this naming convention. By default mise also holds back
+the very newest release for a short safety window
+([`minimum_release_age`](https://mise.jdx.dev/dev-tools/github-backend.html)),
+so a fresh tag may resolve to the previous version for a day or so; pin an
+exact tag with `mise use -g github:akitaonrails/ai-memory@1.30.0` to bypass
+that.
+
+`cargo install ai-memory` is not available: the crate name is already taken
+by an unrelated project on crates.io, as is `ai-memory-core` (the workspace's
+foundational internal crate). Publishing would require renaming at least
+that crate for the registry — a naming decision the project hasn't made yet.
+
+Build from source only when hacking on ai-memory itself or running on a
+platform none of the above covers. On macOS, tagged releases also publish
+native `ai-memory-macos-aarch64.tar.gz` and `ai-memory-macos-x86_64.tar.gz`
+archives when you only need the client CLI.
 
 ```bash
 git clone https://github.com/akitaonrails/ai-memory ~/.ai-memory

--- a/docs/v0.3-roadmap.md
+++ b/docs/v0.3-roadmap.md
@@ -108,17 +108,28 @@ Both `build_batch_request` and `build_request` in
 way to a prompt. Constants are fine for two prompts. If the count
 grows to four+ a small templating helper would earn its keep.
 
-### `Handoff` field grouping
+### `Handoff` field grouping — done
 
-The struct has 16 public fields. The audit suggested grouping into
-nested sub-structs. Not urgent; would force accessor churn across
-the codebase for no operational win. Revisit if/when adding a 17th
-field.
+Shipped in #457: the struct's 18 public fields are now grouped into
+`HandoffScope`, `HandoffOrigin`, `HandoffContent`, and
+`HandoffLifecycle` sub-structs, each `#[serde(flatten)]`ed so the MCP
+wire JSON is unchanged.
 
 ### `cargo install ai-memory` + `mise use -g github:akitaonrails/ai-memory`
 
-Today the only install paths are docker + `git clone + cargo
-build`. ai-jail ships a release-binary GitHub Actions workflow that
-publishes to crates.io + GitHub Releases (tar.gz + sha256 per OS
-target). Mirror that pattern for users who want a host-side binary
-without the rust toolchain.
+Status: mise half done, no code needed; cargo install half blocked.
+
+`mise use -g github:akitaonrails/ai-memory` already works today against
+the existing tagged GitHub Releases — mise's GitHub backend matches the
+`ai-memory-<os>-<arch>.tar.gz` asset naming convention with no plugin or
+registry entry required, and verifies checksum, artifact attestation, and
+SLSA provenance before extracting. Documented in `docs/install.md`.
+
+`cargo install ai-memory` cannot ship as scoped: the crate name `ai-memory`
+is already taken on crates.io by an unrelated project, and so is
+`ai-memory-core`, the workspace's foundational internal crate that every
+other crate here depends on. Publishing would require picking a new
+registry name for at least `ai-memory-core` (keeping the `ai_memory_core`
+Rust path via `package = "..."` in dependents, so no source churn) — a
+naming decision for whoever owns crates.io publishing to make, not
+something to pick unilaterally. Parked until that's decided.


### PR DESCRIPTION
## Summary

- Documents that `mise use -g github:akitaonrails/ai-memory` already works today, with no code/workflow change — verified live against the real tagged GitHub Releases: it matches the `ai-memory-<os>-<arch>.tar.gz` asset naming, checks checksum + GitHub artifact attestation + SLSA provenance, extracts, and runs.
- Records why `cargo install ai-memory` can't ship as scoped in `docs/v0.3-roadmap.md`: both `ai-memory` and `ai-memory-core` (the workspace's foundational internal crate) are already taken on crates.io by unrelated projects. Publishing would need a registry-naming decision (e.g. renaming `ai-memory-core` for the registry via `package = "..."` in dependents, keeping the `ai_memory_core` Rust path unchanged) that this PR intentionally leaves to the maintainer rather than picking unilaterally.
- Fixes the roadmap's stale `Handoff` field grouping entry, which still described the struct as 16 fields/ungrouped/"not urgent" after #457 already shipped the sub-struct grouping.

## Test plan

- [x] Installed `mise` fresh and ran `mise use -g github:akitaonrails/ai-memory` against the real repo; confirmed it resolved a release, verified checksum/attestation/provenance, extracted, and `ai-memory --version` ran correctly.
- [x] Confirmed via `cargo search ai-memory` / `cargo search ai-memory-core` that both names are taken by unrelated crates.io projects.
- [x] Doc-only change — no code touched.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>