### PR TITLE
docs(windows): validate Scenario E on Windows 11 with WinSW v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   — a service runs as `LocalSystem`, so `%LOCALAPPDATA%` would resolve to the
   system profile and quietly serve an empty data directory.
 
+- Scenario E's WinSW steps were executed end to end on real Windows hardware,
+  and the doc now records what they were true for: Windows 11 25H2 (build
+  26200.9168), WinSW v2.12.0, ai-memory v1.38.0, from an elevated PowerShell
+  session against a throwaway service, port and data directory. Install, start,
+  `LocalSystem` + `Automatic`, an MCP `initialize` answered over the bound
+  port, the absolute `--data-dir` honoured, crash recovery ~8s after
+  force-killing the wrapped process, and a clean stop/uninstall all held;
+  the service was configured with `StartType Automatic`, but boot-time
+  startup was not independently exercised (#530).
+
 ## [1.38.0] - 2026-08-30
 
 ### Added

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -422,15 +422,27 @@ Keep running `install-mcp` and `install-hooks` **as your own user**, not
 as the service — they write per-user agent config, and the rule at the
 top of this page still applies.
 
-> Verified from the WinSW project documentation (3.x; requires .NET
-> Framework 4.6.1+ or the self-contained .NET build) and from the
-> ai-memory CLI surface. The job-object failure mode was root-caused on a
-> real Windows install by the reporter of
-> [#530](https://github.com/akitaonrails/ai-memory/issues/530), including
-> the Task Scheduler event IDs above. The WinSW steps themselves have not
-> been executed by a maintainer on Windows hardware — corrections from
-> anyone who runs them, especially the Windows and WinSW versions they
-> were true for, are welcome.
+> Verified from the WinSW project documentation and the ai-memory CLI
+> surface, then run end to end on real hardware by the reporter of
+> [#530](https://github.com/akitaonrails/ai-memory/issues/530), who also
+> root-caused the job-object failure mode above from the Task Scheduler
+> event IDs.
+>
+> **Validated on** Windows 11 25H2 (build 26200.9168) with WinSW v2.12.0
+> (`WinSW-x64.exe`) and ai-memory v1.38.0, from an elevated PowerShell
+> session, against a throwaway service id, port and data directory.
+> Confirmed: `install`; `start`; the service `Running` as `LocalSystem`
+> with `StartType Automatic`; an MCP `initialize` answered over the bound
+> port; the absolute `--data-dir` honoured, with no
+> `systemprofile\AppData\Local\ai-memory` created; crash recovery — the
+> wrapped `ai-memory.exe` was force-killed and a new process was answering
+> 8s later, consistent with the 5-second `<onfailure>` delay plus startup;
+> and a clean `stop` + `uninstall`. The service was configured with
+> `StartType Automatic`; actual boot-time startup was not independently
+> exercised. At the time of this validation (2026-08-31), v2.12.0 was the
+> latest stable WinSW release; the published 3.x releases were
+> prereleases. Corrections from anyone running a different Windows or
+> WinSW version are welcome.
 
 ## Native Hook Command (Claude Code on Windows)
 


### PR DESCRIPTION
#545 documented Scenario E and deliberately left #530 open: the WinSW steps were checked against upstream documentation and the ai-memory CLI surface, but not executed on Windows hardware. This PR is that run.

The branch is reset onto current `main` — the Scenario E draft this PR used to carry is gone, since #545 supersedes it and covers ground mine did not (`sc create`, the corrected Task Scheduler shape, the `LocalSystem` / `%LOCALAPPDATA%` trap). What is left is a two-file diff: the verification note at the end of Scenario E, and a CHANGELOG bullet.

## What was run

The steps exactly as written in `docs/windows.md` at `6ed84bc`, from an elevated PowerShell session, against a throwaway service id, port and data directory so this machine's real ai-memory instance was never touched.

| | |
|---|---|
| Windows | 11 Pro 25H2, build 26200.9168 |
| ai-memory | v1.38.0 release zip, SHA256 verified against the published `.sha256` |
| WinSW | v2.12.0 `WinSW-x64.exe`, SHA256 `05b82d46ad331cc16bdc00de5c6332c1ef818df8ceefcd49c726553209b3a0da` |
| Throwaway service / port / data dir | `ai-memory-validation` / `49375` / `%TEMP%\ai-memory-winsw-validation\data` |

- **install** — exit 0; `Win32_Service` reports `StartName = LocalSystem`, `StartMode = Auto`.
- **start** — exit 0; `127.0.0.1:49375` in LISTEN 1.9s later; `Get-Service` → `Running` / `Automatic`.
- **the server actually answering** — `Running` was not treated as proof: `POST /mcp` with an MCP `initialize` returned HTTP 200 and `serverInfo {"name":"ai-memory","version":"1.38.0"}`.
- **data directory** — the child process's command line carries the absolute `--data-dir`; `db\memory.sqlite`, `wiki\` and `logs\` were created there and the wrapper log shows the watcher rooted at that path; `C:\Windows\System32\config\systemprofile\AppData\Local\ai-memory` was never created, checked before, during and after. The absolute-path warning holds.
- **crash recovery** — force-killed the wrapped `ai-memory.exe` (PID 21184) at 18:16:12.382; a new process (PID 12404) was listening *and* answering `initialize` with HTTP 200 by 18:16:20.429 — 8.0s, consistent with the 5-second `<onfailure>` delay plus startup. Service back to `Running` / `Automatic`.
- **stop** — `Stopped`, port free in 2.3s, no child process left.
- **uninstall** — `sc query` → 1060 (service does not exist), no stray processes, nothing left in the system profile.

## Not exercised

- **Start at boot.** The service was configured with `StartType Automatic`, but boot-time startup was not independently exercised — a reboot was not safe on this machine at the time, and the note says exactly that rather than inferring the outcome.
- **WinSW 3.x.** Worth flagging: at the time of this validation (2026-08-31), `v2.12.0` was the latest stable WinSW release and the published 3.x releases — newest `v3.0.0-alpha.11`, January 2023 — were prereleases, so the 3.x line the previous note pointed at is not something a reader can install as a stable release today. The note now records that with its date, which also makes the doc's own "pin a release tag rather than latest" advice actionable.

`Refs #530` rather than `Closes`: the gap you left open is filled for this Windows/WinSW pair, but boot-time startup was not exercised, so closing it is your call.

Checks run: `scripts/check-changelog-sections.sh`, `scripts/check-changelog-frozen.sh`, `git diff --check`, and `cargo test -p ai-memory-cli --test packaging` (14 passed, including `wrapper_updates_and_install_docs_use_verified_release_assets`, which reads `docs/windows.md`) — all clean. Docs-only, so the `windows` label should not be needed unless you want the job run anyway.
