### PR TITLE
docs(install): document mise github backend (#461)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -13,7 +13,7 @@ path (docker + Claude Code). This page covers everything else:
 - [Installing hooks without docker](#installing-hooks-without-docker)
   (curl-based installer)
 - [Running ai-memory without docker](#running-ai-memory-without-docker)
-  (cargo install, building from source)
+  (mise, building from source)
 - [Managed cross-harness workstreams](managed-workstreams.md)
   (`ai-memory run`, transparent native resume, and argument forwarding)
 - [LLM provider tiers + self-hosted Ollama](#llm-provider-tiers)
@@ -1205,11 +1205,37 @@ automatically; you only set it by hand for custom container setups.
 
 ## Running ai-memory without docker
 
-Most users should stick to the docker wrapper from the Quick start. On macOS,
-tagged releases also publish native `ai-memory-macos-aarch64.tar.gz` and
-`ai-memory-macos-x86_64.tar.gz` archives when you only need the client CLI.
-Build from source only when hacking on ai-memory itself or running on a platform
-docker doesn't support.
+Most users should stick to the docker wrapper from the Quick start. Arch
+Linux users have the [AUR packages](#arch-linux-native-packages-aur). For any
+other host, `mise` installs a tagged release binary directly from GitHub —
+no Rust toolchain needed:
+
+```bash
+mise use -g github:akitaonrails/ai-memory
+```
+
+This uses [mise's GitHub backend](https://mise.jdx.dev/dev-tools/backends/github.html),
+which downloads the release archive matching your OS/arch
+(`ai-memory-linux-x86_64.tar.gz`, `ai-memory-macos-aarch64.tar.gz`, etc.),
+verifies its checksum, GitHub artifact attestation, and SLSA provenance, then
+extracts it and puts `ai-memory` on `PATH`. No dedicated mise plugin or
+registry entry is required — the backend works against any repo whose
+release assets follow this naming convention. By default mise also holds back
+the very newest release for a short safety window
+([`minimum_release_age`](https://mise.jdx.dev/dev-tools/github-backend.html)),
+so a fresh tag may resolve to the previous version for a day or so; pin an
+exact tag with `mise use -g github:akitaonrails/ai-memory@1.30.0` to bypass
+that.
+
+`cargo install ai-memory` is not available: the crate name is already taken
+by an unrelated project on crates.io, as is `ai-memory-core` (the workspace's
+foundational internal crate). Publishing would require renaming at least
+that crate for the registry — a naming decision the project hasn't made yet.
+
+Build from source only when hacking on ai-memory itself or running on a
+platform none of the above covers. On macOS, tagged releases also publish
+native `ai-memory-macos-aarch64.tar.gz` and `ai-memory-macos-x86_64.tar.gz`
+archives when you only need the client CLI.
 
 ```bash
 git clone https://github.com/akitaonrails/ai-memory ~/.ai-memory

--- a/docs/install.md
+++ b/docs/install.md
@@ -1217,8 +1217,11 @@ mise use -g github:akitaonrails/ai-memory
 This uses [mise's GitHub backend](https://mise.jdx.dev/dev-tools/backends/github.html),
 which downloads the release archive matching your OS/arch
 (`ai-memory-linux-x86_64.tar.gz`, `ai-memory-macos-aarch64.tar.gz`, etc.),
-verifies its checksum, GitHub artifact attestation, and SLSA provenance, then
-extracts it and puts `ai-memory` on `PATH`. No dedicated mise plugin or
+verifies its checksum against the published `.sha256` sidecar, then extracts
+it and puts `ai-memory` on `PATH`. (mise can also check GitHub artifact
+attestation and SLSA provenance where a project publishes them; ai-memory's
+release workflow does not emit either today, so only the checksum applies.)
+No dedicated mise plugin or
 registry entry is required — the backend works against any repo whose
 release assets follow this naming convention. By default mise also holds back
 the very newest release for a short safety window

--- a/docs/v0.3-roadmap.md
+++ b/docs/v0.3-roadmap.md
@@ -108,17 +108,28 @@ Both `build_batch_request` and `build_request` in
 way to a prompt. Constants are fine for two prompts. If the count
 grows to four+ a small templating helper would earn its keep.
 
-### `Handoff` field grouping
+### `Handoff` field grouping — done
 
-The struct has 16 public fields. The audit suggested grouping into
-nested sub-structs. Not urgent; would force accessor churn across
-the codebase for no operational win. Revisit if/when adding a 17th
-field.
+Shipped in #457: the struct's 18 public fields are now grouped into
+`HandoffScope`, `HandoffOrigin`, `HandoffContent`, and
+`HandoffLifecycle` sub-structs, each `#[serde(flatten)]`ed so the MCP
+wire JSON is unchanged.
 
 ### `cargo install ai-memory` + `mise use -g github:akitaonrails/ai-memory`
 
-Today the only install paths are docker + `git clone + cargo
-build`. ai-jail ships a release-binary GitHub Actions workflow that
-publishes to crates.io + GitHub Releases (tar.gz + sha256 per OS
-target). Mirror that pattern for users who want a host-side binary
-without the rust toolchain.
+Status: mise half done, no code needed; cargo install half blocked.
+
+`mise use -g github:akitaonrails/ai-memory` already works today against
+the existing tagged GitHub Releases — mise's GitHub backend matches the
+`ai-memory-<os>-<arch>.tar.gz` asset naming convention with no plugin or
+registry entry required, and verifies checksum, artifact attestation, and
+SLSA provenance before extracting. Documented in `docs/install.md`.
+
+`cargo install ai-memory` cannot ship as scoped: the crate name `ai-memory`
+is already taken on crates.io by an unrelated project, and so is
+`ai-memory-core`, the workspace's foundational internal crate that every
+other crate here depends on. Publishing would require picking a new
+registry name for at least `ai-memory-core` (keeping the `ai_memory_core`
+Rust path via `package = "..."` in dependents, so no source churn) — a
+naming decision for whoever owns crates.io publishing to make, not
+something to pick unilaterally. Parked until that's decided.


### PR DESCRIPTION
Carries Murillofilho86's commits from #461 verbatim, plus one maintainer commit.

## Their change
Documents `mise use -g github:akitaonrails/ai-memory` as an install path for hosts without the Docker wrapper or AUR packages, and unblocks the `cargo install` status note in the roadmap.

Verified the asset-naming claim — the release publishes exactly the names the mise GitHub backend expects:

```
ai-memory-linux-x86_64.tar.gz      + .sha256
ai-memory-linux-aarch64.tar.gz     + .sha256
ai-memory-macos-aarch64.tar.gz     + .sha256   (etc.)
```

## Maintainer fix: the supply-chain claim was not true

The text said the backend *"verifies its checksum, GitHub artifact attestation, and SLSA provenance"*. Only the checksum is real:

- `release.yml` runs **no** `attest-build-provenance` step
- the attestations API returns **404** for this repository
- the two `provenance: false` lines in that workflow are buildx *image* settings, unrelated to artifact attestation

The `.sha256` sidecars are genuinely published, so checksum verification does happen.

Claiming a supply-chain guarantee that is not there is worse than claiming none — someone picking this install path for a tool that holds their private notes would be relying on a check nobody performs. Reworded to state what mise does today, while noting the capability exists if the release workflow later emits attestations.

That is a good follow-up in its own right: adding `actions/attest-build-provenance` to the release job would make the original sentence true and is a small change. Not doing it here to keep this docs-only.

## Verification
Docs-only. `cargo fmt --check` and `cargo test --workspace` → **2521 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)