### PR TITLE
fix(tls): trust the platform CA store instead of bundled webpki roots (#492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- The native client now trusts CAs from the platform trust store. It was built
+  with reqwest's `rustls-tls`, which bundles the Mozilla webpki roots and
+  ignores the OS store, so a CA the operator had installed locally — Caddy's
+  `tls internal`, a corporate MITM appliance, any private PKI — was invisible
+  to `ai-memory` even though `curl` and the agent CLIs trusted it. Every HTTPS
+  request failed with `invalid peer certificate: UnknownIssuer`, including
+  `ai-memory hook`, so following this project's own HTTPS-via-proxy Path 2
+  guide left lifecycle capture failing end to end: events spooled locally
+  (queuing touches no network) and the drain could never deliver them.
+  Switched to `rustls-tls-native-roots`; the runtime image installs
+  `ca-certificates`, so the server path keeps a populated store. Reported by
+  @alanmatiasdev (#492).
+
 - Made `hook-drain` say what a pass actually did. The drain already returned
   `sent`/`remaining`/`dropped` counts and `run_drain` discarded all three, so
   three passes that mean opposite things — everything delivered, every queued

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,10 +1353,10 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1937,6 +1947,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,6 +2394,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2394,7 +2411,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2547,6 +2563,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,6 +2617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,6 +2665,29 @@ checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3579,15 +3639,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,15 @@ regex = "1"
 git2 = { version = "0.21", default-features = false, features = ["vendored-libgit2"] }
 
 # LLM provider HTTP.
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+# `rustls-tls` bundles the Mozilla webpki root store and ignores the OS trust
+# store, so a CA an operator installed locally — Caddy's `tls internal`, a
+# corporate MITM appliance, any private PKI — is invisible to this client even
+# though `curl` and the agent CLIs trust it. That made lifecycle capture fail
+# with `UnknownIssuer` on every install following the project's own
+# HTTPS-via-proxy Path 2 (#492). `rustls-tls-native-roots` reads the platform
+# store instead; the runtime image installs `ca-certificates`, so the server
+# path keeps a populated store.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots", "stream"] }
 futures-util = "0.3"
 async-trait = "0.1"
 

--- a/companions/ai-memory-importer/Cargo.toml
+++ b/companions/ai-memory-importer/Cargo.toml
@@ -9,7 +9,9 @@ publish = false
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+# Native roots, matching the workspace: the importer POSTs to the same server
+# an operator may front with a private CA (#492).
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"


### PR DESCRIPTION
Refs #492. Reported by @alanmatiasdev.

**⚠️ This changes TLS behaviour for every outbound HTTPS request in the product. I have tested it but I am not merging it without your sign-off** — see *Blast radius* below.

## The bug

The workspace built reqwest with `rustls-tls`, which compiles in the **Mozilla webpki root store and never consults the OS trust store**. So a CA the operator installed locally — Caddy's `tls internal`, a corporate MITM appliance, any private PKI — was invisible to `ai-memory` while `curl` and the agent CLIs trusted it. That asymmetry is what made this read as an ai-memory bug rather than a PKI one.

Every HTTPS request failed with `invalid peer certificate: UnknownIssuer`, **including `ai-memory hook`**. Because spooling touches no network, capture looked healthy: events queued locally and the drain silently failed to deliver them, forever. Anyone following **this project's own Path 2 guide** ended up with a dead capture path and no signal — the reporter only found it by running `finalize-session` by hand.

## Verified against a private CA the system store does not know

| build | CA supplied | result |
|---|---|---|
| `rustls-tls` (before) | yes | `invalid peer certificate: UnknownIssuer` — **the reporter's exact error** |
| `rustls-tls-native-roots` (after) | yes | handshake succeeds, request reaches HTTP-level parsing |
| after | no | `client error (Connect)` — correctly still rejected |

The middle row is the control that matters: the same CA handed to the **pre-change** binary is still rejected, so the trust comes from the feature change and not from how the CA was supplied. My first attempt at that control was invalid — a failed `git stash` meant nothing rebuilt and I re-tested the new binary — so I reverted `Cargo.toml` explicitly and rebuilt before trusting it.

I used `SSL_CERT_FILE` to point at the test CA rather than modifying a real system trust store. `rustls-native-certs` honours both; the reporter's case is the OS-store half, which I did not exercise directly.

## Blast radius — why I want your call

This affects **every** outbound HTTPS call: LLM providers, embeddings, hooks, MCP clients, the importer.

- **Container: safe.** The runtime image is `debian:bookworm-slim` with `ca-certificates` installed, so the store is populated.
- **Native installs: safe** in any normal configuration — this is the same store `curl` uses.
- **The risk** is an environment with an empty or unreadable trust store, which previously worked off the bundled roots and would now have none. That is unusual, and such a host would already fail `curl`, but it is a real behaviour change rather than a pure bug fix.

The conservative alternative is to keep webpki roots and document that private CAs are unsupported — which I think is worse, since the project ships a guide that walks users straight into this.

## Gate

`cargo fmt --all -- --check` ✅ · `cargo clippy --workspace --all-targets -- -D warnings` ✅ · `cargo test --workspace --all-targets` → **2588 passed, 0 failed** · `cargo deny check` → advisories, bans, licenses, sources all ok (the new transitive `rustls-native-certs` passes policy).

All under the pinned 1.95 toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)