### PR TITLE
fix(mcp): point the antigravity-cli default config at ~/.gemini/config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `install-mcp --client antigravity-cli` wrote to `~/.gemini/antigravity-cli/mcp_config.json`,
+  but the Antigravity CLI documents its global MCP config at
+  `~/.gemini/config/mcp_config.json`; the `antigravity-cli/` directory is its
+  internal data dir and only holds an internal copy of the file. The default
+  path now targets `~/.gemini/config/mcp_config.json`, which also matches the
+  hooks integration (`~/.gemini/config/hooks.json`) (#510).
+
 ## [1.34.0] - 2026-08-28
 
 ### Added

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -1233,7 +1233,7 @@ pub enum McpClient {
     /// Oh My Pi (`omp`) — `~/.omp/agent/mcp.json`.
     #[value(alias = "oh-my-pi")]
     Omp,
-    /// Google Antigravity CLI (`agy`) — `~/.gemini/antigravity-cli/mcp_config.json`.
+    /// Google Antigravity CLI (`agy`) — `~/.gemini/config/mcp_config.json`.
     #[value(alias = "antigravity", alias = "agy")]
     AntigravityCli,
     /// Zero coding agent (Gitlawb/zero) — `~/.config/zero/config.json`,

--- a/crates/ai-memory-cli/src/commands/install_mcp.rs
+++ b/crates/ai-memory-cli/src/commands/install_mcp.rs
@@ -198,7 +198,7 @@ pub(crate) fn mcp_config_path(client: crate::cli::McpClient) -> Result<PathBuf> 
         McpClient::Omp => home()?.join(".omp").join("agent").join("mcp.json"),
         McpClient::AntigravityCli => home()?
             .join(".gemini")
-            .join("antigravity-cli")
+            .join("config")
             .join("mcp_config.json"),
         // Zero resolves its user config under $XDG_CONFIG_HOME falling back
         // to ~/.config; we target the default and --config-file covers
@@ -1147,7 +1147,7 @@ fn render_omp(args: &InstallMcpArgs) -> Result<String> {
 
 fn render_antigravity_cli(args: &InstallMcpArgs) -> Result<String> {
     Ok(format!(
-        "# Antigravity CLI (`agy`) — merge into ~/.gemini/antigravity-cli/mcp_config.json:\n\
+        "# Antigravity CLI (`agy`) — merge into ~/.gemini/config/mcp_config.json:\n\
          #\n\
          # Antigravity CLI uses `serverUrl` (not `url` or `httpUrl`) for\n\
          # streamable-HTTP endpoints. The `timeout` is in milliseconds.\n\
@@ -1887,6 +1887,12 @@ mod tests {
         assert!(pi.contains("~/.pi/agent/extensions/ai-memory.ts"));
         assert!(!pi.contains("~/.omp"));
         assert!(render_for_test(McpClient::AntigravityCli).contains("\"serverUrl\""));
+        // The snippet must point at the documented global config, not the
+        // internal ~/.gemini/antigravity-cli/ data dir (#510).
+        assert!(
+            render_for_test(McpClient::AntigravityCli).contains("~/.gemini/config/mcp_config.json")
+        );
+        assert!(!render_for_test(McpClient::AntigravityCli).contains("~/.gemini/antigravity-cli/"));
         let devin = render_for_test(McpClient::Devin);
         assert!(devin.contains("\"mcpServers\""));
         assert!(devin.contains("\"url\""));
@@ -1955,6 +1961,23 @@ mod tests {
         let default = home_dir().unwrap().join(".kiro");
         assert_eq!(kiro_home(Some("".into())).unwrap(), default);
         assert_eq!(kiro_home(None).unwrap(), default);
+    }
+
+    /// Pin the Antigravity CLI config destination to the documented global
+    /// config at ~/.gemini/config/mcp_config.json. ~/.gemini/antigravity-cli/
+    /// is Antigravity's internal data dir and only holds a copy Antigravity
+    /// itself writes, so a registration there works by coincidence on an
+    /// established install and is silently ignored on a fresh one (#510).
+    #[test]
+    fn antigravity_cli_mcp_config_path_pins_documented_location() {
+        assert_eq!(
+            mcp_config_path(McpClient::AntigravityCli).unwrap(),
+            home_dir()
+                .unwrap()
+                .join(".gemini")
+                .join("config")
+                .join("mcp_config.json")
+        );
     }
 
     /// Pin the append rules: `?` on a bare endpoint, `&` with an existing

--- a/crates/ai-memory-cli/tests/removal.rs
+++ b/crates/ai-memory-cli/tests/removal.rs
@@ -472,7 +472,7 @@ fn uninstall_antigravity_hooks_preserves_user_entries() {
 fn uninstall_mcp_custom_url_removes_antigravity_only_by_endpoint() {
     let _guard = cli_test_lock();
     let home = tempfile::tempdir().unwrap();
-    let config = home.path().join(".gemini/antigravity-cli");
+    let config = home.path().join(".gemini/config");
     std::fs::create_dir_all(&config).unwrap();
     let mcp = config.join("mcp_config.json");
     std::fs::write(

--- a/docs/mcp-install.md
+++ b/docs/mcp-install.md
@@ -446,7 +446,7 @@ capture path; `SessionStart` also fetches pending handoffs.
 **Status:** ✅ MCP supported. ✅ Lifecycle hooks supported via
 `ai-memory install-hooks --agent antigravity-cli --apply`.
 
-**Config file (MCP):** `~/.gemini/antigravity-cli/mcp_config.json`
+**Config file (MCP):** `~/.gemini/config/mcp_config.json`
 
 Antigravity CLI is the successor to Gemini CLI, built in Go with
 parallel subagent support. It uses a separate `mcp_config.json`
@@ -530,7 +530,7 @@ The rendered hooks config looks like:
 - Antigravity CLI uses `serverUrl` for HTTP MCP endpoints, not `url`
   or `httpUrl`. The `--apply` flag writes the correct key.
 - MCP and hooks use separate files: MCP belongs in
-  `~/.gemini/antigravity-cli/mcp_config.json`, while hooks belong in
+  `~/.gemini/config/mcp_config.json`, while hooks belong in
   `~/.gemini/config/hooks.json`.
 - Hook scripts are staged under `~/.local/share/ai-memory/hooks/antigravity-cli/`.
 - Native Windows Docker-wrapper installs render hook entries as


### PR DESCRIPTION
## What changed

- **Changed default:** `install-mcp --client antigravity-cli` now writes to
  `~/.gemini/config/mcp_config.json` (the documented global config) instead of
  `~/.gemini/antigravity-cli/mcp_config.json`. The old file is never migrated,
  rewritten, or deleted — uninstall resolves through the same `mcp_config_path()`
  and never touches Antigravity's internal data dir.
- Rendered snippet header, the `McpClient::AntigravityCli` doc comment, and both
  `docs/mcp-install.md` references now point at the documented path, matching the
  hooks integration (`~/.gemini/config/hooks.json`).

## Why

Fixes #510.

`~/.gemini/antigravity-cli/` is Antigravity's internal data dir (logs,
conversations, OAuth state, brain); the `mcp_config.json` there is only a copy
Antigravity itself writes. A registration written there works by coincidence on
an established install and is silently ignored on a fresh machine. With this
change MCP and hooks agree about where Antigravity reads configuration.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Manual test: built the branch and ran
  `install-mcp --client antigravity-cli --apply` against a real Antigravity
  install where both `mcp_config.json` copies exist byte-identical
  (`~/.gemini/config/` and `~/.gemini/antigravity-cli/`). The command resolved
  the destination to `~/.gemini/config/mcp_config.json`, reported
  `no-op (already up to date)` for the existing registration, left the file
  byte-identical (same sha256 and mtime), and did not touch the internal
  `antigravity-cli/` copy.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected
      any unintended identity before requesting merge.

## CHANGELOG (merge gate)

- [x] I added a `CHANGELOG.md` `[Unreleased]` entry.
- [x] Any changed **default** (flag behaviour, config default, env var,
      response shape) is called out explicitly in "What changed" above.

## Notes for reviewers

- Regression test pins the destination:
  `antigravity_cli_mcp_config_path_pins_documented_location`, plus rendered-
  snippet assertions in `client_specific_shape_keys` (same pattern the Kimi
  fix used in #474).
- No migration/cleanup of the old path, per the note on the issue — writing the
  correct destination is enough; the internal copy is Antigravity's business.
- **Label request:** this touches path handling, so per AGENTS.md the `windows`
  label should be on this PR so the Windows workflow gates it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)