### PR TITLE
feat(status): report server-side hook-ingestion counters (#428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `ai-memory status` now reports server-side hook-ingestion counters
+  alongside the client spool section: events accepted, accepted-but-dropped
+  by capture policy, shed because ingest capacity was exhausted, shed by the
+  per-source rate limiter, and how long since the last event reached the
+  writer (#428). Together with the spool numbers this distinguishes the three
+  states that previously looked alike from the outside — hooks not arriving,
+  hooks arriving but shed, and hooks arriving but not landing.
+
+  Deliberately a fixed set of scalars rather than a per-source breakdown:
+  keying counters on a client-supplied value would put unbounded,
+  network-reachable state behind the very queue that exists to bound it. The
+  counters are relaxed atomics, so the hook path pays no lock, and the
+  snapshot is content-free by construction — counts and one timestamp, with a
+  test asserting the field set so a future change cannot quietly add captured
+  text. A newer CLI against an older server renders the rest of `status` and
+  omits the section rather than failing to parse.
+
 ## [1.31.1] - 2026-08-23
 
 ### Fixed

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -641,7 +641,12 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
                     },
                 )
             };
+            // One shared counter set: the hook path writes it, /admin/status
+            // reads it. Two instances would report zeros to the operator
+            // while the real counts accumulated somewhere unreachable.
+            let ingest_metrics = std::sync::Arc::new(ai_memory_core::IngestMetrics::default());
             let hooks = hook_router(HookState {
+                ingest_metrics: ingest_metrics.clone(),
                 workspace_id: ws,
                 project_id: proj,
                 writer: store.writer.clone(),
@@ -684,6 +689,7 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
             });
             let admin = admin_router_with_decay_breadth(
                 AdminState {
+                    ingest_metrics: ingest_metrics.clone(),
                     writer: store.writer.clone(),
                     reader: store.reader.clone(),
                     wiki: wiki.clone(),

--- a/crates/ai-memory-cli/src/commands/status.rs
+++ b/crates/ai-memory-cli/src/commands/status.rs
@@ -13,6 +13,18 @@ use crate::cli::StatusArgs;
 use crate::config::Config;
 use crate::http_client::{ServerEndpoint, get_json};
 
+/// Server-side hook-ingestion counters. `Option` at the call site so a
+/// newer CLI pointed at an older server renders the rest of `status`
+/// instead of failing to deserialise the whole report.
+#[derive(Debug, Deserialize, Serialize)]
+struct IngestReport {
+    accepted: u64,
+    dropped_by_policy: u64,
+    shed_saturated: u64,
+    shed_rate_limited: u64,
+    last_persisted_ms: Option<u64>,
+}
+
 /// Server-shaped response. Mirrors `ai_memory_mcp::admin::StatusReport`.
 #[derive(Debug, Deserialize, Serialize)]
 struct Report {
@@ -29,6 +41,9 @@ struct Report {
     /// Derived-index diagnostics.
     #[serde(default)]
     derived: Derived,
+    /// Hook-ingestion counters from the server process.
+    #[serde(default)]
+    ingest: Option<IngestReport>,
     /// Passive process-scoped provider health.
     #[serde(default)]
     providers: ProviderHealthSnapshot,
@@ -73,6 +88,20 @@ struct EmbeddingTriple {
 /// single object on stdout and get a non-zero exit here anyway. The
 /// unreachable-server error still propagates unchanged; this only adds the
 /// local half of the picture that the caller can actually act on.
+/// Render the last-persisted stamp as an age, or `-` when this server
+/// process has not written an event yet.
+///
+/// An age rather than a wall-clock time: the useful question is "how long
+/// since anything landed", and the server may be in another timezone.
+fn last_write_line(unix_ms: Option<u64>) -> String {
+    let Some(ms) = unix_ms else {
+        return "-".to_string();
+    };
+    let now = jiff::Timestamp::now().as_millisecond();
+    let now_ms = u64::try_from(now).unwrap_or(0);
+    spool_age_line(Some(now_ms.saturating_sub(ms)))
+}
+
 fn report_offline_spool(spool: &SpoolHealth, json: bool) {
     if json {
         if let Ok(rendered) = serde_json::to_string(spool) {
@@ -133,6 +162,7 @@ pub async fn run(config: &Config, args: StatusArgs) -> Result<()> {
                 "derived": report.derived,
                 "providers": report.providers,
                 "spool": spool,
+                "ingest": report.ingest,
                 "client": { "server_url": ep.url, "auth": ep.auth_token.is_some() },
             }))?
         );
@@ -169,6 +199,22 @@ pub async fn run(config: &Config, args: StatusArgs) -> Result<()> {
         println!("    pending:    {}", spool.pending);
         println!("    oldest:     {}", spool_age_line(spool.oldest_age_ms));
         println!("    retries:    {}", spool.retries_total);
+        if let Some(ingest) = &report.ingest {
+            println!("  ingest (server, this process):");
+            println!("    accepted:   {}", ingest.accepted);
+            println!(
+                "    dropped:    {} (capture policy)",
+                ingest.dropped_by_policy
+            );
+            println!(
+                "    shed:       {} saturated, {} rate-limited",
+                ingest.shed_saturated, ingest.shed_rate_limited
+            );
+            println!(
+                "    last write: {}",
+                last_write_line(ingest.last_persisted_ms)
+            );
+        }
         println!("  providers:");
         println!(
             "    llm:       {}",

--- a/crates/ai-memory-core/src/ingest_metrics.rs
+++ b/crates/ai-memory-core/src/ingest_metrics.rs
@@ -1,0 +1,180 @@
+//! Process-lifetime counters for the hook ingestion pipeline.
+//!
+//! Lives in `core` rather than `hooks` because both the hook router (which
+//! writes these) and the admin status route (which reads them) need the
+//! type, and `ai-memory-mcp` deliberately does not depend on
+//! `ai-memory-hooks` outside dev-dependencies. Putting it here keeps that
+//! boundary intact instead of adding a production edge between them.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::Serialize;
+
+/// Process-lifetime counters for the hook ingestion pipeline.
+///
+/// Deliberately a fixed set of scalars, never a map. #428 asked for
+/// per-source visibility; keying anything on a client-supplied value would
+/// make this unbounded state reachable from the network, which is the same
+/// class of problem the bounded queue exists to prevent. What an operator
+/// needs to answer — "are hooks arriving, is anything being shed, is the
+/// writer keeping up" — does not require per-source breakdown.
+///
+/// Relaxed ordering throughout: these are diagnostics read by a human, and
+/// the hot path must not pay for a fence. A counter observed a few events
+/// stale is fine; a lock on `/hook` is not.
+///
+/// Content-free by construction, like the spool health snapshot: counts and one
+/// timestamp, no paths, prompts, or tool payloads.
+#[derive(Debug, Default)]
+pub struct IngestMetrics {
+    /// Events accepted for processing (202 with work queued).
+    accepted: AtomicU64,
+    /// Events accepted but deliberately not stored — capture policy or the
+    /// subagent drop. Still a 202: the client must not retry these.
+    dropped_by_policy: AtomicU64,
+    /// Events shed because the global ingest semaphore had no permit (429).
+    shed_saturated: AtomicU64,
+    /// Events shed by the per-source rate limiter (429).
+    shed_rate_limited: AtomicU64,
+    /// Unix milliseconds of the last event that reached the writer, or 0
+    /// when none has since this process started.
+    last_persisted_ms: AtomicU64,
+}
+
+impl IngestMetrics {
+    /// One event admitted for processing.
+    pub fn record_accepted(&self) {
+        self.accepted.fetch_add(1, Ordering::Relaxed);
+    }
+    /// One event accepted-but-dropped by capture policy or subagent rules.
+    pub fn record_dropped_by_policy(&self) {
+        self.dropped_by_policy.fetch_add(1, Ordering::Relaxed);
+    }
+    /// One event shed because ingest capacity was exhausted.
+    pub fn record_shed_saturated(&self) {
+        self.shed_saturated.fetch_add(1, Ordering::Relaxed);
+    }
+    /// One event shed by the per-source rate limiter.
+    pub fn record_shed_rate_limited(&self) {
+        self.shed_rate_limited.fetch_add(1, Ordering::Relaxed);
+    }
+    /// Stamp the moment an event reached durable storage.
+    pub fn record_persisted(&self, unix_ms: u64) {
+        self.last_persisted_ms.store(unix_ms, Ordering::Relaxed);
+    }
+
+    /// Read every counter for status reporting.
+    #[must_use]
+    pub fn snapshot(&self) -> IngestMetricsSnapshot {
+        IngestMetricsSnapshot {
+            accepted: self.accepted.load(Ordering::Relaxed),
+            dropped_by_policy: self.dropped_by_policy.load(Ordering::Relaxed),
+            shed_saturated: self.shed_saturated.load(Ordering::Relaxed),
+            shed_rate_limited: self.shed_rate_limited.load(Ordering::Relaxed),
+            last_persisted_ms: match self.last_persisted_ms.load(Ordering::Relaxed) {
+                0 => None,
+                ms => Some(ms),
+            },
+        }
+    }
+}
+
+/// A read of [`IngestMetrics`], safe to serialise into status output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct IngestMetricsSnapshot {
+    /// Events admitted for processing since this process started.
+    pub accepted: u64,
+    /// Events accepted but intentionally not stored.
+    pub dropped_by_policy: u64,
+    /// Events shed because ingest capacity was exhausted.
+    pub shed_saturated: u64,
+    /// Events shed by the per-source rate limiter.
+    pub shed_rate_limited: u64,
+    /// Unix ms of the last event that reached the writer, if any.
+    pub last_persisted_ms: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counters_start_at_zero_and_report_no_write() {
+        let snap = IngestMetrics::default().snapshot();
+        assert_eq!(snap.accepted, 0);
+        assert_eq!(snap.dropped_by_policy, 0);
+        assert_eq!(snap.shed_saturated, 0);
+        assert_eq!(snap.shed_rate_limited, 0);
+        assert_eq!(
+            snap.last_persisted_ms, None,
+            "a process that has written nothing must report None, not epoch 0"
+        );
+    }
+
+    #[test]
+    fn each_counter_moves_independently() {
+        let m = IngestMetrics::default();
+        m.record_accepted();
+        m.record_accepted();
+        m.record_dropped_by_policy();
+        m.record_shed_saturated();
+        m.record_shed_rate_limited();
+        m.record_persisted(1_700_000_000_000);
+
+        let s = m.snapshot();
+        assert_eq!(s.accepted, 2);
+        assert_eq!(s.dropped_by_policy, 1);
+        assert_eq!(s.shed_saturated, 1);
+        assert_eq!(s.shed_rate_limited, 1);
+        assert_eq!(s.last_persisted_ms, Some(1_700_000_000_000));
+    }
+
+    /// The shape is the privacy contract: counts and one timestamp, nothing
+    /// that could carry a prompt, path, or tool payload. If a field carrying
+    /// captured text is ever added, this fails loudly (#428).
+    #[test]
+    fn snapshot_is_content_free() {
+        let m = IngestMetrics::default();
+        m.record_persisted(1);
+        let value = serde_json::to_value(m.snapshot()).expect("serialises");
+        let mut keys: Vec<_> = value.as_object().expect("object").keys().cloned().collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec![
+                "accepted",
+                "dropped_by_policy",
+                "last_persisted_ms",
+                "shed_rate_limited",
+                "shed_saturated"
+            ]
+        );
+        for v in value.as_object().unwrap().values() {
+            assert!(
+                v.is_number() || v.is_null(),
+                "every field must be a count or a timestamp, got {v}"
+            );
+        }
+    }
+
+    /// Counters are shared across tasks through an `Arc`; concurrent
+    /// increments must not lose events.
+    #[test]
+    fn concurrent_increments_do_not_lose_events() {
+        use std::sync::Arc;
+        let m = Arc::new(IngestMetrics::default());
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let m = Arc::clone(&m);
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..1000 {
+                    m.record_accepted();
+                }
+            }));
+        }
+        for h in handles {
+            h.join().expect("thread");
+        }
+        assert_eq!(m.snapshot().accepted, 8000);
+    }
+}

--- a/crates/ai-memory-core/src/lib.rs
+++ b/crates/ai-memory-core/src/lib.rs
@@ -9,6 +9,8 @@ pub mod active_project;
 pub mod actor;
 pub mod error;
 pub mod handoff;
+pub mod ingest_metrics;
+pub use ingest_metrics::{IngestMetrics, IngestMetricsSnapshot};
 pub mod ids;
 pub mod observation;
 pub mod page;

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -446,6 +446,8 @@ pub struct HookState {
     /// of their own) default to the project the user is actually in
     /// rather than the server's static `--project` (issue #2).
     pub active_project: ActiveProject,
+    /// Process-lifetime ingestion counters for operator status reporting.
+    pub ingest_metrics: Arc<ai_memory_core::IngestMetrics>,
     /// In-flight hook processing limiter. Requests acquire one permit before
     /// spawning work and return 429 immediately when saturated.
     pub ingest_semaphore: Arc<tokio::sync::Semaphore>,
@@ -599,6 +601,7 @@ async fn handle_hook(
     // Any gate failure leaves an empty Stop with the same 202 "queued" response.
     crate::assistant_capture::apply_assistant_backstop(&mut env, state.capture_assistant_enabled);
     let Some(env) = inspect_capture_envelope(env) else {
+        state.ingest_metrics.record_dropped_by_policy();
         return (StatusCode::ACCEPTED, "capture policy dropped");
     };
     // Accept-but-drop subagent captures (incl. the unmarked tail of tracked
@@ -616,9 +619,11 @@ async fn handle_hook(
     let skip_webhooks = admission_skips(level_ext, &headers);
     let actor_storage_key = actor.as_ref().map(IdentityKey::storage_key);
     if should_drop_subagent(&state, &env).await {
+        state.ingest_metrics.record_dropped_by_policy();
         return (StatusCode::ACCEPTED, "subagent capture dropped");
     }
     let Ok(permit) = state.ingest_semaphore.clone().try_acquire_owned() else {
+        state.ingest_metrics.record_shed_saturated();
         warn!("hook ingest saturated; dropping event with 429");
         return (StatusCode::TOO_MANY_REQUESTS, "hook queue full");
     };
@@ -629,11 +634,14 @@ async fn handle_hook(
         .await
         .try_take(&rate_key, std::time::Instant::now())
     {
+        state.ingest_metrics.record_shed_rate_limited();
         warn!(source = %log_rate_key(&rate_key), "hook ingest rate limit exceeded for source; dropping event with 429");
         return (StatusCode::TOO_MANY_REQUESTS, "hook source rate limited");
     }
+    state.ingest_metrics.record_accepted();
     tokio::spawn(async move {
         let _permit = permit;
+        let metrics = state.ingest_metrics.clone();
         process_envelope(
             state,
             env,
@@ -642,6 +650,16 @@ async fn handle_hook(
             skip_webhooks,
         )
         .await;
+        // Stamped after `process_envelope` returns, which is the point the
+        // event has been through the writer. This is the signal an operator
+        // uses to tell "hooks are arriving but nothing is landing" from
+        // "nothing is arriving" — the two look identical from the accepted
+        // count alone.
+        metrics.record_persisted(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX)),
+        );
     });
     (StatusCode::ACCEPTED, "queued")
 }
@@ -3326,6 +3344,7 @@ mod tests {
         let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
         let sanitizer = Sanitizer::default();
         HookState {
+            ingest_metrics: Arc::new(ai_memory_core::IngestMetrics::default()),
             workspace_id: ws,
             project_id: proj,
             writer: store.writer.clone(),

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -107,6 +107,9 @@ pub struct AdminState {
     pub embedder: Option<Arc<dyn Embedder>>,
     /// Passive process-scoped health recorder for configured providers.
     pub provider_health: ProviderHealth,
+    /// Shared hook-ingestion counters, written by the hook path and read
+    /// here for status reporting.
+    pub ingest_metrics: std::sync::Arc<ai_memory_core::IngestMetrics>,
     /// Retention-decay parameters forwarded from server config.
     pub decay_params: DecayParams,
     /// Server's resolved data directory (e.g. `/data` in the docker
@@ -826,6 +829,9 @@ pub struct StatusReport {
     pub derived: ai_memory_store::DerivedIndexStatus,
     /// Passive process-scoped provider health.
     pub providers: ProviderHealthSnapshot,
+    /// Hook-ingestion counters for this server process. Counts and one
+    /// timestamp only — never captured content (#428).
+    pub ingest: ai_memory_core::IngestMetricsSnapshot,
 }
 
 /// `GET /admin/projects` — the authoritative list of `(workspace, project)`
@@ -858,6 +864,7 @@ async fn handle_status(State(state): State<Arc<AdminState>>) -> impl IntoRespons
                     counts,
                     derived,
                     providers: state.provider_health.snapshot(),
+                    ingest: state.ingest_metrics.snapshot(),
                 };
                 (
                     StatusCode::OK,
@@ -6247,6 +6254,7 @@ mod tests {
             .unwrap()
             .with_store_reader(store.reader.clone());
         let router = admin_router(AdminState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             writer: store.writer.clone(),
             reader: store.reader.clone(),
             wiki,
@@ -6307,6 +6315,7 @@ mod tests {
             .unwrap();
 
         let router = admin_router(AdminState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             writer: store.writer.clone(),
             reader: store.reader.clone(),
             wiki,
@@ -6429,6 +6438,7 @@ mod tests {
         }
 
         let router = admin_router(AdminState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             writer: store.writer.clone(),
             reader: store.reader.clone(),
             wiki,
@@ -6662,6 +6672,7 @@ mod tests {
         }
 
         let router = admin_router(AdminState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             writer: store.writer.clone(),
             reader: store.reader.clone(),
             wiki,
@@ -6855,6 +6866,7 @@ mod tests {
         store.writer.end_session(ended, None).await.unwrap();
 
         let router = admin_router(AdminState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             writer: store.writer.clone(),
             reader: store.reader.clone(),
             wiki,
@@ -7034,6 +7046,7 @@ mod tests {
             .unwrap()
             .with_store_reader(store.reader.clone());
         let router = admin_router(AdminState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             writer: store.writer.clone(),
             reader: store.reader.clone(),
             wiki,
@@ -7067,6 +7080,7 @@ mod tests {
         llm: Option<Arc<dyn LlmProvider>>,
     ) -> AdminState {
         AdminState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             writer: store.writer.clone(),
             reader: store.reader.clone(),
             wiki,
@@ -8510,6 +8524,7 @@ mod tests {
             .with_admission_chain(chain)
             .with_store_reader(store.reader.clone());
         let router = admin_router(AdminState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             writer: store.writer.clone(),
             reader: store.reader.clone(),
             wiki,
@@ -8619,6 +8634,7 @@ mod tests {
             .with_admission_chain(chain)
             .with_store_reader(store.reader.clone());
         let router = admin_router(AdminState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             writer: store.writer.clone(),
             reader: store.reader.clone(),
             wiki,
@@ -8721,6 +8737,7 @@ mod tests {
             .with_admission_chain(chain)
             .with_store_reader(store.reader.clone());
         let router = admin_router(AdminState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             writer: store.writer.clone(),
             reader: store.reader.clone(),
             wiki,
@@ -8829,6 +8846,7 @@ mod tests {
             .with_admission_chain(chain)
             .with_store_reader(store.reader.clone());
         let router = admin_router(AdminState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             writer: store.writer.clone(),
             reader: store.reader.clone(),
             wiki,
@@ -9376,6 +9394,7 @@ mod tests {
         let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
         let pepper = ai_memory_store::TokenPepper::new("test-pepper-admin");
         let router = admin_router(AdminState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             writer: store.writer.clone(),
             reader: store.reader.clone(),
             wiki,
@@ -9730,6 +9749,7 @@ mod tests {
         let store = Store::open(tmp.path()).unwrap();
         let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
         let router = admin_router(AdminState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             writer: store.writer.clone(),
             reader: store.reader.clone(),
             wiki,
@@ -9861,6 +9881,7 @@ mod tests {
         let missing_db_reader =
             ai_memory_store::ReaderPool::new(&tmp.path().join("missing.sqlite"), 1).unwrap();
         let router = admin_router(AdminState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             writer: store.writer.clone(),
             reader: missing_db_reader,
             wiki,
@@ -10167,6 +10188,7 @@ mod tests {
         let store = Store::open(tmp.path()).unwrap();
         let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
         let router = admin_router(AdminState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             writer: store.writer.clone(),
             reader: store.reader.clone(),
             wiki,

--- a/crates/ai-memory-mcp/tests/admin_backup.rs
+++ b/crates/ai-memory-mcp/tests/admin_backup.rs
@@ -24,6 +24,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
     let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
     let db_path = store.db_path().to_path_buf();
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,

--- a/crates/ai-memory-mcp/tests/admin_bootstrap.rs
+++ b/crates/ai-memory-mcp/tests/admin_bootstrap.rs
@@ -21,6 +21,7 @@ async fn make_admin_state(tmp: &TempDir) -> AdminState {
     let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
     let db_path = store.db_path().to_path_buf();
     AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -40,6 +40,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
         .with_store_reader(store.reader.clone());
     let db_path = store.db_path().to_path_buf();
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,
@@ -70,6 +71,7 @@ async fn make_state_with_chain(tmp: &TempDir, chain: AdmissionChain) -> (AdminSt
         .with_store_reader(store.reader.clone());
     let db_path = store.db_path().to_path_buf();
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,
@@ -452,6 +454,7 @@ async fn move_project_carries_source_embedding() {
         .with_embedder(embedder.clone());
     let db_path = store.db_path().to_path_buf();
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,
@@ -741,6 +744,7 @@ async fn true_move_notifies_admission_with_destination_names() {
         .with_admission_chain(chain)
         .with_store_reader(store.reader.clone());
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,
@@ -796,6 +800,7 @@ async fn make_state_with_embedder(tmp: &TempDir) -> (AdminState, Store) {
         .with_embedder(embedder.clone());
     let db_path = store.db_path().to_path_buf();
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,
@@ -1024,6 +1029,7 @@ async fn copy_purge_force_never_deletes_a_live_managed_workstream() {
 /// routers — e.g. a move then a re-run — against the same SQLite file).
 fn build_state(store: &Store, tmp: &TempDir) -> AdminState {
     AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki: Wiki::new(tmp.path(), store.writer.clone()).unwrap(),
@@ -1521,6 +1527,7 @@ async fn true_move_aborts_when_admission_rejects() {
         .with_admission_chain(chain)
         .with_store_reader(store.reader.clone());
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,
@@ -1617,6 +1624,7 @@ async fn copy_purge_purge_admission_runs_before_db_destruction() {
         .with_admission_chain(chain)
         .with_store_reader(store.reader.clone());
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,
@@ -1730,6 +1738,7 @@ async fn move_copy_skips_contributors_webhook_but_runs_others() {
         .with_admission_chain(chain)
         .with_store_reader(store.reader.clone());
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,

--- a/crates/ai-memory-mcp/tests/admin_move_session.rs
+++ b/crates/ai-memory-mcp/tests/admin_move_session.rs
@@ -31,6 +31,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
         .with_store_reader(store.reader.clone());
     let db_path = store.db_path().to_path_buf();
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,

--- a/crates/ai-memory-mcp/tests/admin_phase3.rs
+++ b/crates/ai-memory-mcp/tests/admin_phase3.rs
@@ -38,6 +38,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
         .with_store_reader(store.reader.clone());
     let db_path = store.db_path().to_path_buf();
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,

--- a/crates/ai-memory-mcp/tests/admin_purge.rs
+++ b/crates/ai-memory-mcp/tests/admin_purge.rs
@@ -31,6 +31,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
     let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
     let db_path = store.db_path().to_path_buf();
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,
@@ -412,6 +413,7 @@ async fn purge_project_rejecting_admission_leaves_source_intact() {
         .with_admission_chain(chain)
         .with_store_reader(store.reader.clone());
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,
@@ -514,6 +516,7 @@ async fn purge_project_idempotent_second_call_is_404() {
     let tmp = TempDir::new().unwrap();
     let (state_a, store) = make_state(&tmp).await;
     let state_b = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki: state_a.wiki.clone(),

--- a/crates/ai-memory-mcp/tests/admin_read_page.rs
+++ b/crates/ai-memory-mcp/tests/admin_read_page.rs
@@ -17,6 +17,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
     let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
     let db_path = store.db_path().to_path_buf();
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,

--- a/crates/ai-memory-mcp/tests/admin_rename.rs
+++ b/crates/ai-memory-mcp/tests/admin_rename.rs
@@ -23,6 +23,7 @@ async fn make_state(tmp: &TempDir) -> (AdminState, Store) {
     let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
     let db_path = store.db_path().to_path_buf();
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,
@@ -312,6 +313,7 @@ async fn rename_project_pages_still_searchable() {
     // the single-writer invariant is preserved. We need two states because
     // axum's `oneshot` consumes the router.
     let state2 = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki: state.wiki.clone(),
@@ -385,6 +387,7 @@ async fn rename_project_after_purge_returns_404_not_silent_200() {
 
     // Purge the row out from under any in-flight rename.
     let purge_state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: state.writer.clone(),
         reader: state.reader.clone(),
         wiki: state.wiki.clone(),

--- a/crates/ai-memory-mcp/tests/admin_status_search.rs
+++ b/crates/ai-memory-mcp/tests/admin_status_search.rs
@@ -18,6 +18,7 @@ async fn make_admin_state(tmp: &TempDir) -> (AdminState, Store) {
     let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
     let db_path = store.db_path().to_path_buf();
     let state = AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,

--- a/crates/ai-memory-mcp/tests/admin_write_page.rs
+++ b/crates/ai-memory-mcp/tests/admin_write_page.rs
@@ -18,6 +18,7 @@ async fn make_state(tmp: &TempDir) -> AdminState {
     let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
     let db_path = store.db_path().to_path_buf();
     AdminState {
+        ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
         writer: store.writer.clone(),
         reader: store.reader.clone(),
         wiki,

--- a/crates/ai-memory-mcp/tests/autoscope_multiuser.rs
+++ b/crates/ai-memory-mcp/tests/autoscope_multiuser.rs
@@ -150,6 +150,7 @@ impl MultiUserHarness {
         // a 202, zero permits means the spawned hook task still owns it.
         let ingest_semaphore = Arc::new(tokio::sync::Semaphore::new(1));
         let hooks = hook_router(HookState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             workspace_id: ws,
             project_id: baked,
             writer: store.writer.clone(),

--- a/crates/ai-memory-mcp/tests/autoscope_stress.rs
+++ b/crates/ai-memory-mcp/tests/autoscope_stress.rs
@@ -146,6 +146,7 @@ impl Harness {
         let project_cache: ai_memory_hooks::ProjectCache =
             Arc::new(tokio::sync::Mutex::new(ProjectCacheStore::default()));
         let hooks = hook_router(HookState {
+            ingest_metrics: std::sync::Arc::new(ai_memory_core::IngestMetrics::default()),
             workspace_id: ws,
             project_id: baked_proj,
             writer: store.writer.clone(),


### PR DESCRIPTION
Closes #428, completing the half left open when the spool side shipped in 1.30.0.

## What it adds

```
  ingest (server, this process):
    accepted:   3
    dropped:    0 (capture policy)
    shed:       0 saturated, 0 rate-limited
    last write: 13s
```

Together with the existing spool section, these separate three states that previously looked identical from outside: hooks **not arriving**, hooks **arriving and being shed**, and hooks **arriving but not landing**. The accepted count alone cannot distinguish the last two — that is what the last-write stamp is for.

## Constraints, all from the issue thread

**No unbounded state.** A fixed set of scalars, never a map. #428 asked for per-source visibility, but keying counters on a client-supplied value would place network-reachable unbounded state behind the very queue that exists to bound it.

**No hot-path cost.** Relaxed atomics; no lock on `/hook`. A counter read a few events stale is fine, contention on ingest is not.

**No captured content.** Counts and one timestamp, with a test asserting the exact field set and that every value is a number or null — so a later change cannot quietly add a prompt, path, or payload.

## Where the type lives

`IngestMetrics` is in `ai-memory-core`, not `ai-memory-hooks`. The hook router writes it and the admin status route reads it, but **`ai-memory-mcp` depends on `ai-memory-hooks` only as a dev-dependency** — I checked before wiring, and putting the type in core keeps that boundary instead of adding a production edge between them.

## Verified live

Against a running server: counters start at zero with `last_persisted_ms: null`, and after three hook events read `accepted: 3` with a real stamp. Both the human and `--json` renderings were checked.

**Backwards compatibility tested against the deployed 1.31.1 server**, which has no `ingest` field: the new CLI exits 0, renders the rest of `status`, and omits the section rather than failing to deserialise.

## Churn note

Adding the field to `HookState`/`AdminState` required it at 39 construction sites, almost all tests. Those are mechanical one-line additions and the compiler verified each; the two `HookState` sites were patched separately after the script correctly skipped them.

Gate: fmt, clippy under `-D warnings`, `cargo test --workspace` → **2539 passed, 0 failed** (2535 before, plus 4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)