### PR TITLE
fix(hooks): count tool family labels in the summary, stop naming them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Stopped a session summary spending its characters on tool family labels. The
+  summary #477 added names the busiest tools, but for the seven agents that go
+  through `closed_tool_agent` — Claude Code among them — a tool observation's
+  title is written by `safe_tool_title` as `tool <family>`, and `ToolFamily`
+  has four variants. Measured on a live 1,885-page instance, 21,136 of 29,804
+  `PostToolUse` observations (71%) carried one of three such literals against
+  56 real tool names in the other 29%, and every tool mention in every summary
+  there was a family label: `580 completed tool calls across tool non-file,
+  tool unknown and tool file` spent 47 characters to say that some calls
+  touched files and some did not. Family labels are now counted but not named,
+  and a session with nothing else to name drops the clause instead of filling
+  it. The predicate lives beside the writer and is derived from the same serde
+  representation, so a new `ToolFamily` variant cannot escape it. (#527)
+
 ## [1.36.0] - 2026-08-29
 
 ### Added
@@ -61,20 +76,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   will, because it is a fresh online copy.
 
 ### Fixed
-- Stopped a session summary spending its characters on tool family labels. The
-  summary #477 added names the busiest tools, but for the seven agents that go
-  through `closed_tool_agent` — Claude Code among them — a tool observation's
-  title is written by `safe_tool_title` as `tool <family>`, and `ToolFamily`
-  has four variants. Measured on a live 1,885-page instance, 21,136 of 29,804
-  `PostToolUse` observations (71%) carried one of three such literals against
-  56 real tool names in the other 29%, and every tool mention in every summary
-  there was a family label: `580 completed tool calls across tool non-file,
-  tool unknown and tool file` spent 47 characters to say that some calls
-  touched files and some did not. Family labels are now counted but not named,
-  and a session with nothing else to name drops the clause instead of filling
-  it. The predicate lives beside the writer and is derived from the same serde
-  representation, so a new `ToolFamily` variant cannot escape it. (#477)
-
 - The CHANGELOG frozen-section check no longer fires on a branch that merged
   `main` after a release. It compared line ranges since the merge base, so a
   newly released section arriving through the merge read as lines the branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   will, because it is a fresh online copy.
 
 ### Fixed
+- Stopped a session summary spending its characters on tool family labels. The
+  summary #477 added names the busiest tools, but for the seven agents that go
+  through `closed_tool_agent` — Claude Code among them — a tool observation's
+  title is written by `safe_tool_title` as `tool <family>`, and `ToolFamily`
+  has four variants. Measured on a live 1,885-page instance, 21,136 of 29,804
+  `PostToolUse` observations (71%) carried one of three such literals against
+  56 real tool names in the other 29%, and every tool mention in every summary
+  there was a family label: `580 completed tool calls across tool non-file,
+  tool unknown and tool file` spent 47 characters to say that some calls
+  touched files and some did not. Family labels are now counted but not named,
+  and a session with nothing else to name drops the clause instead of filling
+  it. The predicate lives beside the writer and is derived from the same serde
+  representation, so a new `ToolFamily` variant cannot escape it. (#477)
+
 - The CHANGELOG frozen-section check no longer fires on a branch that merged
   `main` after a release. It compared line ranges since the merge base, so a
   newly released section arriving through the merge read as lines the branch

--- a/crates/ai-memory-hooks/src/payload.rs
+++ b/crates/ai-memory-hooks/src/payload.rs
@@ -4,7 +4,7 @@ use ai_memory_core::{AgentKind, OBSERVATION_BODY_MAX_BYTES, ObservationKind, tru
 use serde::{Deserialize, Serialize};
 
 use crate::capture_policy::{
-    ToolObservationMetadata, tool_observation_metadata, tool_observation_outcome,
+    ToolFamily, ToolObservationMetadata, tool_observation_metadata, tool_observation_outcome,
 };
 
 /// Durable excerpt ceiling for user prompts. Prompts retain more working
@@ -612,6 +612,22 @@ fn safe_tool_title(metadata: &ToolObservationMetadata) -> String {
     )
 }
 
+/// `true` when `title` is one this module produced from a [`ToolFamily`]
+/// rather than from the harness's own tool name.
+///
+/// Derived from the same serde representation [`safe_tool_title`] writes, so
+/// a new `ToolFamily` variant is recognised here without a second edit — the
+/// two cannot drift into disagreeing about what this module emits.
+///
+/// The distinction matters downstream: a family is a partition of the calls,
+/// not a name for what they did, so a reader gains nothing from being told a
+/// session spent itself "across tool non-file and tool unknown".
+pub(crate) fn is_safe_tool_title(title: &str) -> bool {
+    title.strip_prefix("tool ").is_some_and(|family| {
+        serde_json::from_value::<ToolFamily>(serde_json::Value::String(family.to_owned())).is_ok()
+    })
+}
+
 fn safe_tool_body(
     event: HookEvent,
     metadata: Option<&ToolObservationMetadata>,
@@ -993,6 +1009,50 @@ fn normalize_token(value: &str, max_len: usize) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The predicate must accept exactly what `safe_tool_title` emits, for
+    /// every `ToolFamily` variant — including any added later. Building the
+    /// input through the writer rather than by hand is what keeps the two
+    /// from drifting; a hand-written list would pass while a new variant
+    /// silently escaped.
+    #[test]
+    fn the_predicate_recognises_every_title_the_writer_can_emit() {
+        for family in [
+            ToolFamily::File,
+            ToolFamily::SearchList,
+            ToolFamily::NonFile,
+            ToolFamily::Unknown,
+        ] {
+            let written = safe_tool_title(&ToolObservationMetadata {
+                tool_family: family,
+                tool_call_id: None,
+            });
+            assert!(
+                is_safe_tool_title(&written),
+                "{written:?} is written by safe_tool_title and must be recognised"
+            );
+        }
+    }
+
+    /// A harness's own tool name is never mistaken for a family label, even
+    /// when it happens to start with the same word.
+    #[test]
+    fn a_real_tool_name_is_not_a_family_label() {
+        for name in [
+            "Bash",
+            "Edit",
+            "tool",
+            "tool ",
+            "tool Bash",
+            "toolfile",
+            "Tool file",
+        ] {
+            assert!(
+                !is_safe_tool_title(name),
+                "{name:?} is not something safe_tool_title writes"
+            );
+        }
+    }
 
     #[test]
     fn project_source_parses_both_spellings_and_defaults_closed() {

--- a/crates/ai-memory-hooks/src/payload.rs
+++ b/crates/ai-memory-hooks/src/payload.rs
@@ -1011,18 +1011,32 @@ mod tests {
     use super::*;
 
     /// The predicate must accept exactly what `safe_tool_title` emits, for
-    /// every `ToolFamily` variant — including any added later. Building the
-    /// input through the writer rather than by hand is what keeps the two
-    /// from drifting; a hand-written list would pass while a new variant
-    /// silently escaped.
+    /// every `ToolFamily` variant. Inputs are built *through* the writer
+    /// rather than written by hand, so the two cannot drift apart on what a
+    /// family title looks like.
+    ///
+    /// The list below is checked by the compiler, not by trust: the
+    /// wildcard-free `match` stops compiling the moment a variant is added,
+    /// which routes whoever adds it here. Without that this test would keep
+    /// passing while the new variant went uncovered — the comment would be
+    /// making a promise the enumeration does not keep.
     #[test]
     fn the_predicate_recognises_every_title_the_writer_can_emit() {
-        for family in [
+        let every_variant = [
             ToolFamily::File,
             ToolFamily::SearchList,
             ToolFamily::NonFile,
             ToolFamily::Unknown,
-        ] {
+        ];
+        for family in every_variant {
+            match family {
+                ToolFamily::File
+                | ToolFamily::SearchList
+                | ToolFamily::NonFile
+                | ToolFamily::Unknown => {}
+            }
+        }
+        for family in every_variant {
             let written = safe_tool_title(&ToolObservationMetadata {
                 tool_family: family,
                 tool_call_id: None,

--- a/crates/ai-memory-hooks/src/synth.rs
+++ b/crates/ai-memory-hooks/src/synth.rs
@@ -14,7 +14,7 @@ use ai_memory_core::{
 };
 use jiff::tz::TimeZone;
 
-use crate::payload::truncate_for_title;
+use crate::payload::{is_safe_tool_title, truncate_for_title};
 
 const RAW_OBSERVATION_MAX_LINES: usize = 500;
 const RAW_OBSERVATION_HEAD_LINES: usize = 250;
@@ -232,24 +232,39 @@ fn session_summary(tally: &SessionTally<'_>) -> String {
         let mut by_calls: Vec<(&str, usize)> =
             tally.tool_counts.iter().map(|(k, v)| (*k, *v)).collect();
         by_calls.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
-        let named: Vec<&str> = by_calls
+        // A `tool <family>` title is what `safe_tool_title` writes when the
+        // harness's own tool name is not carried through: a partition of the
+        // calls, never a name for them. Listing those spends the reader's
+        // attention to say "some of the calls touched files and some did
+        // not", so they are counted but not named, and a session with
+        // nothing else to name drops the clause rather than filling it.
+        let nameable: Vec<&str> = by_calls
             .iter()
-            .take(SUMMARY_MAX_NAMED_TOOLS)
             .map(|(name, _)| *name)
+            .filter(|name| !is_safe_tool_title(name))
             .collect();
-        let tools = if by_calls.len() > SUMMARY_MAX_NAMED_TOOLS {
-            format!(
-                "{} and {} more",
-                join_and(&named),
-                by_calls.len() - SUMMARY_MAX_NAMED_TOOLS
-            )
+        parts.push(if nameable.is_empty() {
+            format!("{calls} completed tool call{}", plural(calls))
         } else {
-            join_and(&named)
-        };
-        parts.push(format!(
-            "{calls} completed tool call{} across {tools}",
-            plural(calls)
-        ));
+            let named: Vec<&str> = nameable
+                .iter()
+                .copied()
+                .take(SUMMARY_MAX_NAMED_TOOLS)
+                .collect();
+            let tools = if by_calls.len() > named.len() {
+                format!(
+                    "{} and {} more",
+                    join_and(&named),
+                    by_calls.len() - named.len()
+                )
+            } else {
+                join_and(&named)
+            };
+            format!(
+                "{calls} completed tool call{} across {tools}",
+                plural(calls)
+            )
+        });
     }
 
     if let (Some(start), Some(end)) = (tally.start, tally.end)
@@ -565,6 +580,44 @@ mod tests {
         assert_eq!(
             page.frontmatter_json["summary"],
             serde_json::json!("1 prompt, 1 completed tool call across Bash, over 5m.")
+        );
+    }
+
+    /// Measured on a live 1,885-page instance: 21,136 of 29,804 `PostToolUse`
+    /// observations (71%) carried one of three `tool <family>` literals,
+    /// against 56 real tool names in the other 29%. Every tool mention in
+    /// every summary on that instance was a family label, so the clause was
+    /// spending characters to say nothing.
+    #[test]
+    fn family_labels_are_counted_but_not_named() {
+        let mut observations = vec![obs(ObservationKind::UserPrompt, "do the thing")];
+        for (tool, calls) in [("tool non-file", 9), ("tool file", 4), ("tool unknown", 2)] {
+            for _ in 0..calls {
+                observations.push(obs(ObservationKind::PostToolUse, tool));
+            }
+        }
+        let summary = session_summary(&tally_session(&observations));
+        assert_eq!(summary, "1 prompt, 15 completed tool calls.");
+        assert!(
+            !summary.contains("across"),
+            "nothing nameable is left, so the clause must go rather than be filled: {summary}"
+        );
+    }
+
+    /// A session that mixes both keeps the names it has. The families still
+    /// count toward the total and toward "and N more", because they are real
+    /// groups of calls — they just are not worth a reader's attention.
+    #[test]
+    fn real_names_survive_alongside_family_labels() {
+        let mut observations = vec![obs(ObservationKind::UserPrompt, "do the thing")];
+        for (tool, calls) in [("tool non-file", 20), ("Bash", 5), ("Edit", 2)] {
+            for _ in 0..calls {
+                observations.push(obs(ObservationKind::PostToolUse, tool));
+            }
+        }
+        assert_eq!(
+            session_summary(&tally_session(&observations)),
+            "1 prompt, 27 completed tool calls across Bash and Edit and 1 more."
         );
     }
 


### PR DESCRIPTION
Follow-up to #477, which is mine.

The summary I added there names the busiest tools. For the seven agents routed through
`closed_tool_agent` — Claude Code among them — a tool observation's title is not the harness's tool
name. `safe_tool_title` writes `tool <family>`, and `ToolFamily` has four variants. So the summary
was listing a partition of the calls and presenting it as a description of them.

## What that produces

Straight from a live instance:

```
8 prompts, 580 completed tool calls across tool non-file, tool unknown and tool file, over 19h 30m.
2 prompts, 53 completed tool calls across tool non-file, tool file and tool unknown, over 5h 20m.
```

The clause costs 47 characters to say that some of the calls touched files and some did not. The
bare count beside it is strictly more informative.

## Measured

Every `PostToolUse` observation on a 1,885-page production instance:

| | n | |
|---|---|---|
| title is a `tool <family>` literal | **21,136** | **71%** |
| title is a real tool name | 8,668 | 29% |

Three distinct literals on one side (`tool non-file`, `tool file`, `tool unknown`), 56 distinct real
names on the other (`Bash` 4,039, `Read` 1,943, `Edit` 1,478, `Write` 492, …). Of the summaries that
existed on that instance, **every tool mention was a family label** — 11 of 11.

The split is structural, not incidental: `closed_tool_agent` covers `ClaudeCode`, `CommandCode`,
`OpenCode`, `Pi`, `AntigravityCli`, `Hermes` and `Pool`, so the flagship agent is on the opaque side
and always will be.

## The change

Family labels are counted but not named.

- Nothing else to name → the clause is dropped, not filled: `1 prompt, 15 completed tool calls.`
- Mixed → the real names survive and the families fold into `and N more`, which stays true because
  they are real groups of calls: `1 prompt, 27 completed tool calls across Bash and Edit and 1 more.`

The total is untouched in both cases.

## On the predicate

It lives in `payload.rs` next to `safe_tool_title` and recognises a title by round-tripping the
suffix through the same serde representation the writer emits, rather than listing the four
literals. That is deliberate: a hand-written list would pass its own test while a fifth `ToolFamily`
variant escaped it silently — the drift class from #490, where I restated half a predicate and it
diverged from the original. The test builds its inputs *through* `safe_tool_title` for the same
reason.

## What I am not claiming

The 71% is one operator's corpus. The direction of the finding does not depend on the ratio — a
family label carries no naming information at any frequency — but if your instances show a different
mix, the change is still a strict subtraction of text that says nothing.

I have not touched the body renderer, which lists per-tool counts and where a family breakdown is
arguably useful; only the one-line summary, where it is not.

Gates: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --workspace` (2,633 passed / 0 failed), `cargo deny check`,
`scripts/check-changelog-sections.sh`, `scripts/check-changelog-frozen.sh`.
