### PR TITLE
docs(install): document hook latency expectations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   text. A newer CLI against an older server renders the rest of `status` and
   omits the section rather than failing to parse.
 
+### Docs
+- Documented the order of magnitude reported for lifecycle-hook overhead,
+  including the fact that a completed tool call normally pays for both pre- and
+  post-tool hooks, the measured native-versus-script figures, and the host
+  factors that make them reference data rather than a performance guarantee
+  (#446).
+
 ## [1.31.1] - 2026-08-23
 
 ### Fixed

--- a/docs/install.md
+++ b/docs/install.md
@@ -421,6 +421,24 @@ then stages runnable copies under `~/.local/share/ai-memory/hooks/<agent>/` so
 the agent can execute files owned by your user. Re-run `install-hooks --apply`
 after package upgrades to refresh those staged copies.
 
+### Hook latency expectations
+
+Hook-capable agents launch one short-lived hook process per lifecycle event. A
+successful tool call normally fires both a pre-tool and a post-tool event, so
+per-invocation overhead is paid twice. As an order-of-magnitude reference, one
+independent v1.29.0 evaluation on native macOS aarch64 measured about 145 ms per
+`posix-native` invocation (about 290 ms per completed tool call) and about 172
+ms per legacy `.sh` invocation.
+
+Those figures are one host's measurements, not a benchmark or performance
+guarantee. Process startup, filesystem and security software, the selected
+data directory, authentication, and host load can all change the result. The
+native hook fast path skips full config loading and tracing, and normally
+spools locally instead of waiting for the server, so keep the installer's
+native default where supported. Latency-sensitive deployments should measure
+their own agent host before opting into additional captured events or choosing
+a script fallback.
+
 ### Capture-policy capability and refresh
 
 `[capture] ignore_paths` is enforced only by native `ai-memory hook` commands


### PR DESCRIPTION
## What changed

- Added a short Hook latency expectations section to `docs/install.md`.
- Documented that a completed tool call normally pays for both pre- and post-tool hook invocations.
- Recorded the independent v1.29.0 macOS aarch64 measurements from #446 as order-of-magnitude reference data: about 145 ms per `posix-native` invocation (~290 ms per completed tool call) and about 172 ms per legacy `.sh` invocation.
- Explicitly stated that the figures are one-host measurements rather than a benchmark or performance guarantee, and listed the host factors that can change them.
- Added the required `[Unreleased]` CHANGELOG entry.

No runtime behavior or default changed.

## Why

In the #446 follow-up, the maintainer called out that the measured hook overhead was worth documenting because the current install guide did not state its order of magnitude. This makes the per-tool-call cost visible without presenting one reporter's machine as an SLA, and reinforces why the native hook path remains the recommended default.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `git diff --check` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` ? no Rust source changed; not rerun after cleaning the Windows target directory
- [ ] `cargo test --workspace` ? attempted on native Windows; compilation reached workspace test linking but exhausted the 19.4 GiB available on `D:` (`target` grew to 20.1 GiB), so no complete result is claimed
- [x] Manual verification: figures and context match the #446 report and maintainer follow-up; wording marks them as reference data, not a guarantee

## Commit attribution

- [x] I verified the commit author and GitHub noreply email.

## CHANGELOG (merge gate)

- [x] Added a `CHANGELOG.md` `[Unreleased]` Docs entry.
- [x] No default changed.

## Notes for reviewers

This is intentionally documentation-only. It does not introduce a benchmark command or make claims about current-version performance beyond preserving the reported v1.29.0 reference point with explicit caveats.
