### PR TITLE
fix(hooks): resolve a symlinked binary before probing for hooks/

### DIFF
--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -4183,7 +4183,10 @@ fn resolve_hooks_dir(explicit: Option<&Path>, agent: AgentChoice) -> Result<Path
             return Ok(path.clone());
         }
     }
-    anyhow::bail!("could not locate hooks directory. Tried: {:?}", candidates,);
+    anyhow::bail!(
+        "could not locate hooks directory. Tried: {candidates:?}. \
+         Pass --hooks-dir <directory containing {sub}/> to point at the bundle explicitly.",
+    );
 }
 
 fn hook_source_candidates(
@@ -4217,20 +4220,38 @@ fn hook_source_candidates(
 }
 
 fn repo_root_guess() -> Option<PathBuf> {
-    // When the binary lives under target/{debug,release}/<name>, the
-    // workspace root is two parents up.
-    std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent()?.parent()?.parent().map(Path::to_path_buf))
+    repo_root_from_exe(&current_exe_resolved()?)
+}
+
+/// When the binary lives under target/{debug,release}/<name>, the
+/// workspace root is two parents up.
+fn repo_root_from_exe(exe: &Path) -> Option<PathBuf> {
+    Some(exe.parent()?.parent()?.parent()?.to_path_buf())
 }
 
 /// Directory the running binary lives in. The release tarball ships the
 /// `hooks/` bundle right next to the binary, so a no-`--source`
 /// `install-hooks` finds it there (issue #107).
 fn exe_dir_guess() -> Option<PathBuf> {
-    std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(Path::to_path_buf))
+    Some(current_exe_resolved()?.parent()?.to_path_buf())
+}
+
+/// Path of the running binary with symlinks resolved.
+///
+/// Both guesses above are relative to where the binary *lives*, not to how
+/// it was invoked. `~/.local/bin/ai-memory -> <repo>/target/release/ai-memory`
+/// is the layout the quick start suggests, and without this the repo-root
+/// guess walks up from the link's own directory to `$HOME` while the tarball
+/// guess stops at `~/.local/bin` — leaving the bundled `hooks/` unreachable
+/// from every candidate, whatever the cwd (issue #546).
+fn current_exe_resolved() -> Option<PathBuf> {
+    std::env::current_exe().ok().map(resolve_exe_path)
+}
+
+/// Canonicalise an executable path, keeping the original when the target
+/// cannot be resolved (deleted binary, or a filesystem that refuses).
+fn resolve_exe_path(exe: PathBuf) -> PathBuf {
+    fs::canonicalize(&exe).unwrap_or(exe)
 }
 
 // CLAUDE_CODE_EVENTS + build_claude_code_payload now live in
@@ -6700,6 +6721,47 @@ model = "gpt-5"
             candidates[4],
             PathBuf::from("/home/alice/.local/share/ai-memory/hooks/claude-code")
         );
+    }
+
+    /// #546: `~/.local/bin/ai-memory -> <repo>/target/release/ai-memory` is
+    /// what the quick start's `~/.local/bin` layout produces for a source
+    /// build. Discovery is derived from the binary's own location, so the
+    /// link has to be resolved first or every candidate misses the checkout.
+    #[cfg(unix)]
+    #[test]
+    fn hooks_are_found_through_a_symlinked_binary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        let exe = repo.join("target").join("release").join("ai-memory");
+        fs::create_dir_all(exe.parent().unwrap()).unwrap();
+        fs::write(&exe, b"").unwrap();
+        let link_dir = tmp.path().join("home").join(".local").join("bin");
+        fs::create_dir_all(&link_dir).unwrap();
+        let link = link_dir.join("ai-memory");
+        std::os::unix::fs::symlink(&exe, &link).unwrap();
+
+        let resolved = resolve_exe_path(link);
+        let candidates = hook_source_candidates(
+            "claude-code",
+            repo_root_from_exe(&resolved),
+            resolved.parent().map(Path::to_path_buf),
+            None,
+        );
+
+        assert_eq!(
+            candidates[0],
+            fs::canonicalize(&repo)
+                .unwrap()
+                .join("hooks")
+                .join("claude-code"),
+            "the checkout must be the first candidate, not the symlink's ancestor"
+        );
+    }
+
+    #[test]
+    fn resolve_exe_path_keeps_an_unresolvable_path() {
+        let missing = PathBuf::from("/definitely/not/here/ai-memory");
+        assert_eq!(resolve_exe_path(missing.clone()), missing);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #546.

## Problem

`install-hooks` builds its hook-bundle candidates from where the binary lives — `repo_root_guess()` and `exe_dir_guess()`, both reading `std::env::current_exe()` as-is. Through the layout the quick start encourages (`~/.local/bin` on `PATH`, pointing into a source build), `current_exe()` returns the symlink itself, so:

- the repo-root guess walks three parents up from `~/.local/bin/ai-memory` and lands on `$HOME`;
- the tarball guess stops at `~/.local/bin`.

Neither ever reaches the checkout, so every candidate misses and the command fails:

```
Error: could not locate hooks directory. Tried:
["/Users/me/hooks/claude-code", "/Users/me/.local/bin/hooks/claude-code", ...]
```

The cwd is never consulted, so `cd`-ing into the repo root — the obvious thing to try, and what the macOS guide implies — does not help.

## Fix

Canonicalise the executable path once (`current_exe_resolved`), keeping the original when it cannot be resolved (deleted binary, or a filesystem that refuses), and derive both guesses from it. The parent-walk itself moves into `repo_root_from_exe(&Path)` so it can be tested against an injected root instead of the real `current_exe()`.

The failure message now also names `--hooks-dir` as the explicit escape hatch, which it never mentioned.

## Tests

- `hooks_are_found_through_a_symlinked_binary` (unix): builds `<tmp>/repo/target/release/ai-memory` plus a `<tmp>/home/.local/bin/ai-memory` symlink and asserts the first candidate is the checkout's `hooks/claude-code`. Fails before the change.
- `resolve_exe_path_keeps_an_unresolvable_path`: covers the fallback branch.

Verified end-to-end on macOS as well — through a symlink, from an unrelated cwd:

```
$ /tmp/scratch/ai-memory install-hooks --agent claude-code
# Hook scripts: /Users/me/workspace/ai-memory/hooks/claude-code
```

Local gate: `cargo fmt --all -- --check`, `git diff --check`, `TAILWIND_SKIP=1 cargo test --workspace`, `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings` — all clean.

## Note for review — `windows` label

Labelled `windows` because this is path handling: `fs::canonicalize` returns extended-length (`\\?\C:\…`) paths on Windows, so the resolved exe path — and the hooks directory derived from it — can carry that prefix into rendered output and staged-script paths. The behaviour is unchanged for the common Windows case (no symlink to resolve, `canonicalize` still normalises), but the native Windows workflow should run before merge.

## Not included

The related inconsistency noted in #546 — `resolve_hooks_dir` passing `dirs::data_local_dir()` for the last candidate instead of the resolved `data_dir`, which also sends `stage_hook_scripts` to the platform default rather than the data dir in use — is left out to keep this change scoped. Happy to follow up in a separate PR.


