### PR TITLE
fix(wrapper): route Windows helper commands at the host server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The Windows Docker wrapper's thin-client commands now reach a
+  loopback-published server instead of failing with `Connection refused (os
+  error 111)`. `ai-memory status`, `search`, `bootstrap` and every other
+  thin-client command runs inside a short-lived helper container, where the
+  CLI's default `http://127.0.0.1:49374` resolves to that helper rather than
+  to the Windows host, so a healthy `docker run -p 127.0.0.1:49374:49374`
+  server was unreachable from the wrapper while `curl` from PowerShell worked.
+  The wrapper now injects `AI_MEMORY_SERVER_URL=http://host.docker.internal:49374`
+  for those commands, matching what the POSIX wrapper has done on macOS since
+  (#107) — Docker Desktop gives Linux containers no host networking on either
+  platform. `install-mcp`, `install-hooks` and `setup-agent` still render
+  `http://127.0.0.1:49374` into host-side agent config, because
+  `host.docker.internal` does not resolve on the Windows host, and an explicit
+  `AI_MEMORY_SERVER_URL` (homelab or remote server) is still honoured. (#464)
+
 ## [1.31.0] - 2026-08-22
 
 ### Fixed

--- a/bin/ai-memory.ps1
+++ b/bin/ai-memory.ps1
@@ -26,6 +26,26 @@ function Get-EnvOrDefault {
     return $value
 }
 
+# Resolve the real subcommand, skipping the global options that may precede
+# it. `--config` and `--data-dir` take a separate value, so their argument has
+# to be stepped over as well or it would be mistaken for the subcommand.
+function Get-WrapperSubcommand {
+    param([string[]]$WrapperArgs)
+
+    $Index = 0
+    while ($Index -lt $WrapperArgs.Count) {
+        $Arg = $WrapperArgs[$Index]
+        if ($Arg -eq "--config" -or $Arg -eq "--data-dir") {
+            $Index += 2
+        } elseif ($Arg -like "--*") {
+            $Index += 1
+        } else {
+            return $Arg
+        }
+    }
+    return ""
+}
+
 $Image = Get-EnvOrDefault "AI_MEMORY_IMAGE" "akitaonrails/ai-memory:latest"
 $Docker = Get-EnvOrDefault "AI_MEMORY_DOCKER" "docker"
 $DataVolume = Get-EnvOrDefault "AI_MEMORY_DATA_VOLUME" "ai-memory-data"
@@ -128,6 +148,26 @@ foreach ($Name in @(
     if (-not [string]::IsNullOrEmpty([Environment]::GetEnvironmentVariable($Name))) {
         $DockerArgs += @("-e", $Name)
     }
+}
+
+# Docker Desktop gives Windows no host networking for Linux containers, so a
+# thin-client command (status, search, bootstrap, ...) reaches the loopback-
+# published server from this helper container through Docker Desktop's host
+# alias; 127.0.0.1 would mean the helper container itself and the call dies
+# with "Connection refused". But install-mcp/install-hooks/setup-agent RENDER
+# the URL into the *host* agent config, and host.docker.internal does NOT
+# resolve on the Windows host: baking it in silently breaks MCP and every
+# capture hook. So for those commands leave AI_MEMORY_SERVER_URL unset, letting
+# the CLI render its host-reachable default (http://127.0.0.1:49374).
+# (issue #107)
+$RendersHostConfig = (Get-WrapperSubcommand $CommandArgs) -in @(
+    "install-mcp",
+    "install-hooks",
+    "setup-agent"
+)
+if (-not $RendersHostConfig -and
+    [string]::IsNullOrEmpty([Environment]::GetEnvironmentVariable("AI_MEMORY_SERVER_URL"))) {
+    $DockerArgs += @("-e", "AI_MEMORY_SERVER_URL=http://host.docker.internal:49374")
 }
 
 $DockerArgs += $Image

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -1444,6 +1444,102 @@ fn powershell_wrapper_trims_paths_with_single_character_separators() {
     );
 }
 
+// The PowerShell counterpart of run_wrapper_on_fake_macos: a fake `docker.cmd`
+// records the argv the wrapper built. No `uname` shadowing is needed because
+// the Windows arm under test is selected by running on Windows at all.
+#[cfg(windows)]
+fn run_powershell_wrapper(args: &[&str]) -> String {
+    run_powershell_wrapper_with_server_url(args, None)
+}
+
+#[cfg(windows)]
+fn run_powershell_wrapper_with_server_url(args: &[&str], server_url: Option<&str>) -> String {
+    let tmp = tempfile::tempdir().unwrap();
+    let docker_args = tmp.path().join("docker-args.txt");
+    let docker = tmp.path().join("docker.cmd");
+    std::fs::write(
+        &docker,
+        "@echo off\r\n>\"%AI_MEMORY_TEST_DOCKER_ARGS%\" echo %*\r\nexit /b 0\r\n",
+    )
+    .unwrap();
+
+    let mut command = Command::new("powershell.exe");
+    // See the execution-policy note on the OAuth-token test below.
+    command
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+        ])
+        .arg(repo_root().join("bin/ai-memory.ps1"))
+        .args(args)
+        .env("AI_MEMORY_DOCKER", &docker)
+        .env("AI_MEMORY_TEST_DOCKER_ARGS", &docker_args)
+        .env("AI_MEMORY_DATA_VOLUME", "test-ai-memory-data")
+        .env_remove("AI_MEMORY_DATA_DIR");
+    match server_url {
+        Some(url) => command.env("AI_MEMORY_SERVER_URL", url),
+        None => command.env_remove("AI_MEMORY_SERVER_URL"),
+    };
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "PowerShell wrapper failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    std::fs::read_to_string(docker_args).unwrap()
+}
+
+// The Windows mirror of macos_wrapper_routes_urls_by_real_subcommand: Docker
+// Desktop gives Linux containers no host networking on Windows either, so the
+// helper container cannot reach the host-published server over loopback.
+#[cfg(windows)]
+#[test]
+fn windows_wrapper_routes_urls_by_real_subcommand() {
+    for subcommand in ["install-mcp", "install-hooks", "setup-agent"] {
+        let args = run_powershell_wrapper(&[subcommand]);
+        assert!(
+            !args.contains("AI_MEMORY_SERVER_URL=http://host.docker.internal:49374"),
+            "{subcommand} renders host-side config and must keep loopback defaults; got {args}"
+        );
+    }
+
+    let args = run_powershell_wrapper(&["status"]);
+    assert!(
+        args.contains("AI_MEMORY_SERVER_URL=http://host.docker.internal:49374"),
+        "thin-client commands must reach the host server through Docker Desktop; got {args}"
+    );
+
+    let args = run_powershell_wrapper(&["search", "install-hooks"]);
+    assert!(
+        args.contains("AI_MEMORY_SERVER_URL=http://host.docker.internal:49374"),
+        "only the actual subcommand should control URL routing; got {args}"
+    );
+
+    let args = run_powershell_wrapper(&["--config", "C:\\tmp\\config.toml", "install-hooks"]);
+    assert!(
+        !args.contains("AI_MEMORY_SERVER_URL=http://host.docker.internal:49374"),
+        "global options before install-hooks must not hide the real subcommand; got {args}"
+    );
+
+    // A homelab/remote server is configured through the environment, and the
+    // helper container must not be redirected back at the local Docker host.
+    let args =
+        run_powershell_wrapper_with_server_url(&["status"], Some("http://192.168.1.50:49374"));
+    assert!(
+        !args.contains("AI_MEMORY_SERVER_URL=http://host.docker.internal:49374"),
+        "an explicit AI_MEMORY_SERVER_URL must win over the Docker Desktop alias; got {args}"
+    );
+    assert!(
+        args.contains("-e AI_MEMORY_SERVER_URL"),
+        "an explicit AI_MEMORY_SERVER_URL must still be forwarded by name; got {args}"
+    );
+}
+
 #[cfg(windows)]
 #[test]
 fn powershell_wrapper_forwards_subscription_oauth_tokens_without_putting_values_in_argv() {

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -69,7 +69,13 @@ inside WSL2, no Windows wrapper is involved.
 ## Scenario B: Native Windows With Docker Desktop
 
 Use this when the agent CLI runs as a native Windows process and you want
-the ai-memory server to run from the Docker image.
+the ai-memory server to run from the Docker image. The wrapper renders
+host-side agent config with `http://127.0.0.1:49374`, but its own thin-client
+commands reach the server from inside a helper container via Docker Desktop's
+`host.docker.internal` alias, because Docker Desktop gives Linux containers no
+host networking on Windows. Set `AI_MEMORY_SERVER_URL` only when the server
+lives somewhere else (a homelab or remote host); the wrapper honours it and
+skips the alias.
 
 ```powershell
 # Install the Windows Docker wrapper.
@@ -106,7 +112,9 @@ if (($UserPath -split ';') -notcontains $UserBin) {
     $env:Path = "$env:Path;$UserBin"
 }
 
-# Start the server with Docker Desktop.
+# Start the server with Docker Desktop. The image default allowlist includes
+# host.docker.internal so wrapper thin-client commands (status, search, …) are
+# not rejected with 403.
 docker run -d --name ai-memory `
     --restart unless-stopped `
     -p 127.0.0.1:49374:49374 `


### PR DESCRIPTION
## What changed

The native Windows Docker wrapper (`bin/ai-memory.ps1`) defaulted every
helper-container command to `http://127.0.0.1:49374` when
`AI_MEMORY_SERVER_URL` was unset.

- **Before:** with a healthy `docker run -p 127.0.0.1:49374:49374` server,
  `ai-memory status` failed with `Connection refused (os error 111)`, while
  `curl.exe http://127.0.0.1:49374/admin/status` from PowerShell worked. The
  wrapper runs the CLI inside a short-lived helper container, so `127.0.0.1`
  meant *that helper*, not the Windows host.
- **After:** thin-client commands get
  `AI_MEMORY_SERVER_URL=http://host.docker.internal:49374` injected and reach
  the host-published server.

**No changed default for host-side output.** `install-mcp`, `install-hooks`
and `setup-agent` still render `http://127.0.0.1:49374` into host agent
config, because `host.docker.internal` does not resolve on the Windows host —
baking it in would silently break MCP and every capture hook. An explicit
`AI_MEMORY_SERVER_URL` (homelab / remote server) still wins, so those setups
are unaffected.

## Why

This is the same constraint issue #107 fixed for macOS: Docker Desktop gives
Linux containers no host networking on Windows either. The POSIX wrapper's
`Darwin` arm already keys the decision off `RENDERS_HOST_CONFIG`:

```bash
if [ -z "${AI_MEMORY_SERVER_URL:-}" ] && [ "${RENDERS_HOST_CONFIG}" -eq 0 ]; then
  ENV_ARGS+=(-e "AI_MEMORY_SERVER_URL=http://host.docker.internal:49374")
fi
```

The PowerShell wrapper never received it. This PR ports that existing
semantics rather than rewriting the address globally, including the argv scan
that resolves the real subcommand past global options (`--config` and
`--data-dir` consume a value, so their argument is stepped over).

The image-side half already works: `docker/Dockerfile` allowlists
`host.docker.internal` in `AI_MEMORY_ALLOWED_HOSTS` for exactly this reason.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (`packaging`: 14/14, including the new test)
- [x] Manual test: on Windows 11 + Docker Desktop against a real
      `akitaonrails/ai-memory:latest` container, with `AI_MEMORY_SERVER_URL`
      unset. `ai-memory status` now reports
      `server: http://host.docker.internal:49374` and returns live data
      (1 page, 2 sessions, 100 observations) where it previously failed with
      `Connection refused`. `ai-memory install-mcp --client cursor` still
      renders `"url": "http://127.0.0.1:49374/mcp"` for the host.

New regression test `windows_wrapper_routes_urls_by_real_subcommand` mirrors
the existing `macos_wrapper_routes_urls_by_real_subcommand`, using the same
fake-`docker.cmd` pattern as the current `#[cfg(windows)]` wrapper test. It
covers the three host-config subcommands, a thin client, `search install-hooks`
(routing must follow the real subcommand), global options preceding the
subcommand, and one case the macOS test does not have: an explicit
`AI_MEMORY_SERVER_URL` must win over the alias and still be forwarded by name.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected
      any unintended identity before requesting merge.

## CHANGELOG (merge gate)

- [x] Added a `CHANGELOG.md` `[Unreleased]` / `### Fixed` entry.
- [x] The host-side rendering behaviour is called out explicitly in
      "What changed" above.

## Notes for reviewers

**This PR needs the `windows` label.** Per `AGENTS.md`, PRs touching
platform-sensitive code should opt into `windows.yml` before merge, and the
new test is `#[cfg(windows)]` — it does not compile in `ci.yml` at all. I
cannot add labels as an outside contributor, so could a maintainer apply it?

Two design points worth scrutiny:

1. I duplicated the subcommand scan in PowerShell instead of factoring it out,
   since the two wrappers share no code. The `Get-WrapperSubcommand` arm list
   must stay in sync with the Bash `RENDERS_HOST_CONFIG` case.
2. I kept the emptiness test as `IsNullOrEmpty` to match both the Bash `-z`
   and the neighbouring env-allowlist gate, rather than `IsNullOrWhiteSpace`,
   so a whitespace-only value cannot produce two conflicting `-e` flags.

`bin/ai-memory.ps1` was strictly ASCII with no BOM, and I kept it that way —
Windows PowerShell 5.1 decodes a BOM-less file as ANSI, so I avoided the
non-ASCII characters used freely in the Bash wrapper's comments.

Made with [Cursor](https://cursor.com)