### PR TITLE
fix(web): block remote Markdown image fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   text. A newer CLI against an older server renders the rest of `status` and
   omits the section rather than failing to parse.
 
+### Fixed
+- Prevented stored Markdown from automatically fetching external image URLs
+  when viewed in the web UI, while preserving clickable external links and
+  same-origin relative images (#491).
+
 ### Docs
 - Documented the order of magnitude reported for lifecycle-hook overhead,
   including the fact that a completed tool call normally pays for both pre- and

--- a/README.md
+++ b/README.md
@@ -760,7 +760,10 @@ Useful entry points:
   browser view of the markdown wiki. `--enable-web` also mounts a
   read-only JSON frontend API at `/api/v1` (workspaces, projects, pages,
   recent, briefing, search) so custom web UIs can read the memory without
-  opening SQLite or wiki files directly:
+  opening SQLite or wiki files directly. Rendered pages keep external links
+  clickable, but image sources must be relative or root-relative; absolute
+  external images are neutralized so viewing stored Markdown cannot act as a
+  remote beacon:
 
   ```text
   GET  /api/v1/workspaces

--- a/crates/ai-memory-web/src/markdown.rs
+++ b/crates/ai-memory-web/src/markdown.rs
@@ -258,7 +258,7 @@ fn sanitize_event(event: Event<'_>) -> Event<'_> {
             id,
         }) => Event::Start(Tag::Image {
             link_type,
-            dest_url: safe_url(dest_url),
+            dest_url: safe_image_url(dest_url),
             title,
             id,
         }),
@@ -276,6 +276,29 @@ fn safe_url(url: CowStr<'_>) -> CowStr<'_> {
         || lower.starts_with('#')
         || !lower.contains(':')
     {
+        url
+    } else {
+        CowStr::Boxed("#".into())
+    }
+}
+
+/// Allow images only from the current origin.
+///
+/// Unlike links, images are fetched as soon as untrusted markdown is viewed.
+/// An absolute or network-path URL would therefore disclose the viewer's IP,
+/// user agent, and view timing without a click. Keep ordinary external links
+/// clickable, but neutralise every non-relative image target. Backslashes are
+/// rejected because browsers can interpret them as URL path separators.
+fn safe_image_url(url: CowStr<'_>) -> CowStr<'_> {
+    let trimmed = url.trim_start();
+    let is_network_path = trimmed.starts_with("//")
+        || trimmed.starts_with("\\\\")
+        || trimmed.starts_with("/\\")
+        || trimmed.starts_with("\\/");
+    let is_relative =
+        trimmed.starts_with('/') || trimmed.starts_with('#') || !trimmed.contains(':');
+
+    if !trimmed.is_empty() && is_relative && !is_network_path && !trimmed.contains('\\') {
         url
     } else {
         CowStr::Boxed("#".into())
@@ -386,6 +409,49 @@ mod tests {
         let html = render("[x](javascript:alert(1))", "default", "scratch");
         assert!(html.contains("href=\"#\""));
         assert!(!html.contains("javascript:"));
+    }
+
+    #[test]
+    fn preserves_clickable_external_links() {
+        let html = render("[docs](https://example.com/docs)", "default", "scratch");
+        assert!(html.contains(r#"href="https://example.com/docs""#));
+    }
+
+    #[test]
+    fn neutralises_external_images_without_hiding_alt_text() {
+        for target in [
+            "https://example.invalid/pixel.png",
+            "http://example.invalid/pixel.png",
+            "//example.invalid/pixel.png",
+            r"\\example.invalid\pixel.png",
+            r"/\example.invalid/pixel.png",
+            "data:image/png;base64,AA==",
+        ] {
+            let markdown = format!("![remote pixel]({target})");
+            let html = render(&markdown, "default", "scratch");
+            assert!(html.contains("src=\"#\""), "target {target}: {html}");
+            assert!(
+                html.contains("alt=\"remote pixel\""),
+                "target {target}: {html}"
+            );
+            assert!(!html.contains("example.invalid"), "target {target}: {html}");
+        }
+    }
+
+    #[test]
+    fn preserves_relative_images() {
+        for target in [
+            "images/diagram.png",
+            "../shared/diagram.png",
+            "/static/logo.svg",
+        ] {
+            let markdown = format!("![local]({target})");
+            let html = render(&markdown, "default", "scratch");
+            assert!(
+                html.contains(&format!(r#"src="{target}""#)),
+                "target {target}: {html}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- apply a dedicated same-origin policy to rendered Markdown images
- preserve external clickable links and relative/root-relative images
- add regression coverage for schemes, protocol-relative URLs, UNC-style paths, alt text, and local images
- document the behavior in the README and changelog

## Why

Stored Markdown was sanitized for script execution, but an absolute image URL was still emitted unchanged. Merely viewing a page could therefore contact an arbitrary remote host and disclose the viewer IP, user agent, and view timing without a click.

The root cause was sharing the link URL allow-list with image sources even though links and auto-fetched subresources have different privacy boundaries.

## Impact

External links remain clickable. Relative and root-relative images continue to render. External and scheme-bearing image targets are neutralized before HTML rendering.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `TAILWIND_SKIP=1 cargo test --workspace`
- `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- `cargo deny check`
- independent adversarial review: P0/P1/P2 = 0
