### PR TITLE
fix(hooks): report what a hook-drain pass did instead of exiting silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Made `hook-drain` say what a pass actually did. The drain already returned
+  `sent`/`remaining`/`dropped` counts and `run_drain` discarded all three, so
+  three passes that mean opposite things — everything delivered, every queued
+  event discarded undelivered at the retry cap or the spool TTL, and nothing
+  attempted at all because another drainer held the lock — were byte-identical
+  on both streams and in the exit code. A drain that silently loses capture was
+  therefore indistinguishable in the field from one that works, which is how
+  #493 was reported: exit 0, no output, an empty `hook-drain.log`, and no way
+  to tell which of the three had happened. A pass that leaves nothing behind
+  stays silent, so `hook-drain.log` keeps receiving only warnings and a healthy
+  instance never grows it; a pass that leaves events queued or drops them, and
+  a pass that found the lock held, now each emit one stderr line. stderr, not
+  stdout: the drainer's stdout is contractually empty and the detached helper
+  already redirects stderr into the log. This changes no delivery behaviour —
+  it only stops the existing behaviour being unfalsifiable. (#493)
 - Stopped the scaffolding filter discarding terse prompts. The identifier
   branch added in #484 fired on any single token carrying a digit and a
   hyphen, underscore or bracket, which is the shape of a bare model id and

--- a/crates/ai-memory-cli/src/commands/hook.rs
+++ b/crates/ai-memory-cli/src/commands/hook.rs
@@ -317,11 +317,53 @@ pub async fn run_drain(data_dir: Option<PathBuf>) -> anyhow::Result<()> {
     )
     .await
     {
-        Ok(hook_spool::LockedDrainResult::Drained(_))
-        | Ok(hook_spool::LockedDrainResult::LockBusy) => {}
+        Ok(outcome) => {
+            let _ = write_drain_report(&mut std::io::stderr(), &outcome);
+        }
         Err(err) => eprintln!("ai-memory hook-drain warning: failed to acquire drain lock: {err}"),
     }
     Ok(())
+}
+
+/// Report a drain pass on stderr when it ended with events undelivered.
+///
+/// Silent on a clean pass (nothing queued, or everything delivered) so
+/// `hook-drain.log` stays warning-only, matching the rotation budget in
+/// [`hook_drain_process`]. stderr, never stdout: the drainer's stdout is
+/// contractually empty and the detached helper redirects stderr into the log.
+///
+/// Without this the drain discarded its own [`hook_spool::DrainResult`], so a
+/// pass that dropped every queued event without sending it was byte-identical,
+/// on both streams and in the exit code, to one that delivered them all — and
+/// so was a pass that did nothing because another drainer held the lock (#493).
+fn write_drain_report<W: std::io::Write>(
+    w: &mut W,
+    outcome: &hook_spool::LockedDrainResult,
+) -> std::io::Result<()> {
+    match outcome {
+        hook_spool::LockedDrainResult::LockBusy => writeln!(
+            w,
+            "ai-memory hook-drain warning: another drainer holds the spool lock; \
+             this pass delivered nothing and left queued events untouched"
+        ),
+        hook_spool::LockedDrainResult::Drained(result) => {
+            if result.remaining == 0 && result.dropped == 0 {
+                return Ok(());
+            }
+            // "acknowledged", not "delivered": `sent` counts what the server
+            // ACKed, and an ack also covers an item the server accepted and then
+            // dropped by capture policy (`accepted_indices` includes protocol
+            // drops). Reporting those as delivered would assert storage the
+            // drain cannot observe — the precise confusion #493 was written in.
+            writeln!(
+                w,
+                "ai-memory hook-drain warning: {} event(s) acknowledged by the server, \
+                 {} still queued, {} DROPPED undelivered (past the retry cap or \
+                 older than the spool TTL)",
+                result.sent, result.remaining, result.dropped
+            )
+        }
+    }
 }
 
 fn env_lookup(name: &str) -> Option<String> {
@@ -1020,6 +1062,83 @@ mod tests {
             write_success_response(&mut output, agent, event).unwrap();
             assert_eq!(output, expected, "{agent:?} {event:?}");
         }
+    }
+
+    fn drain_report(outcome: &hook_spool::LockedDrainResult) -> String {
+        let mut out = Vec::new();
+        write_drain_report(&mut out, outcome).unwrap();
+        String::from_utf8(out).unwrap()
+    }
+
+    /// A pass with nothing left behind says nothing, so `hook-drain.log` keeps
+    /// receiving only warnings and a healthy instance never grows it.
+    #[test]
+    fn drain_report_is_silent_on_a_clean_pass() {
+        for result in [
+            hook_spool::DrainResult::default(),
+            hook_spool::DrainResult {
+                sent: 12,
+                remaining: 0,
+                dropped: 0,
+            },
+        ] {
+            let report = drain_report(&hook_spool::LockedDrainResult::Drained(result));
+            assert!(report.is_empty(), "clean pass emitted: {report}");
+        }
+    }
+
+    /// The regression #493 exists for. Three passes that mean opposite things —
+    /// everything delivered, everything discarded undelivered, and nothing even
+    /// attempted because another drainer held the lock — used to produce the
+    /// same empty output and the same exit 0, which is what left the reporter
+    /// unable to tell a working drain from a silently lossy one. Pin that each
+    /// one is now distinguishable from the other two.
+    #[test]
+    fn drain_report_separates_loss_and_contention_from_a_clean_pass() {
+        let clean = drain_report(&hook_spool::LockedDrainResult::Drained(
+            hook_spool::DrainResult {
+                sent: 5,
+                remaining: 0,
+                dropped: 0,
+            },
+        ));
+        let lossy = drain_report(&hook_spool::LockedDrainResult::Drained(
+            hook_spool::DrainResult {
+                sent: 0,
+                remaining: 0,
+                dropped: 7,
+            },
+        ));
+        let busy = drain_report(&hook_spool::LockedDrainResult::LockBusy);
+
+        assert!(clean.is_empty());
+        assert!(
+            lossy.contains("DROPPED") && lossy.contains('7'),
+            "a pass that discarded 7 undelivered events must name the loss: {lossy}"
+        );
+        assert!(
+            busy.contains("lock"),
+            "a contended pass must say it delivered nothing: {busy}"
+        );
+        assert_ne!(lossy, busy);
+        assert_ne!(lossy, clean);
+        assert_ne!(busy, clean);
+    }
+
+    /// Events merely still queued (server down, or the budget ran out) are a
+    /// warning too — they are the state that precedes the drop — but they must
+    /// not be reported as lost.
+    #[test]
+    fn drain_report_distinguishes_still_queued_from_dropped() {
+        let report = drain_report(&hook_spool::LockedDrainResult::Drained(
+            hook_spool::DrainResult {
+                sent: 1,
+                remaining: 4,
+                dropped: 0,
+            },
+        ));
+        assert!(report.contains("4 still queued"), "{report}");
+        assert!(report.contains("0 DROPPED"), "{report}");
     }
 
     #[test]

--- a/crates/ai-memory-cli/src/commands/hook.rs
+++ b/crates/ai-memory-cli/src/commands/hook.rs
@@ -341,10 +341,14 @@ fn write_drain_report<W: std::io::Write>(
     outcome: &hook_spool::LockedDrainResult,
 ) -> std::io::Result<()> {
     match outcome {
+        // Says what this pass did, not what the spool holds: `LockBusy` is
+        // returned before `drain_until_quiescent` lists anything, so the count
+        // of queued events is unknown here. Asserting one would repeat, inside
+        // the fix, the confusion the fix is for.
         hook_spool::LockedDrainResult::LockBusy => writeln!(
             w,
             "ai-memory hook-drain warning: another drainer holds the spool lock; \
-             this pass delivered nothing and left queued events untouched"
+             this pass attempted no delivery and left the spool untouched"
         ),
         hook_spool::LockedDrainResult::Drained(result) => {
             if result.remaining == 0 && result.dropped == 0 {
@@ -1115,6 +1119,11 @@ mod tests {
         assert!(
             lossy.contains("DROPPED") && lossy.contains('7'),
             "a pass that discarded 7 undelivered events must name the loss: {lossy}"
+        );
+        assert!(
+            !busy.contains("queued"),
+            "LockBusy is returned before the spool is listed, so the report must \
+             not claim anything about queued events: {busy}"
         );
         assert!(
             busy.contains("lock"),


### PR DESCRIPTION
Partial for #493 — the observability half, not the delivery fix. I cannot reproduce the macOS
symptom and this does not attempt to.

## The part of #493 that is reproducible anywhere

`run_drain` discarded its own result:

```rust
Ok(hook_spool::LockedDrainResult::Drained(_))
| Ok(hook_spool::LockedDrainResult::LockBusy) => {}
```

The drain already computes `sent` / `remaining` / `dropped`, and all three were thrown away. So three
passes that mean opposite things were byte-identical on both streams and in the exit code:

- every queued event delivered;
- every queued event **discarded undelivered** — past `MAX_ATTEMPTS`, or older than `MAX_AGE_MS`,
  both of which `load_live_entry` handles by deleting the file;
- **nothing attempted at all**, because another drainer held the spool lock and
  `DrainLockWait::Bounded(30s)` expired.

A drain silently losing capture is therefore indistinguishable in the field from one that works.
That is the shape of the #493 report itself: exit 0, no output, an empty `hook-drain.log`, and no way
for the reporter to tell which of the three they were in. Whatever the macOS root cause turns out to
be, it was diagnosed blind because the drain says nothing about its own outcome.

## What this changes

A pass that leaves nothing behind stays silent, so `hook-drain.log` keeps receiving only warnings and
a healthy instance never grows it — the rotation budget in `hook_drain_process` still holds. A pass
that leaves events queued or drops them, and a pass that found the lock held, each emit one stderr
line.

stderr, not stdout: the drainer's stdout is contractually empty, and the detached helper already
redirects stderr into `logs/hook-drain.log` (`stderr_file: spec.stderr_log.clone()`).

The wording says **"acknowledged"**, not "delivered". `sent` counts what the server ACKed via
`delete_accepted_indices`, and an ack also covers an item the server accepted and then dropped by
capture policy. Reporting those as delivered would assert storage the drain cannot observe — which
is the precise confusion #493 was written in, so it seemed worth not repeating in the fix.

**No delivery behaviour changes.** This only stops the existing behaviour being unfalsifiable.

## What it does not do

It does not explain why the drain makes no network request on macOS. @swhite1122's listener probe is
convincing and I have no way to reproduce it — the three cases above are what this makes
distinguishable, and if the macOS symptom is none of them, this narrows it rather than solving it.

One asymmetry worth flagging while looking, in case it is relevant: `spool_health` filters spool
files through `created_ms_from_name`, and the comment there says AppleDouble sidecars are *"Not
hypothetical on macOS"* — `._<original>.json` on filesystems without extended attributes, with a
dedicated test case. `list_entries`, which is what `drain` walks, applies no such filter: it takes
every `*.json`. `Vec<PathBuf>::sort` orders by bytes, so `._…` (0x2E) sorts before any digit and such
a file is processed first. It would fail to parse and be dropped, which on its own only costs a
phantom entry — but the two paths disagree about what counts as a spool file, and only one of them
was hardened. I have not connected that to the reported symptom and am not claiming it is the cause.

Gates: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --workspace` (2,588 passed / 0 failed), `cargo deny check`,
`scripts/check-changelog-sections.sh`.

Refs #493.
