### PR TITLE
fix(hooks): invoke rather than quote the Codex Windows hook command (#515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `install-hooks --agent codex --apply` produced a Windows command every Codex
+  hook rejected. Codex evaluates its `hooks.json` command strings with
+  PowerShell, where a quoted path in command position is a string expression
+  rather than an invocation, so each hook exited 1 with a ParserError and
+  captured nothing. The command now carries PowerShell's `&` call operator.
+  Scoped to Codex deliberately: `&` separates commands under cmd.exe, which is
+  what Claude Code's runner uses, so applying it everywhere would break the
+  integration that works today. A rendering test pins both directions, and
+  `uninstall` still recognises the new form (#515).
 ## [1.34.0] - 2026-08-28
 
 ### Added

--- a/crates/ai-memory-cli/src/commands/render_shared.rs
+++ b/crates/ai-memory-cli/src/commands/render_shared.rs
@@ -1399,7 +1399,8 @@ fn hook_command(
                 .and_then(|s| s.to_str())
                 .unwrap_or_default();
             let mut cmd = format!(
-                "{}{} hook --event {event} --agent {agent} --server-url {}",
+                "{}{}{} hook --event {event} --agent {agent} --server-url {}",
+                powershell_call_operator(context.agent),
                 win_double_quote(&exe),
                 native_data_dir_arg(context.data_dir, NativeQuote::Windows),
                 win_double_quote(server_url),
@@ -1587,8 +1588,70 @@ fn powershell_quote(s: &str) -> String {
 /// Bash. The quoted values (binary path, URL, hex auth token) never
 /// contain a literal `"`; any is stripped defensively rather than risk a
 /// broken command line.
+/// `& ` when this agent's Windows hook command is evaluated by PowerShell,
+/// otherwise empty.
+///
+/// `win_double_quote` wraps the executable path because cmd.exe needs it —
+/// see the note on that function. PowerShell parses a quoted literal in
+/// command position as a *string expression* rather than an invocation, so
+/// the same quoting that makes the command correct under cmd.exe makes it a
+/// no-op that exits 1 with a ParserError under PowerShell. Every Codex hook
+/// died that way on Windows (#515).
+///
+/// Deliberately an allowlist keyed on the agent, not a global change. The
+/// call operator is **not** valid under cmd.exe, where `&` separates
+/// commands — emitting it for Claude Code would break the integration that
+/// works today. An agent joins this list only once its runner has been
+/// observed, because both the failure and the false fix are silent: a wrong
+/// answer either way produces a hook that installs cleanly and captures
+/// nothing.
+fn powershell_call_operator(agent: &str) -> &'static str {
+    // Codex evaluates `~/.codex/hooks.json` command strings with PowerShell
+    // on Windows (#515, reproduced against Codex CLI on a native install).
+    if agent == "codex" { "& " } else { "" }
+}
+
 fn win_double_quote(s: &str) -> String {
     format!("\"{}\"", s.replace('"', ""))
+}
+
+/// #515: Codex evaluates its Windows hook command with PowerShell, where a
+/// quoted path in command position is a string expression rather than an
+/// invocation — every hook exited 1 with a ParserError. The call operator
+/// fixes that, and must NOT appear for a cmd.exe runner, where `&`
+/// separates commands and would break a working integration.
+#[test]
+fn codex_windows_command_invokes_rather_than_quotes() {
+    let cmd = hook_command(
+        Path::new("stop.sh"),
+        "http://127.0.0.1:49374",
+        None,
+        HookCommandContext::new(HookCommandPlatform::WindowsNative, "codex", None, None),
+    );
+    assert!(
+        cmd.starts_with("& \""),
+        "codex must use the call operator: {cmd}"
+    );
+}
+
+#[test]
+fn claude_code_windows_command_is_unchanged_by_the_codex_fix() {
+    let cmd = hook_command(
+        Path::new("stop.sh"),
+        "http://127.0.0.1:49374",
+        None,
+        HookCommandContext::new(
+            HookCommandPlatform::WindowsNative,
+            "claude-code",
+            None,
+            None,
+        ),
+    );
+    assert!(
+        !cmd.starts_with("&"),
+        "cmd.exe treats `&` as a separator; claude-code must keep the bare quoted path: {cmd}"
+    );
+    assert!(cmd.starts_with('"'), "expected a quoted exe path: {cmd}");
 }
 
 #[cfg(test)]

--- a/crates/ai-memory-cli/src/commands/uninstall.rs
+++ b/crates/ai-memory-cli/src/commands/uninstall.rs
@@ -1485,6 +1485,16 @@ mod tests {
         assert!(hook_command_is_ours(cmd));
     }
 
+    /// #515 gave Codex's Windows command a leading `& ` call operator.
+    /// `hook_command_is_ours` matches on substrings, so the prefix is
+    /// harmless — but if that ever became a prefix match, uninstall would
+    /// silently stop finding Codex hooks and leave them behind.
+    #[test]
+    fn hook_signature_matches_a_powershell_call_operator_command() {
+        let cmd = r#"& "C:\Users\alice\bin\ai-memory.exe" --data-dir "C:\Users\alice\AppData\Local\ai-memory" hook --event session-start --agent codex --server-url "http://h:49374""#;
+        assert!(hook_command_is_ours(cmd));
+    }
+
     #[test]
     fn hook_signature_rejects_third_party_with_generic_name() {
         // A user's own hook that happens to be named stop.sh — no prefix.


### PR DESCRIPTION
Closes #515. Reported by @magsonleone.

## The bug

`win_double_quote` wraps the executable path, and its own doc comment says why:

> Claude Code on Windows runs hook commands via **cmd.exe**, which does not honour POSIX single quotes; double quotes work in both cmd.exe and Git Bash.

True for cmd.exe. **Codex evaluates its `hooks.json` command strings with PowerShell**, where a quoted literal in command position is a *string expression* rather than an invocation. Every Codex hook on Windows exited 1 with a ParserError while installing perfectly cleanly — one quoting rule applied to two surfaces with different grammars.

## Scoped to Codex, deliberately

`&` is PowerShell's call operator and a **command separator under cmd.exe**. Applying it globally would break Claude Code, which works today. So the predicate is an allowlist keyed on the agent, and the doc comment says an agent joins it only once its runner has been *observed* — because both the bug and a wrong fix are silent: either way you get a hook that installs cleanly and captures nothing.

I looked for a structural signal to key on instead and there isn't one — `for_bash_runner()` returns the same value as `current()` on Windows, so it names an intent rather than discriminating a runner.

## Tests

- **Both directions**: Codex must start with `& "`, Claude Code must *not* start with `&` and must keep its bare quoted path. The second is the regression guard that matters.
- **The interaction I was most worried about**: `uninstall` identifies our hooks by substring (`ai-memory`, ` hook --event `, ` --agent `, ` --server-url `), so a leading `& ` is harmless — but there is now a test saying so, because if that ever became a prefix match, uninstall would silently leave Codex hooks behind.

`cargo fmt` ✅ · `clippy --workspace --all-targets -D warnings` ✅ · `cargo test --workspace --all-targets` → **2613 passed, 0 failed** (pinned 1.95).

## What I did not verify

The PowerShell evaluation itself. I tested the rendering and the Windows CI job runs the suite, but that Codex-parses-with-PowerShell is @magsonleone's observation, not something I reproduced — I have no Windows machine. Labelled `windows` so the platform job runs.

@magsonleone — if you can confirm against your install, and say whether any other agent on your machine routes through PowerShell, I will extend the allowlist with that evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)