### PR TITLE
test(run): stop asserting that three round-trips fit in 100ms

### DIFF
--- a/crates/ai-memory-cli/src/commands/run.rs
+++ b/crates/ai-memory-cli/src/commands/run.rs
@@ -1618,7 +1618,16 @@ mod tests {
         let prepared = prepare_managed_run_with_retry(
             &endpoint,
             &request,
-            Duration::from_millis(100),
+            // A wall-clock give-up deadline, not a latency assertion. This
+            // test is about the retry loop reaching the third attempt, and at
+            // 100ms it was really asserting that three HTTP round-trips fit
+            // inside 100ms — which a loaded CI runner does not guarantee, so
+            // it failed intermittently on both ubuntu and macOS with the
+            // 409 the mock is supposed to retry past. The window is generous
+            // because nothing here should depend on its size; the loop still
+            // returns the instant the third attempt succeeds, so the fast
+            // path stays a few milliseconds.
+            Duration::from_secs(5),
             Duration::from_millis(1),
         )
         .await


### PR DESCRIPTION
A pre-existing flake, surfaced while trying to get #496's CI green. **Unrelated to that change**, so it is here rather than folded into it.

## The flake

`prepare_waits_for_a_previous_launcher_to_finish` drove the retry loop with a **100ms** give-up window:

```rust
prepare_managed_run_with_retry(&endpoint, &request, Duration::from_millis(100), Duration::from_millis(1))
```

`retry_window` is a wall-clock deadline (`let deadline = Instant::now() + retry_window`). So the test was really asserting that **three HTTP round-trips against a local mock complete inside 100ms** — which a loaded CI runner does not guarantee. When it does not, the deadline passes while the mock is still returning the 409 the loop exists to retry past, and the test dies on the `unwrap`:

```
called `Result::unwrap()` on an `Err` value:
server returned 409 Conflict: {"error":"workstream is already active: owned by workstation:42"}
```

Observed on **both** ubuntu-latest and macos-latest in one run, and again on macOS after a re-run — while passing locally every time, on both the branch and `main`.

## The fix

The assertion that matters is `attempts == 3`: the loop retries until the third attempt succeeds. Nothing in this test should depend on how long that takes, so the window is now generous enough never to bind. The loop returns the instant the third attempt succeeds, so the test still runs in **0.01s**.

**I checked it is not now vacuous.** With the window set to zero it fails with the same 409, so the retry path is still genuinely exercised rather than skipped past.

## Why not just re-run CI

Because it failed twice, on two platforms, and a test that passes only when the runner is fast is one that will keep costing people time — and it teaches the reflex of re-running red CI, which is how a real failure eventually gets waved through.

Worth flagging that widening a budget is exactly what made things *worse* the last time I touched a flake in this repo — raising the autoscope Windows budget saturated the runner and broke an unrelated 2s subprocess timeout. This case is different: the budget here is a client-side give-up deadline inside one unit test against a local mock, so a larger value consumes no runner time and delays nothing that succeeds.

`cargo fmt --all -- --check` ✅ · `cargo clippy --workspace --all-targets -- -D warnings` ✅ · `cargo test --workspace --all-targets` → **2588 passed, 0 failed**, pinned 1.95 toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)