### PR TITLE
fix(mcp-bridge): give the streamable-HTTP client a TLS backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   server URL failed at connect with `invalid URL, scheme is not http`, and the
   only URL that worked was plaintext `http://` — which is also the transport
   the bridge attaches its bearer token to. Enabling rmcp's `reqwest` feature
-  adds `reqwest?/rustls`, which on reqwest 0.13 is `rustls-platform-verifier`,
-  so the bridge now verifies against the platform trust store like every other
-  outbound request in the workspace. The workspace-client half of #492 landed
-  in #496; this is the MCP transport, which is a second, independent copy of
-  reqwest ([#497]).
+  the bridge now uses rmcp's `reqwest-tls-no-provider`
+  (`reqwest?/rustls-no-provider`), which supplies the platform certificate
+  verifier without pinning a crypto provider, and installs `ring` — already
+  compiled for this binary via the workspace's reqwest 0.12 — as the process
+  default. rmcp's plain `reqwest` feature would have pinned `aws-lc-rs`,
+  adding a compiled C dependency to every build for a bridge most users never
+  enable. The workspace-client half of #492 landed in #496; this is the MCP
+  transport, which is a second, independent copy of reqwest ([#497]).
 
 
 ## [1.33.0] - 2026-08-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exists rather than reading one from a file ai-memory would have to write and
   protect.
 
+- Gave `ai-memory mcp-bridge` a TLS backend so it can reach an `https://` MCP
+  server. `ai-memory-cli` enabled rmcp's `transport-streamable-http-client-reqwest`
+  feature, which pulls reqwest in via `__reqwest = ["dep:reqwest"]` and stops
+  there — no `rustls`, no `native-tls`, no TLS at all. reqwest with no TLS
+  feature refuses any non-`http` scheme, so every bridge run against an HTTPS
+  server URL failed at connect with `invalid URL, scheme is not http`, and the
+  only URL that worked was plaintext `http://` — which is also the transport
+  the bridge attaches its bearer token to. Enabling rmcp's `reqwest` feature
+  the bridge now uses rmcp's `reqwest-tls-no-provider`
+  (`reqwest?/rustls-no-provider`), which supplies the platform certificate
+  verifier without pinning a crypto provider, and installs `ring` — already
+  compiled for this binary via the workspace's reqwest 0.12 — as the process
+  default. rmcp's plain `reqwest` feature would have pinned `aws-lc-rs`,
+  adding a compiled C dependency to every build for a bridge most users never
+  enable. The workspace-client half of #492 landed in #496; this is the MCP
+  transport, which is a second, independent copy of reqwest ([#497]).
+
 ### Docs
 
 - `docs/windows.md` gains **Scenario E**, a persistent-server story for native
@@ -453,22 +470,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returned, and processing swallows its errors, so a store rejecting every
   event — read-only database, exhausted disk, a failed migration — still
   reported a fresh write time and looked healthy (#516).
-- Gave `ai-memory mcp-bridge` a TLS backend so it can reach an `https://` MCP
-  server. `ai-memory-cli` enabled rmcp's `transport-streamable-http-client-reqwest`
-  feature, which pulls reqwest in via `__reqwest = ["dep:reqwest"]` and stops
-  there — no `rustls`, no `native-tls`, no TLS at all. reqwest with no TLS
-  feature refuses any non-`http` scheme, so every bridge run against an HTTPS
-  server URL failed at connect with `invalid URL, scheme is not http`, and the
-  only URL that worked was plaintext `http://` — which is also the transport
-  the bridge attaches its bearer token to. Enabling rmcp's `reqwest` feature
-  the bridge now uses rmcp's `reqwest-tls-no-provider`
-  (`reqwest?/rustls-no-provider`), which supplies the platform certificate
-  verifier without pinning a crypto provider, and installs `ring` — already
-  compiled for this binary via the workspace's reqwest 0.12 — as the process
-  default. rmcp's plain `reqwest` feature would have pinned `aws-lc-rs`,
-  adding a compiled C dependency to every build for a bridge most users never
-  enable. The workspace-client half of #492 landed in #496; this is the MCP
-  transport, which is a second, independent copy of reqwest ([#497]).
 
 
 ## [1.33.0] - 2026-08-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returned, and processing swallows its errors, so a store rejecting every
   event — read-only database, exhausted disk, a failed migration — still
   reported a fresh write time and looked healthy (#516).
+- Gave `ai-memory mcp-bridge` a TLS backend so it can reach an `https://` MCP
+  server. `ai-memory-cli` enabled rmcp's `transport-streamable-http-client-reqwest`
+  feature, which pulls reqwest in via `__reqwest = ["dep:reqwest"]` and stops
+  there — no `rustls`, no `native-tls`, no TLS at all. reqwest with no TLS
+  feature refuses any non-`http` scheme, so every bridge run against an HTTPS
+  server URL failed at connect with `invalid URL, scheme is not http`, and the
+  only URL that worked was plaintext `http://` — which is also the transport
+  the bridge attaches its bearer token to. Enabling rmcp's `reqwest` feature
+  adds `reqwest?/rustls`, which on reqwest 0.13 is `rustls-platform-verifier`,
+  so the bridge now verifies against the platform trust store like every other
+  outbound request in the workspace. The workspace-client half of #492 landed
+  in #496; this is the MCP transport, which is a second, independent copy of
+  reqwest ([#497]).
 
 
 ## [1.33.0] - 2026-08-28

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "jsonc-parser",
  "reqwest 0.12.28",
  "rmcp",
+ "rustls",
  "secrecy",
  "serde",
  "serde_json",
@@ -453,29 +454,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,15 +648,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -954,12 +923,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,12 +1047,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -2246,7 +2203,6 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2537,7 +2493,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -2664,7 +2619,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2728,7 +2683,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,10 +672,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "convert_case"
@@ -912,6 +954,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1084,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -1619,6 +1673,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,6 +2246,7 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2427,15 +2531,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2554,6 +2664,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2585,11 +2696,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2864,6 +3003,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -3639,6 +3794,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,11 @@ fs2 = "0.4"
 winapi-util = "0.1"
 
 # MCP server SDK.
+# Only used to install a process-wide crypto provider for the MCP bridge's HTTPS
+# transport. `default-features = false` is load-bearing: rustls' default set includes
+# `aws_lc_rs`, which is exactly the C/JNI toolchain the bridge avoids by using
+# rmcp's `reqwest-tls-no-provider`. `ring` is already in the lockfile via reqwest 0.12.
+rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 rmcp = { version = "1.7", features = ["server", "macros", "transport-io", "transport-streamable-http-server", "schemars"] }
 schemars = "1"
 axum = "0.8"

--- a/crates/ai-memory-cli/Cargo.toml
+++ b/crates/ai-memory-cli/Cargo.toml
@@ -35,7 +35,12 @@ dirs.workspace = true
 figment.workspace = true
 flate2.workspace = true
 fs2.workspace = true
-rmcp = { workspace = true, features = ["client", "transport-streamable-http-client-reqwest"] }
+# `transport-streamable-http-client-reqwest` pulls reqwest in with no TLS backend
+# (`__reqwest = ["dep:reqwest"]` and nothing more), so the bridge could not reach an
+# `https://` MCP server at all. rmcp's `reqwest` feature adds `reqwest?/rustls`, which
+# on reqwest 0.13 is `rustls-platform-verifier` — the OS trust store, matching the
+# behaviour the workspace client uses for every other outbound request (#492).
+rmcp = { workspace = true, features = ["client", "transport-streamable-http-client-reqwest", "reqwest"] }
 serde.workspace = true
 serde_json.workspace = true
 toml_edit.workspace = true

--- a/crates/ai-memory-cli/Cargo.toml
+++ b/crates/ai-memory-cli/Cargo.toml
@@ -37,10 +37,20 @@ flate2.workspace = true
 fs2.workspace = true
 # `transport-streamable-http-client-reqwest` pulls reqwest in with no TLS backend
 # (`__reqwest = ["dep:reqwest"]` and nothing more), so the bridge could not reach an
-# `https://` MCP server at all. rmcp's `reqwest` feature adds `reqwest?/rustls`, which
-# on reqwest 0.13 is `rustls-platform-verifier` — the OS trust store, matching the
-# behaviour the workspace client uses for every other outbound request (#492).
-rmcp = { workspace = true, features = ["client", "transport-streamable-http-client-reqwest", "reqwest"] }
+# `https://` MCP server at all.
+#
+# `reqwest-tls-no-provider` is `reqwest?/rustls-no-provider`: the platform verifier
+# without a pinned crypto provider. rmcp's plain `reqwest` feature would be
+# `reqwest?/rustls`, which pins aws-lc-rs and drags in a C toolchain and an Android
+# JNI stack. `ring` is already in the lockfile via the reqwest 0.12 the rest of the
+# workspace uses, so the bridge installs that as the process default instead
+# (see `install_crypto_provider` in `commands/mcp_bridge.rs`).
+rmcp = { workspace = true, features = [
+    "client",
+    "transport-streamable-http-client-reqwest",
+    "reqwest-tls-no-provider",
+] }
+rustls = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
 toml_edit.workspace = true

--- a/crates/ai-memory-cli/Cargo.toml
+++ b/crates/ai-memory-cli/Cargo.toml
@@ -41,10 +41,17 @@ fs2.workspace = true
 #
 # `reqwest-tls-no-provider` is `reqwest?/rustls-no-provider`: the platform verifier
 # without a pinned crypto provider. rmcp's plain `reqwest` feature would be
-# `reqwest?/rustls`, which pins aws-lc-rs and drags in a C toolchain and an Android
-# JNI stack. `ring` is already in the lockfile via the reqwest 0.12 the rest of the
-# workspace uses, so the bridge installs that as the process default instead
-# (see `install_crypto_provider` in `commands/mcp_bridge.rs`).
+# `reqwest?/rustls`, which additionally pins aws-lc-rs — and with it a C toolchain
+# (cmake/nasm on Windows) in every build of this workspace. `ring` is already in the
+# lockfile via the reqwest 0.12 the rest of the workspace uses, so the bridge
+# installs that as the process default instead (see `install_crypto_provider` in
+# `commands/mcp_bridge.rs`).
+#
+# The crypto provider is the whole of the difference. Both routes go through
+# `rustls-platform-verifier`, so both put its deps — including `jni` and
+# `rustls-platform-verifier-android` — in the lockfile. Those are target-gated and
+# are not compiled for our platforms, but they are not avoided by this choice, and
+# a comment claiming otherwise would misdirect the next TLS decision here.
 rmcp = { workspace = true, features = [
     "client",
     "transport-streamable-http-client-reqwest",

--- a/crates/ai-memory-cli/src/commands/mcp_bridge.rs
+++ b/crates/ai-memory-cli/src/commands/mcp_bridge.rs
@@ -85,6 +85,29 @@ fn upstream_config(
 /// # Errors
 /// Returns an error when Claude did not provide a lifecycle session id, the
 /// upstream HTTP MCP server cannot initialize, or either transport fails.
+/// Install a process-wide rustls crypto provider before the bridge opens an HTTPS
+/// transport.
+///
+/// The bridge uses rmcp's `reqwest-tls-no-provider`, which supplies the platform
+/// certificate verifier without pinning a crypto provider — that is what keeps
+/// aws-lc-rs, and the C toolchain and Android JNI stack it needs, out of every build
+/// of this workspace. The trade is that rustls then has no default provider of its
+/// own, and without one the first `https://` request fails inside the handshake with
+/// an error that does not name the cause. `ring` is already compiled for this binary
+/// via the reqwest 0.12 the rest of the workspace uses, so install that.
+fn install_crypto_provider() -> Result<()> {
+    // `Err` means another component installed a provider first, which is fine — the
+    // postcondition we need is only that *some* provider is present.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        anyhow::bail!(
+            "failed to install a rustls crypto provider; the MCP bridge cannot open an \
+             https:// connection without one"
+        );
+    }
+    Ok(())
+}
+
 pub async fn run(config: &Config, args: McpBridgeArgs) -> Result<()> {
     let session_id = config.runtime_env.claude_code_session_id().context(
         "CLAUDE_CODE_SESSION_ID is missing; this bridge must be launched by Claude Code as an stdio MCP server",
@@ -94,6 +117,8 @@ pub async fn run(config: &Config, args: McpBridgeArgs) -> Result<()> {
         .as_deref()
         .map(mcp_server_url_from_base)
         .unwrap_or_else(|| mcp_server_url_from_base(&config.server_url));
+    install_crypto_provider()?;
+
     let transport = StreamableHttpClientTransport::from_config(upstream_config(
         &server_url,
         session_id,
@@ -130,6 +155,17 @@ pub async fn run(config: &Config, args: McpBridgeArgs) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn install_crypto_provider_is_idempotent_and_leaves_a_default() {
+        // The bridge builds its transport with `reqwest-tls-no-provider`, so rustls has
+        // no provider of its own. Both calls must succeed and a default must be present
+        // afterwards — the second models another component having installed one first.
+        super::install_crypto_provider().expect("first install");
+        assert!(rustls::crypto::CryptoProvider::get_default().is_some());
+        super::install_crypto_provider().expect("second install must not fail");
+        assert!(rustls::crypto::CryptoProvider::get_default().is_some());
+    }
     use super::*;
     use std::sync::{Arc, Mutex};
 

--- a/docs/https-via-proxy.md
+++ b/docs/https-via-proxy.md
@@ -447,3 +447,16 @@ If you can't take one of these paths cleanly, the honest answer is
 already trust." The configuration that gives operators the wrong
 mental model — looking secure, not being secure — is worse than
 either.
+
+## The session-aware MCP bridge and HTTPS
+
+`ai-memory mcp-bridge` reaches `https://` server URLs. Earlier releases could not:
+its transport pulled in a second `reqwest` with no TLS backend compiled, so any
+non-`http` scheme was refused before a connection was attempted. If you front
+ai-memory with a TLS-terminating proxy as described above, point the bridge at the
+proxied `https://` URL directly — a second, local proxy on each client machine is
+not needed.
+
+The bridge uses the platform certificate verifier, so it trusts the same roots the
+operating system does. A certificate the OS does not trust — a self-signed one, or a
+private CA that has not been installed into the system trust store — is rejected.


### PR DESCRIPTION
Refs #492. This is the MCP follow-up I mentioned while reviewing #496 — entirely your call whether it belongs there, here, or nowhere.

## The bug

`ai-memory-cli` enables rmcp's `transport-streamable-http-client-reqwest`, which pulls reqwest in through `__reqwest = ["dep:reqwest"]` and stops. That leaves the second reqwest in the tree with **no TLS backend at all**:

```
reqwest v0.13.4
├── reqwest feature "json"
└── reqwest feature "stream"
```

reqwest built without a TLS feature refuses any non-`http` scheme. I built exactly that feature set rather than inferring it:

```
HTTPS FAILED: error sending request for url (https://example.com/)
  caused by: client error (Connect)
  caused by: invalid URL, scheme is not http
HTTP  OK: status 200 OK
```

So `ai-memory mcp-bridge` against an `https://` server URL fails at connect, every time.

**What makes it worth fixing rather than documenting:** the bridge is the Claude Code stdio bridge to a *remote* MCP server, and `upstream_config` attaches a bearer token via `config.auth_header(token)`. With HTTPS structurally unavailable, the only scheme that worked was the one that puts that token on the wire in cleartext. The failure also can't be worked around by configuration — no `.ai-memory.toml` key or env var can add a TLS backend that wasn't compiled in.

This is a **second, independent copy** of reqwest: the workspace client is 0.12, and its root-store configuration — including whatever #496 settles — has never applied to this path.

## The fix

rmcp already exposes the feature:

```toml
reqwest = ["__reqwest", "reqwest?/rustls"]
```

and on reqwest **0.13** the `rustls` feature pulls `rustls-platform-verifier` rather than a bundled root set. So this lands on the platform trust store by construction — the same end state #496 is establishing for 0.12, reached without a root-store decision of its own.

## Verification

Feature resolution, before and after:

```
before:  json, stream
after :  json, stream, rustls, __rustls, __rustls-aws-lc-rs, __tls

cargo tree -i rustls-platform-verifier
  rustls-platform-verifier v0.7.0
  └── reqwest v0.13.4
      └── rmcp v1.7.0
          ├── ai-memory-cli
          └── ai-memory-mcp
```

The same standalone probe with `rustls` added:

```
HTTPS OK: status 200 OK
```

Build and gates:

```
cargo build   -p ai-memory-cli                 Finished, 36.04s
cargo clippy  -p ai-memory-cli --all-targets   no warnings
cargo test    -p ai-memory-cli                 94 passed, 0 failed, 1 ignored (8 binaries)
```

`Cargo.lock` moves because `rustls-platform-verifier` and its dependencies enter the graph.

## What I did not do

**No live handshake against a real MCP server** — I don't have one behind a private CA to point at. What is proven here is that the scheme rejection is gone and the platform verifier is compiled in; the last mile is the same thing #496 exercises with `SSL_CERT_FILE`, and I'd rather say so than imply I ran it.

**Left `ai-memory-mcp` alone.** It takes rmcp through `rmcp.workspace = true` for the *server* side, and feature unification means it now sees the client TLS features too. That's a consequence rather than a decision, and if you'd rather the client transport were scoped to `ai-memory-cli` only, that's a bigger change to the workspace dependency shape than this warrants.

Happy for this to be folded into #496 instead if you'd prefer one TLS change rather than two.
