### PR TITLE
fix(hooks): avoid PowerShell HOME collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- PowerShell compatibility hooks no longer assign to a local `$home` variable.
+  PowerShell names are case-insensitive, so that collided with the automatic
+  read-only `$HOME` variable and emitted `VariableNotWritable` for every hook
+  payload carrying a cwd. The marker-boundary helper now uses `$userHome`, with
+  native Windows and static shell regressions covering the error stream and
+  reserved-name contract (#498).
+
 ## [1.32.2] - 2026-08-26
 
 ### Fixed

--- a/crates/ai-memory-hooks/tests/powershell_home.rs
+++ b/crates/ai-memory-hooks/tests/powershell_home.rs
@@ -1,0 +1,55 @@
+//! Windows PowerShell marker-boundary regression tests.
+
+#![cfg(windows)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crate should live under crates/ai-memory-hooks")
+        .to_path_buf()
+}
+
+#[test]
+fn marker_lookup_does_not_assign_to_powershell_home() {
+    let temp = tempfile::tempdir().unwrap();
+    let helper = repo_root()
+        .join("hooks")
+        .join("lib")
+        .join("ai-memory-hook.ps1");
+    let helper = helper.to_string_lossy().replace('\'', "''");
+    let program = format!(
+        ". '{helper}'; $Error.Clear(); \
+         $null = Get-AiMemoryMarkerToml -Cwd $env:AI_MEMORY_TEST_CWD; \
+         if ($Error.Count -ne 0) {{ \
+             [Console]::Error.Write(($Error | Out-String)); exit 17 \
+         }}; [Console]::Out.Write('ok')"
+    );
+    let output = Command::new("powershell.exe")
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            &program,
+        ])
+        .env("AI_MEMORY_TEST_CWD", temp.path())
+        .output()
+        .expect("run PowerShell marker lookup");
+    assert!(
+        output.status.success(),
+        "PowerShell marker lookup failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "PowerShell marker lookup polluted stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.stdout, b"ok");
+}

--- a/hooks/lib/ai-memory-hook.ps1
+++ b/hooks/lib/ai-memory-hook.ps1
@@ -39,16 +39,16 @@ function Get-AiMemoryMarkerToml {
     param([string] $Cwd)
     if (-not $Cwd) { return $null }
     $dir = $Cwd
-    $home = if ($env:HOME) { $env:HOME } else { $env:USERPROFILE }
+    $userHome = if ($env:HOME) { $env:HOME } else { $env:USERPROFILE }
     $boundary = $null
-    if ($home) {
-        $homePrefix = $home.TrimEnd([char[]]@('/', '\')) + [IO.Path]::DirectorySeparatorChar
-        $insideHome = ($dir -eq $home) -or $dir.StartsWith(
-            $homePrefix,
+    if ($userHome) {
+        $userHomePrefix = $userHome.TrimEnd([char[]]@('/', '\')) + [IO.Path]::DirectorySeparatorChar
+        $insideHome = ($dir -eq $userHome) -or $dir.StartsWith(
+            $userHomePrefix,
             [StringComparison]::OrdinalIgnoreCase
         )
         if ($insideHome) {
-            $boundary = $home
+            $boundary = $userHome
         } else {
             $probe = $dir
             while ($probe -and (Test-Path $probe)) {

--- a/tests/hooks/test_lib.sh
+++ b/tests/hooks/test_lib.sh
@@ -144,6 +144,11 @@ PS_ANTIGRAVITY_STATIC=$(grep -q 'function Test-AiMemoryAntigravityInitialInvocat
     && printf 'ok' || printf 'missing')
 assert_eq "powershell antigravity hook has invocation guard" "ok" "$PS_ANTIGRAVITY_STATIC"
 
+PS_HOME_STATIC=$(grep -Fq '$userHome = if ($env:HOME)' hooks/lib/ai-memory-hook.ps1 \
+    && ! grep -Eq '\$home[[:space:]]*=' hooks/lib/ai-memory-hook.ps1 \
+    && printf 'ok' || printf 'missing')
+assert_eq "powershell marker helper avoids read-only HOME" "ok" "$PS_HOME_STATIC"
+
 # --- json_string -------------------------------------------------------
 JSON_INPUT='quoted "thing" \ path
 next line'


### PR DESCRIPTION
## Summary

- rename the local PowerShell home variable to avoid the case-insensitive collision with read-only `$HOME`
- add a Windows integration regression test that dot-sources the production helper and asserts marker lookup leaves no PowerShell error output
- add a lightweight shell-source assertion and changelog entry

## Scope

This fixes the deterministic PowerShell error-stream pollution described in the issue. It intentionally does not claim that this variable collision explains every reported missing Codex ingestion event.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p ai-memory-hooks -j 2`
- `cargo clippy -p ai-memory-hooks --tests -j 2 -- -D warnings`
- `bash tests/hooks/test_lib.sh` (Git Bash; 45 tests)

Closes #498

Suggested label: `windows`
