### PR TITLE
fix(hooks): post PowerShell JSON as UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- PowerShell compatibility hooks now encode JSON request bodies as explicit
+  UTF-8 bytes and declare `charset=utf-8`. Windows PowerShell 5.1 otherwise
+  encoded string bodies using a host-dependent legacy code page, so prompts,
+  paths, or tool content containing non-ASCII text could make `/hook` return
+  HTTP 400 and disappear from memory while ASCII events still worked. A native
+  Windows loopback test now round-trips Chinese and Portuguese text byte for
+  byte (#500).
+
 ## [1.32.2] - 2026-08-26
 
 ### Fixed

--- a/crates/ai-memory-hooks/tests/powershell_utf8.rs
+++ b/crates/ai-memory-hooks/tests/powershell_utf8.rs
@@ -1,0 +1,130 @@
+//! Windows PowerShell compatibility-hook transport regression tests.
+
+#![cfg(windows)]
+
+use std::io::{Read as _, Write as _};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crate should live under crates/ai-memory-hooks")
+        .to_path_buf()
+}
+
+fn header_end(bytes: &[u8]) -> Option<usize> {
+    bytes.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+fn receive_one_request(listener: TcpListener) -> (String, Vec<u8>) {
+    listener.set_nonblocking(true).unwrap();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let (mut stream, _) = loop {
+        match listener.accept() {
+            Ok(connection) => break connection,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                assert!(Instant::now() < deadline, "PowerShell hook never connected");
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(error) => panic!("mock hook server accept failed: {error}"),
+        }
+    };
+    stream.set_nonblocking(false).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+
+    let mut request = Vec::new();
+    let (body_start, body_len) = loop {
+        let mut chunk = [0_u8; 4096];
+        let read = stream.read(&mut chunk).expect("read hook request");
+        assert!(read > 0, "hook request ended before its headers");
+        request.extend_from_slice(&chunk[..read]);
+        if let Some(end) = header_end(&request) {
+            let headers = String::from_utf8_lossy(&request[..end]);
+            let len = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .expect("PowerShell request should carry Content-Length");
+            break (end + 4, len);
+        }
+    };
+    while request.len() < body_start + body_len {
+        let mut chunk = [0_u8; 4096];
+        let read = stream.read(&mut chunk).expect("read hook request body");
+        assert!(read > 0, "hook request body ended early");
+        request.extend_from_slice(&chunk[..read]);
+    }
+
+    stream
+        .write_all(b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+        .unwrap();
+    let headers = String::from_utf8(request[..body_start - 4].to_vec()).unwrap();
+    let body = request[body_start..body_start + body_len].to_vec();
+    (headers, body)
+}
+
+#[test]
+fn powershell_hook_posts_json_as_utf8_bytes() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let server = format!("http://{}", listener.local_addr().unwrap());
+    let receiver = thread::spawn(move || receive_one_request(listener));
+
+    let payload = serde_json::json!({
+        "session_id": "utf8-regression",
+        "prompt": "中文记忆测试：行动完成 — Validação: não, memória, correção, ação"
+    })
+    .to_string();
+    let script = repo_root()
+        .join("hooks")
+        .join("lib")
+        .join("ai-memory-hook.ps1");
+    let script = script.to_string_lossy().replace('\'', "''");
+    let program = format!(
+        ". '{script}'; function Read-AiMemoryStdin {{ $env:AI_MEMORY_TEST_PAYLOAD }}; \
+         Invoke-AiMemoryHook -Event 'user-prompt' -Agent 'codex'"
+    );
+    let output = Command::new("powershell.exe")
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            &program,
+        ])
+        .env("AI_MEMORY_HOOK_URL", server)
+        .env("AI_MEMORY_TEST_PAYLOAD", &payload)
+        .output()
+        .expect("run PowerShell hook");
+    assert!(
+        output.status.success(),
+        "PowerShell hook failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let (headers, body) = receiver.join().unwrap();
+    assert!(
+        headers
+            .lines()
+            .any(|line| line.eq_ignore_ascii_case("Content-Type: application/json; charset=utf-8")),
+        "request did not declare UTF-8 JSON: {headers}"
+    );
+    assert_eq!(body, payload.as_bytes());
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        parsed["prompt"],
+        "中文记忆测试：行动完成 — Validação: não, memória, correção, ação"
+    );
+}

--- a/hooks/lib/ai-memory-hook.ps1
+++ b/hooks/lib/ai-memory-hook.ps1
@@ -324,6 +324,7 @@ function Invoke-AiMemoryHook {
         $Headers["Authorization"] = "Bearer $env:AI_MEMORY_AUTH_TOKEN"
     }
 
+    $BodyBytes = [Text.Encoding]::UTF8.GetBytes($Payload)
     try {
         Invoke-WebRequest `
             -UseBasicParsing `
@@ -331,8 +332,8 @@ function Invoke-AiMemoryHook {
             -Method Post `
             -Uri "$Server/hook?event=$Event&agent=$Agent$QS$SessionQS" `
             -Headers $Headers `
-            -ContentType "application/json" `
-            -Body $Payload | Out-Null
+            -ContentType "application/json; charset=utf-8" `
+            -Body $BodyBytes | Out-Null
     } catch {
     }
     if ($Agent -eq "devin" -and $Event -eq "session-end") {

--- a/tests/hooks/test_lib.sh
+++ b/tests/hooks/test_lib.sh
@@ -144,6 +144,12 @@ PS_ANTIGRAVITY_STATIC=$(grep -q 'function Test-AiMemoryAntigravityInitialInvocat
     && printf 'ok' || printf 'missing')
 assert_eq "powershell antigravity hook has invocation guard" "ok" "$PS_ANTIGRAVITY_STATIC"
 
+PS_UTF8_STATIC=$(grep -Fq '$BodyBytes = [Text.Encoding]::UTF8.GetBytes($Payload)' hooks/lib/ai-memory-hook.ps1 \
+    && grep -Fq 'application/json; charset=utf-8' hooks/lib/ai-memory-hook.ps1 \
+    && grep -Fq -- '-Body $BodyBytes' hooks/lib/ai-memory-hook.ps1 \
+    && printf 'ok' || printf 'missing')
+assert_eq "powershell hook posts explicit UTF-8 JSON bytes" "ok" "$PS_UTF8_STATIC"
+
 # --- json_string -------------------------------------------------------
 JSON_INPUT='quoted "thing" \ path
 next line'


### PR DESCRIPTION
## What changed

- PowerShell compatibility hooks now encode their JSON payload as explicit UTF-8 bytes before `Invoke-WebRequest`.
- The request declares `Content-Type: application/json; charset=utf-8`.
- Added a native Windows PowerShell 5.1 integration test with a real loopback HTTP listener. It asserts the raw body bytes, Content-Type, JSON parse, and exact Chinese/Portuguese text round-trip.
- Added a lightweight shell contract assertion for non-Windows CI.
- Added the required CHANGELOG entry.

## Why

Windows PowerShell 5.1 does not reliably encode a string `-Body` as UTF-8. ASCII hook payloads could succeed while prompts, paths, or tool content containing non-ASCII text reached `/hook` with incompatible bytes, returned HTTP 400, and disappeared from memory. Encoding before transport fixes the shared `.ps1` helper for every compatibility-hook agent.

Closes #500.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo test -p ai-memory-hooks -j 2` ? 269 unit tests + the new Windows integration test passed
- [x] `cargo clippy -p ai-memory-hooks --tests -j 2 -- -D warnings`
- [x] `tests/hooks/test_lib.sh` ? 45 passed, 0 failed (Git for Windows Bash with the incompatible WSL/PowerShell bridge excluded)
- [x] Manual protocol verification is part of the integration test: real `powershell.exe` ? TCP listener, byte-for-byte UTF-8 assertion
- [ ] Full `cargo test --workspace` ? not rerun locally; the complete Windows debug test graph exceeds this machine's available build disk/RAM, so repository CI remains authoritative

## Commit attribution

- [x] Verified GitHub noreply identity.

## CHANGELOG (merge gate)

- [x] Added an `[Unreleased]` Fixed entry.
- [x] No default changed.

## Notes for reviewers

Please add the `windows` label so the native Windows workflow runs before merge. The runtime regression test is `#![cfg(windows)]`; Linux/macOS still receive the static shell contract assertion.

The only runtime tradeoff is one bounded byte-array allocation per PowerShell hook payload. Payload sizes are already hard-capped, and no server or native-hook behavior changes.
