### PR TITLE
fix(hooks): stop harness scaffolding becoming the session page title (#484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Session page titles were the first user prompt taken verbatim, so whatever
+  the harness put in that payload became the title the page is indexed and
+  displayed under — IDE context blocks, a shell prompt echoed into a paste, a
+  bare model id. Measured across one live instance: 21 of 330 real session
+  pages (6.4%), at a flat rate month over month rather than a decaying legacy
+  population. Titles that read as harness scaffolding are now skipped in
+  favour of the next real prompt, and a session whose every candidate is
+  scaffolding falls back to its own identity rather than a shared literal.
+  The predicate tests the *shape* of the text rather than matching a list of
+  known offenders, since three classes from one corpus is a sample of that
+  operator's harnesses and a blocklist would fail silently on the fourth.
+  New writes only — existing titles are unchanged. Reported by @samirhvbr
+  (#484).
+
 ## [1.32.0] - 2026-08-24
 
 ### Added

--- a/crates/ai-memory-core/src/lib.rs
+++ b/crates/ai-memory-core/src/lib.rs
@@ -15,6 +15,8 @@ pub mod ids;
 pub mod observation;
 pub mod page;
 pub mod routing_skills;
+pub mod scaffolding;
+pub use scaffolding::looks_like_scaffolding;
 pub mod routing_snippet;
 pub mod sanitize;
 pub mod slots;

--- a/crates/ai-memory-core/src/scaffolding.rs
+++ b/crates/ai-memory-core/src/scaffolding.rs
@@ -1,0 +1,134 @@
+//! Does a candidate title look like harness scaffolding rather than something
+//! a person wrote? (#484)
+//!
+//! Session page titles come from the first user prompt, taken verbatim. But a
+//! prompt payload is whatever the harness put there, and harnesses inject:
+//! IDE context blocks, a shell prompt echoed into a paste, a bare model id.
+//! Measured across one instance's 330 real session pages, 6.4% carried a
+//! title that was not user content, and the rate was flat month over month
+//! rather than decaying — a live writer defect, not legacy data.
+//!
+//! Deliberately a **shape** test, not a list of known offenders. Three
+//! classes observed on one corpus is a sample of that operator's harnesses,
+//! not of the problem; a blocklist is wrong on the fourth harness and fails
+//! silently, because a bad title just looks like a title. `transcript.rs`
+//! already carries a narrower version of this idea for `<system-reminder>`
+//! and `<user_info>` on the workstream path.
+
+/// Characters that open a decorated shell prompt rather than prose.
+/// Box-drawing and the powerline separators commonly echoed into a paste.
+const PROMPT_DECORATION: [char; 9] = [
+    '\u{250c}', // ┌
+    '\u{251c}', // ├
+    '\u{2514}', // └
+    '\u{2500}', // ─
+    '\u{2502}', // │
+    '\u{256d}', // ╭
+    '\u{2570}', // ╰
+    '\u{279c}', // ➜
+    '\u{276f}', // ❯
+];
+
+/// `true` when `candidate` reads as harness scaffolding rather than user
+/// prose, and so should not become a page title.
+///
+/// Errs toward keeping text: a false positive silently discards a real title,
+/// while a false negative only reproduces today's behaviour.
+#[must_use]
+pub fn looks_like_scaffolding(candidate: &str) -> bool {
+    let trimmed = candidate.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+
+    // A markup/context block: `<ide_opened_file>…`, `<system-reminder>…`,
+    // `<user_info>…`. Requires a closing bracket so a bare comparison like
+    // "< 5ms is fine" stays prose.
+    if let Some(rest) = trimmed.strip_prefix('<')
+        && let Some(tag) = rest.split('>').next()
+        && !tag.is_empty()
+        && tag.len() <= 64
+        && tag
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '/')
+        && rest.contains('>')
+    {
+        return true;
+    }
+
+    // A decorated shell prompt echoed into the paste.
+    if trimmed.starts_with(PROMPT_DECORATION) {
+        return true;
+    }
+
+    // A bare identifier rather than a sentence: no whitespace anywhere, and
+    // carrying identifier punctuation. Real prompts essentially always
+    // contain a space; requiring the punctuation too keeps a one-word prompt
+    // like "help" or "continue" as a legitimate title.
+    if !trimmed.contains(char::is_whitespace)
+        && trimmed
+            .chars()
+            .any(|c| c.is_ascii_digit() || c == '[' || c == ']')
+        && trimmed.chars().any(|c| c == '-' || c == '_' || c == '[')
+    {
+        return true;
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_three_observed_classes_are_scaffolding() {
+        // From the #484 corpus survey: 16 IDE blocks, 4 prompt echoes, 1
+        // model id across 330 real session pages.
+        assert!(looks_like_scaffolding(
+            "<ide_opened_file>The user opened the file /home/samir/x/main.rs"
+        ));
+        assert!(looks_like_scaffolding(
+            "┌─[samir@samirb3 12:56:36] ~/x/ai-usagebar/gnome-extension"
+        ));
+        assert!(looks_like_scaffolding("claude-opus-5[1m]"));
+    }
+
+    #[test]
+    fn the_adjacent_paths_known_offenders_are_covered() {
+        // `transcript.rs` drops these on the workstream path; the same
+        // shapes must not survive as a title here.
+        assert!(looks_like_scaffolding("<system-reminder>Do not mention…"));
+        assert!(looks_like_scaffolding("<user_info>cwd=/home/x"));
+    }
+
+    #[test]
+    fn real_prompts_are_kept() {
+        for prompt in [
+            "Make the backpressure test deterministic",
+            "why is the sweep deleting pinned pages?",
+            "help",
+            "continue",
+            "< 5ms is fine for this path",
+            "run bin/ci",
+            "fix issue-484",
+        ] {
+            assert!(
+                !looks_like_scaffolding(prompt),
+                "{prompt:?} is user prose and must be kept"
+            );
+        }
+    }
+
+    #[test]
+    fn a_hyphenated_word_alone_is_not_an_identifier() {
+        // No digits and no brackets, so it stays prose even without a space.
+        assert!(!looks_like_scaffolding("well-done"));
+    }
+
+    #[test]
+    fn empty_or_blank_is_scaffolding() {
+        assert!(looks_like_scaffolding(""));
+        assert!(looks_like_scaffolding("   "));
+    }
+}

--- a/crates/ai-memory-hooks/src/synth.rs
+++ b/crates/ai-memory-hooks/src/synth.rs
@@ -10,6 +10,7 @@ use std::collections::BTreeMap;
 
 use ai_memory_core::{
     NewPage, Observation, ObservationKind, PagePath, ProjectId, SessionId, Tier, WorkspaceId,
+    looks_like_scaffolding,
 };
 use jiff::tz::TimeZone;
 
@@ -31,7 +32,7 @@ pub fn synthesize_session_page(
     // One tally for the whole page: the body renderer and the summary builder
     // describe the same session and must not scan it twice to do so.
     let tally = tally_session(observations);
-    let title = derive_title(observations);
+    let title = derive_title(observations, session_id);
     let body = render_body(session_id, observations, &title, &tally);
     let mut frontmatter_json = serde_json::json!({
         "title": title,
@@ -63,18 +64,38 @@ pub fn synthesize_session_page(
     }
 }
 
-fn derive_title(observations: &[Observation]) -> String {
+/// Title for a synthesised session page.
+///
+/// Prefers the first user prompt that reads as something a person wrote.
+/// A prompt payload is whatever the harness put there, so IDE context
+/// blocks, an echoed shell prompt, or a bare model id can arrive in the
+/// same field (#484) — those are skipped rather than becoming the title the
+/// page is indexed and displayed under.
+///
+/// Falls through in decreasing order of confidence: a usable prompt, then
+/// any usable observation title, then the session's own path. The literal
+/// "session" remains only for the case where there is nothing else at all.
+fn derive_title(observations: &[Observation], session_id: SessionId) -> String {
     for obs in observations {
-        if obs.kind == ObservationKind::UserPrompt && !obs.title.is_empty() {
+        if obs.kind == ObservationKind::UserPrompt
+            && !obs.title.is_empty()
+            && !looks_like_scaffolding(&obs.title)
+        {
             return obs.title.clone();
         }
     }
     for obs in observations {
-        if !obs.title.is_empty() {
+        if !obs.title.is_empty() && !looks_like_scaffolding(&obs.title) {
             return obs.title.clone();
         }
     }
-    "session".to_string()
+    // Every candidate was scaffolding. The page still needs a title, and its
+    // own identity is more use to a reader than the word "session" repeated
+    // across every such page.
+    if observations.is_empty() {
+        return "session".to_string();
+    }
+    format!("Session {session_id}")
 }
 
 /// The per-session counts that both the rendered body and the frontmatter
@@ -325,6 +346,12 @@ fn human_ts(ts: &jiff::Timestamp) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// One id per call is fine: assertions here never depend on its value,
+    /// only on whether the fallback path was taken at all.
+    fn test_session_id() -> SessionId {
+        SessionId::new()
+    }
     use ai_memory_core::{ObservationId, SessionId};
     use jiff::Timestamp;
 
@@ -423,7 +450,7 @@ mod tests {
         );
         assert_ne!(
             summary,
-            derive_title(&observations),
+            derive_title(&observations, test_session_id()),
             "a summary equal to the title is dropped as a repeat"
         );
     }
@@ -507,19 +534,86 @@ mod tests {
         );
     }
 
+    /// The #484 defect: the three classes measured across a live corpus must
+    /// not become titles, and the page must still get a usable one.
+    #[test]
+    fn harness_scaffolding_does_not_become_the_title() {
+        for scaffold in [
+            "<ide_opened_file>The user opened the file /home/samir/x/main.rs",
+            "\u{250c}\u{2500}[samir@samirb3 12:56:36] ~/x/ai-usagebar",
+            "claude-opus-5[1m]",
+        ] {
+            let obs = vec![
+                obs(ObservationKind::UserPrompt, scaffold),
+                obs(
+                    ObservationKind::UserPrompt,
+                    "Make the backpressure test deterministic",
+                ),
+            ];
+            assert_eq!(
+                derive_title(&obs, test_session_id()),
+                "Make the backpressure test deterministic",
+                "{scaffold:?} must be skipped in favour of the next real prompt"
+            );
+        }
+    }
+
+    /// Every candidate is scaffolding. The page still needs a title, and
+    /// "session" repeated across every such page is not one.
+    #[test]
+    fn an_all_scaffolding_session_falls_back_to_its_identity() {
+        let sid = test_session_id();
+        let obs = vec![
+            obs(ObservationKind::UserPrompt, "<ide_opened_file>x"),
+            obs(ObservationKind::UserPrompt, "claude-opus-5[1m]"),
+        ];
+        let title = derive_title(&obs, sid);
+        assert_eq!(title, format!("Session {sid}"));
+        assert_ne!(title, "session", "must not collapse to a shared literal");
+    }
+
+    /// The title is also what `page_descriptor` filters against — a body line
+    /// equal to it is dropped as a repeat. Changing which string becomes the
+    /// title therefore changes which body lines survive, so a filtered page
+    /// must still render a body whose prompts are intact.
+    #[test]
+    fn a_filtered_title_still_leaves_the_prompts_in_the_body() {
+        let obs = vec![
+            obs(ObservationKind::UserPrompt, "<ide_opened_file>noise"),
+            obs(
+                ObservationKind::UserPrompt,
+                "Make the backpressure test deterministic",
+            ),
+        ];
+        let title = derive_title(&obs, test_session_id());
+        let tally = tally_session(&obs);
+        let body = render_body(test_session_id(), &obs, &title, &tally);
+        assert!(
+            body.contains("Make the backpressure test deterministic"),
+            "the promoted prompt must still appear in the body: {body}"
+        );
+        assert!(
+            body.contains("<ide_opened_file>noise"),
+            "the skipped prompt is still session history and must be recorded"
+        );
+    }
+
     #[test]
     fn title_falls_back_through_kinds() {
         let no_prompt = vec![obs(ObservationKind::PostToolUse, "Edit")];
-        assert_eq!(derive_title(&no_prompt), "Edit");
+        assert_eq!(derive_title(&no_prompt, test_session_id()), "Edit");
 
         let empty: Vec<Observation> = vec![];
-        assert_eq!(derive_title(&empty), "session");
+        assert_eq!(derive_title(&empty, test_session_id()), "session");
 
         let with_prompt = vec![
             obs(ObservationKind::PostToolUse, "Edit"),
             obs(ObservationKind::UserPrompt, "fix the auth bug"),
         ];
-        assert_eq!(derive_title(&with_prompt), "fix the auth bug");
+        assert_eq!(
+            derive_title(&with_prompt, test_session_id()),
+            "fix the auth bug"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #484. Reported by @samirhvbr.

## The defect

`derive_title` returns the first user prompt unchanged. A prompt payload is whatever the harness put there, so IDE context blocks, an echoed shell prompt, and a bare model id all became the title the page is **indexed and displayed under**. `page_descriptor` sitting next to it has been fixed twice (#463, #477); `derive_title` had not been touched since `747c32d`.

Measured across a live instance — all 1,835 session pages, not a sample — **21 of the 330 real sessions (6.4%)**, at a flat rate month over month (8.6% July, 4.8% August) rather than a decaying legacy population. The 1,505 lifecycle-only stubs were excluded as #386's population: a symptom of being a stub, not of this defect. That split is what makes the number actionable — 21 of 1,835 would have been rounded away.

## Shape, not a blocklist

The predicate asks *"does this read as something a person wrote?"* rather than matching known offenders. Three classes from one corpus is a sample of **that operator's harnesses**, not of the problem; a list is wrong on the fourth harness and fails silently, because a bad title just looks like a title.

It lives in `ai-memory-core` so the workstream path — which already drops `<system-reminder>` and `<user_info>` with a narrower version of the same idea at `transcript.rs:1833` — can share it later.

**It errs toward keeping text.** A false positive silently discards a real title; a false negative only reproduces today's behaviour. So `help` and `continue` survive as titles, and `< 5ms is fine for this path` is prose, while `claude-opus-5[1m]` is not — no whitespace anywhere *and* identifier punctuation.

## Fallback order

Usable prompt → any usable observation title → the session's own identity. The literal `"session"` now survives only for a session with no observations at all: collapsing every filtered page onto one shared string trades a bad title for an ambiguous one.

## Tests

- **The three measured classes**, each asserted to yield the *next real prompt* instead.
- **All-scaffolding session** — the case the issue asked for explicitly; asserts it does not collapse to `"session"`.
- **Descriptor interaction** — the title is what `page_descriptor` filters body lines against, so changing which string becomes the title changes which lines survive. Asserts the promoted prompt still appears in the body, and that the *skipped* one is still recorded, since it remains session history.
- Predicate unit tests including false-positive guards.

Control verified: disabling the filter makes `harness_scaffolding_does_not_become_the_title` fail with the `<ide_opened_file>` case.

## Scope

New writes only. The existing 21 are not rewritten, and the `session-start` half is deliberately out of scope — per the reporter's evidence its most recent instance is one day after #386 merged with none in the twelve days since, so that is closed at the source.

`cargo fmt` ✅ · `clippy -D warnings` ✅ · `cargo test --workspace --all-targets` → **2580 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)