### PR TITLE
fix(embed): report skipped pages in the scheduled backfill tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The scheduled embedding backfill now reports how many pages it skipped.
+  It logged `embedded`, `failed` and `errors`, so a tick that passed over
+  every page and a tick with nothing to do produced the same completion
+  line — a page being skipped once an hour was indistinguishable from a
+  quiet, healthy scheduler. The count was already being returned by the
+  backfill and discarded at the caller. Reported by @barrosohub, who also
+  read the source to narrow it down (#509).
+
 ## [1.35.0] - 2026-08-29
 
 ### Added

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -1102,6 +1102,7 @@ async fn start_maintenance_scheduler(
                         Ok(outcome) => info!(
                             scopes = outcome.scopes,
                             embedded = outcome.embedded,
+                            skipped = outcome.skipped,
                             failed = outcome.failed,
                             errors = outcome.errors,
                             elapsed_ms = started.elapsed().as_millis(),
@@ -1299,6 +1300,10 @@ async fn run_scheduled_lint_tick(
 struct ScheduledEmbeddingBackfillTickOutcome {
     scopes: usize,
     embedded: usize,
+    /// Pages that already had a current embedding. Reported because a
+    /// tick that skipped everything and a tick that had nothing to do
+    /// are otherwise indistinguishable in the log.
+    skipped: usize,
     failed: usize,
     errors: usize,
 }
@@ -1329,6 +1334,7 @@ async fn run_scheduled_embedding_backfill_tick(
         {
             Ok(counts) => {
                 outcome.embedded += counts.embedded;
+                outcome.skipped += counts.skipped;
                 outcome.failed += counts.failed;
             }
             Err(e) => {
@@ -2636,6 +2642,58 @@ mod tests {
                 .unwrap();
             assert_eq!(embedded.len(), 1, "each project should get embeddings");
         }
+    }
+
+    /// A tick that skipped every page and a tick that had nothing to do
+    /// both embed zero pages. Without `skipped` in the completion line
+    /// they are the same log entry, so a page being passed over every
+    /// hour reads as a quiet, healthy scheduler (#509).
+    #[tokio::test]
+    async fn scheduled_embedding_tick_distinguishes_skipped_work_from_an_idle_pass() {
+        let (_tmp, store, wiki, ws, first, second) = two_project_wiki().await;
+        let embedder: Arc<dyn Embedder> = Arc::new(SyntheticEmbedder::new(16));
+
+        let idle =
+            run_scheduled_embedding_backfill_tick(&store.reader, &store.writer, &wiki, &embedder)
+                .await
+                .unwrap();
+        assert_eq!(
+            (idle.embedded, idle.skipped),
+            (0, 0),
+            "no pages yet: nothing embedded and nothing skipped"
+        );
+
+        for (project, name) in [(first, "first"), (second, "second")] {
+            write_test_page(
+                &wiki,
+                ws,
+                project,
+                &format!("notes/{name}.md"),
+                name,
+                Tier::Semantic,
+            )
+            .await;
+        }
+
+        let first_pass =
+            run_scheduled_embedding_backfill_tick(&store.reader, &store.writer, &wiki, &embedder)
+                .await
+                .unwrap();
+        assert_eq!((first_pass.embedded, first_pass.skipped), (2, 0));
+
+        let second_pass =
+            run_scheduled_embedding_backfill_tick(&store.reader, &store.writer, &wiki, &embedder)
+                .await
+                .unwrap();
+        assert_eq!(
+            (second_pass.embedded, second_pass.failed),
+            (0, 0),
+            "the work is done, so the tick embeds nothing"
+        );
+        assert_eq!(
+            second_pass.skipped, 2,
+            "but it must still say it passed over two pages, or it is              indistinguishable from the idle tick above"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #509 (the part of it that is real).

## What was wrong

`run_scheduled_embedding_backfill_tick` logs `scopes`, `embedded`, `failed` and `elapsed_ms`. It does not log `skipped`, even though `run_embedding_backfill` already returns that count and the sibling auto-improve tick already reports its own. The number was being absorbed nowhere.

The consequence is that a scope where every page was passed over logs exactly what an empty scope logs:

```
scopes=1 embedded=0 failed=0 errors=0   # skipped every page
scopes=1 embedded=0 failed=0 errors=0   # nothing to do
```

That is what made #509 undiagnosable from outside the process. The reporter could see `status` counting a page as missing while every tick in the window claimed a clean pass, with no number anywhere to say whether the page had been looked at at all.

## The test

It pins the distinction rather than the field: an idle tick and a tick that skipped two pages must not produce the same numbers. Without the one-line accumulation it fails with `left: 0, right: 2` on that assertion, which is the defect stated directly.

## Scope

Only the counter. I investigated a second theory on #509 — that `status`'s unscoped missing-count and the tick's registry-derived scope enumeration could disagree — and **refuted it**: `V18` installs a `BEFORE INSERT` trigger on `pages` rejecting a mismatched pair, `Wiki` guards six write entry points, `move_project_workspace` restamps every domain row transactionally, and `ensure_project_with_id` is `ON CONFLICT DO NOTHING`. The state cannot occur, so there is nothing to fix there and I have not touched the enumeration. Details and the correction are on the issue.

The reporter's incident remains unexplained; this makes a recurrence legible rather than claiming a cause.