### PR TITLE
feat(sweep): opt-in bounded retention for raw observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Bounded raw-observation retention as an opt-in fourth pass of the M8 forget
+  sweep, disabled by default. Nothing in the tree could delete an `observations`
+  row for age: the sweep acts on pages only, so raw capture grew without limit.
+  Measured on a three-month-old install, `observations` plus its FTS shadow and
+  four indexes were ~5.4 GB of a 5.53 GB store (5,236,232 rows), against 0.03 GB
+  of `pages` — the 2,365 compiled pages that hold the durable value. The nightly
+  backup tarball was 2.7 GB, almost all of it capture already distilled into
+  30 MB of Markdown. `decay.observation_retention_days` (default `0` = disabled)
+  now lets an operator bound that, and `decay.observation_prune_batch` (default
+  `5000`) bounds each transaction. (#508)
+
+  The pass deletes an observation only when its session was already consolidated
+  into a summary page that is still live, and the row is older than the
+  configured age. That is three gates on columns the schema already maintains:
+  `sessions.summary_page_id` is written only by the session-end path, so it
+  already implies `ended_at IS NOT NULL`; `pages.superseded_at IS NULL` excludes
+  a session whose page decay has evicted, because that session's raw rows are
+  now the only surviving copy; and a hard-deleted page has already NULLed the
+  pointer through `ON DELETE SET NULL`, so the join finds nothing. The prune
+  therefore runs LAST, after this same run's evictions and hard-deletes, rather
+  than letting raw capture outlive its distillation by one sweep. A session with
+  no `sessions` row, or one still running, matches nothing and can never lose a
+  row.
+
+  Each batch is one transaction sent as its own message to the single-writer
+  actor, so every other pending write interleaves between batches and a
+  multi-million row prune never holds the write lock across the run. Measured on
+  a 300,000-row store built from the shipped migrations: ~23-27 ms per 5,000-row
+  batch including the FTS trigger work, plus ~2-4 ms to commit. The session-end
+  observation watermark (`sessions.ended_observation_count`) is repaired in the
+  same transaction and only downward, so a resumed session's genuinely new work
+  is still read as new work instead of `AlreadyEnded`. One `prune_observations`
+  audit row is written per batch that actually deleted, inside that batch's
+  transaction. Zero migrations: every access is an index seek on
+  `idx_observations_project_created` and `idx_observations_session`, both of
+  which predate this change.
+
+  The cost is stated rather than hidden: for a pruned session the raw transcript
+  view returns empty, `raw_hits` can no longer match the exact original wording,
+  a manual auto-improve rerun rejects with `too_few_observations`, and a
+  `move_session` with `PagesMode::Regenerate` has nothing left to rebuild the
+  page from. All of it is reachable only by setting a positive age. Note that
+  SQLite does not return freed pages to the OS without `VACUUM`, so the `.db`
+  file will not shrink after the first prune — the `ai-memory backup` tarball
+  will, because it is a fresh online copy.
+
 ## [1.32.2] - 2026-08-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `idx_observations_project_created` and `idx_observations_session`, both of
   which predate this change.
 
-  The cost is stated rather than hidden: for a pruned session the raw transcript
+  The cost is stated rather than hidden, and it is not just disk: observations
+  are the input to consolidation, so pruning is irreversible — a pruned session
+  can never be re-consolidated (not with a better model, a better prompt, or a
+  fixed consolidator bug) and its summary page becomes the only surviving
+  account of that session. Concretely: the raw transcript
   view returns empty, `raw_hits` can no longer match the exact original wording,
   a manual auto-improve rerun rejects with `too_few_observations`, and a
   `move_session` with `PagesMode::Regenerate` has nothing left to rebuild the

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -7,8 +7,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ai_memory_consolidate::{
-    AutoImproveReviewConfig, Consolidator, EmbedBackfillOptions, ScheduledAutoImproveSettings,
-    run_auto_improve_scheduler_tick, run_embedding_backfill, run_lint, run_sweep_with_breadth,
+    AutoImproveReviewConfig, Consolidator, EmbedBackfillOptions, ObservationRetention,
+    ScheduledAutoImproveSettings, run_auto_improve_scheduler_tick, run_embedding_backfill,
+    run_lint, run_sweep_with_options,
 };
 use ai_memory_core::{ActiveProject, ProjectId, Sanitizer, WorkspaceId};
 use ai_memory_hooks::{
@@ -17,7 +18,7 @@ use ai_memory_hooks::{
 };
 use ai_memory_llm::{Embedder, LlmProvider, ProviderHealth, build_embedder, build_provider};
 use ai_memory_mcp::{
-    AdminState, AiMemoryServer, ScopeInvalidation, admin_router_with_decay_breadth,
+    AdminState, AiMemoryServer, ScopeInvalidation, admin_router_with_sweep_tuning,
 };
 use ai_memory_store::{ReaderPool, Store, WriterHandle};
 use ai_memory_web::{WebMountSpec, mount_web_router, normalize_prefix, web_base_href};
@@ -525,6 +526,7 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
         .with_wiki(wiki.clone())
         .with_decay_params(decay_params)
         .with_decay_breadth_weight(config.decay.breadth_weight)
+        .with_observation_retention(config.decay.observation_retention())
         .with_auto_improve_require_approval(config.auto_improve.require_approval)
         .with_auto_improve_review_config(auto_improve_review_config_from_settings(
             &config.auto_improve,
@@ -687,7 +689,7 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
                 sanitizer: sanitizer.clone(),
                 data_dir: config.data_dir.clone(),
             });
-            let admin = admin_router_with_decay_breadth(
+            let admin = admin_router_with_sweep_tuning(
                 AdminState {
                     ingest_metrics: ingest_metrics.clone(),
                     writer: store.writer.clone(),
@@ -717,6 +719,7 @@ pub async fn run(config: &Config, args: ServeArgs) -> Result<()> {
                     trusted_proxy_identity: trusted_proxy_identity_enabled(&config.auth),
                 },
                 config.decay.breadth_weight,
+                config.decay.observation_retention(),
             );
             // Multi-rung auth assembly:
             //   - rung 0 (no bearer_token configured) → AuthState::new
@@ -966,6 +969,7 @@ async fn start_maintenance_scheduler(
                             &wiki,
                             &decay.decay_params(),
                             decay.breadth_weight,
+                            decay.observation_retention(),
                         )
                         .await?;
                         if outcome.errors > 0 {
@@ -980,6 +984,7 @@ async fn start_maintenance_scheduler(
                             evicted = outcome.evicted,
                             expired = outcome.expired,
                             hard_deleted = outcome.hard_deleted,
+                            observations_pruned = outcome.observations_pruned,
                             errors = outcome.errors,
                             elapsed_ms = started.elapsed().as_millis(),
                             "scheduled forget sweep completed"
@@ -1195,6 +1200,7 @@ struct ScheduledSweepTickOutcome {
     evicted: usize,
     expired: usize,
     hard_deleted: usize,
+    observations_pruned: usize,
     errors: usize,
 }
 
@@ -1204,6 +1210,7 @@ async fn run_scheduled_sweep_tick(
     wiki: &Wiki,
     decay: &ai_memory_store::DecayParams,
     breadth_weight: f64,
+    retention: ObservationRetention,
 ) -> Result<ScheduledSweepTickOutcome> {
     let scopes = reader.list_all_scopes().await?;
     let mut outcome = ScheduledSweepTickOutcome {
@@ -1212,7 +1219,7 @@ async fn run_scheduled_sweep_tick(
     };
 
     for scope in scopes {
-        match run_sweep_with_breadth(
+        match run_sweep_with_options(
             reader,
             writer,
             Some(wiki),
@@ -1220,6 +1227,7 @@ async fn run_scheduled_sweep_tick(
             scope.project_id,
             decay,
             breadth_weight,
+            retention,
             false,
         )
         .await
@@ -1229,6 +1237,7 @@ async fn run_scheduled_sweep_tick(
                 outcome.evicted += report.evicted.iter().filter(|page| page.deleted).count();
                 outcome.expired += report.expired.len();
                 outcome.hard_deleted += report.hard_deleted;
+                outcome.observations_pruned += report.observations_pruned;
             }
             Err(e) => {
                 outcome.errors += 1;
@@ -2521,9 +2530,16 @@ mod tests {
             cold_threshold: 2.0,
             ..ai_memory_store::DecayParams::default()
         };
-        let outcome = run_scheduled_sweep_tick(&store.reader, &store.writer, &wiki, &decay, 0.0)
-            .await
-            .unwrap();
+        let outcome = run_scheduled_sweep_tick(
+            &store.reader,
+            &store.writer,
+            &wiki,
+            &decay,
+            0.0,
+            ObservationRetention::default(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(outcome.scopes, 2);
         assert_eq!(outcome.errors, 0);

--- a/crates/ai-memory-cli/src/config.rs
+++ b/crates/ai-memory-cli/src/config.rs
@@ -61,6 +61,11 @@ pub struct DecaySettings {
     pub hard_delete_after_days: i64,
     /// Optional weight for the number of distinct authenticated readers.
     pub breadth_weight: f64,
+    /// Age past which a consolidated session's raw observations may be pruned.
+    /// `0` disables the pass; nothing is deleted until an operator opts in.
+    pub observation_retention_days: i64,
+    /// Observation rows deleted per prune transaction.
+    pub observation_prune_batch: usize,
 }
 
 impl Default for DecaySettings {
@@ -74,6 +79,8 @@ impl Default for DecaySettings {
             cold_threshold: base.cold_threshold,
             hard_delete_after_days: base.hard_delete_after_days,
             breadth_weight: 0.0,
+            observation_retention_days: 0,
+            observation_prune_batch: ai_memory_consolidate::DEFAULT_OBSERVATION_PRUNE_BATCH,
         }
     }
 }
@@ -89,6 +96,19 @@ impl DecaySettings {
             salience_default: self.salience_default,
             cold_threshold: self.cold_threshold,
             hard_delete_after_days: self.hard_delete_after_days,
+        }
+    }
+
+    /// Opt-in observation prune bound consumed by the M8 sweep.
+    ///
+    /// Deliberately separate from [`Self::decay_params`]: keeping it out of the
+    /// public `DecayParams` struct is what lets every downstream Rust caller
+    /// that builds one directly keep compiling — and keep today's behaviour.
+    #[must_use]
+    pub fn observation_retention(self) -> ai_memory_consolidate::ObservationRetention {
+        ai_memory_consolidate::ObservationRetention {
+            days: self.observation_retention_days,
+            batch: self.observation_prune_batch,
         }
     }
 }
@@ -924,6 +944,19 @@ impl Config {
             );
         }
 
+        // Fail closed at load rather than at 3am inside a destructive pass: a
+        // negative age would be a nonsensical cutoff, and a zero batch would
+        // spin the prune loop forever without deleting anything.
+        if config.decay.observation_retention_days < 0 {
+            anyhow::bail!(
+                "decay.observation_retention_days must be greater than or equal to zero \
+                 (0 disables observation pruning)"
+            );
+        }
+        if config.decay.observation_prune_batch == 0 {
+            anyhow::bail!("decay.observation_prune_batch must be greater than zero");
+        }
+
         // Fail at startup rather than shipping a prompt that is all scaffolding
         // and no observations: below this floor the fixed system prompt and page
         // conventions consume the entire budget, so every consolidation would
@@ -1349,6 +1382,11 @@ mod tests {
         assert_eq!(cfg.maintenance.lint_interval_secs, 86_400);
         assert_eq!(cfg.maintenance.embedding_backfill_interval_secs, 0);
         assert_eq!(cfg.decay.breadth_weight, 0.0);
+        // Observation pruning must stay OFF by default: an install that never
+        // opts in keeps every raw observation it has today.
+        assert_eq!(cfg.decay.observation_retention_days, 0);
+        assert_eq!(cfg.decay.observation_prune_batch, 5_000);
+        assert!(!cfg.decay.observation_retention().is_enabled());
         assert!(!cfg.slots.per_user);
         assert!(cfg.auto_improve.scheduler.enabled);
         assert_eq!(cfg.auto_improve.scheduler.interval_secs, 3_600);
@@ -1413,6 +1451,27 @@ mod tests {
             assert!(
                 error.to_string().contains("breadth_weight"),
                 "unexpected error for {value}: {error:#}"
+            );
+        }
+    }
+
+    /// A negative retention age or a zero batch is rejected at load, beside
+    /// the breadth-weight guard, so a destructive pass can never be configured
+    /// into a nonsensical shape.
+    #[test]
+    fn load_rejects_destructive_invalid_observation_retention() {
+        for (key, value) in [
+            ("observation_retention_days", "-1"),
+            ("observation_prune_batch", "0"),
+        ] {
+            let tmp = TempDir::new().unwrap();
+            let config_path = tmp.path().join("config.toml");
+            std::fs::write(&config_path, format!("[decay]\n{key} = {value}\n")).unwrap();
+            let error = Config::load(Some(&config_path), Some(tmp.path().to_path_buf()))
+                .expect_err("invalid observation retention must fail closed");
+            assert!(
+                error.to_string().contains(key),
+                "unexpected error for {key} = {value}: {error:#}"
             );
         }
     }

--- a/crates/ai-memory-cli/templates/config.default.toml
+++ b/crates/ai-memory-cli/templates/config.default.toml
@@ -87,6 +87,11 @@ log_level = "info"
 # observations older than that — but ONLY for sessions already consolidated into
 # a page that is still live. Unconsolidated sessions, and sessions whose page was
 # evicted by decay, keep every row. 0 (the default) disables the pass entirely.
+# Pruning is IRREVERSIBLE: observations are the input to consolidation, so a
+# pruned session can never be re-consolidated (a better model, a better prompt,
+# or a fixed consolidator bug make no difference) and its summary page becomes
+# the only surviving account of that session. The 0 default is a contract: this
+# pass never runs unless an operator sets a positive age here.
 # SQLite does not return freed pages to the OS without VACUUM, so the .db file
 # will not shrink after the first prune; the `ai-memory backup` tarball will.
 #   - A quarter of raw capture: observation_retention_days = 90

--- a/crates/ai-memory-cli/templates/config.default.toml
+++ b/crates/ai-memory-cli/templates/config.default.toml
@@ -80,6 +80,17 @@ log_level = "info"
 #   - Bigger access boost (frequently-used stuff lasts longer): sigma = 1.0
 #   - Bigger time-pressure on access: mu = 0.08
 #   - Reward pages used by more identified operators: breadth_weight = 0.2
+#
+# Raw observations are the store's growth driver (a busy install can add
+# gigabytes a year), while the durable value is the compiled pages. Set
+# observation_retention_days to a positive number to let the sweep delete raw
+# observations older than that — but ONLY for sessions already consolidated into
+# a page that is still live. Unconsolidated sessions, and sessions whose page was
+# evicted by decay, keep every row. 0 (the default) disables the pass entirely.
+# SQLite does not return freed pages to the OS without VACUUM, so the .db file
+# will not shrink after the first prune; the `ai-memory backup` tarball will.
+#   - A quarter of raw capture: observation_retention_days = 90
+#   - Smaller transactions on a slow disk: observation_prune_batch = 2000
 [decay]
 lambda = 0.02
 sigma = 0.6
@@ -88,6 +99,8 @@ salience_default = 1.0
 cold_threshold = 0.20
 hard_delete_after_days = 180
 breadth_weight = 0.0
+observation_retention_days = 0     # 0 = never prune raw observations
+observation_prune_batch = 5000     # rows per prune transaction
 
 # Privacy strip.
 #

--- a/crates/ai-memory-consolidate/src/lib.rs
+++ b/crates/ai-memory-consolidate/src/lib.rs
@@ -64,7 +64,10 @@ pub use embed::{
     EmbedBackfillCounts, EmbedBackfillError, EmbedBackfillOptions, run_embedding_backfill,
 };
 pub use lint::{LintError, LintFinding, LintOptions, LintReport, run_lint, stale_days_for};
-pub use sweep::{EvictedPage, SweepError, SweepReport, run_sweep, run_sweep_with_breadth};
+pub use sweep::{
+    DEFAULT_OBSERVATION_PRUNE_BATCH, EvictedPage, ObservationRetention, SweepError, SweepReport,
+    run_sweep, run_sweep_with_breadth, run_sweep_with_options,
+};
 pub use types::{
     ConsolidatedBatch, ConsolidatedPage, ConsolidatedPageUpdate, ConsolidationOutcome, PageKind,
     SlotKind,

--- a/crates/ai-memory-consolidate/src/sweep.rs
+++ b/crates/ai-memory-consolidate/src/sweep.rs
@@ -18,8 +18,16 @@
 //! `hard_delete_after_days` and their supersession ancestry. A page recreated
 //! at the same path is a separate live chain and is preserved. Ordinary
 //! supersession rows are safe because only decay writes `superseded_at`.
+//!
+//! Observation prune pass (opt-in, disabled unless
+//! `ObservationRetention::days > 0`) deletes raw observations older than the
+//! configured age, and only for sessions already distilled into a page that is
+//! still live. It runs LAST so both of this run's page deletions are already
+//! visible to its predicate: a session whose summary page was evicted or
+//! hard-deleted by the passes above keeps its raw capture, because that capture
+//! is now the only surviving copy.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use ai_memory_core::{PageId, ProjectId, Tier, WorkspaceId};
 use ai_memory_store::{
@@ -79,7 +87,55 @@ pub struct SweepReport {
     pub expired: Vec<ExpiredPage>,
     /// Number of page-version rows permanently deleted on this pass.
     pub hard_deleted: usize,
+    /// Observations the prune predicate matched. Reported in both modes; `0`
+    /// when observation retention is disabled, which is the default.
+    pub observations_prunable: usize,
+    /// Observation rows permanently deleted. Always `0` on `dry_run`, exactly
+    /// like the wiki-routed passes above.
+    pub observations_pruned: usize,
+    /// Distinct consolidated sessions that lost rows, so the blast radius is a
+    /// number in the response rather than a claim in a changelog.
+    pub observation_prune_sessions: usize,
+    /// Transactions the prune spent. Makes the batching bound observable.
+    pub observation_prune_batches: usize,
 }
+
+/// Opt-in bound on how long raw observations outlive their consolidation.
+///
+/// Deliberately a type of its own rather than two more
+/// [`DecayParams`] fields: the retention coefficients are a public struct that
+/// downstream Rust callers construct directly, and widening it would break
+/// them. Same reasoning the access-breadth coefficient already carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ObservationRetention {
+    /// Age in days past which a consolidated session's observations may be
+    /// pruned. `0` disables the pass entirely — the default, so an existing
+    /// install behaves exactly as it did before this pass existed.
+    pub days: i64,
+    /// Rows deleted per transaction.
+    pub batch: usize,
+}
+
+/// Disabled: nothing is ever pruned until an operator sets a positive age.
+impl Default for ObservationRetention {
+    fn default() -> Self {
+        Self {
+            days: 0,
+            batch: DEFAULT_OBSERVATION_PRUNE_BATCH,
+        }
+    }
+}
+
+impl ObservationRetention {
+    /// `true` when the pass is enabled and can delete something.
+    #[must_use]
+    pub const fn is_enabled(self) -> bool {
+        self.days > 0 && self.batch > 0
+    }
+}
+
+/// Default rows per prune transaction.
+pub const DEFAULT_OBSERVATION_PRUNE_BATCH: usize = 5_000;
 
 /// Errors raised by the sweep.
 #[derive(Debug, Error)]
@@ -91,6 +147,9 @@ pub enum SweepError {
     /// The optional access-breadth coefficient was negative or non-finite.
     #[error("decay breadth_weight must be a finite number greater than or equal to zero")]
     InvalidBreadthWeight,
+    /// The opt-in observation retention age was negative.
+    #[error("decay observation_retention_days must be greater than or equal to zero")]
+    InvalidObservationRetention,
 }
 
 const US_PER_DAY: f64 = 86_400_000_000.0;
@@ -139,7 +198,7 @@ pub async fn run_sweep(
 #[allow(clippy::too_many_arguments)]
 pub async fn run_sweep_with_breadth(
     reader: &ReaderPool,
-    _writer: &WriterHandle,
+    writer: &WriterHandle,
     wiki: Option<&Wiki>,
     workspace_id: WorkspaceId,
     project_id: ProjectId,
@@ -147,8 +206,45 @@ pub async fn run_sweep_with_breadth(
     breadth_weight: f64,
     dry_run: bool,
 ) -> Result<SweepReport, SweepError> {
+    run_sweep_with_options(
+        reader,
+        writer,
+        wiki,
+        workspace_id,
+        project_id,
+        params,
+        breadth_weight,
+        ObservationRetention::default(),
+        dry_run,
+    )
+    .await
+}
+
+/// Run a sweep with the breadth coefficient and the opt-in observation prune.
+///
+/// The prune is the only pass that can delete raw capture, and it is off unless
+/// `retention.days` is positive.
+///
+/// # Errors
+/// Returns [`SweepError::InvalidObservationRetention`] for a negative age, in
+/// addition to the errors documented by [`run_sweep_with_breadth`].
+#[allow(clippy::too_many_arguments)]
+pub async fn run_sweep_with_options(
+    reader: &ReaderPool,
+    writer: &WriterHandle,
+    wiki: Option<&Wiki>,
+    workspace_id: WorkspaceId,
+    project_id: ProjectId,
+    params: &DecayParams,
+    breadth_weight: f64,
+    retention: ObservationRetention,
+    dry_run: bool,
+) -> Result<SweepReport, SweepError> {
     if !breadth_weight.is_finite() || breadth_weight < 0.0 {
         return Err(SweepError::InvalidBreadthWeight);
+    }
+    if retention.days < 0 {
+        return Err(SweepError::InvalidObservationRetention);
     }
     let candidates = reader.decay_candidates(workspace_id, project_id).await?;
     let breadth =
@@ -199,6 +295,18 @@ pub async fn run_sweep_with_breadth(
     }
 
     let mut hard_deleted = 0usize;
+    let mut observations_prunable = 0usize;
+    let mut observations_pruned = 0usize;
+    let mut observation_prune_sessions = 0usize;
+    let mut observation_prune_batches = 0usize;
+    let observation_cutoff_us = Timestamp::now()
+        .as_microsecond()
+        .saturating_sub(retention.days.saturating_mul(US_PER_DAY_I64));
+    if retention.is_enabled() {
+        observations_prunable = reader
+            .prunable_observation_count(workspace_id, project_id, observation_cutoff_us)
+            .await?;
+    }
     if !dry_run {
         for page in &mut expired {
             let path = match ai_memory_core::PagePath::new(page.path.clone()) {
@@ -284,6 +392,37 @@ pub async fn run_sweep_with_breadth(
                 }
             }
         }
+
+        // LAST on purpose. Both passes above can strip a session of its
+        // distillation — decay stamps `superseded_at`, hard-delete removes the
+        // row and the `ON DELETE SET NULL` foreign key clears the pointer — and
+        // the prune predicate reads exactly those two columns. Running here
+        // means this run's own evictions already exclude their sessions,
+        // instead of a batch of raw capture outliving its page by one sweep.
+        //
+        // Unlike the wiki-routed passes this one runs without a `wiki` handle:
+        // observations have no Markdown file, so there is no source of truth
+        // for reconciliation to re-index and no store-only-mutation hazard.
+        if retention.is_enabled() {
+            let mut touched: HashSet<ai_memory_core::SessionId> = HashSet::new();
+            loop {
+                let outcome = writer
+                    .prune_consolidated_observations(
+                        workspace_id,
+                        project_id,
+                        observation_cutoff_us,
+                        retention.batch,
+                    )
+                    .await?;
+                observation_prune_batches += 1;
+                observations_pruned += outcome.deleted;
+                touched.extend(outcome.sessions_touched.iter().copied());
+                if outcome.deleted < retention.batch {
+                    break;
+                }
+            }
+            observation_prune_sessions = touched.len();
+        }
     }
 
     Ok(SweepReport {
@@ -292,6 +431,10 @@ pub async fn run_sweep_with_breadth(
         evicted,
         expired,
         hard_deleted,
+        observations_prunable,
+        observations_pruned,
+        observation_prune_sessions,
+        observation_prune_batches,
     })
 }
 

--- a/crates/ai-memory-consolidate/tests/observation_retention.rs
+++ b/crates/ai-memory-consolidate/tests/observation_retention.rs
@@ -1,0 +1,544 @@
+//! The opt-in observation prune, end to end.
+//!
+//! Raw observations are ~98% of a mature store's bytes, and their durable value
+//! was already distilled into pages. Deleting them is safe exactly when that
+//! distillation still exists — so these tests hold the pass to the only
+//! discrimination that makes it safe: a session consolidated into a live page
+//! loses its old raw capture; a session with equally old capture and no page,
+//! or with a page decay already evicted, keeps every row.
+//!
+//! They also pin the two properties an operator has to be able to trust without
+//! reading the SQL: nothing is deleted at the shipped defaults, and the FTS
+//! index stops matching what the prune removed.
+
+use ai_memory_consolidate::{ObservationRetention, run_sweep, run_sweep_with_options};
+use ai_memory_core::{
+    AgentKind, NewObservation, NewPage, NewSession, ObservationKind, PageId, PagePath, ProjectId,
+    Sanitized, Sanitizer, SessionId, Tier, WorkspaceId,
+};
+use ai_memory_store::{DecayParams, Store, WriterHandle};
+use rusqlite::{Connection, params};
+use tempfile::TempDir;
+
+const US_PER_DAY: i64 = 86_400_000_000;
+/// Well past any retention age used below, so age is never what separates the
+/// fixtures — only whether the session was consolidated.
+const OBS_AGE_DAYS: i64 = 400;
+const RETENTION_DAYS: i64 = 90;
+
+/// A session whose observations the prune is allowed to delete: ended, with a
+/// live summary page.
+const CONSOLIDATED_BODY: &str = "consolidated capture zebrafinch";
+/// A session with identical, equally old capture that was never consolidated.
+const RAW_BODY: &str = "unconsolidated capture zebrafinch";
+/// A session that WAS consolidated, but whose page decay has since evicted —
+/// the raw rows are now the only surviving copy.
+const EVICTED_BODY: &str = "evicted capture zebrafinch";
+
+struct Fixture {
+    ws: WorkspaceId,
+    proj: ProjectId,
+    consolidated: SessionId,
+    unconsolidated: SessionId,
+    evicted: SessionId,
+}
+
+/// Three sessions x three observations each, all backdated to the same age.
+async fn seed(store: &Store) -> Fixture {
+    let ws = store
+        .writer
+        .get_or_create_workspace("default".to_string())
+        .await
+        .expect("ws");
+    let proj = store
+        .writer
+        .get_or_create_project(ws, "retention".to_string(), None)
+        .await
+        .expect("proj");
+
+    let consolidated = session(store, ws, proj, 1, CONSOLIDATED_BODY).await;
+    let unconsolidated = session(store, ws, proj, 2, RAW_BODY).await;
+    let evicted = session(store, ws, proj, 3, EVICTED_BODY).await;
+
+    // Only the first two ends link a page; the third's page is evicted below.
+    let page = write_page(&store.writer, ws, proj, "sessions/consolidated.md").await;
+    store
+        .writer
+        .end_session(consolidated, Some(page))
+        .await
+        .expect("end consolidated");
+    let evicted_page = write_page(&store.writer, ws, proj, "sessions/evicted.md").await;
+    store
+        .writer
+        .end_session(evicted, Some(evicted_page))
+        .await
+        .expect("end evicted");
+
+    let conn = aux(store);
+    // Decay eviction, exactly as `soft_delete_for_decay_if_latest` writes it:
+    // the row survives as a tombstone but the Markdown is gone.
+    conn.execute(
+        "UPDATE pages SET is_latest = 0, superseded_at = ?1 WHERE id = ?2",
+        params![
+            jiff::Timestamp::now().as_microsecond(),
+            evicted_page.as_bytes()
+        ],
+    )
+    .expect("evict page");
+    let then_us = jiff::Timestamp::now().as_microsecond() - OBS_AGE_DAYS * US_PER_DAY;
+    conn.execute("UPDATE observations SET created_at = ?1", params![then_us])
+        .expect("backdate observations");
+
+    Fixture {
+        ws,
+        proj,
+        consolidated,
+        unconsolidated,
+        evicted,
+    }
+}
+
+async fn session(store: &Store, ws: WorkspaceId, proj: ProjectId, n: u8, body: &str) -> SessionId {
+    let mut raw = [0u8; 16];
+    raw[15] = n;
+    let id = SessionId::from_slice(&raw).expect("session id");
+    store
+        .writer
+        .begin_session(NewSession {
+            id,
+            workspace_id: ws,
+            project_id: proj,
+            agent_kind: AgentKind::ClaudeCode,
+            cwd: None,
+            actor_user: None,
+        })
+        .await
+        .expect("begin session");
+    let sanitizer = Sanitizer::builtin();
+    for i in 0..3 {
+        store
+            .writer
+            .insert_observation(Sanitized::new(
+                NewObservation {
+                    session_id: id,
+                    workspace_id: ws,
+                    project_id: proj,
+                    kind: ObservationKind::UserPrompt,
+                    extension: None,
+                    source_event: None,
+                    title: format!("obs {n}-{i}"),
+                    body: body.to_string(),
+                    importance: 5,
+                },
+                &sanitizer,
+            ))
+            .await
+            .expect("insert observation");
+    }
+    id
+}
+
+async fn write_page(writer: &WriterHandle, ws: WorkspaceId, proj: ProjectId, path: &str) -> PageId {
+    writer
+        .upsert_page(NewPage {
+            workspace_id: ws,
+            project_id: proj,
+            path: PagePath::new(path.to_string()).expect("path"),
+            title: path.into(),
+            body: "distilled".into(),
+            tier: Tier::Episodic,
+            frontmatter_json: serde_json::json!({}),
+            pinned: false,
+            links: Vec::new(),
+            author_id: None,
+            expires_at: None,
+            entities: Vec::new(),
+        })
+        .await
+        .expect("upsert page")
+}
+
+fn aux(store: &Store) -> Connection {
+    let conn = Connection::open(store.db_path()).expect("aux conn");
+    conn.pragma_update(None, "busy_timeout", 5_000).unwrap();
+    conn
+}
+
+fn observations_for(conn: &Connection, session: SessionId) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM observations WHERE session_id = ?1",
+        params![session.as_bytes()],
+        |row| row.get(0),
+    )
+    .expect("count observations")
+}
+
+fn fts_matches(conn: &Connection, needle: &str) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM observations_fts WHERE observations_fts MATCH ?1",
+        params![needle],
+        |row| row.get(0),
+    )
+    .expect("fts match")
+}
+
+fn enabled() -> ObservationRetention {
+    ObservationRetention {
+        days: RETENTION_DAYS,
+        batch: 5_000,
+    }
+}
+
+/// The no-change proof. `run_sweep` is what every existing caller reaches, and
+/// `ObservationRetention::default()` is what the shipped config produces. On a
+/// store full of ancient consolidated capture, both must delete nothing at all.
+#[tokio::test]
+async fn the_default_configuration_prunes_no_observation() {
+    let tmp = TempDir::new().expect("tempdir");
+    let store = Store::open(tmp.path()).expect("store");
+    let f = seed(&store).await;
+    let params = DecayParams::default();
+
+    let report = run_sweep(
+        &store.reader,
+        &store.writer,
+        None,
+        f.ws,
+        f.proj,
+        &params,
+        false,
+    )
+    .await
+    .expect("sweep");
+    assert_eq!(report.observations_pruned, 0);
+    assert_eq!(
+        report.observations_prunable, 0,
+        "disabled must not even count"
+    );
+    assert_eq!(report.observation_prune_batches, 0);
+
+    let report = run_sweep_with_options(
+        &store.reader,
+        &store.writer,
+        None,
+        f.ws,
+        f.proj,
+        &params,
+        0.0,
+        ObservationRetention::default(),
+        false,
+    )
+    .await
+    .expect("sweep");
+    assert_eq!(report.observations_pruned, 0);
+
+    let conn = aux(&store);
+    for s in [f.consolidated, f.unconsolidated, f.evicted] {
+        assert_eq!(
+            observations_for(&conn, s),
+            3,
+            "the default configuration must leave every observation in place"
+        );
+    }
+}
+
+/// The discrimination the whole feature rests on. Same scope, same age, same
+/// body length: the ONLY difference is whether the session's work still exists
+/// as a page. Consolidated loses its rows; unconsolidated and decay-evicted
+/// keep theirs.
+#[tokio::test]
+async fn only_a_consolidated_session_with_a_live_page_loses_its_observations() {
+    let tmp = TempDir::new().expect("tempdir");
+    let store = Store::open(tmp.path()).expect("store");
+    let f = seed(&store).await;
+
+    let report = run_sweep_with_options(
+        &store.reader,
+        &store.writer,
+        None,
+        f.ws,
+        f.proj,
+        &DecayParams::default(),
+        0.0,
+        enabled(),
+        false,
+    )
+    .await
+    .expect("sweep");
+
+    assert_eq!(report.observations_pruned, 3);
+    assert_eq!(report.observations_prunable, 3);
+    assert_eq!(report.observation_prune_sessions, 1);
+
+    let conn = aux(&store);
+    assert_eq!(
+        observations_for(&conn, f.consolidated),
+        0,
+        "a consolidated session's old raw capture must be pruned"
+    );
+    assert_eq!(
+        observations_for(&conn, f.unconsolidated),
+        3,
+        "a session never consolidated into a page must keep every row"
+    );
+    assert_eq!(
+        observations_for(&conn, f.evicted),
+        3,
+        "raw capture whose summary page decay already evicted is the last copy"
+    );
+}
+
+/// `observations_fts` is `content='observations'`, so a stale index would keep
+/// returning hits for rows that no longer exist. The `observations_fts_ad`
+/// trigger is supposed to prevent that; assert it rather than trust it.
+#[tokio::test]
+async fn the_fts_index_stops_matching_pruned_bodies() {
+    let tmp = TempDir::new().expect("tempdir");
+    let store = Store::open(tmp.path()).expect("store");
+    let f = seed(&store).await;
+    let conn = aux(&store);
+
+    assert_eq!(fts_matches(&conn, "consolidated"), 3);
+    assert_eq!(fts_matches(&conn, "zebrafinch"), 9);
+
+    run_sweep_with_options(
+        &store.reader,
+        &store.writer,
+        None,
+        f.ws,
+        f.proj,
+        &DecayParams::default(),
+        0.0,
+        enabled(),
+        false,
+    )
+    .await
+    .expect("sweep");
+
+    assert_eq!(
+        fts_matches(&conn, "consolidated"),
+        0,
+        "the FTS index must no longer match a pruned body"
+    );
+    assert_eq!(
+        fts_matches(&conn, "zebrafinch"),
+        6,
+        "only the pruned rows may leave the index"
+    );
+    // The drift check behind `fts_drift_status` compares these two directly.
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM observations", [], |r| r.get(0))
+        .unwrap();
+    let docsize: i64 = conn
+        .query_row("SELECT COUNT(*) FROM observations_fts_docsize", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(rows, docsize, "FTS docsize must track the delete exactly");
+}
+
+/// A dry run must be able to answer "how much would this delete?" without
+/// opening a write transaction. Counting is the whole point; deleting is not.
+#[tokio::test]
+async fn a_dry_run_counts_without_deleting() {
+    let tmp = TempDir::new().expect("tempdir");
+    let store = Store::open(tmp.path()).expect("store");
+    let f = seed(&store).await;
+
+    let report = run_sweep_with_options(
+        &store.reader,
+        &store.writer,
+        None,
+        f.ws,
+        f.proj,
+        &DecayParams::default(),
+        0.0,
+        enabled(),
+        true,
+    )
+    .await
+    .expect("sweep");
+
+    assert_eq!(report.observations_prunable, 3);
+    assert_eq!(report.observations_pruned, 0);
+    assert_eq!(report.observation_prune_batches, 0);
+    let conn = aux(&store);
+    assert_eq!(observations_for(&conn, f.consolidated), 3);
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM audit_log WHERE op = 'prune_observations'",
+            [],
+            |r| r.get::<_, i64>(0)
+        )
+        .unwrap(),
+        0,
+        "a dry run must not write an audit row either"
+    );
+}
+
+/// The bound that keeps a multi-million row delete off the write lock: one
+/// transaction per batch, looping until a short batch. With `batch = 1` the
+/// three eligible rows must cost four batches (three full, one short) and still
+/// land completely.
+#[tokio::test]
+async fn the_prune_deletes_in_bounded_batches() {
+    let tmp = TempDir::new().expect("tempdir");
+    let store = Store::open(tmp.path()).expect("store");
+    let f = seed(&store).await;
+
+    let report = run_sweep_with_options(
+        &store.reader,
+        &store.writer,
+        None,
+        f.ws,
+        f.proj,
+        &DecayParams::default(),
+        0.0,
+        ObservationRetention {
+            days: RETENTION_DAYS,
+            batch: 1,
+        },
+        false,
+    )
+    .await
+    .expect("sweep");
+
+    assert_eq!(report.observations_pruned, 3);
+    assert_eq!(
+        report.observation_prune_batches, 4,
+        "each row is its own transaction, plus the short batch that ends the loop"
+    );
+    assert_eq!(
+        report.observation_prune_sessions, 1,
+        "a session split across batches must be counted once"
+    );
+    let conn = aux(&store);
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM audit_log WHERE op = 'prune_observations'",
+            [],
+            |r| r.get::<_, i64>(0)
+        )
+        .unwrap(),
+        3,
+        "one audit row per batch that actually deleted, none for the empty one"
+    );
+}
+
+/// `session_end_disposition` reads `sessions.ended_observation_count` against a
+/// live `COUNT(*)`. Prune without repairing that watermark and a resumed
+/// session's genuinely new work reads as `AlreadyEnded` forever.
+#[tokio::test]
+async fn the_session_end_watermark_follows_the_prune() {
+    let tmp = TempDir::new().expect("tempdir");
+    let store = Store::open(tmp.path()).expect("store");
+    let f = seed(&store).await;
+    let conn = aux(&store);
+
+    let watermark = |conn: &Connection, s: SessionId| -> i64 {
+        conn.query_row(
+            "SELECT ended_observation_count FROM sessions WHERE id = ?1",
+            params![s.as_bytes()],
+            |row| row.get(0),
+        )
+        .expect("watermark")
+    };
+    assert_eq!(watermark(&conn, f.consolidated), 3);
+
+    run_sweep_with_options(
+        &store.reader,
+        &store.writer,
+        None,
+        f.ws,
+        f.proj,
+        &DecayParams::default(),
+        0.0,
+        enabled(),
+        false,
+    )
+    .await
+    .expect("sweep");
+
+    assert_eq!(
+        watermark(&conn, f.consolidated),
+        0,
+        "the watermark must come back down to the surviving row count"
+    );
+    // Idempotent and one-directional: a second sweep with nothing left to
+    // delete must not touch it again.
+    run_sweep_with_options(
+        &store.reader,
+        &store.writer,
+        None,
+        f.ws,
+        f.proj,
+        &DecayParams::default(),
+        0.0,
+        enabled(),
+        false,
+    )
+    .await
+    .expect("second sweep");
+    assert_eq!(watermark(&conn, f.consolidated), 0);
+}
+
+/// Observations younger than the retention age are never eligible, however
+/// thoroughly their session was consolidated — the age gate is what keeps
+/// consolidation, auto-improve review and the `raw_hits` fallback whole.
+#[tokio::test]
+async fn recent_observations_survive_a_consolidated_session() {
+    let tmp = TempDir::new().expect("tempdir");
+    let store = Store::open(tmp.path()).expect("store");
+    let f = seed(&store).await;
+    let conn = aux(&store);
+    let recent = jiff::Timestamp::now().as_microsecond() - US_PER_DAY;
+    conn.execute(
+        "UPDATE observations SET created_at = ?1 WHERE session_id = ?2",
+        params![recent, f.consolidated.as_bytes()],
+    )
+    .expect("freshen");
+
+    let report = run_sweep_with_options(
+        &store.reader,
+        &store.writer,
+        None,
+        f.ws,
+        f.proj,
+        &DecayParams::default(),
+        0.0,
+        enabled(),
+        false,
+    )
+    .await
+    .expect("sweep");
+
+    assert_eq!(report.observations_pruned, 0);
+    assert_eq!(observations_for(&conn, f.consolidated), 3);
+}
+
+/// A negative age is a nonsensical cutoff and must stop the sweep before it
+/// mutates anything, exactly as an invalid breadth coefficient does.
+#[tokio::test]
+async fn a_negative_retention_age_stops_the_sweep() {
+    let tmp = TempDir::new().expect("tempdir");
+    let store = Store::open(tmp.path()).expect("store");
+    let f = seed(&store).await;
+
+    let error = run_sweep_with_options(
+        &store.reader,
+        &store.writer,
+        None,
+        f.ws,
+        f.proj,
+        &DecayParams::default(),
+        0.0,
+        ObservationRetention {
+            days: -1,
+            batch: 5_000,
+        },
+        false,
+    )
+    .await
+    .expect_err("a negative retention age must fail closed");
+    assert!(error.to_string().contains("observation_retention_days"));
+}

--- a/crates/ai-memory-consolidate/tests/observation_retention.rs
+++ b/crates/ai-memory-consolidate/tests/observation_retention.rs
@@ -286,6 +286,16 @@ async fn only_a_consolidated_session_with_a_live_page_loses_its_observations() {
         3,
         "raw capture whose summary page decay already evicted is the last copy"
     );
+    assert_eq!(
+        conn.query_row(
+            "SELECT detail FROM audit_log WHERE op = 'prune_observations'",
+            [],
+            |r| r.get::<_, String>(0)
+        )
+        .expect("exactly one audit row for the single deleting batch"),
+        "{\"deleted\":3}",
+        "the audit row must record how many rows the batch deleted"
+    );
 }
 
 /// `observations_fts` is `content='observations'`, so a stale index would keep

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -46,10 +46,10 @@ use std::pin::Pin;
 use ai_memory_consolidate::{
     AutoImproveReviewConfig, AutoImproveTelemetryParams, AutoImproveTelemetryReport, Bootstrap,
     BootstrapConfig, BootstrapOutcome, BootstrapSource, CuratorParams, CuratorReport,
-    EmbedBackfillCounts, EmbedBackfillOptions, SourceCounts, prune_sources_to_budget,
-    render_auto_improve_telemetry_report_markdown, render_curator_report_markdown,
-    run_auto_improve_review, run_auto_improve_telemetry_report, run_curator_report_with_breadth,
-    run_embedding_backfill, run_lint, run_sweep_with_breadth,
+    EmbedBackfillCounts, EmbedBackfillOptions, ObservationRetention, SourceCounts,
+    prune_sources_to_budget, render_auto_improve_telemetry_report_markdown,
+    render_curator_report_markdown, run_auto_improve_review, run_auto_improve_telemetry_report,
+    run_curator_report_with_breadth, run_embedding_backfill, run_lint, run_sweep_with_options,
 };
 use ai_memory_core::{
     ActiveProject, AgentKind, AutoImproveProposalId, Capability, DEFAULT_PROJECT_NAME,
@@ -81,8 +81,13 @@ use tracing::{info, warn};
 
 const CONTRIBUTORS_WEBHOOK_NAME: &str = "contributors";
 
-#[derive(Clone, Copy)]
-struct DecayBreadthWeight(f64);
+/// Sweep knobs that live beside `DecayParams` rather than inside it, injected
+/// as one Extension so adding the next one is not a third router constructor.
+#[derive(Clone, Copy, Default)]
+struct SweepTuning {
+    breadth_weight: f64,
+    retention: ObservationRetention,
+}
 
 /// Shared state for the admin router.
 #[derive(Clone)]
@@ -541,6 +546,16 @@ pub fn admin_router(state: AdminState) -> Router {
 
 /// Build the admin router with the optional distinct-reader retention weight.
 pub fn admin_router_with_decay_breadth(state: AdminState, breadth_weight: f64) -> Router {
+    admin_router_with_sweep_tuning(state, breadth_weight, ObservationRetention::default())
+}
+
+/// Build the admin router with every sweep knob that lives outside
+/// `DecayParams`, including the opt-in observation prune (disabled by default).
+pub fn admin_router_with_sweep_tuning(
+    state: AdminState,
+    breadth_weight: f64,
+    retention: ObservationRetention,
+) -> Router {
     let state = Arc::new(state);
     let operational = Router::new()
         .route("/admin/backup", post(handle_backup))
@@ -613,7 +628,10 @@ pub fn admin_router_with_decay_breadth(state: AdminState, breadth_weight: f64) -
             require_root_for_multiuser_admin,
         ))
         .with_state(state)
-        .layer(axum::Extension(DecayBreadthWeight(breadth_weight)))
+        .layer(axum::Extension(SweepTuning {
+            breadth_weight,
+            retention,
+        }))
 }
 
 async fn require_root_for_multiuser_admin(
@@ -2096,7 +2114,7 @@ async fn handle_auto_improve_report(
 
 async fn handle_curator(
     State(state): State<Arc<AdminState>>,
-    axum::Extension(breadth): axum::Extension<DecayBreadthWeight>,
+    axum::Extension(tuning): axum::Extension<SweepTuning>,
     Json(req): Json<CuratorRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let mode = req.mode.as_deref().map(str::trim).filter(|s| !s.is_empty());
@@ -2127,7 +2145,7 @@ async fn handle_curator(
         &req.workspace,
         &req.project,
         params.clone(),
-        breadth.0,
+        tuning.breadth_weight,
     )
     .await
     .map_err(|e| internal_err(e.to_string()))?;
@@ -2757,19 +2775,20 @@ struct ForgetSweepRequest {
 
 async fn handle_forget_sweep(
     State(state): State<Arc<AdminState>>,
-    axum::Extension(breadth): axum::Extension<DecayBreadthWeight>,
+    axum::Extension(tuning): axum::Extension<SweepTuning>,
     Json(req): Json<ForgetSweepRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let (ws, proj) = lookup_ws_proj_no_create(&state, &req.workspace, &req.project).await?;
 
-    run_sweep_with_breadth(
+    run_sweep_with_options(
         &state.reader,
         &state.writer,
         Some(&state.wiki),
         ws,
         proj,
         &state.decay_params,
-        breadth.0,
+        tuning.breadth_weight,
+        tuning.retention,
         req.dry_run,
     )
     .await

--- a/crates/ai-memory-mcp/src/lib.rs
+++ b/crates/ai-memory-mcp/src/lib.rs
@@ -16,5 +16,6 @@ mod server;
 pub use actor::actor_from_headers;
 pub use admin::{
     AdminState, ScopeInvalidation, ScopeInvalidator, admin_router, admin_router_with_decay_breadth,
+    admin_router_with_sweep_tuning,
 };
 pub use server::{AiMemoryServer, MEMORY_INSTRUCTIONS};

--- a/crates/ai-memory-mcp/src/server.rs
+++ b/crates/ai-memory-mcp/src/server.rs
@@ -6,8 +6,8 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use ai_memory_consolidate::{
-    AutoImproveReviewConfig, Consolidator, projection::cap_text_with_marker,
-    run_auto_improve_review, run_lint, run_sweep_with_breadth,
+    AutoImproveReviewConfig, Consolidator, ObservationRetention, projection::cap_text_with_marker,
+    run_auto_improve_review, run_lint, run_sweep_with_options,
 };
 use ai_memory_core::{
     ActiveProject, AgentKind, FeedbackKind, HandoffId, HandoffState, NewHandoff, PageId, PagePath,
@@ -381,6 +381,9 @@ pub struct AiMemoryServer {
     decay_params: DecayParams,
     /// Optional distinct-reader reinforcement coefficient.
     decay_breadth_weight: f64,
+    /// Opt-in bound on how long raw observations outlive their consolidation.
+    /// Default is disabled, so `memory_forget_sweep` deletes no raw capture.
+    observation_retention: ObservationRetention,
     /// M9 embedder for hybrid query. When `None`, `memory_query`
     /// still fuses FTS5 with entity matches and graph-neighbour expansion.
     embedder: Option<Arc<dyn Embedder>>,
@@ -1258,6 +1261,7 @@ impl AiMemoryServer {
             wiki: None,
             decay_params: DecayParams::default(),
             decay_breadth_weight: 0.0,
+            observation_retention: ObservationRetention::default(),
             embedder: None,
             reranker: None,
             client_activity: Arc::new(std::sync::Mutex::new(ClientActivityBuffer::new())),
@@ -1767,6 +1771,14 @@ impl AiMemoryServer {
     #[must_use]
     pub fn with_decay_breadth_weight(mut self, breadth_weight: f64) -> Self {
         self.decay_breadth_weight = breadth_weight;
+        self
+    }
+
+    /// Set the opt-in observation prune bound used by `memory_forget_sweep`.
+    /// Unset, the sweep never deletes a raw observation.
+    #[must_use]
+    pub fn with_observation_retention(mut self, retention: ObservationRetention) -> Self {
+        self.observation_retention = retention;
         self
     }
 
@@ -2375,7 +2387,7 @@ impl AiMemoryServer {
     }
 
     /// Run the M8 forget sweep over episodic pages.
-    #[tool(description = "Run the retention sweep. THREE passes, and they \
+    #[tool(description = "Run the retention sweep. FOUR passes, and they \
         differ on what they will delete. (1) TTL: pages whose frontmatter \
         expires_at is in the past are hard-deleted (file + rows) REGARDLESS \
         OF TIER OR PIN — an explicit expiry overrides a pin, so a pinned \
@@ -2386,8 +2398,15 @@ impl AiMemoryServer {
         evicted to a tombstone; only this pass exempts semantic / procedural \
         / pinned pages. (3) Hard-delete: tombstones older than \
         hard_delete_after_days and their supersession ancestry are removed \
-        permanently. The report's expired / hard_deleted counts come from \
-        passes 1 and 3. Pass dry_run=true to preview.")]
+        permanently. (4) Observation prune: raw observations older than \
+        decay.observation_retention_days are deleted permanently, in bounded \
+        batches, but ONLY for sessions already consolidated into a summary \
+        page that is still live — an unconsolidated session, or one whose \
+        page pass 2 or 3 just removed, keeps every row. This pass is DISABLED \
+        by default (observation_retention_days = 0) and deletes nothing until \
+        an operator opts in; when off, observations_pruned is 0. The report's \
+        expired / hard_deleted / observations_pruned counts come from passes \
+        1, 3 and 4. Pass dry_run=true to preview.")]
     async fn memory_forget_sweep(
         &self,
         Parameters(args): Parameters<SweepArgs>,
@@ -2405,7 +2424,7 @@ impl AiMemoryServer {
                 &aps_actor,
             )
             .await?;
-        let report = run_sweep_with_breadth(
+        let report = run_sweep_with_options(
             &self.reader,
             &self.writer,
             self.wiki.as_ref(),
@@ -2413,6 +2432,7 @@ impl AiMemoryServer {
             proj,
             &self.decay_params,
             self.decay_breadth_weight,
+            self.observation_retention,
             args.dry_run.unwrap_or(false),
         )
         .await
@@ -5953,7 +5973,7 @@ mod tests {
 
     /// `memory_forget_sweep` is admin-gated and destructive, and the surface
     /// an agent reads is the only place it can learn what the tool will
-    /// delete. Both surfaces must name all three passes and must not claim a
+    /// delete. Both surfaces must name all four passes and must not claim a
     /// blanket pin exemption.
     ///
     /// The description previously said "Semantic / procedural / pinned pages
@@ -5996,6 +6016,28 @@ mod tests {
         assert!(
             desc.contains("hard_delete_after_days"),
             "description must name the hard-delete pass; got: {desc}"
+        );
+        // The fourth pass deletes raw capture, not pages, and can remove
+        // millions of rows on a real install. An agent that cannot read it
+        // here cannot know the tool touches observations at all — which is the
+        // exact regression this test was written to stop.
+        assert!(
+            desc.contains("observation_retention_days"),
+            "description must name the observation prune pass; got: {desc}"
+        );
+        assert!(
+            desc.contains("consolidated") && desc.contains("still live"),
+            "description must state that only consolidated sessions with a live \
+             page are pruned; got: {desc}"
+        );
+        assert!(
+            desc.contains("DISABLED"),
+            "description must state that observation pruning is off by default; \
+             got: {desc}"
+        );
+        assert!(
+            !desc.contains("THREE passes"),
+            "the three-pass wording must not come back now there are four; got: {desc}"
         );
         // A bare unqualified exemption sentence is exactly the regression
         // this guards, so reject the old wording verbatim.

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -46,8 +46,8 @@ pub use error::{StoreError, StoreResult};
 pub use maintenance::MaintenanceJob;
 pub use ops::{
     AdmittedSession, DeleteWorkspaceSummary, EmbeddingWrite, HookSessionAdmission,
-    IngestObservationOutcome, LifecycleOnlyEndOutcome, MoveSessionSummary, MoveSummary, PagesMode,
-    PurgeSummary, ReorgSummary,
+    IngestObservationOutcome, LifecycleOnlyEndOutcome, MoveSessionSummary, MoveSummary,
+    ObservationPruneOutcome, PagesMode, PurgeSummary, ReorgSummary,
 };
 pub use reader::{
     ActivityWindow, AgentSessionCount, AutoImproveCandidateSession, BriefPageBody, BriefingPage,

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -1957,6 +1957,129 @@ pub fn hard_delete_decayed_page_chain(
     Ok(n)
 }
 
+/// One batch of an observation prune, as reported by
+/// [`prune_consolidated_observations`].
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ObservationPruneOutcome {
+    /// Observation rows permanently deleted by this batch.
+    pub deleted: usize,
+    /// Distinct sessions that lost rows in this batch. Returned rather than
+    /// counted so a caller looping over batches can deduplicate a session whose
+    /// rows straddle a batch boundary.
+    pub sessions_touched: Vec<SessionId>,
+    /// Sessions whose `ended_observation_count` watermark was lowered back onto
+    /// the surviving row count.
+    pub sessions_resynced: usize,
+}
+
+/// Permanently delete one bounded batch of raw observations belonging to
+/// sessions that were already distilled into a live summary page.
+///
+/// Raw capture is the store's growth driver, but it is also the only input
+/// consolidation, auto-improvement and the `raw_hits` fallback have. Deleting
+/// it is safe exactly when its durable distillation still exists, so the
+/// predicate joins through `sessions.summary_page_id` — the marker
+/// [`end_session_row`] writes — and requires the page it points at to still be
+/// live. `superseded_at IS NOT NULL` means decay already evicted that page, so
+/// its session's raw capture is the last copy and must stay; a page hard-deleted
+/// by the same sweep is excluded for free, because the `ON DELETE SET NULL`
+/// foreign key has already cleared the pointer. A session with no `sessions`
+/// row, or one that never ended, matches nothing and can never be pruned.
+///
+/// `ORDER BY created_at` makes the batching deterministic: a run interrupted
+/// halfway leaves a clean age boundary rather than holes, so the next run
+/// resumes on a store whose invariant ("everything older than X is gone for
+/// consolidated sessions") is still one comparison.
+///
+/// The watermark resync is not optional. `session_end_disposition` compares a
+/// live `COUNT(*)` against the persisted `sessions.ended_observation_count`;
+/// leaving the watermark above reality would make a resumed session's genuinely
+/// new work read as `AlreadyEnded` and never be re-consolidated. The
+/// `ended_observation_count > (…)` guard keeps the repair idempotent and
+/// one-directional — it can only lower a watermark that is now above reality.
+/// Bounding it to the ids the delete returned also repairs sessions whose row
+/// lives in a different scope than the observations being pruned.
+pub fn prune_consolidated_observations(
+    conn: &mut Connection,
+    workspace_id: WorkspaceId,
+    project_id: ProjectId,
+    cutoff_us: i64,
+    batch: usize,
+) -> StoreResult<ObservationPruneOutcome> {
+    if batch == 0 {
+        return Ok(ObservationPruneOutcome::default());
+    }
+    let tx = conn.transaction()?;
+    let mut deleted = 0usize;
+    let mut sessions: BTreeSet<Vec<u8>> = BTreeSet::new();
+    {
+        let mut stmt = tx.prepare(
+            "DELETE FROM observations \
+             WHERE id IN ( \
+                 SELECT o.id FROM observations o \
+                 WHERE o.workspace_id = ?1 \
+                   AND o.project_id = ?2 \
+                   AND o.created_at < ?3 \
+                   AND EXISTS ( \
+                       SELECT 1 FROM sessions s \
+                       JOIN pages p ON p.id = s.summary_page_id \
+                       WHERE s.id = o.session_id \
+                         AND p.superseded_at IS NULL \
+                   ) \
+                 ORDER BY o.created_at \
+                 LIMIT ?4 \
+             ) \
+             RETURNING session_id",
+        )?;
+        let rows = stmt.query_map(
+            params![
+                workspace_id.as_bytes(),
+                project_id.as_bytes(),
+                cutoff_us,
+                u64::try_from(batch).unwrap_or(u64::MAX),
+            ],
+            |row| row.get::<_, Vec<u8>>(0),
+        )?;
+        for row in rows {
+            sessions.insert(row?);
+            deleted += 1;
+        }
+    }
+    let mut sessions_touched = Vec::with_capacity(sessions.len());
+    let mut sessions_resynced = 0usize;
+    if deleted > 0 {
+        for session_id in &sessions {
+            sessions_touched.push(SessionId::from_slice(session_id)?);
+            sessions_resynced += tx.execute(
+                "UPDATE sessions \
+                 SET ended_observation_count = ( \
+                         SELECT COUNT(*) FROM observations o WHERE o.session_id = sessions.id \
+                     ) \
+                 WHERE id = ?1 \
+                   AND ended_observation_count > ( \
+                         SELECT COUNT(*) FROM observations o WHERE o.session_id = sessions.id \
+                     )",
+                params![session_id],
+            )?;
+        }
+        audit(
+            &tx,
+            "prune_observations",
+            Some(workspace_id.as_bytes()),
+            Some(project_id.as_bytes()),
+            None,
+            None,
+            Timestamp::now().as_microsecond(),
+        )?;
+    }
+    tx.commit()?;
+    Ok(ObservationPruneOutcome {
+        deleted,
+        sessions_touched,
+        sessions_resynced,
+    })
+}
+
 /// Insert a new handoff in state=open.
 pub fn insert_handoff(conn: &mut Connection, h: &NewHandoff) -> StoreResult<HandoffId> {
     let tx = conn.transaction()?;

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -2062,7 +2062,7 @@ pub fn prune_consolidated_observations(
                 params![session_id],
             )?;
         }
-        audit(
+        audit_with_detail(
             &tx,
             "prune_observations",
             Some(workspace_id.as_bytes()),
@@ -2070,6 +2070,7 @@ pub fn prune_consolidated_observations(
             None,
             None,
             Timestamp::now().as_microsecond(),
+            &format!("{{\"deleted\":{deleted}}}"),
         )?;
     }
     tx.commit()?;
@@ -2582,9 +2583,35 @@ fn audit(
     author_id: Option<&[u8; 16]>,
     at: i64,
 ) -> StoreResult<()> {
+    audit_with_detail(
+        tx,
+        op,
+        workspace_id,
+        project_id,
+        page_id,
+        author_id,
+        at,
+        "{}",
+    )
+}
+
+/// `audit`, but with a caller-supplied JSON `detail` payload. Exists so a
+/// destructive batch can record what it did (e.g. the observation prune's
+/// deleted-row count) instead of leaving a gap only inferable from timestamps.
+#[allow(clippy::too_many_arguments)]
+fn audit_with_detail(
+    tx: &rusqlite::Transaction<'_>,
+    op: &str,
+    workspace_id: Option<&[u8; 16]>,
+    project_id: Option<&[u8; 16]>,
+    page_id: Option<&[u8; 16]>,
+    author_id: Option<&[u8; 16]>,
+    at: i64,
+    detail: &str,
+) -> StoreResult<()> {
     tx.execute(
         "INSERT INTO audit_log (at, op, workspace_id, project_id, page_id, author_id, detail) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, '{}')",
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         params![
             at,
             op,
@@ -2592,6 +2619,7 @@ fn audit(
             project_id.map(|b| &b[..]),
             page_id.map(|b| &b[..]),
             author_id.map(|b| &b[..]),
+            detail,
         ],
     )?;
     Ok(())

--- a/crates/ai-memory-store/src/reader.rs
+++ b/crates/ai-memory-store/src/reader.rs
@@ -3156,6 +3156,42 @@ impl ReaderPool {
         .await
     }
 
+    /// Count the observations the prune pass would delete for this scope.
+    ///
+    /// Same predicate as
+    /// [`prune_consolidated_observations`](crate::ops::prune_consolidated_observations),
+    /// read-only, so a dry run can report a number without any chance of a
+    /// write. Kept beside the delete rather than derived from it because the
+    /// dry run must never open a write transaction at all.
+    ///
+    /// # Errors
+    /// Propagates SQL errors.
+    pub async fn prunable_observation_count(
+        &self,
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+        cutoff_us: i64,
+    ) -> StoreResult<usize> {
+        self.with_conn(move |conn| {
+            let n: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM observations o \
+                 WHERE o.workspace_id = ?1 \
+                   AND o.project_id = ?2 \
+                   AND o.created_at < ?3 \
+                   AND EXISTS ( \
+                       SELECT 1 FROM sessions s \
+                       JOIN pages p ON p.id = s.summary_page_id \
+                       WHERE s.id = o.session_id \
+                         AND p.superseded_at IS NULL \
+                   )",
+                params![workspace_id.as_bytes(), project_id.as_bytes(), cutoff_us],
+                |row| row.get(0),
+            )?;
+            Ok(usize::try_from(n).unwrap_or(0))
+        })
+        .await
+    }
+
     /// Return the number of DISTINCT operators that reinforced each
     /// `is_latest = 1` page of a project, for the sweep's breadth term.
     ///

--- a/crates/ai-memory-store/src/writer.rs
+++ b/crates/ai-memory-store/src/writer.rs
@@ -26,8 +26,8 @@ use crate::auto_improve::{
 use crate::error::{StoreError, StoreResult};
 use crate::ops::{
     self, AdmittedSession, DeleteWorkspaceSummary, EmbeddingWrite, HookSessionAdmission,
-    IngestObservationOutcome, LifecycleOnlyEndOutcome, MoveSessionSummary, MoveSummary, PagesMode,
-    PurgeSummary, ReorgSummary,
+    IngestObservationOutcome, LifecycleOnlyEndOutcome, MoveSessionSummary, MoveSummary,
+    ObservationPruneOutcome, PagesMode, PurgeSummary, ReorgSummary,
 };
 use crate::session_consolidation::SessionConsolidationJob;
 use crate::users::{self, TOKEN_HASH_LEN};
@@ -245,6 +245,13 @@ pub(crate) enum WriteCmd {
         expected_latest_id: Option<PageId>,
         cutoff_us: i64,
         reply: oneshot::Sender<StoreResult<usize>>,
+    },
+    PruneConsolidatedObservations {
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+        cutoff_us: i64,
+        batch: usize,
+        reply: oneshot::Sender<StoreResult<ObservationPruneOutcome>>,
     },
     HealCatchAllRepoPaths {
         home: Option<String>,
@@ -1130,6 +1137,35 @@ impl WriterHandle {
             tombstone_id,
             expected_latest_id,
             cutoff_us,
+            reply: tx,
+        })
+        .await?;
+        rx.await.map_err(|_| StoreError::WriterClosed)?
+    }
+
+    /// Delete one bounded batch of raw observations whose session was already
+    /// consolidated into a live summary page, repairing the session end
+    /// watermark in the same transaction.
+    ///
+    /// One batch is one transaction and one mailbox message, so a multi-million
+    /// row prune never holds the write lock across the whole run — every other
+    /// pending write interleaves between batches.
+    ///
+    /// # Errors
+    /// Returns [`StoreError::WriterClosed`] or propagates SQL errors.
+    pub async fn prune_consolidated_observations(
+        &self,
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+        cutoff_us: i64,
+        batch: usize,
+    ) -> StoreResult<ObservationPruneOutcome> {
+        let (tx, rx) = oneshot::channel();
+        self.send(WriteCmd::PruneConsolidatedObservations {
+            workspace_id,
+            project_id,
+            cutoff_us,
+            batch,
             reply: tx,
         })
         .await?;
@@ -2096,6 +2132,22 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
                     cutoff_us,
                 );
                 send_or_warn(reply, result, "hard_delete_decayed_page_chain");
+            }
+            WriteCmd::PruneConsolidatedObservations {
+                workspace_id,
+                project_id,
+                cutoff_us,
+                batch,
+                reply,
+            } => {
+                let result = ops::prune_consolidated_observations(
+                    &mut conn,
+                    workspace_id,
+                    project_id,
+                    cutoff_us,
+                    batch,
+                );
+                send_or_warn(reply, result, "prune_consolidated_observations");
             }
             WriteCmd::HealCatchAllRepoPaths { home, reply } => {
                 let result = ops::heal_catch_all_repo_paths(&mut conn, home.as_deref());

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,7 +143,16 @@ from hook paths.
    version ancestry only within that sweep's resolved workspace/project,
    together with entity-index rows orphaned by the purge. A newer page recreated
    at the same path is preserved. Semantic / pinned / freshly-touched pages
-   survive.
+   survive. A fourth pass, disabled unless `[decay] observation_retention_days`
+   is positive, then deletes raw `observations` older than that age — but only
+   for sessions already consolidated into a summary page that is still live, so
+   raw capture is never removed while it is the last copy of that session's
+   work. It runs last so this run's own evictions and hard-deletes already
+   exclude their sessions, deletes in `observation_prune_batch` transactions so
+   a multi-million row prune cannot hold the write lock, and repairs
+   `sessions.ended_observation_count` downward in the same transaction. Freed
+   SQLite pages are reused, not returned to the OS: the `.db` file does not
+   shrink, the backup tarball does.
    Scheduled sweep, rule-based lint, and opt-in embedding backfill ticks
    enumerate every existing workspace/project scope before doing per-project
    work, matching the auto-improvement scheduler's store-wide scope model. A
@@ -502,6 +511,8 @@ mu = 0.04                          # ↑ if recent hits should count more
 cold_threshold = 0.20              # below this → remove file + retain tombstone
 hard_delete_after_days = 180
 breadth_weight = 0.0               # opt-in reward for distinct operators
+observation_retention_days = 0     # 0 = never prune raw observations
+observation_prune_batch = 5000     # rows per prune transaction
 
 [slots]                           # optional shared-server injection boundary
 per_user = false                  # shared + own slots in agent context

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -153,7 +153,11 @@ from hook paths.
    work. It runs last so this run's own evictions and hard-deletes already
    exclude their sessions, deletes in `observation_prune_batch` transactions so
    a multi-million row prune cannot hold the write lock, and repairs
-   `sessions.ended_observation_count` downward in the same transaction. Freed
+   `sessions.ended_observation_count` downward in the same transaction. The
+   prune is irreversible in a specific sense: observations are the input to
+   consolidation, so a pruned session can never be re-consolidated — not with
+   a better model, a better prompt, or a fixed consolidator bug — and its
+   summary page becomes the only surviving account of that session. Freed
    SQLite pages are reused, not returned to the OS: the `.db` file does not
    shrink, the backup tarball does.
    Scheduled sweep, rule-based lint, and opt-in embedding backfill ticks


### PR DESCRIPTION
## What changed

Adds a **fourth, opt-in pass to the existing M8 forget sweep** that deletes raw `observations` older than a configured age — and only for sessions already consolidated into a summary page that is still live. No new top-level command.

**Before:** nothing in the tree could delete an `observations` row for age. `git grep -nE "DELETE FROM observations|prune_observation|observation_retention"` over `upstream/main` returns **nothing**; the M8 sweep acts on `pages` only. Raw capture grew without bound.

**After:** with `decay.observation_retention_days` set to a positive value, `ai-memory forget-sweep` / `memory_forget_sweep` / the scheduled `[maintenance]` tick also prune consolidated raw capture, in bounded transactions, with counts in the response and one audit row per batch that actually deleted.

**CHANGED DEFAULT: none.**
- `decay.observation_retention_days` defaults to `0`, and `0` means *disabled*. Not "prune after 0 days" — the pass does not run at all, not even the count query.
- `decay.observation_prune_batch` defaults to `5000` and is inert while the pass is off.
- `run_sweep` and `run_sweep_with_breadth` keep their exact signatures and delegate with `ObservationRetention::default()` (= disabled). `ai_memory_store::DecayParams` is untouched, so every downstream Rust caller that constructs it directly still compiles and still gets today's behaviour.
- `admin_router` and `admin_router_with_decay_breadth` keep their shapes.
- An existing install upgrading to this build deletes exactly zero observations until an operator edits config.

**Response shape:** `SweepReport` gains four additive fields — `observations_prunable`, `observations_pruned`, `observation_prune_sessions`, `observation_prune_batches` — all `0` at the default. `SweepReport` is `#[derive(Serialize)]` only; `POST /admin/forget-sweep` returns it via `serde_json::to_value` and `crates/ai-memory-cli/src/commands/forget_sweep.rs` deserializes into `serde_json::Value` and pretty-prints. There is no typed consumer to break.

## Why

Measured on a three-month-old deployment (`memory.djalmajr.dev`), SQLite 5.53 GB total, via `dbstat`:

| object | size | % |
|---|---|---|
| `observations` | 3.39 GB | 61.2% |
| `observations_fts_data` | 0.79 GB | 14.4% |
| four indexes on `observations` | 1.22 GB | ~22% |
| **observations footprint** | **~5.4 GB** | **~98%** |
| `pages` (the compiled knowledge) | 0.03 GB | 0.5% |
| `page_embeddings` | 0.01 GB | 0.1% |

5,236,232 observation rows against 2,365 pages. The nightly `ai-memory backup` tarball is 2.7 GB, ~98% of which is raw capture whose durable value was already distilled into 30 MB of Markdown. Projected ~22 GB/year, unbounded.

Raw capture is not worthless — it is the only input consolidation, auto-improve review and the `raw_hits` fallback have. So the feature does not bound it by age alone; it bounds it by age *and* proof that the distillation survived.

## Decision

Extend the M8 sweep rather than add a command, and gate the delete on the schema's own consolidation marker.

**Placement.** `run_sweep_with_options(reader, writer, wiki, ws, proj, params, breadth_weight, retention, dry_run)` sits beside `run_sweep_with_breadth`, which keeps its exact signature and delegates with the disabled default — the same layering the file already uses for `run_sweep -> run_sweep_with_breadth`. `ObservationRetention` is its own type rather than two more `DecayParams` fields, for the reason already documented in-tree for `breadth_weight`: `DecayParams` is a public struct downstream callers construct directly, and widening it would break them. `run_sweep_with_breadth` previously took `_writer: &WriterHandle` unused; the prune is its first real use, so no signature churn was needed to get a writer.

The prune runs LAST inside the existing `if !dry_run` block. The same sweep run may have just (a) decay-evicted a session's summary page (`superseded_at` stamped) or (b) hard-deleted it (row gone, so `sessions.summary_page_id` is NULLed by the FK). Running last means both of this run's effects are already visible to the predicate, so a session that just lost its distillation is excluded in the same pass instead of one pass later.

**Three gates, all on columns the schema already maintains.**

```sql
-- candidate count (dry run, reader connection, no write transaction)
SELECT COUNT(*) FROM observations o
WHERE o.workspace_id = ?1 AND o.project_id = ?2 AND o.created_at < ?3
  AND EXISTS (SELECT 1 FROM sessions s
              JOIN pages p ON p.id = s.summary_page_id
              WHERE s.id = o.session_id AND p.superseded_at IS NULL);

-- one batch, one transaction
DELETE FROM observations WHERE id IN (
    SELECT o.id FROM observations o
    WHERE o.workspace_id = ?1 AND o.project_id = ?2 AND o.created_at < ?3
      AND EXISTS (SELECT 1 FROM sessions s
                  JOIN pages p ON p.id = s.summary_page_id
                  WHERE s.id = o.session_id AND p.superseded_at IS NULL)
    ORDER BY o.created_at LIMIT ?4
) RETURNING session_id;
```

- **Gate 1 — `summary_page_id IS NOT NULL`** (implied by the JOIN) is the schema's own "consolidated" marker. The only writer is `end_session_row` (`upstream/main:crates/ai-memory-store/src/ops.rs:1073-1090`), which sets `ended_at`, `summary_page_id` and `ended_observation_count` in one UPDATE — so `summary_page_id IS NOT NULL` *already implies* `ended_at IS NOT NULL`. Adding an `ended_at IS NOT NULL` clause would be redundant and I did not carry one. Mid-session PreCompact/PostCompaction checkpoints write the session page through the wiki but never touch `sessions`, so a still-running session is never eligible.
- **Gate 2 — `p.superseded_at IS NULL`.** Gate 1 alone is not enough on a real install: session pages are written `tier: episodic, pinned: false`, so they are themselves decay candidates. Decay sets `is_latest = 0, superseded_at = now` on the exact row `summary_page_id` points at — the Markdown is gone but the row survives until `hard_delete_after_days`. Without this gate the sweep would delete the raw capture of sessions whose distillation had **already been thrown away**. `superseded_at IS NULL` is the correct discriminator and not a guess: `upstream/main:crates/ai-memory-consolidate/src/sweep.rs:20` states the invariant verbatim — *"Ordinary supersession rows are safe because only decay writes `superseded_at`."* I chose it over `p.is_latest = 1` deliberately: `is_latest = 1` would also exclude a page merely superseded by an ordinary rewrite, which would silently turn the feature into a near-no-op on installs that re-consolidate.
- **Gate 3 — hard-deleted summary pages.** Nothing in the SQL. The `pages` row disappearing fires `summary_page_id BLOB REFERENCES pages(id) ON DELETE SET NULL` (`upstream/main:crates/ai-memory-store/migrations/V01__init.sql:87`, preserved verbatim through the V50 table rebuild), with `foreign_keys = ON` at runtime (`upstream/main:crates/ai-memory-store/src/lib.rs:123`), so the JOIN finds nothing. This is *why* the pass runs last.

**Why it cannot touch an unconsolidated session:** a session with no `sessions` row (the phantoms the UNION's second leg at `upstream/main:crates/ai-memory-store/src/reader.rs:2559-2568` exists to surface) has nothing for the EXISTS to match; a `sessions` row with `summary_page_id IS NULL` is excluded by the JOIN; a decay-evicted or hard-deleted page is excluded by gates 2 and 3.

**The watermark resync is not optional.** `session_end_disposition` (`upstream/main:crates/ai-memory-store/src/reader.rs:2639-2680`) decides `ReEndWithNewWork` vs `AlreadyEnded` by comparing a live `COUNT(*) FROM observations WHERE session_id = ?` against the persisted `sessions.ended_observation_count` (V35). Deleting rows without repairing that watermark leaves `current < watermark` forever, so a genuinely resumed session's new work would be misread as `AlreadyEnded` and never re-consolidated. In the same transaction, for each session id `RETURNING` handed back:

```sql
UPDATE sessions
SET ended_observation_count = (SELECT COUNT(*) FROM observations o WHERE o.session_id = sessions.id)
WHERE id = ?1
  AND ended_observation_count > (SELECT COUNT(*) FROM observations o WHERE o.session_id = sessions.id);
```

The `>` guard makes it idempotent and one-directional — it can only lower a watermark now above reality, never raise one. Bounding it to the `RETURNING` ids (rather than a scope-wide scan) also covers cross-scope sessions, whose `sessions` row lives in a different `(workspace, project)` than the observations being pruned.

**Audit.** One `prune_observations` row per batch that actually deleted, written *inside* the same transaction and gated on `deleted > 0`, via `audit_with_detail` — a sibling the existing `audit` now delegates to — recording `{"deleted": N}` in `audit_log.detail` so a later "where did these go?" reads the count instead of inferring it from a gap in timestamps — byte-for-byte the pattern `hard_delete_decayed_page_chain` uses (`if n > 0 { … audit(…) } tx.commit()`). Inside the transaction is what makes "only when the write happened" true: the audit row and the deletes commit or roll back together. `author_id` is `None`, with the justification `soft_delete_for_decay` already carries in-tree: a scheduled/admin system operation is not a user-attributable page edit.

## Reproducibility

Every number below is command output from this branch, not an estimate.

**Query plans.** Store built from all 50 shipped migrations, populated with 6,000 sessions / 300,000 observations (150,000 eligible in one project; a second project with 150,000 rows and no pages at all), then `ANALYZE`d. SQLite 3.46.0.

```
--- count ---
SEARCH o USING INDEX idx_observations_project_created (workspace_id=? AND project_id=? AND created_at<?)
CORRELATED SCALAR SUBQUERY 1
  SEARCH s USING INDEX sqlite_autoindex_sessions_1 (id=?)
  SEARCH p USING INDEX sqlite_autoindex_pages_1 (id=?)
--- delete ---
SEARCH observations USING COVERING INDEX sqlite_autoindex_observations_1 (id=?)
LIST SUBQUERY 2
  SEARCH o USING INDEX idx_observations_project_created (workspace_id=? AND project_id=? AND created_at<?)
  CORRELATED SCALAR SUBQUERY 1
    SEARCH s USING INDEX sqlite_autoindex_sessions_1 (id=?)
    SEARCH p USING INDEX sqlite_autoindex_pages_1 (id=?)
--- watermark ---
SEARCH sessions USING INDEX sqlite_autoindex_sessions_1 (id=?)
CORRELATED SCALAR SUBQUERY
  SEARCH o USING COVERING INDEX idx_observations_session (session_id=?)
```

Every access is an index seek. No full table scan, no temp b-tree, no sort step.

**Batch cost** (release build, WAL, macOS/APFS SSD):

```
count query: 150000 eligible in 101.399958ms
batch 0: deleted 5000 in 23.093625ms (+commit 4.269041ms)
batch 1: deleted 5000 in 23.780459ms (+commit 3.271959ms)
batch 2: deleted 5000 in 26.513625ms (+commit 1.948084ms)
after: project a = 135000, project b = 150000, fts docsize = 285000
unconsolidated sessions that lost rows: 0
```

The second project — same volume, no pages, so no consolidated session — lost nothing. The FTS docsize tracked the 15,000-row delete exactly. Extrapolating those per-batch timings to the 5,236,232-row install: a first prune of ~3.4M eligible rows is ~680 batches. At the measured ~28 ms per batch that is on the order of 20 seconds of *intermittent* write activity spread over 680 independent transactions, and I would expect it to be slower on the production store, whose b-tree is far larger than the one I measured and whose cache will be cold — but I have not measured that, so treat the 20 seconds as a floor rather than an estimate. What the batching guarantees regardless is the shape: no single transaction holds the write lock for more than one batch. (That extrapolation is arithmetic on my measurements, not a measurement of the production box.)

**Schema facts, read out of the built V50 schema rather than inferred:**
- Triggers on `observations`: `["observations_fts_ai", "observations_fts_ad", "observations_fts_au", "observations_ws_proj_pairing_ai"]`. Only `_ad` fires on DELETE, and it issues the FTS `'delete'` command (`upstream/main:crates/ai-memory-store/migrations/V07__observations_fts_and_link_index.sql:22-25`). No manual FTS maintenance was added.
- `SELECT sql FROM sqlite_master WHERE sql LIKE '%REFERENCES observations%'` returns **0 rows**. No cascade, no orphan, no second index to repair.

## Severity

Medium, and one-directional. The pass is off by default and does nothing on an unmodified install. Once enabled it performs an irreversible delete, which is why it carries the destructive-path standard: dry-run first, explicit counts in the response, per-scope reporting (`run_sweep_*` is already per `(workspace, project)`; `run_scheduled_sweep_tick` enumerates every scope and now aggregates `observations_pruned` into its log line), audit rows written only when the write happened, and a bounded batch so a 3.4M-row delete cannot hold the write lock for minutes.

## Security handling

No new surface. The pass is reachable only through paths that are already admin-gated: `memory_forget_sweep` calls `require_admin_capability` before doing anything, `POST /admin/forget-sweep` sits behind the existing admin router, and the scheduled tick runs in-process from the operator's own config. No new endpoint, no new argument on any tool, no change to authorization. The MCP tool gains no parameter — the retention bound comes from server config, not from a caller-supplied value, so an agent cannot ask for a more aggressive prune than the operator configured.

The MCP tool *description* changed from "THREE passes" to "FOUR passes" and now names the prune, its consolidation gate, and its default-off state. That is a security-relevant change in itself: `forget_sweep_surfaces_name_every_pass_and_scope_the_pin_exemption` exists (from #485) precisely because "the surface an agent reads is the only place it can learn what the tool will delete". A fourth pass that deletes millions of rows and is not named there is the exact regression that test guards, so the test was extended with matching assertions rather than merely updated.

## Evidence

New store surface (mirrors `hard_delete_decayed_page_chain`):
- `ai_memory_store::ops::prune_consolidated_observations(conn, ws, proj, cutoff_us, batch) -> StoreResult<ObservationPruneOutcome>` — `crates/ai-memory-store/src/ops.rs:2002` (this branch). One transaction per batch. `ObservationPruneOutcome { deleted, sessions_touched, sessions_resynced }` at ops.rs:1963; `sessions_touched` returns the ids rather than a count so the caller can dedupe a session whose rows straddle a batch boundary.
- `WriteCmd::PruneConsolidatedObservations` (writer.rs:249) + `WriterHandle::prune_consolidated_observations` (writer.rs:1156) + dispatch (writer.rs:2136), beside `hard_delete_decayed_page_chain`.
- `ReaderPool::prunable_observation_count(ws, proj, cutoff_us)` — reader.rs:3169. Reader connection only; the dry run cannot write.

Sweep:
- `ObservationRetention { days, batch }` + `Default` (disabled) + `is_enabled()` — sweep.rs:110-138.
- `run_sweep_with_options` — sweep.rs:232. Fourth pass at sweep.rs:406, last inside `if !dry_run`.
- `SweepError::InvalidObservationRetention` for a negative age, mirroring `InvalidBreadthWeight`.

Config (`[decay]`, the same struct that already holds `hard_delete_after_days` and the opt-in-default-0 `breadth_weight`):
- fields at config.rs:66/68, defaults at config.rs:82-83, `observation_retention()` accessor at config.rs:108.
- validation at config.rs:950-958, mirroring the `breadth_weight` guard; negative test `load_rejects_destructive_invalid_observation_retention` at config.rs:1462, beside `load_rejects_destructive_invalid_breadth_weights`.
- default-off assertions folded into the existing `defaults_have_canonical_endings` at config.rs:1387-1389.
- Env overrides come free from figment's `Env::prefixed("AI_MEMORY_").split("__")`: `AI_MEMORY_DECAY__OBSERVATION_RETENTION_DAYS`, `AI_MEMORY_DECAY__OBSERVATION_PRUNE_BATCH`.
- `crates/ai-memory-cli/templates/config.default.toml` — both keys added *inside* `[decay]`. Deliberate: `crates/ai-memory-cli/src/commands/init.rs` asserts `[auth]` must remain the LAST section, so inventing a `[retention]` section below it would have broken that test. The rendered template already round-trips through a full `Config` extract, so the new keys ride that assertion for free.

Sibling call sites — every one is live, none optional:
- `crates/ai-memory-cli/src/commands/serve.rs:1201` `run_scheduled_sweep_tick` threads the options; `observations_pruned` added to `ScheduledSweepTickOutcome` (serve.rs:1203) and to the completion log line (serve.rs:987).
- `crates/ai-memory-mcp/src/admin.rs` — the `DecayBreadthWeight(f64)` Extension became `SweepTuning { breadth_weight, retention }`; `admin_router_with_decay_breadth` is kept and delegates to the new `admin_router_with_sweep_tuning` (admin.rs:554), so no public fn changed shape. `handle_curator` reads the same Extension and was updated with it.
- `crates/ai-memory-mcp/src/server.rs` — `with_observation_retention` (server.rs:1780) beside `with_decay_breadth_weight`; `memory_forget_sweep` now calls `run_sweep_with_options`; tool description at server.rs:2390.
- `crates/ai-memory-cli/src/commands/serve.rs:529/722/972` wire config into the MCP server, the admin router, and the scheduled tick.

**Observation consumers — grepped before changing their lifetime, each verified:**
- `search_observations_for_project` -> the `memory_query` `raw_hits` fallback. LOSES raw fallback matches inside pruned sessions. Bounded by gates 1+2: a pruned session's content is by definition in a live compiled page, which the primary page search covers. The real loss is snippet fidelity to the exact original wording.
- `observations_for_session` -> consolidator, auto_improve, hooks router. LOSES re-consolidation of a pruned session. Safe: the consolidator returns `ConsolidatorError::EmptySession` (`upstream/main:crates/ai-memory-consolidate/src/consolidator.rs:140/424`), which `upstream/main:crates/ai-memory-hooks/src/router.rs:3181` already treats as `return Ok(())` — success, not failure. The queued-job path burns `SESSION_CONSOLIDATION_MAX_ATTEMPTS` then goes terminal: bounded, not a retry loop, and only reachable under the opt-in `consolidate_on_session_end`.
- `session_end_disposition` — **this is the one that breaks if the prune is naive.** Handled by the in-transaction resync above and pinned by `the_session_end_watermark_follows_the_prune`.
- `session_scope_from_observations` -> returns `None` for a fully pruned session; the consolidator falls back to the `sessions` row's own scope, and the case only arises for a session already consolidated into a page in that same scope.
- `session_ids_touching_scope` (`upstream/main:crates/ai-memory-store/src/reader.rs:2559-2568`) — the UNION's second leg exists to surface sessions with observations but NO `sessions` row; those can never satisfy the JOIN to `sessions`, so the prune cannot orphan a scope's only handle on them.
- `sessions_for_scope_filtered` — the per-session observation count column drops toward 0 for pruned sessions. **No session disappears from the listing**; membership still comes from the `sessions` row via the first UNION leg. Visible UI change.
- `session_observations_scoped` -> the web route `/workspaces/{w}/projects/{p}/sessions/{id}/observations` and `memory_read_session_observations`. The raw transcript view of a pruned session returns empty with `total = 0`. This is the feature's intended, operator-chosen cost.
- `auto_improve` `min_observations` preflight — a MANUAL rerun on a pruned session rejects with `too_few_observations`. Scheduled review is unaffected in practice: `auto_improve_candidate_sessions` only selects sessions past the scheduler watermark with no prior run or claim, and any operator-set retention age is far beyond that window.
- `sweep_hollow_projects` (`upstream/main:crates/ai-memory-store/src/ops.rs:307-323`) — SAFE, verified against the exact predicate text: the hollow test also requires `NOT EXISTS pages AND NOT EXISTS sessions`, and a consolidated session leaves both behind by definition, so pruning its observations can never make a project look hollow and get it auto-deleted.
- `observations` vs `observations_fts_docsize` drift check behind `fts_drift_status` — SAFE, and asserted directly by the new test.
- status / per-scope observation totals — counts drop, which is the point. `MAX(created_at)` is unaffected because only old rows are pruned.
- briefing/recent activity counts — all `created_at > ?` windows; any sane retention age is far outside them.
- `move_project_workspace`, `move_session`, `reorg_sessions`, `purge_project` — reported counts shrink. Behaviourally safe except `move_session` with `PagesMode::Regenerate`, which is in the fence below.
- `crates/ai-memory-cli/src/commands/reindex.rs` — reindex explicitly documents observations as episodic DB-only state it does not rebuild. No interaction.

## Migrations

**ZERO migrations.** Stated explicitly because it removes a whole class of risk: `upstream/main` is at V50, and a new migration would have to be re-numbered contiguously at push time and would race any other open PR adding one.

Proven by EXPLAIN QUERY PLAN against a real store built from all 50 migrations and `ANALYZE`d (output above), not by inspection. The indexes doing the work all pre-date this change:
- `idx_observations_project_created ON observations(workspace_id, project_id, created_at DESC)` — V08. Equality on the scope pair, range on `created_at`: an exact fit for the driving scan.
- `idx_observations_session ON observations(session_id, created_at)` — V01. Serves the watermark recount as a COVERING index.
- `sqlite_autoindex_sessions_1` / `sqlite_autoindex_pages_1` — the implicit PK indexes on the two `BLOB PRIMARY KEY` tables, used for both EXISTS probes.

`idx_observations_created_at` is not used by this predicate and needs no change.

## Test plan

- [x] `cargo fmt --all -- --check` — exit 0, no output.
- [x] `git diff --check` — exit 0, no output.
- [x] `TAILWIND_SKIP=1 cargo test --workspace --no-fail-fast` — exit 0 (captured from a redirect, not teed). 68 suites, **2619 passed, 0 failed, 2 ignored** (head `b03a2d8e`, post-v1.34.0 merge, includes the new audit-detail assert).
- [x] `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings` — exit 0, zero warnings.
- [x] `cargo deny check` — exit 0: `advisories ok, bans ok, licenses ok, sources ok`.
- [x] `cargo test --manifest-path companions/ai-memory-importer/Cargo.toml` — exit 0, 19 passed.

New suite `crates/ai-memory-consolidate/tests/observation_retention.rs` — 8 tests, all green:
`the_default_configuration_prunes_no_observation`, `only_a_consolidated_session_with_a_live_page_loses_its_observations`, `the_fts_index_stops_matching_pruned_bodies`, `a_dry_run_counts_without_deleting`, `the_prune_deletes_in_bounded_batches`, `the_session_end_watermark_follows_the_prune`, `recent_observations_survive_a_consolidated_session`, `a_negative_retention_age_stops_the_sweep`.

**Six of the eight were proved red by reverting the production change**, across four independent
reverts. The two that were not — `a_dry_run_counts_without_deleting` and
`a_negative_retention_age_stops_the_sweep` — stayed green under every revert: they pin paths that
do not delete, so no revert of the delete logic can make them fail. They are guards on behaviour
this PR must not change, not regression tests for it, and are not claimed as such.

**A — consolidation gate removed from the DELETE predicate** (age-only prune):
```
test result: FAILED. 4 passed; 4 failed
only_a_consolidated_session_with_a_live_page_loses_its_observations:269
  assertion `left == right` failed
    left: 9      <- all nine rows deleted
   right: 3      <- only the three consolidated ones may go
the_fts_index_stops_matching_pruned_bodies:323
  assertion failed: only the pruned rows may leave the index
    left: 0    right: 6
recent_observations_survive_a_consolidated_session:515
    left: 6    right: 0
```
Restored -> `test result: ok. 8 passed; 0 failed`.

**B — default flipped from disabled to 90 days:**
```
the_default_configuration_prunes_no_observation:213
  assertion `left == right` failed
    left: 3    right: 0
test result: FAILED. 7 passed; 1 failed

config::tests::defaults_have_canonical_endings ... FAILED
  crates/ai-memory-cli/src/config.rs:1387
    left: 90   right: 0
```
Restored -> both green.

**C — in-transaction watermark resync neutralized:**
```
the_session_end_watermark_follows_the_prune:462
  assertion failed: the watermark must come back down to the surviving row count
    left: 3    right: 0
test result: FAILED. 7 passed; 1 failed
```
`left: 3` against 0 surviving rows is exactly the `current < watermark` state that makes a resumed session read as `AlreadyEnded` forever. Restored -> green.

**D — MCP tool description reverted to "THREE passes":**
```
forget_sweep_surfaces_name_every_pass_and_scope_the_pin_exemption ... FAILED
  crates/ai-memory-mcp/src/server.rs:6017
  description must name the observation prune pass; got: Run the retention sweep. THREE passes, …
test result: FAILED. 0 passed; 1 failed
```
Restored -> green.

Manual test beyond the suite: built a 300,000-row store from the shipped migrations (two projects — one fully consolidated, one with no pages at all), ran three real 5,000-row batches through the exact production SQL, and confirmed by query afterwards that project A dropped 150,000 -> 135,000, project B stayed at 150,000, `observations_fts_docsize` landed at 285,000 in lockstep, and `unconsolidated sessions that lost rows = 0`. Timings quoted under Reproducibility.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected any unintended
      identity before requesting merge.

## CHANGELOG (merge gate)

- [x] `CHANGELOG.md` `[Unreleased]` -> `### Added`, past-tense verb-first with the long WHY the neighbours use. The trailing reference is **`(#508)`**.
- [x] The default is called out explicitly in "What changed": `observation_retention_days = 0` means disabled, and an existing install behaves exactly as today.

Docs touched: `docs/ARCHITECTURE.md` §7 sweep prose (now names the fourth pass) and the `[decay]` config block. **`docs/install.md` needs no change** — it documents no `[decay]` key at all; its only sweep mentions are the generic command table. Saying so explicitly rather than leaving it ambiguous.

## What this PR deliberately does NOT change

- **No default behaviour.** With the knob unset nothing is deleted, no count query runs, and no audit row is written.
- **No migration.** V50 stays the head.
- **No new top-level command.** The M8 sweep is the shape; this extends it.
- **`DecayParams` is untouched.** No downstream Rust caller breaks.
- **No public fn changed shape.** `run_sweep`, `run_sweep_with_breadth`, `admin_router`, `admin_router_with_decay_breadth` all keep their signatures; the new behaviour lives in delegating siblings.
- **`observations_fts` is not maintained by hand.** The existing `observations_fts_ad` trigger does it; verified by test, not assumed.
- **`ai-memory status` gains no "prunable observations" line**, and `MaintenanceJob` gains no new job. Both were considered and dropped to hold the one-concern line.
- **The `raw_hits` recall loss for old sessions is not eliminated**, only bounded by gates 1+2. Snippet fidelity to the exact original wording of a pruned session is gone.
- **`move_session` with `PagesMode::Regenerate` becomes irreversible for a pruned session.** Regenerate deliberately clears `summary_page_id` so the next consolidation rebuilds the page from observations (`upstream/main:crates/ai-memory-store/src/ops.rs:3380`); for a pruned session there is nothing left to rebuild from. This is not eliminated by any gate — only by the opt-in default and the operator-chosen age. Naming it rather than burying it.
- **The `.db` file will not shrink after the first prune.** SQLite does not return freed pages to the OS without `VACUUM`; freed pages are reused for subsequent writes. The `ai-memory backup` tarball *will* shrink, because it is a fresh online-backup copy. This is in the CHANGELOG and the config template so it does not arrive as a bug report.

## Related, not superseded

- **PR #445** `improve(sanitize): head-tail truncation for observation bodies` — shrinks NEW rows; this removes OLD ones. Complementary, disjoint files. I stayed out of them.
- **Issue #387** `[Epic] Strong per-session deletion across retained layers` — the store op here (`prune_consolidated_observations`) is mechanically adjacent to what a targeted per-session forget would need, but the purpose is different (bounded retention vs. operator-directed erasure) and the predicate is the opposite shape (age + consolidated vs. exact session id regardless of state). Related, **not** pre-empting the epic.

## Notes for reviewers

**`observations_prunable` and `observations_pruned` can disagree on a live sweep, by design.**
The dry-run count is taken before this run's decay evictions and hard-deletes; the live count is
produced after them. A sweep that evicts a summary page therefore reports a `prunable` larger than
`pruned` — the session lost its distillation during the same pass and was correctly excluded from
the prune. The ordering is deliberate: running the prune last means a session that just lost its
page is protected in the same sweep rather than one sweep later.


Four decisions I'd like you to overrule if you disagree — each is isolated so a change is a one-liner per site.

1. **Key name.** I chose `observation_retention_days` because "retention" is the noun the whole M8 subsystem already uses (M8 retention sweep, retention params, `retention_score_with_breadth`). The alternative `prune_observations_after_days` is symmetric with its neighbour `hard_delete_after_days`. The semantics differ slightly and that was my tiebreak: `hard_delete_after_days` is a grace period measured from an EVENT (the tombstone write), whereas this is an age threshold on the ROW itself.

2. **The prune runs without a `wiki` handle.** The TTL and decay passes refuse store-only mutation ("wiki unavailable; refusing store-only decay eviction") because the Markdown file is the source of truth and reconciliation would re-index it. Observations have NO wiki file — they exist only in SQLite — so that reasoning does not transfer, and running wiki-less lets bare-store tests cover the pass directly. It is a deliberate asymmetry with the sibling passes and I am flagging it rather than slipping it in.

3. **`observations_prunable` is computed on live runs too**, not only dry runs. It makes the report symmetric with `candidates_evaluated`, but it is strictly redundant work when `observations_pruned` is the number that matters. Measured cost: ~101 ms per 150,000 eligible rows on a reader connection. Happy to move it behind `if dry_run`.

4. **`observation_prune_batch = 5000` is measured on one machine** (~25 ms/batch, release build, APFS SSD). A slower disk scales roughly linearly. 2,000 would give more headroom on constrained deployments; I had no way to justify picking that over the measured value.

One correction to a claim I could not substantiate, so it is nowhere in this PR: I expected `ORDER BY o.created_at` to be what pins the query plan (without it, a planner flip to `SCAN sessions`). **I could not reproduce that** — on my 300k-row `ANALYZE`d store the plan was identical with and without it. The `ORDER BY` is kept, and both the code comment and this body justify it on determinism alone: oldest-first means a run interrupted halfway leaves a clean age boundary rather than holes.
