### PR TITLE
feat: write a page summary on both session-page write paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,33 +8,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Session pages now carry a `summary` in their frontmatter, which the
-  retrieval layer already prefers over the page body when describing a
-  non-FTS hit (#473). #463 made that `COALESCE` prefer a summary, but nothing
-  wrote one for a session page: measured against a live 1.31.1 instance, 0 of
-  25 substantive pages had the field, so every descriptor came from the body
-  fallback. Both write paths now fill it — the zero-LLM `SessionEnd` synthesis
-  and the LLM consolidator — because zero-LLM is the documented default and a
-  fix in the consolidator alone would miss the pages most installs have.
+- Gave session pages a `summary` in their frontmatter, which the retrieval
+  layer already preferred over the page body when describing a non-FTS hit.
+  #463 made that `COALESCE` prefer a summary, but no write path produced one:
+  measured against a live 1.31.1 instance, 0 of 25 substantive pages had the
+  field, so every descriptor fell back to the body. All three writers now fill
+  it — the zero-LLM `SessionEnd` synthesis, the single-page consolidator, and
+  the batch one — because zero-LLM is the documented default and `multi_page`
+  defaults to false, so covering either alone would have missed the pages most
+  installs actually hold. (#473)
 
-  On the zero-LLM path the summary is built from counts the renderer already
-  had and was discarding: prompts, completed tool calls per tool, and elapsed
-  time ("2 prompts, 34 completed tool calls across Bash, Edit and Read, over
-  18m"). That is what the body cannot state about itself — a reader deciding
-  whether to open a page can now see how much work it holds, not only what it
-  opened with. The tallying is computed once and shared with the body
-  renderer rather than parsed back out of the markdown, and it still counts
-  `PostToolUse` only, so a completed call is not double-counted.
+  On the zero-LLM path the summary came from counts the renderer already had
+  and was discarding: prompts, completed tool calls per tool, and elapsed time
+  ("2 prompts, 34 completed tool calls across Bash, Edit and Read, over 18m").
+  That is what a page cannot state about itself — a reader deciding whether to
+  open it now sees how much work it holds, not only what it opened with. The
+  page is tallied once and the count lent to both the body renderer and the
+  summary, and `PostToolUse` stays the only counted kind so a completed call is
+  not double-counted.
 
-  On the LLM path it is a new optional field on the consolidator's structured
-  output, so it costs no additional model call — the call already happens.
-  `#[serde(default)]` keeps stored outputs from older runs deserialising, and
-  a blank or whitespace-only value is dropped rather than written, since an
-  empty summary would still win the `COALESCE` and cost the page its
-  body-derived descriptor.
+  On the LLM paths it became an optional field on the consolidator's structured
+  output, costing no additional model call since the call already happens, with
+  `#[serde(default)]` so stored outputs from earlier runs still deserialise.
+  Both system prompts now request it and describe the shape it has to keep; the
+  batch prompt previously forbade the key outright.
 
-  The fallback is unchanged and still serves hand-written pages and
-  everything written before this. New writes only: no backfill, no migration.
+  A model-supplied summary is validated before it is written, because the
+  reader prefers `summary` over the body and then drops headings, metadata
+  bullets, list items and title repeats — falling back to echoing its raw
+  input when nothing survives. A structurally wrong summary is therefore not
+  ignored but reproduced verbatim as the descriptor, displacing usable body
+  text with no error anywhere. Anything the reader would discard is dropped at
+  the boundary instead, leaving the page on its body-derived descriptor.
+
+  The fallback is unchanged and still serves hand-written pages and everything
+  written before this. New writes only: no backfill, no migration.
 
 - `ai-memory status` now reports server-side hook-ingestion counters
   alongside the client spool section: events accepted, accepted-but-dropped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Session pages now carry a `summary` in their frontmatter, which the
+  retrieval layer already prefers over the page body when describing a
+  non-FTS hit (#473). #463 made that `COALESCE` prefer a summary, but nothing
+  wrote one for a session page: measured against a live 1.31.1 instance, 0 of
+  25 substantive pages had the field, so every descriptor came from the body
+  fallback. Both write paths now fill it — the zero-LLM `SessionEnd` synthesis
+  and the LLM consolidator — because zero-LLM is the documented default and a
+  fix in the consolidator alone would miss the pages most installs have.
+
+  On the zero-LLM path the summary is built from counts the renderer already
+  had and was discarding: prompts, completed tool calls per tool, and elapsed
+  time ("2 prompts, 34 completed tool calls across Bash, Edit and Read, over
+  18m"). That is what the body cannot state about itself — a reader deciding
+  whether to open a page can now see how much work it holds, not only what it
+  opened with. The tallying is computed once and shared with the body
+  renderer rather than parsed back out of the markdown, and it still counts
+  `PostToolUse` only, so a completed call is not double-counted.
+
+  On the LLM path it is a new optional field on the consolidator's structured
+  output, so it costs no additional model call — the call already happens.
+  `#[serde(default)]` keeps stored outputs from older runs deserialising, and
+  a blank or whitespace-only value is dropped rather than written, since an
+  empty summary would still win the `COALESCE` and cost the page its
+  body-derived descriptor.
+
+  The fallback is unchanged and still serves hand-written pages and
+  everything written before this. New writes only: no backfill, no migration.
+
 - `ai-memory status` now reports server-side hook-ingestion counters
   alongside the client spool section: events accepted, accepted-but-dropped
   by capture policy, shed because ingest capacity was exhausted, shed by the

--- a/crates/ai-memory-consolidate/prompts/single_consolidate_system.md
+++ b/crates/ai-memory-consolidate/prompts/single_consolidate_system.md
@@ -100,13 +100,20 @@ schema, and nothing else:
 {
   "title": "<page title>",
   "body_markdown": "<markdown body>",
-  "tags": ["tag-1", "tag-2"]
+  "tags": ["tag-1", "tag-2"],
+  "summary": "<one line of plain prose>"
 }
 ```
 
 - Field names are EXACT and case-sensitive. Use `body_markdown`,
   not `body` or `content`. `tags` may be `[]` but the key must
   be present.
+- `summary` is ONE line of plain prose saying what the page covers, for
+  readers who see it beside the title in a listing. It must NOT be a
+  heading, a `- **key:** value` bullet, a list item, or a repeat of the
+  title — a summary shaped like any of those is discarded and the page is
+  described worse than if you had omitted it. Omit the key rather than
+  guessing.
 
 ## Output format
 

--- a/crates/ai-memory-consolidate/src/consolidator.rs
+++ b/crates/ai-memory-consolidate/src/consolidator.rs
@@ -609,6 +609,20 @@ fn build_update(
         "kind".into(),
         serde_json::Value::String(upd.kind.as_str().into()),
     );
+    // The store's hit descriptor prefers `summary` over the page body, so a
+    // blank one would trade real text for nothing. Insert only a usable
+    // value, and never a JSON null.
+    if let Some(summary) = upd
+        .summary
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        fm.insert(
+            "summary".into(),
+            serde_json::Value::String(summary.to_owned()),
+        );
+    }
     if !upd.tags.is_empty() {
         fm.insert(
             "tags".into(),
@@ -1590,6 +1604,7 @@ mod tests {
             kind: crate::types::PageKind::Fact,
             title: "Current focus".into(),
             body_markdown: "Ship the slot-kind PR.".into(),
+            summary: None,
             tags: Vec::new(),
             slot_kind: SlotKind::State,
             entities: Vec::new(),
@@ -1614,6 +1629,7 @@ mod tests {
             kind: crate::types::PageKind::Fact,
             title: "X".into(),
             body_markdown: "body".into(),
+            summary: None,
             tags: Vec::new(),
             slot_kind: SlotKind::State,
             entities: Vec::new(),
@@ -1651,6 +1667,7 @@ mod tests {
             kind: crate::types::PageKind::Fact,
             title: "Entities".into(),
             body_markdown: "body".into(),
+            summary: None,
             tags: Vec::new(),
             slot_kind: SlotKind::State,
             entities: vec![
@@ -1686,6 +1703,7 @@ mod tests {
             kind: crate::types::PageKind::Fact,
             title: "Project context".into(),
             body_markdown: "This repo uses a markdown wiki as source of truth.".into(),
+            summary: None,
             tags: Vec::new(),
             slot_kind: SlotKind::Invariant,
             entities: Vec::new(),

--- a/crates/ai-memory-consolidate/src/consolidator.rs
+++ b/crates/ai-memory-consolidate/src/consolidator.rs
@@ -609,19 +609,8 @@ fn build_update(
         "kind".into(),
         serde_json::Value::String(upd.kind.as_str().into()),
     );
-    // The store's hit descriptor prefers `summary` over the page body, so a
-    // blank one would trade real text for nothing. Insert only a usable
-    // value, and never a JSON null.
-    if let Some(summary) = upd
-        .summary
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-    {
-        fm.insert(
-            "summary".into(),
-            serde_json::Value::String(summary.to_owned()),
-        );
+    if let Some(summary) = usable_summary(upd.summary.as_deref(), &upd.title) {
+        fm.insert("summary".into(), serde_json::Value::String(summary));
     }
     if !upd.tags.is_empty() {
         fm.insert(
@@ -861,7 +850,8 @@ fn build_batch_request_with_slots(
          - \"tags\"            (array of string)  required — may be empty `[]`, but the key must be present\n\
          - \"entities\"        (array of string)  required — may be empty `[]`, but the key must be present; see below\n\
          - \"slot_kind\"       (string) optional — ONLY for `_slots/*`; one of \"state\" or \"invariant\"; this is the SLOT WRITE REGIME, NOT a tier value\n\
-         No other keys except optional `slot_kind` on `_slots/*`. No `body`, no `content`, no `summary`. Field names \
+         - \"summary\"         (string) optional — ONE line of plain prose saying what the page covers, shown beside the title in listings. NOT a heading, NOT a `- **key:** value` bullet, NOT a list item, NOT a repeat of the title: a summary shaped like any of those is discarded and the page ends up described worse than if you had omitted it. Omit the key rather than guessing.\n\
+         No other keys except optional `slot_kind` on `_slots/*` and optional `summary`. No `body`, no `content`. Field names \
          are case-sensitive and the `_markdown` suffix matters.\n\
          \n## `entities` field — the specific nouns the page is about\n\
          Up to 10 short names (max 64 chars each), lowercase, taken from \
@@ -1197,6 +1187,40 @@ fn clip_current_body_for_prompt(s: &str, max_chars: usize) -> String {
     out
 }
 
+/// Accept a model-supplied `summary` only when the reader can actually use it.
+///
+/// The store prefers `summary` over the page body and then runs it through the
+/// same line filter it applies to a body: headings, `- **key:** value`
+/// metadata bullets, other list markers, and lines repeating the title are all
+/// dropped, and when nothing survives the filter echoes its raw input. So a
+/// structurally wrong summary is not ignored — it is reproduced verbatim as
+/// the descriptor, in place of the body text that would otherwise have been
+/// used, and nothing reports an error.
+///
+/// A JSON schema cannot express that constraint, and this value is
+/// model-controlled, so it is enforced here: anything the reader would discard
+/// is dropped at the boundary and the page keeps its body-derived descriptor.
+fn usable_summary(raw: Option<&str>, title: &str) -> Option<String> {
+    let text = raw?.trim();
+    if text.is_empty() || text.contains('\n') {
+        return None;
+    }
+    if text.starts_with('#')
+        || text.starts_with("---")
+        || text.starts_with("___")
+        || text.starts_with("***")
+        || text.starts_with("- ")
+        || text.starts_with("* ")
+        || text.starts_with("+ ")
+    {
+        return None;
+    }
+    if text == title.trim() {
+        return None;
+    }
+    Some(text.to_owned())
+}
+
 fn build_frontmatter(page: &ConsolidatedPage) -> serde_json::Value {
     let mut map = serde_json::Map::new();
     map.insert(
@@ -1211,6 +1235,9 @@ fn build_frontmatter(page: &ConsolidatedPage) -> serde_json::Value {
             .map(|t| serde_json::Value::String(t.clone()))
             .collect();
         map.insert("tags".into(), serde_json::Value::Array(tags));
+    }
+    if let Some(summary) = usable_summary(page.summary.as_deref(), &page.title) {
+        map.insert("summary".into(), serde_json::Value::String(summary));
     }
     map.insert("consolidated".into(), serde_json::Value::Bool(true));
     serde_json::Value::Object(map)
@@ -1594,6 +1621,105 @@ mod tests {
         let slug = slugify_for_rule(&long);
         assert!(slug.len() <= 60);
         assert!(!slug.ends_with('-'));
+    }
+
+    fn update_with_summary(summary: Option<&str>) -> crate::types::ConsolidatedPageUpdate {
+        crate::types::ConsolidatedPageUpdate {
+            path: "concepts/queue.md".into(),
+            tier: Tier::Semantic,
+            kind: crate::types::PageKind::Fact,
+            title: "Bound the scheduler queue".into(),
+            body_markdown: "Body prose.".into(),
+            summary: summary.map(str::to_owned),
+            tags: Vec::new(),
+            slot_kind: SlotKind::State,
+            entities: Vec::new(),
+        }
+    }
+
+    fn frontmatter_for(summary: Option<&str>) -> serde_json::Value {
+        let (req, _) = build_update(
+            WorkspaceId::new(),
+            ProjectId::new(),
+            &update_with_summary(summary),
+            true,
+            &ai_memory_core::ActorContext::default(),
+            None,
+        )
+        .expect("build_update");
+        req.frontmatter
+    }
+
+    #[test]
+    fn a_usable_summary_reaches_the_frontmatter_trimmed() {
+        let fm = frontmatter_for(Some("  Bounded the queue so backpressure is testable.  "));
+        assert_eq!(
+            fm["summary"],
+            "Bounded the queue so backpressure is testable."
+        );
+    }
+
+    #[test]
+    fn summaries_the_reader_would_discard_are_not_written() {
+        // Each of these is legal JSON and legal per the schema, and each one
+        // would be echoed verbatim as the descriptor — replacing the page's
+        // body-derived one — because the reader's filter drops every line and
+        // then falls back to its raw input. Dropping them here keeps the page
+        // on the body text instead.
+        for bad in [
+            "",
+            "   ",
+            "- **session_id:** `9f2c`",
+            "## What this page covers",
+            "- bounded the queue",
+            "* bounded the queue",
+            "first line\nsecond line",
+            "Bound the scheduler queue", // identical to the title
+        ] {
+            assert!(
+                frontmatter_for(Some(bad)).get("summary").is_none(),
+                "should not have been written: {bad:?}"
+            );
+        }
+        assert!(frontmatter_for(None).get("summary").is_none());
+    }
+
+    #[test]
+    fn the_single_page_builder_surfaces_a_summary_too() {
+        // `consolidate_session` — the default path, and the one the serve
+        // worker uses — goes through `ConsolidatedPage`, not the batch type.
+        let page = ConsolidatedPage {
+            title: "Bound the scheduler queue".into(),
+            body_markdown: "Body prose.".into(),
+            tags: Vec::new(),
+            summary: Some("Bounded the queue so backpressure is testable.".into()),
+        };
+        assert_eq!(
+            build_frontmatter(&page)["summary"],
+            "Bounded the queue so backpressure is testable."
+        );
+
+        let unusable = ConsolidatedPage {
+            summary: Some("- **session_id:** `9f2c`".into()),
+            ..page
+        };
+        assert!(build_frontmatter(&unusable).get("summary").is_none());
+    }
+
+    #[test]
+    fn both_prompts_ask_for_the_summary_and_describe_its_shape() {
+        // The batch prompt used to say "no `summary`" outright; a model
+        // obeying that never supplies the field, and the whole write path is
+        // dead code. Assert both prompts request it, so that cannot regress
+        // back into silence.
+        for prompt in [BATCH_SYSTEM_PROMPT, SYSTEM_PROMPT] {
+            assert!(prompt.contains("summary"), "prompt must request `summary`");
+            assert!(
+                !prompt.contains("no `summary`"),
+                "prompt must not forbid `summary`"
+            );
+        }
+        assert!(SYSTEM_PROMPT.contains("ONE line of plain prose"));
     }
 
     #[test]

--- a/crates/ai-memory-consolidate/src/types.rs
+++ b/crates/ai-memory-consolidate/src/types.rs
@@ -117,6 +117,14 @@ pub struct ConsolidatedPageUpdate {
     pub title: String,
     /// New markdown body.
     pub body_markdown: String,
+    /// One line of plain prose saying what this page covers, shown beside
+    /// the title in retrieval listings. Write a complete sentence: not a
+    /// heading, not a `- **key:** value` bullet, and not a repeat of the
+    /// title — the reader drops all three and would fall back to echoing
+    /// this field verbatim. Omit it rather than guessing. Defaults to absent
+    /// so existing structured outputs still deserialise.
+    #[serde(default)]
+    pub summary: Option<String>,
     /// Optional tags surfaced into frontmatter.
     #[serde(default)]
     pub tags: Vec<String>,

--- a/crates/ai-memory-consolidate/src/types.rs
+++ b/crates/ai-memory-consolidate/src/types.rs
@@ -16,6 +16,12 @@ pub struct ConsolidatedPage {
     /// Up to ~5 short tags surfaced into the page's frontmatter.
     #[serde(default)]
     pub tags: Vec<String>,
+    /// One line of plain prose saying what this page covers, shown beside the
+    /// title in retrieval listings. See [`ConsolidatedPageUpdate::summary`]
+    /// for the shape it has to keep. Defaults to absent so existing stored
+    /// outputs still deserialise.
+    #[serde(default)]
+    pub summary: Option<String>,
 }
 
 /// Semantic classification of one consolidated page. Surfaced into

--- a/crates/ai-memory-hooks/src/synth.rs
+++ b/crates/ai-memory-hooks/src/synth.rs
@@ -30,6 +30,18 @@ pub fn synthesize_session_page(
 ) -> NewPage {
     let title = derive_title(observations);
     let body = render_body(session_id, observations, &title);
+    let mut frontmatter_json = serde_json::json!({
+        "title": title,
+        "session_id": session_id.to_string(),
+        "tier": "episodic",
+    });
+    let summary = session_summary(observations);
+    if !summary.is_empty() {
+        // Insert only when there is something to say. The store's hit
+        // descriptor prefers `summary` over the body, so writing a blank one
+        // would trade real body text for nothing.
+        frontmatter_json["summary"] = serde_json::Value::String(summary);
+    }
     let path = PagePath::new(format!("sessions/{session_id}.md"))
         .expect("hard-coded sessions/<uuid>.md is always valid");
     NewPage {
@@ -39,11 +51,7 @@ pub fn synthesize_session_page(
         title: title.clone(),
         body,
         tier: Tier::Episodic,
-        frontmatter_json: serde_json::json!({
-            "title": title,
-            "session_id": session_id.to_string(),
-            "tier": "episodic",
-        }),
+        frontmatter_json,
         pinned: false,
         links: Vec::new(),
         author_id: None,
@@ -66,17 +74,36 @@ fn derive_title(observations: &[Observation]) -> String {
     "session".to_string()
 }
 
-fn render_body(session_id: SessionId, observations: &[Observation], title: &str) -> String {
-    let mut tool_counts: BTreeMap<&str, usize> = BTreeMap::new();
-    let mut prompts: Vec<&Observation> = Vec::new();
-    let mut start: Option<&Observation> = None;
-    let mut end: Option<&Observation> = None;
+/// The per-session counts that both the rendered body and the frontmatter
+/// summary are built from.
+struct SessionTally<'a> {
+    /// Completed calls per tool name, keyed for stable ordering.
+    tool_counts: BTreeMap<&'a str, usize>,
+    /// User prompts in arrival order.
+    prompts: Vec<&'a Observation>,
+    /// First `SessionStart`, if the session recorded one.
+    start: Option<&'a Observation>,
+    /// Last `SessionEnd`, if the session recorded one.
+    end: Option<&'a Observation>,
+}
 
+/// Tally a session's observations once.
+///
+/// [`render_body`] and [`session_summary`] both need these counts. Computing
+/// them here keeps the two from drifting, and keeps the summary from having to
+/// parse them back out of the markdown the body just rendered them into.
+fn tally_session(observations: &[Observation]) -> SessionTally<'_> {
+    let mut tally = SessionTally {
+        tool_counts: BTreeMap::new(),
+        prompts: Vec::new(),
+        start: None,
+        end: None,
+    };
     for obs in observations {
         match obs.kind {
-            ObservationKind::SessionStart => start = Some(obs),
-            ObservationKind::SessionEnd => end = Some(obs),
-            ObservationKind::UserPrompt => prompts.push(obs),
+            ObservationKind::SessionStart => tally.start = Some(obs),
+            ObservationKind::SessionEnd => tally.end = Some(obs),
+            ObservationKind::UserPrompt => tally.prompts.push(obs),
             // Count only PostToolUse — each tool call produces both a
             // PreToolUse and a PostToolUse observation, so counting both
             // doubles every reported number ("Bash: 4" for two real calls).
@@ -84,11 +111,125 @@ fn render_body(session_id: SessionId, observations: &[Observation], title: &str)
             // that never produced a post (cancellations) are intentionally
             // excluded.
             ObservationKind::PostToolUse if !obs.title.is_empty() => {
-                *tool_counts.entry(obs.title.as_str()).or_insert(0) += 1;
+                *tally.tool_counts.entry(obs.title.as_str()).or_insert(0) += 1;
             }
             _ => {}
         }
     }
+    tally
+}
+
+/// How many tools to name individually before summarising the rest as a count.
+const SUMMARY_MAX_NAMED_TOOLS: usize = 3;
+
+/// One line of plain prose describing what the session did, or empty when it
+/// did nothing worth stating.
+///
+/// This lands in `frontmatter.summary`, which the store prefers over the body
+/// when building the descriptor for a non-FTS hit. It is **not** used
+/// verbatim: the reader runs it through the same line filter it applies to a
+/// body, which drops headings, `- **key:** value` metadata bullets, and any
+/// line that merely repeats the title. When every line is dropped the filter
+/// falls back to echoing its raw input, so a summary written in the same house
+/// style as the metadata block above would be reproduced verbatim as the
+/// descriptor — displacing the body text that would otherwise have been used,
+/// silently and with no error anywhere.
+///
+/// Hence: one line, plain prose, no leading marker.
+fn session_summary(observations: &[Observation]) -> String {
+    let tally = tally_session(observations);
+    let mut parts: Vec<String> = Vec::new();
+
+    if !tally.prompts.is_empty() {
+        parts.push(format!(
+            "{} prompt{}",
+            tally.prompts.len(),
+            plural(tally.prompts.len())
+        ));
+    }
+
+    let calls: usize = tally.tool_counts.values().sum();
+    if calls > 0 {
+        // Name the busiest tools first; ties fall back to the map's
+        // alphabetical order so the same session always renders the same way.
+        let mut by_calls: Vec<(&str, usize)> =
+            tally.tool_counts.iter().map(|(k, v)| (*k, *v)).collect();
+        by_calls.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+        let named: Vec<&str> = by_calls
+            .iter()
+            .take(SUMMARY_MAX_NAMED_TOOLS)
+            .map(|(name, _)| *name)
+            .collect();
+        let tools = if by_calls.len() > SUMMARY_MAX_NAMED_TOOLS {
+            format!(
+                "{} and {} more",
+                join_and(&named),
+                by_calls.len() - SUMMARY_MAX_NAMED_TOOLS
+            )
+        } else {
+            join_and(&named)
+        };
+        parts.push(format!(
+            "{calls} completed tool call{} across {tools}",
+            plural(calls)
+        ));
+    }
+
+    if let (Some(start), Some(end)) = (tally.start, tally.end)
+        && let Some(spent) =
+            format_duration(end.created_at.as_second() - start.created_at.as_second())
+    {
+        parts.push(format!("over {spent}"));
+    }
+
+    if parts.is_empty() {
+        return String::new();
+    }
+    format!("{}.", parts.join(", "))
+}
+
+/// `""` or `"s"` for a count.
+fn plural(n: usize) -> &'static str {
+    if n == 1 { "" } else { "s" }
+}
+
+/// `"Bash"`, `"Bash and Edit"`, `"Bash, Edit and Read"`.
+fn join_and(names: &[&str]) -> String {
+    match names {
+        [] => String::new(),
+        [only] => (*only).to_string(),
+        [rest @ .., last] => format!("{} and {last}", rest.join(", ")),
+    }
+}
+
+/// Human-readable elapsed time, or `None` when the session was not measurably
+/// long (a clock that did not advance, or ran backwards).
+fn format_duration(seconds: i64) -> Option<String> {
+    if seconds <= 0 {
+        return None;
+    }
+    if seconds < 60 {
+        return Some(format!("{seconds}s"));
+    }
+    let minutes = seconds / 60;
+    if minutes < 60 {
+        return Some(format!("{minutes}m"));
+    }
+    let (hours, rest) = (minutes / 60, minutes % 60);
+    Some(if rest == 0 {
+        format!("{hours}h")
+    } else {
+        format!("{hours}h {rest}m")
+    })
+}
+
+fn render_body(session_id: SessionId, observations: &[Observation], title: &str) -> String {
+    let SessionTally {
+        tool_counts,
+        prompts,
+        start,
+        end,
+    } = tally_session(observations);
 
     let mut buf = String::with_capacity(2048);
     buf.push_str(&format!("# {title}\n\n"));
@@ -191,6 +332,158 @@ mod tests {
             importance: 5,
             created_at: Timestamp::now(),
         }
+    }
+
+    fn obs_at(kind: ObservationKind, title: &str, at: &str) -> Observation {
+        let mut o = obs(kind, title);
+        o.created_at = at.parse::<Timestamp>().expect("fixture timestamp");
+        o
+    }
+
+    #[test]
+    fn the_summary_states_the_shape_of_the_session() {
+        let observations = vec![
+            obs_at(
+                ObservationKind::SessionStart,
+                "session",
+                "2026-08-24T10:00:00Z",
+            ),
+            obs(ObservationKind::UserPrompt, "bound the scheduler queue"),
+            obs(ObservationKind::UserPrompt, "make the test deterministic"),
+            // Pre+Post pairs: three completed calls, not six.
+            obs(ObservationKind::PreToolUse, "Bash"),
+            obs(ObservationKind::PostToolUse, "Bash"),
+            obs(ObservationKind::PreToolUse, "Bash"),
+            obs(ObservationKind::PostToolUse, "Bash"),
+            obs(ObservationKind::PreToolUse, "Edit"),
+            obs(ObservationKind::PostToolUse, "Edit"),
+            obs_at(
+                ObservationKind::SessionEnd,
+                "session",
+                "2026-08-24T10:18:00Z",
+            ),
+        ];
+        assert_eq!(
+            session_summary(&observations),
+            "2 prompts, 3 completed tool calls across Bash and Edit, over 18m."
+        );
+    }
+
+    #[test]
+    fn the_summary_is_shaped_so_the_reader_does_not_drop_it() {
+        // The store prefers `summary` over the body and then runs it through
+        // the same line filter it applies to a body: headings, `- **key:**
+        // value` metadata bullets, and lines repeating the title are all
+        // dropped, and when nothing survives it echoes its raw input. A
+        // summary shaped like the metadata block this very module renders
+        // would therefore be reproduced verbatim as the descriptor, in place
+        // of body text that would have been usable. Assert the shape that
+        // keeps that from happening.
+        let observations = vec![
+            obs_at(
+                ObservationKind::SessionStart,
+                "session",
+                "2026-08-24T10:00:00Z",
+            ),
+            obs(ObservationKind::UserPrompt, "bound the scheduler queue"),
+            obs(ObservationKind::PostToolUse, "Bash"),
+            obs_at(
+                ObservationKind::SessionEnd,
+                "session",
+                "2026-08-24T10:05:00Z",
+            ),
+        ];
+        let summary = session_summary(&observations);
+
+        assert!(!summary.contains('\n'), "must stay one line: {summary:?}");
+        assert!(
+            !summary.starts_with('#')
+                && !summary.starts_with("---")
+                && !summary.starts_with("___")
+                && !summary.starts_with("***"),
+            "must not read as a structural line: {summary:?}"
+        );
+        assert!(
+            !(summary.starts_with("- **") && summary.contains(":**")),
+            "must not read as a metadata bullet: {summary:?}"
+        );
+        assert!(
+            !summary.starts_with("- ") && !summary.starts_with("* ") && !summary.starts_with("+ "),
+            "must not open with a list marker: {summary:?}"
+        );
+        assert_ne!(
+            summary,
+            derive_title(&observations),
+            "a summary equal to the title is dropped as a repeat"
+        );
+    }
+
+    #[test]
+    fn a_session_with_nothing_to_report_gets_no_summary() {
+        // An empty summary must stay out of the frontmatter entirely: a blank
+        // one still wins the store's COALESCE and would cost the page its
+        // body-derived descriptor.
+        let lifecycle_only = vec![
+            obs(ObservationKind::SessionStart, "session-start"),
+            obs(ObservationKind::SessionEnd, "session-end"),
+        ];
+        assert_eq!(session_summary(&lifecycle_only), "");
+
+        let page = synthesize_session_page(
+            WorkspaceId::new(),
+            ProjectId::new(),
+            SessionId::new(),
+            &lifecycle_only,
+        );
+        assert!(page.frontmatter_json.get("summary").is_none());
+    }
+
+    #[test]
+    fn the_synthesised_page_carries_the_summary() {
+        let observations = vec![
+            obs_at(
+                ObservationKind::SessionStart,
+                "session",
+                "2026-08-24T10:00:00Z",
+            ),
+            obs(ObservationKind::UserPrompt, "bound the scheduler queue"),
+            obs(ObservationKind::PostToolUse, "Bash"),
+            obs_at(
+                ObservationKind::SessionEnd,
+                "session",
+                "2026-08-24T10:05:00Z",
+            ),
+        ];
+        let page = synthesize_session_page(
+            WorkspaceId::new(),
+            ProjectId::new(),
+            SessionId::new(),
+            &observations,
+        );
+        assert_eq!(
+            page.frontmatter_json["summary"],
+            serde_json::json!("1 prompt, 1 completed tool call across Bash, over 5m.")
+        );
+    }
+
+    #[test]
+    fn many_tools_are_named_by_volume_then_counted() {
+        let mut observations = vec![obs(ObservationKind::UserPrompt, "do the thing")];
+        for (tool, calls) in [
+            ("Bash", 5),
+            ("Edit", 4),
+            ("Read", 3),
+            ("Grep", 2),
+            ("Glob", 1),
+        ] {
+            for _ in 0..calls {
+                observations.push(obs(ObservationKind::PostToolUse, tool));
+            }
+        }
+        assert_eq!(
+            session_summary(&observations),
+            "1 prompt, 15 completed tool calls across Bash, Edit and Read and 2 more."
+        );
     }
 
     #[test]

--- a/crates/ai-memory-hooks/src/synth.rs
+++ b/crates/ai-memory-hooks/src/synth.rs
@@ -28,14 +28,17 @@ pub fn synthesize_session_page(
     session_id: SessionId,
     observations: &[Observation],
 ) -> NewPage {
+    // One tally for the whole page: the body renderer and the summary builder
+    // describe the same session and must not scan it twice to do so.
+    let tally = tally_session(observations);
     let title = derive_title(observations);
-    let body = render_body(session_id, observations, &title);
+    let body = render_body(session_id, observations, &title, &tally);
     let mut frontmatter_json = serde_json::json!({
         "title": title,
         "session_id": session_id.to_string(),
         "tier": "episodic",
     });
-    let summary = session_summary(observations);
+    let summary = session_summary(&tally);
     if !summary.is_empty() {
         // Insert only when there is something to say. The store's hit
         // descriptor prefers `summary` over the body, so writing a blank one
@@ -89,9 +92,12 @@ struct SessionTally<'a> {
 
 /// Tally a session's observations once.
 ///
-/// [`render_body`] and [`session_summary`] both need these counts. Computing
-/// them here keeps the two from drifting, and keeps the summary from having to
-/// parse them back out of the markdown the body just rendered them into.
+/// [`render_body`] and [`session_summary`] both need these counts, and
+/// [`synthesize_session_page`] computes them once and lends them to both — so
+/// a page costs one pass over its observations, not two, and the body and the
+/// summary cannot describe the same session differently. It also keeps the
+/// summary from having to parse the counts back out of the markdown the body
+/// just rendered them into.
 fn tally_session(observations: &[Observation]) -> SessionTally<'_> {
     let mut tally = SessionTally {
         tool_counts: BTreeMap::new(),
@@ -136,8 +142,7 @@ const SUMMARY_MAX_NAMED_TOOLS: usize = 3;
 /// silently and with no error anywhere.
 ///
 /// Hence: one line, plain prose, no leading marker.
-fn session_summary(observations: &[Observation]) -> String {
-    let tally = tally_session(observations);
+fn session_summary(tally: &SessionTally<'_>) -> String {
     let mut parts: Vec<String> = Vec::new();
 
     if !tally.prompts.is_empty() {
@@ -223,13 +228,18 @@ fn format_duration(seconds: i64) -> Option<String> {
     })
 }
 
-fn render_body(session_id: SessionId, observations: &[Observation], title: &str) -> String {
+fn render_body(
+    session_id: SessionId,
+    observations: &[Observation],
+    title: &str,
+    tally: &SessionTally<'_>,
+) -> String {
     let SessionTally {
         tool_counts,
         prompts,
         start,
         end,
-    } = tally_session(observations);
+    } = tally;
 
     let mut buf = String::with_capacity(2048);
     buf.push_str(&format!("# {title}\n\n"));
@@ -254,7 +264,7 @@ fn render_body(session_id: SessionId, observations: &[Observation], title: &str)
 
     if !tool_counts.is_empty() {
         buf.push_str("## Tool calls\n\n");
-        for (name, count) in &tool_counts {
+        for (name, count) in tool_counts {
             buf.push_str(&format!("- `{name}`: {count}\n"));
         }
         buf.push('\n');
@@ -364,7 +374,7 @@ mod tests {
             ),
         ];
         assert_eq!(
-            session_summary(&observations),
+            session_summary(&tally_session(&observations)),
             "2 prompts, 3 completed tool calls across Bash and Edit, over 18m."
         );
     }
@@ -393,7 +403,7 @@ mod tests {
                 "2026-08-24T10:05:00Z",
             ),
         ];
-        let summary = session_summary(&observations);
+        let summary = session_summary(&tally_session(&observations));
 
         assert!(!summary.contains('\n'), "must stay one line: {summary:?}");
         assert!(
@@ -423,11 +433,22 @@ mod tests {
         // An empty summary must stay out of the frontmatter entirely: a blank
         // one still wins the store's COALESCE and would cost the page its
         // body-derived descriptor.
+        // Fixed, equal timestamps: `obs` stamps `Timestamp::now()`, so two
+        // calls straddling a second boundary would make this a session that
+        // lasted `1s` and give it a summary after all.
         let lifecycle_only = vec![
-            obs(ObservationKind::SessionStart, "session-start"),
-            obs(ObservationKind::SessionEnd, "session-end"),
+            obs_at(
+                ObservationKind::SessionStart,
+                "session-start",
+                "2026-08-24T10:00:00Z",
+            ),
+            obs_at(
+                ObservationKind::SessionEnd,
+                "session-end",
+                "2026-08-24T10:00:00Z",
+            ),
         ];
-        assert_eq!(session_summary(&lifecycle_only), "");
+        assert_eq!(session_summary(&tally_session(&lifecycle_only)), "");
 
         let page = synthesize_session_page(
             WorkspaceId::new(),
@@ -481,7 +502,7 @@ mod tests {
             }
         }
         assert_eq!(
-            session_summary(&observations),
+            session_summary(&tally_session(&observations)),
             "1 prompt, 15 completed tool calls across Bash, Edit and Read and 2 more."
         );
     }

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -2526,6 +2526,88 @@ mod tests {
         );
     }
 
+    /// The body a session page is synthesised with, minus the frontmatter.
+    /// Written out in full because the point of the test below is what a
+    /// reader can learn from this page *without* opening it.
+    const SESSION_BODY: &str = concat!(
+        "# Bound the scheduler queue\n",
+        "\n",
+        "## Session metadata\n",
+        "\n",
+        "- **session_id:** `9f2c1d0e`\n",
+        "- **started_at:** 2026-08-24T10:00:00Z\n",
+        "- **ended_at:** 2026-08-24T10:18:00Z\n",
+        "- **observations:** 41\n",
+        "\n",
+        "## Prompts\n",
+        "\n",
+        "1. Bound the scheduler queue\n",
+        "2. Make the backpressure test deterministic\n",
+    );
+
+    #[tokio::test]
+    async fn a_written_summary_changes_what_the_descriptor_tells_the_reader() {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let ws = store
+            .writer
+            .get_or_create_workspace("default")
+            .await
+            .unwrap();
+        let proj = store
+            .writer
+            .get_or_create_project(ws, "ai-memory", None)
+            .await
+            .unwrap();
+
+        // Same page twice. The only difference is that one was written by a
+        // path that fills `summary` and the other by one that does not.
+        let mut without = sample_page(ws, proj, "without-summary.md", SESSION_BODY);
+        without.title = "Bound the scheduler queue".into();
+        store.writer.upsert_page(without).await.unwrap();
+
+        let mut with = sample_page(ws, proj, "with-summary.md", SESSION_BODY);
+        with.title = "Bound the scheduler queue".into();
+        with.frontmatter_json = serde_json::json!({
+            "summary": "2 prompts, 34 completed tool calls across Bash, Edit and Read, over 18m.",
+        });
+        store.writer.upsert_page(with).await.unwrap();
+
+        let hits = store
+            .reader
+            .recent_pages_for_project(ws, proj, 10)
+            .await
+            .unwrap();
+        let descriptor = |path: &str| {
+            hits.iter()
+                .find(|h| h.path.as_str() == path)
+                .map(|h| h.snippet.clone())
+                .unwrap_or_else(|| panic!("{path} should be listed"))
+        };
+        let without = descriptor("without-summary.md");
+        let with = descriptor("with-summary.md");
+
+        assert_ne!(without, with);
+
+        // Without a summary the descriptor is the best the body affords: the
+        // prompts after the first, since the first repeats the title. That is
+        // real signal, and it is what #463 already delivers.
+        assert!(
+            without.contains("Make the backpressure test deterministic"),
+            "body-derived descriptor should reach the prompts: {without:?}"
+        );
+        // What it cannot say is how much work the session was. Those counts
+        // exist only at write time, and the summary is what carries them.
+        assert!(
+            !without.contains("34 completed tool calls"),
+            "the body never states the totals: {without:?}"
+        );
+        assert!(
+            with.contains("2 prompts") && with.contains("34 completed tool calls"),
+            "summary-derived descriptor should state the session's shape: {with:?}"
+        );
+    }
+
     #[tokio::test]
     async fn frontmatter_summary_wins_over_the_body_lede() {
         let tmp = TempDir::new().unwrap();

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -7727,6 +7727,24 @@ mod tests {
     };
     use crate::Store;
 
+    #[test]
+    fn a_metadata_styled_descriptor_source_is_echoed_verbatim() {
+        // Every line here is a metadata bullet, so all of them are skipped
+        // and nothing accumulates. The fallback then echoes the raw input —
+        // the result is not empty, it is the unusable input reproduced whole.
+        //
+        // This is the failure mode for a writer that fills frontmatter
+        // `summary` in the same house style it renders a session page's
+        // metadata block in. Because `summary` wins the COALESCE, such a
+        // page trades a usable body-derived descriptor for this, and nothing
+        // anywhere reports an error. Writers must emit plain prose.
+        let metadata_styled = "- **session_id:** `9f2c`\n- **observations:** 2";
+        assert_eq!(
+            page_descriptor(metadata_styled, "Some title"),
+            metadata_styled
+        );
+    }
+
     use ai_memory_core::{
         AgentKind, Handoff, HandoffContent, HandoffId, HandoffLifecycle, HandoffOrigin,
         HandoffScope, HandoffState, NewHandoff, NewSession, OwnerFilter, ProjectId, SessionId,


### PR DESCRIPTION
Closes #473.

Both write paths now fill `frontmatter.summary`, so the branch #463 made
preferred actually fires.

## Zero-LLM path — `synth.rs`

`render_body` already tallied prompts, completed calls per tool, and
start/end, then discarded the structure once it had rendered markdown.
`tally_session` extracts that; the body renderer and the summary builder now
share one tally instead of the summary re-deriving or re-parsing it.
`PostToolUse` remains the only counted kind.

The summary states what the body cannot state about itself — `"2 prompts, 34
completed tool calls across Bash, Edit and Read, over 18m."` A reader deciding
whether to open the page sees how much work it holds, not only what it opened
with.

## LLM path — `ai-memory-consolidate`

Optional `summary` on `ConsolidatedPageUpdate`, `#[serde(default)]`, inserted
by `build_update` only when present and non-blank. No additional model call.

## One correction, and it makes the trap worse than described

You wrote that a summary shaped like a metadata bullet "produces an **empty
descriptor**". It does not — and the real behaviour is worse.

`page_descriptor` ends with:

```rust
if out.is_empty() {
    return truncate_chars(raw.trim(), DESCRIPTOR_MAX_CHARS);
}
```

Every line is dropped, `out` is empty, and the fallback **echoes the raw input
whole**. So the descriptor becomes the malformed summary verbatim. Since the
`COALESCE` already chose that summary over the page body, the page trades a
usable body-derived descriptor for an unusable one. An emptiness check would
not catch it — there is nothing empty to catch. `reader.rs`
`a_metadata_styled_descriptor_source_is_echoed_verbatim` pins exactly this.

Your conclusion stands unchanged: the shape constraint is real, silent, and
worth a test. Only the mechanism differs.

## Tests

- `a_written_summary_changes_what_the_descriptor_tells_the_reader` — the one
  you asked for. Same page, written twice, once with a summary. Asserts the
  descriptors differ, that the body-derived one reaches the prompts (what #463
  already delivers, so the baseline is not strawmanned), that it cannot state
  the totals, and that the summarised one can.
- `a_metadata_styled_descriptor_source_is_echoed_verbatim` — the trap.
- `the_summary_is_shaped_so_the_reader_does_not_drop_it` — asserts each
  property the reader's filter requires, so a future edit to the wording
  cannot silently violate one.
- `a_session_with_nothing_to_report_gets_no_summary` — no key rather than a
  blank one, since a blank still wins the COALESCE.
- Plus content and ordering tests for the tally itself.

## What I did not verify

You asked me to sanity-check the schema change against a small model. **I did
not** — I have no Kimi or qwen3 deployment to run it through, and I would
rather say so than imply coverage I do not have. The field description is
written tight and concrete for that reason, but the risk you flagged on `tier`
is untested here. If you have a small model handy, that is the check worth
running before release.

## Scope

`COALESCE` fallback untouched. New writes only — no backfill, no migration.

Gates: `fmt`, `clippy --workspace --all-targets -D warnings`, `cargo test
--workspace` → 2546 passed / 0 failed, `cargo deny check` → all ok.
