### PR TITLE
docs(architecture): fix stale multi-workspace web UI future-work note

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -597,8 +597,12 @@ when `LLM_API_KEY` is absent and stores vectors under the distinct
 * **Richer curator actions.** The shipped curator stages only one report page;
   future work can add individual merge/supersession/link-fix proposals while
   keeping deletes and semantic rewrites review-gated.
-* **Multi-workspace UI / web dashboard.** Out of scope for v1; revisit
-  once the headless server has been load-tested.
+* **Write surface for the web UI.** The multi-workspace read-only wiki
+  browser shipped in `ai-memory-web` (`/web` — project list, page tree,
+  page view, search). Browsers still can't mutate anything (notes,
+  consolidate, lint, purge stay CLI/MCP-only); an authenticated "edit
+  this page" surface is a deliberate v2 conversation. See
+  [`docs/frontend-api.md`](frontend-api.md#10-known-gaps-planned-iterations-not-blockers).
 * **Real LongMemEval-S harness.** The recall-eval framework exists
   ([`crates/ai-memory-consolidate/tests/recall_eval.rs`](../crates/ai-memory-consolidate/tests/recall_eval.rs));
   porting LongMemEval-S itself requires the dataset.


### PR DESCRIPTION
## Summary

- `docs/ARCHITECTURE.md`'s "Future work" section still listed "Multi-workspace UI / web dashboard. Out of scope for v1; revisit once the headless server has been load-tested."
- That note was written 2026-05-22. The read-only wiki browser (`ai-memory-web`, mounted at `/web`: project list across workspaces, per-project page tree, page view, search) shipped the very next day, 2026-05-23 (`2a57644`, "ai-memory-web: read-only HTTP wiki browser"). The bullet described already-completed work.
- Replaced it with the gap that's actually still open: the web UI has no write surface (browsers can't edit pages, consolidate, lint, or purge — that stays CLI/MCP-only), already tracked as a known gap in `docs/frontend-api.md`'s "Known gaps" section. Linked the two docs together instead of duplicating the description.

## Test plan

- [x] Doc-only change — no code touched.
- [x] Confirmed via `git blame`/`git log` that the web UI predates removal of the stale note by one day (commit `2a57644`).
- [x] Verified the new anchor link (`frontend-api.md#10-known-gaps-planned-iterations-not-blockers`) matches GitHub's heading-anchor slug for `## 10. Known gaps (planned iterations, not blockers)`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>