### PR TITLE
fix(routing): pin managed skill payloads to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# These files are embedded verbatim by include_str!, so checkout EOLs become
+# part of the CLI and MCP payload contract.
+crates/ai-memory-core/src/routing_skills/*/SKILL.md text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Made managed routing `SKILL.md` payloads byte-identical across release
+  platforms. Windows builds previously embedded CRLF from the runner checkout
+  while Linux and macOS builds embedded LF, so one tag returned different
+  bytes through CLI installs and `memory_install_self_routing`. The embedded
+  assets now use LF everywhere without rewriting user-authored files. (#502)
 - The native client now trusts CAs from the platform trust store. It was built
   with reqwest's `rustls-tls`, which bundles the Mozilla webpki roots and
   ignores the OS store, so a CA the operator had installed locally — Caddy's

--- a/README.md
+++ b/README.md
@@ -629,6 +629,8 @@ one matching entry.
   (`ai-memory install-instructions`, or `--target AGENTS.md` for AGENTS-based
   projects) when you want new tool guidance. The refresh writes the slim
   markered snippet and managed Agent Skills from the same binary-owned assets.
+  Managed skill payloads use LF line endings on every release platform, while
+  user-authored files keep their existing line endings.
 
 For every client in the [Support Matrix](#support-matrix), plus curl-based hook
 installs, source builds, CLI environment variables, and the full subcommand

--- a/crates/ai-memory-core/src/routing_skills.rs
+++ b/crates/ai-memory-core/src/routing_skills.rs
@@ -147,6 +147,22 @@ mod tests {
     }
 
     #[test]
+    fn managed_skill_payloads_use_lf_line_endings() {
+        for skill in MANAGED_SKILLS {
+            assert!(
+                !skill.content.contains('\r'),
+                "{} must use LF line endings",
+                skill.name
+            );
+            assert!(
+                skill.content.ends_with('\n'),
+                "{} must end with a newline",
+                skill.name
+            );
+        }
+    }
+
+    #[test]
     fn relative_paths_are_safe_relative_skill_markdown_files() {
         for skill in MANAGED_SKILLS {
             let expected_suffix = format!("{}/SKILL.md", skill.name);
@@ -197,8 +213,7 @@ mod tests {
     }
 
     fn parse_frontmatter(skill: &ManagedSkill) -> Frontmatter {
-        let content = skill.content.replace("\r\n", "\n");
-        let Some(rest) = content.strip_prefix("---\n") else {
+        let Some(rest) = skill.content.strip_prefix("---\n") else {
             panic!("{} must start with frontmatter", skill.name);
         };
         let Some((frontmatter, _body)) = rest.split_once("\n---\n") else {

--- a/docs/install.md
+++ b/docs/install.md
@@ -1752,6 +1752,9 @@ with the slim snippet, leaves unrelated instructions before and after it alone,
 and writes a timestamped `.bak-*` backup before changing an existing file.
 Managed skill files contain an ai-memory ownership marker; same-name user skills
 without that marker are preserved unless you explicitly force replacement.
+Their embedded payloads use LF line endings on every release platform, so CLI
+installs and `memory_install_self_routing` return the same bytes on Windows,
+Linux, and macOS. This does not rewrite line endings in user-authored files.
 `install-instructions --print` previews only the instruction snippet; run
 `install-skills --print` when you want to preview the managed skill payloads.
 


### PR DESCRIPTION
## Summary

- Pin only the compile-time embedded managed SKILL.md assets to LF via .gitattributes.
- Add a regression test that rejects carriage returns and remove the test-only normalization that masked the platform difference.
- Document the cross-platform byte contract without changing user-authored files.

## Evidence

The v1.32.1 Windows and Linux release artifacts were downloaded and verified against their published SHA-256 sidecars. Running install-instructions from each artifact produced different bytes for all five managed skills:

- Windows: every line ending was CRLF.
- Linux: every line ending was LF.
- After EOL normalization, every corresponding payload was byte-identical.

For ai-memory-retrieval/SKILL.md specifically, Windows emitted 6,486 bytes with 84 CRLF sequences; Linux emitted 6,402 bytes with 84 LF sequences. The Linux output matched the repository blob. The release workflow builds on windows-latest after a normal checkout, and include_str! embeds the resulting working-tree bytes verbatim.

The markered AGENTS.md snippet was already byte-identical LF on both platforms, so the platform-dependent managed skill payloads were not a deliberate package-wide Windows EOL policy.

## Why this scope

The attribute targets only crates/ai-memory-core/src/routing_skills/*/SKILL.md. It does not force every Markdown file in the repository to LF and does not add runtime normalization or allocations across the CLI and MCP consumers.

## Validation

- cargo fmt --all -- --check
- git diff --check
- TAILWIND_SKIP=1 cargo test --workspace -j 1 -- --test-threads=1
- TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -j 1 -- -D warnings
- cargo deny check
- cargo test -p ai-memory-core routing_skills -j 1 -- --test-threads=1 after rebasing onto current upstream/main