### PR TITLE
feat(purge): `--compact` for purge-project and delete-workspace (#540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wiki git history keeps page content in its objects and commit messages, and
   earlier backups still contain it. `docs/lifecycle-ops.md` states that
   boundary in a table so it is not inferred from the command name.
+- `ai-memory purge-project --compact` and `compact: true` on
+  `POST /admin/delete-workspace` reclaim the freed bytes, the way
+  `purge-session --compact` already did. Both commands described themselves as
+  deleting "ALL its data", which no delete in this system does: measured with a
+  canary token, the text was still recoverable from `memory.sqlite` after the
+  purge, because rows go and bytes stay in free pages until the file is
+  rewritten. The commands' help text and the admin endpoint docs now say what
+  they remove instead of promising byte-level removal, and
+  `docs/lifecycle-ops.md` carries the same boundary table for the whole
+  destructive family rather than for `purge-session` alone (#540).
+
+  Compaction is scope-aware rather than a copy of the session batch. A session
+  purge dirties `observations_fts` and `pages_fts`; a project or workspace
+  delete also cascades into `workstreams` and their `workstream_events`, whose
+  content is indexed by a third FTS table that no session purge can reach.
+  Rebuilding only the session's two would have left that index holding entries
+  for rows that no longer exist, with the response still reporting
+  `compacted: true`. A test asserts the set is exhaustive against the schema,
+  so an FTS index added later fails there rather than being silently skipped.
+  The internal purges that back `move-project`'s merge teardown and
+  `merge-workspace`'s shell delete stay uncompacted — those are steps of a
+  move, not an operator asking to reclaim bytes.
 
 ### Fixed
 - The hook drain no longer stalls the whole spool behind one undeliverable

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -145,9 +145,12 @@ pub enum Command {
     /// `is_latest=false` (they were a multi-project mash-up) so the
     /// next consolidation can regenerate them per-project. Idempotent.
     Reorg(ReorgArgs),
-    /// Permanently delete a project and ALL its data (pages, sessions,
-    /// observations, handoffs, embeddings, on-disk wiki files).
-    /// This is irreversible — requires `--confirm`.
+    /// Permanently delete a project: its rows (pages, sessions, observations,
+    /// handoffs, embeddings, managed workstreams) and its on-disk wiki files.
+    ///
+    /// Irreversible, and requires `--confirm`. A logical delete by default —
+    /// the rows become unreachable, but their bytes stay in free pages of the
+    /// database file until it is rewritten. `--compact` reclaims them.
     PurgeProject(PurgeProjectArgs),
     /// Permanently delete ONE session and everything derived from it.
     ///
@@ -609,6 +612,19 @@ pub struct PurgeProjectArgs {
     /// out — purging is destructive and irreversible.
     #[arg(long)]
     pub confirm: bool,
+    /// Also reclaim the freed bytes: rebuild the affected FTS indexes and
+    /// VACUUM the database after the delete commits.
+    ///
+    /// Without this the purge is a logical delete — the project is gone from
+    /// the API and from search, but its bytes stay in free pages of the
+    /// database file until it is next rewritten, as with any SQLite delete.
+    ///
+    /// This rewrites the WHOLE database and needs free disk space of about
+    /// its size, so it takes minutes on a large store. It also does NOT make
+    /// the content forensically unrecoverable: the wiki git history and any
+    /// backup taken before the purge still contain it.
+    #[arg(long)]
+    pub compact: bool,
 }
 
 /// Arguments for `purge-session`.

--- a/crates/ai-memory-cli/src/commands/purge_project.rs
+++ b/crates/ai-memory-cli/src/commands/purge_project.rs
@@ -15,6 +15,8 @@ struct PurgeProjectRequest {
     confirm: bool,
     /// Purge even when a managed workstream still holds a live run lease.
     force: bool,
+    /// Rebuild the FTS indexes and VACUUM after the delete commits.
+    compact: bool,
 }
 
 /// Run the `purge-project` subcommand.
@@ -49,6 +51,7 @@ pub async fn run(config: &Config, args: PurgeProjectArgs) -> Result<()> {
             project: project.clone(),
             confirm: true,
             force: args.force,
+            compact: args.compact,
         },
     )
     .await?;
@@ -88,6 +91,16 @@ pub async fn run(config: &Config, args: PurgeProjectArgs) -> Result<()> {
         println!(
             "Warning: {} wiki file(s) could not be removed from disk (DB rows are gone).",
             failed.len()
+        );
+    }
+    if report["compacted"].as_bool().unwrap_or(false) {
+        println!("Database compacted: freed bytes reclaimed.");
+    } else {
+        println!(
+            "Note: this was a logical delete. The project is unreachable through \
+             the API and search, but its bytes remain in the database file until \
+             it is rewritten. Re-run with --compact to reclaim them (slow), and \
+             see `docs/lifecycle-ops.md` for what that does and does not guarantee."
         );
     }
     Ok(())

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -6841,7 +6841,14 @@ mod tests {
         //    points at it (exactly the purge-on-live-server scenario).
         state
             .writer
-            .purge_project(ws, proj, "default/heal-project", None, false)
+            .purge_project(
+                ws,
+                proj,
+                "default/heal-project",
+                None,
+                false,
+                ai_memory_store::Compaction::Skip,
+            )
             .await
             .unwrap();
         assert!(
@@ -7643,7 +7650,14 @@ mod tests {
 
         state
             .writer
-            .purge_project(ws, proj, "default/repo-root-project", None, false)
+            .purge_project(
+                ws,
+                proj,
+                "default/repo-root-project",
+                None,
+                false,
+                ai_memory_store::Compaction::Skip,
+            )
             .await
             .unwrap();
 

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -21,11 +21,12 @@
 //! - `POST /admin/commit`         — stage + commit the wiki tree via git.
 //! - `GET  /admin/checkpoints`    — list recent wiki git checkpoints.
 //! - `POST /admin/restore-page`   — restore one page from a checkpoint.
-//! - `POST /admin/purge-project`  — delete a project and all its data.
+//! - `POST /admin/purge-project`  — delete a project's rows and wiki files.
 //! - `POST /admin/purge-session`  — delete one session and what it derived.
 //! - `POST /admin/rename-project` — rename a project (column-only; no files move).
 //! - `POST /admin/rename-workspace` — rename a workspace and refresh scope manifests.
-//! - `POST /admin/delete-workspace` — delete a workspace and all of its projects.
+//! - `POST /admin/delete-workspace` — delete a workspace's rows and every
+//!   project under it.
 //! - `POST /admin/merge-workspace` — fold every project of one workspace into
 //!   another, then delete the emptied source workspace.
 //! - `POST /admin/move-project`   — move a project into another workspace
@@ -3398,6 +3399,11 @@ struct PurgeProjectRequest {
     /// out from under a running agent, which then cannot save its history.
     #[serde(default)]
     force: bool,
+    /// Reclaim freed bytes: rebuild the FTS indexes and `VACUUM` after the
+    /// delete commits. Off by default; see `ai_memory_store::Compaction` for
+    /// the cost and for what it does not guarantee.
+    #[serde(default)]
+    compact: bool,
 }
 
 /// Wire-format summary returned by `POST /admin/purge-project`.
@@ -3432,6 +3438,10 @@ pub struct PurgeProjectReport {
     /// Post-purge checkpoint, if the purge changed the tree.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checkpoint: Option<String>,
+    /// Whether the freed bytes were reclaimed (`compact: true` was requested
+    /// and the FTS rebuilds plus `VACUUM` ran). Not a claim of erasure — the
+    /// wiki git history and pre-purge backups still hold the content.
+    pub compacted: bool,
 }
 
 async fn remove_workstream_segment_storage(
@@ -3560,9 +3570,15 @@ async fn handle_purge_project(
         Err(e) => return e,
     };
 
+    let compaction = if req.compact {
+        ai_memory_store::Compaction::Reclaim
+    } else {
+        ai_memory_store::Compaction::Skip
+    };
+
     let summary = match state
         .writer
-        .purge_project(ws_id, proj_id, &label, author_id, req.force)
+        .purge_project(ws_id, proj_id, &label, author_id, req.force, compaction)
         .await
     {
         Ok(s) => s,
@@ -3622,6 +3638,7 @@ async fn handle_purge_project(
         files_failed,
         pre_checkpoint,
         checkpoint,
+        compacted: summary.compacted,
     };
 
     (
@@ -3715,6 +3732,11 @@ struct DeleteWorkspaceRequest {
     /// non-empty workspace is refused so a typo can't wipe live data.
     #[serde(default)]
     force: bool,
+    /// Reclaim freed bytes: rebuild the FTS indexes and `VACUUM` after the
+    /// delete commits. Off by default; see `ai_memory_store::Compaction` for
+    /// the cost and for what it does not guarantee.
+    #[serde(default)]
+    compact: bool,
 }
 
 /// Wire-format summary returned by `POST /admin/delete-workspace`.
@@ -3743,6 +3765,10 @@ pub struct DeleteWorkspaceResult {
     /// Post-delete mirror checkpoint, if one was taken.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checkpoint: Option<String>,
+    /// Whether the freed bytes were reclaimed (`compact: true` was requested
+    /// and the FTS rebuilds plus `VACUUM` ran). Not a claim of erasure — the
+    /// wiki git history and pre-delete backups still hold the content.
+    pub compacted: bool,
 }
 
 /// `POST /admin/delete-workspace` — remove a workspace and, via cascade, every
@@ -3756,7 +3782,12 @@ async fn handle_delete_workspace(
     let actor = actor_ext
         .map(|axum::Extension(a)| a)
         .unwrap_or_else(ai_memory_core::ActorContext::anonymous);
-    match delete_workspace_core(&state, &req.workspace, req.force, actor).await {
+    let compaction = if req.compact {
+        ai_memory_store::Compaction::Reclaim
+    } else {
+        ai_memory_store::Compaction::Skip
+    };
+    match delete_workspace_core(&state, &req.workspace, req.force, actor, compaction).await {
         Ok(result) => (
             StatusCode::OK,
             Json(serde_json::to_value(&result).unwrap_or(serde_json::Value::Null)),
@@ -3775,6 +3806,7 @@ async fn delete_workspace_core(
     workspace: &str,
     force: bool,
     actor: ai_memory_core::ActorContext,
+    compaction: ai_memory_store::Compaction,
 ) -> Result<DeleteWorkspaceResult, MoveErr> {
     let ws_id = lookup_ws_no_create(state, workspace).await?;
 
@@ -3816,7 +3848,11 @@ async fn delete_workspace_core(
     let pre_checkpoint =
         checkpoint_or_500(&state.wiki, format!("pre-delete-workspace {workspace}"))?;
 
-    let summary = match state.writer.delete_workspace(ws_id, force).await {
+    let summary = match state
+        .writer
+        .delete_workspace(ws_id, force, compaction)
+        .await
+    {
         Ok(s) => s,
         Err(e) => {
             let status = match &e {
@@ -3870,6 +3906,7 @@ async fn delete_workspace_core(
         files_failed,
         pre_checkpoint,
         checkpoint: checkpoint_or_warn(&state.wiki, format!("delete-workspace {workspace}")),
+        compacted: summary.compacted,
     })
 }
 
@@ -5623,7 +5660,14 @@ async fn copy_purge_merge(
     // `purge_project` here, so the audit author is left NULL.
     let summary = match state
         .writer
-        .purge_project(src_ws, src_proj, &label, None, false)
+        .purge_project(
+            src_ws,
+            src_proj,
+            &label,
+            None,
+            false,
+            ai_memory_store::Compaction::Skip,
+        )
         .await
     {
         Ok(s) => s,
@@ -5844,21 +5888,28 @@ async fn handle_merge_workspace(
     // Every project moved → the source workspace is now empty. Delete the shell
     // with force=false: it must be empty, so a race that repopulated it aborts
     // safely without wiping fresh data.
-    let source_workspace_deleted =
-        match delete_workspace_core(&state, &req.from, false, actor).await {
-            Ok(_) => true,
-            Err((_status, body)) => {
-                // The moves succeeded; only the final empty-shell delete failed
-                // (e.g. a concurrent write recreated a project). No data was
-                // lost, so report success-with-caveat instead of a hard error.
-                warn!(
-                    workspace = %req.from,
-                    "merge-workspace: source drained but shell delete failed: {:?}",
-                    body
-                );
-                false
-            }
-        };
+    let source_workspace_deleted = match delete_workspace_core(
+        &state,
+        &req.from,
+        false,
+        actor,
+        ai_memory_store::Compaction::Skip,
+    )
+    .await
+    {
+        Ok(_) => true,
+        Err((_status, body)) => {
+            // The moves succeeded; only the final empty-shell delete failed
+            // (e.g. a concurrent write recreated a project). No data was
+            // lost, so report success-with-caveat instead of a hard error.
+            warn!(
+                workspace = %req.from,
+                "merge-workspace: source drained but shell delete failed: {:?}",
+                body
+            );
+            false
+        }
+    };
 
     let report = MergeWorkspaceReport {
         from: req.from,

--- a/crates/ai-memory-mcp/tests/admin_move.rs
+++ b/crates/ai-memory-mcp/tests/admin_move.rs
@@ -1946,6 +1946,45 @@ async fn delete_workspace_force_removes_everything() {
     );
 }
 
+/// #540: the `compact` field must be reachable over HTTP on this endpoint
+/// too, and the response must say which mode ran. Absent is the default.
+#[tokio::test]
+async fn delete_workspace_compact_defaults_off_and_is_reported_either_way() {
+    for (request, expected) in [
+        (json!({ "workspace": "victim", "force": true }), false),
+        (
+            json!({ "workspace": "victim", "force": true, "compact": false }),
+            false,
+        ),
+        (
+            json!({ "workspace": "victim", "force": true, "compact": true }),
+            true,
+        ),
+    ] {
+        let tmp = TempDir::new().unwrap();
+        let (state, store) = make_state(&tmp).await;
+        seed_page(&store, &state.wiki, "victim", "proj", "notes/a.md", "body").await;
+        seed_page(&store, &state.wiki, "keeper", "proj", "notes/b.md", "body").await;
+
+        let resp = post(state, "/admin/delete-workspace", request.clone()).await;
+        assert_eq!(resp.status(), StatusCode::OK, "{request}");
+        let body = body_json(resp).await;
+        assert_eq!(
+            body["compacted"].as_bool(),
+            Some(expected),
+            "compacted must report what actually ran, for {request}: {body}"
+        );
+        assert!(
+            body["pages_deleted"].as_u64().unwrap_or(0) >= 1,
+            "the delete happens either way: {body}"
+        );
+        // A VACUUM rewrites the whole file, so the surviving workspace is the
+        // thing most likely to be damaged by getting this wrong.
+        let survivor = store.reader.find_workspace("keeper".into()).await.unwrap();
+        assert!(survivor.is_some(), "the untargeted workspace survives");
+    }
+}
+
 #[tokio::test]
 async fn delete_workspace_unknown_is_404() {
     let tmp = TempDir::new().unwrap();

--- a/crates/ai-memory-mcp/tests/admin_purge.rs
+++ b/crates/ai-memory-mcp/tests/admin_purge.rs
@@ -561,3 +561,43 @@ async fn purge_project_idempotent_second_call_is_404() {
         "second purge must 404 because project is already gone"
     );
 }
+
+/// #540: `compact` is a wire field, so the boundary the store enforces has to
+/// be reachable over HTTP and reported back. Absent means the default, and
+/// the response says which of the two happened rather than leaving the
+/// caller to assume.
+#[tokio::test]
+async fn purge_project_compact_defaults_off_and_is_reported_either_way() {
+    for (request, expected) in [
+        (
+            json!({ "workspace": "default", "project": "doomed", "confirm": true }),
+            false,
+        ),
+        (
+            json!({ "workspace": "default", "project": "doomed", "confirm": true, "compact": false }),
+            false,
+        ),
+        (
+            json!({ "workspace": "default", "project": "doomed", "confirm": true, "compact": true }),
+            true,
+        ),
+    ] {
+        let tmp = TempDir::new().unwrap();
+        let (state, store) = make_state(&tmp).await;
+        seed_two_projects(&store, &state.wiki).await;
+
+        let resp = post(state, "/admin/purge-project", request.clone()).await;
+        assert_eq!(resp.status(), StatusCode::OK, "{request}");
+        let body = body_json(resp).await;
+        assert_eq!(
+            body["compacted"].as_bool(),
+            Some(expected),
+            "compacted must report what actually ran, for {request}: {body}"
+        );
+        // The purge itself is unaffected by the mode.
+        assert!(
+            body["pages_deleted"].as_u64().unwrap_or(0) >= 1,
+            "the delete happens either way: {body}"
+        );
+    }
+}

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -148,6 +148,9 @@ pub struct PurgeSummary {
     /// pre-delete identifiers to remove `raw/workstreams/<id>/` after the SQL
     /// transaction commits and to report any filesystem partial failure.
     pub workstream_ids: Vec<String>,
+    /// Whether the freed bytes were reclaimed (the FTS rebuilds and `VACUUM`
+    /// ran). False for the default logical delete.
+    pub compacted: bool,
 }
 use jiff::Timestamp;
 use rusqlite::{Connection, OptionalExtension, Transaction, params};
@@ -2801,41 +2804,20 @@ pub fn insert_wiki_migration(
     Ok(())
 }
 
-/// Delete a project and all its data inside one transaction.
+/// Whether a destructive operation should reclaim the freed bytes afterwards.
 ///
-/// Execution order:
-/// 1. Count rows in each dependent table (pages/all versions, sessions,
-///    observations, handoffs, embeddings) before the delete so we can
-///    report how many rows were removed.
-/// 2. Collect all distinct page paths stored under the project — these are
-///    the on-disk files the caller must clean up after this function returns.
-/// 3. DELETE FROM projects WHERE id = ? — the ON DELETE CASCADE clauses in
-///    V01 + V02 propagate the delete to pages, sessions, observations,
-///    handoffs, and page_embeddings automatically.
-/// 4. Commit and return the [`PurgeSummary`].
-///
-/// The `workspace_project_label` string is passed in by the caller (the
-/// admin handler has the human-readable names; the writer only has IDs) and
-/// forwarded verbatim into [`PurgeSummary::label`] for logging.
-///
-/// `force` overrides the live-managed-run guard (step 0): `workstreams`
-/// cascades out of `projects`, so purging a scope whose lease is still live
-/// would delete the lease row out from under a running agent.
-///
-/// # Errors
-/// Returns [`StoreError::ManagedRunActive`] when a managed run's lease is
-/// still live and `force` is false, or [`StoreError`] if any SQL statement
-/// fails. The transaction is rolled back automatically on error.
-/// Whether [`purge_session`] should reclaim the freed bytes afterwards.
+/// Shared by [`purge_session`], [`purge_project`] and [`delete_workspace`].
 ///
 /// A purge is a logical delete: the rows are gone and nothing can reach them
 /// through the API or through search, but their bytes remain in free pages of
 /// the database file until the file is rewritten — exactly as for any other
 /// SQLite delete.
 ///
-/// [`Compaction::Reclaim`] additionally rebuilds the affected FTS5 indexes
-/// (the tokens survive an ordinary delete inside the index segments) and runs
-/// `VACUUM`, after the deletion has committed.
+/// [`Compaction::Reclaim`] additionally rebuilds the FTS5 indexes the
+/// operation actually touched (the tokens survive an ordinary delete inside
+/// the index segments) and runs `VACUUM`, after the deletion has committed.
+/// Which indexes those are is per-operation, not universal — see
+/// [`reclaim_after_commit`].
 ///
 /// # Cost and limits
 ///
@@ -2852,8 +2834,44 @@ pub fn insert_wiki_migration(
 pub enum Compaction {
     /// Leave the freed pages alone. The default, and what #387 promises.
     Skip,
-    /// Rebuild the affected FTS indexes and `VACUUM` after committing.
+    /// Rebuild the touched FTS indexes and `VACUUM` after committing.
     Reclaim,
+}
+
+/// FTS5 indexes a *session* purge can dirty.
+const SESSION_SCOPED_FTS: &[&str] = &["observations_fts", "pages_fts"];
+
+/// FTS5 indexes a *project* or *workspace* purge can dirty.
+///
+/// The extra one over [`SESSION_SCOPED_FTS`] is `workstream_events_fts`:
+/// `workstreams` cascades out of both `projects` and `workspaces`, and
+/// `workstream_events` cascades out of that (`V31__managed_workstreams.sql`).
+/// A managed workstream's event ledger is reachable from neither a session id
+/// nor a page, so no session purge ever touches this index and a project or
+/// workspace purge always can.
+const SCOPE_WIDE_FTS: &[&str] = &["observations_fts", "pages_fts", "workstream_events_fts"];
+
+/// Rebuild the named FTS5 indexes, then `VACUUM`.
+///
+/// Both steps run *after* the deleting transaction has committed: `VACUUM`
+/// cannot run inside one, and a rebuild is a whole-index operation we do not
+/// want holding the write lock for the duration of the delete.
+///
+/// `fts_tables` is the set the caller's delete actually touched, and that set
+/// differs per operation — passing the wrong one is a silent defect, because
+/// an ordinary delete leaves the tokens inside the index segments and
+/// `VACUUM` alone does not clear them. An index omitted here keeps stale
+/// entries for rows that no longer exist.
+fn reclaim_after_commit(conn: &Connection, fts_tables: &[&str]) -> StoreResult<()> {
+    // Every call site passes a compile-time constant, never caller input;
+    // FTS5 offers no bind-parameter form for the rebuild statement.
+    let mut batch = String::new();
+    for table in fts_tables {
+        batch.push_str(&format!("INSERT INTO {table}({table}) VALUES('rebuild'); "));
+    }
+    batch.push_str("VACUUM;");
+    conn.execute_batch(&batch)?;
+    Ok(())
 }
 
 /// What [`purge_session`] removed. All counts are rows actually deleted.
@@ -3065,15 +3083,8 @@ pub fn purge_session(
 
     tx.commit()?;
 
-    // Outside the transaction: `VACUUM` cannot run inside one, and a rebuild
-    // is a whole-index operation we do not want holding the write lock for
-    // the duration of the delete.
     if compaction == Compaction::Reclaim {
-        conn.execute_batch(
-            "INSERT INTO observations_fts(observations_fts) VALUES('rebuild'); \
-             INSERT INTO pages_fts(pages_fts) VALUES('rebuild'); \
-             VACUUM;",
-        )?;
+        reclaim_after_commit(conn, SESSION_SCOPED_FTS)?;
     }
 
     Ok(PurgeSessionSummary {
@@ -3086,6 +3097,36 @@ pub fn purge_session(
     })
 }
 
+/// Delete a project's rows inside one transaction.
+///
+/// Execution order:
+/// 1. Count rows in each dependent table (pages/all versions, sessions,
+///    observations, handoffs, embeddings) before the delete so we can
+///    report how many rows were removed.
+/// 2. Collect all distinct page paths stored under the project — these are
+///    the on-disk files the caller must clean up after this function returns.
+/// 3. DELETE FROM projects WHERE id = ? — the ON DELETE CASCADE clauses in
+///    V01 + V02 propagate the delete to pages, sessions, observations,
+///    handoffs, and page_embeddings automatically.
+/// 4. Commit and return the [`PurgeSummary`].
+///
+/// The `workspace_project_label` string is passed in by the caller (the
+/// admin handler has the human-readable names; the writer only has IDs) and
+/// forwarded verbatim into [`PurgeSummary::label`] for logging.
+///
+/// `force` overrides the live-managed-run guard (step 0): `workstreams`
+/// cascades out of `projects`, so purging a scope whose lease is still live
+/// would delete the lease row out from under a running agent.
+///
+/// `compaction` decides whether the freed bytes are reclaimed afterwards. The
+/// default leaves them in free pages of the database file, exactly as any
+/// other SQLite delete does — see [`Compaction`], whose caveats apply here
+/// verbatim.
+///
+/// # Errors
+/// Returns [`StoreError::ManagedRunActive`] when a managed run's lease is
+/// still live and `force` is false, or [`StoreError`] if any SQL statement
+/// fails. The transaction is rolled back automatically on error.
 pub fn purge_project(
     conn: &mut Connection,
     workspace_id: &WorkspaceId,
@@ -3093,6 +3134,7 @@ pub fn purge_project(
     workspace_project_label: &str,
     author_id: Option<ai_memory_core::UserId>,
     force: bool,
+    compaction: Compaction,
 ) -> StoreResult<PurgeSummary> {
     let tx = conn.transaction()?;
 
@@ -3221,6 +3263,11 @@ pub fn purge_project(
     )?;
 
     tx.commit()?;
+
+    if compaction == Compaction::Reclaim {
+        reclaim_after_commit(conn, SCOPE_WIDE_FTS)?;
+    }
+
     Ok(PurgeSummary {
         label: workspace_project_label.to_string(),
         page_paths,
@@ -3232,6 +3279,7 @@ pub fn purge_project(
         workstreams_deleted,
         managed_runs_deleted,
         workstream_ids,
+        compacted: compaction == Compaction::Reclaim,
     })
 }
 
@@ -3248,6 +3296,9 @@ pub struct DeleteWorkspaceSummary {
     pub managed_runs_deleted: u64,
     /// Pre-delete identifiers for post-commit raw-segment cleanup.
     pub workstream_ids: Vec<String>,
+    /// Whether the freed bytes were reclaimed (the FTS rebuilds and `VACUUM`
+    /// ran). False for the default logical delete.
+    pub compacted: bool,
 }
 
 /// Delete a workspace row. Refuses a workspace that still holds projects
@@ -3257,6 +3308,11 @@ pub struct DeleteWorkspaceSummary {
 /// observations / handoffs / managed workstreams. The caller removes the
 /// on-disk workspace and raw workstream directories afterwards.
 ///
+/// `compaction` decides whether the freed bytes are reclaimed afterwards. The
+/// default leaves them in free pages of the database file, exactly as any
+/// other SQLite delete does — see [`Compaction`], whose caveats apply here
+/// verbatim.
+///
 /// # Errors
 /// [`StoreError::WorkspaceNotEmpty`] when it still holds projects and `force`
 /// is false; [`StoreError::NotFound`] when the workspace does not exist.
@@ -3264,6 +3320,7 @@ pub fn delete_workspace(
     conn: &mut Connection,
     workspace_id: &WorkspaceId,
     force: bool,
+    compaction: Compaction,
 ) -> StoreResult<DeleteWorkspaceSummary> {
     let tx = conn.transaction()?;
     let wid = workspace_id.as_bytes();
@@ -3303,12 +3360,18 @@ pub fn delete_workspace(
         return Err(StoreError::NotFound("workspace".into()));
     }
     tx.commit()?;
+
+    if compaction == Compaction::Reclaim {
+        reclaim_after_commit(conn, SCOPE_WIDE_FTS)?;
+    }
+
     Ok(DeleteWorkspaceSummary {
         projects_deleted,
         pages_deleted,
         workstreams_deleted,
         managed_runs_deleted,
         workstream_ids,
+        compacted: compaction == Compaction::Reclaim,
     })
 }
 
@@ -4140,7 +4203,7 @@ pub(crate) mod tests {
         let prepared = open_managed_run(&mut conn, &ws, &proj);
 
         // Non-empty (holds the "scratch" project + a page) → refused w/o force.
-        let err = delete_workspace(&mut conn, &ws, false).unwrap_err();
+        let err = delete_workspace(&mut conn, &ws, false, Compaction::Skip).unwrap_err();
         assert!(
             matches!(err, StoreError::WorkspaceNotEmpty(n) if n >= 1),
             "expected WorkspaceNotEmpty, got {err:?}"
@@ -4155,7 +4218,7 @@ pub(crate) mod tests {
         assert_eq!(ws_still, 1, "refused delete must not touch the row");
 
         // Force cascades: project + page gone, workspace row gone.
-        let summary = delete_workspace(&mut conn, &ws, true).unwrap();
+        let summary = delete_workspace(&mut conn, &ws, true, Compaction::Skip).unwrap();
         assert!(
             summary.projects_deleted >= 1 && summary.pages_deleted >= 1,
             "{summary:?}"
@@ -4177,7 +4240,7 @@ pub(crate) mod tests {
 
         // Deleting again → NotFound.
         assert!(matches!(
-            delete_workspace(&mut conn, &ws, true).unwrap_err(),
+            delete_workspace(&mut conn, &ws, true, Compaction::Skip).unwrap_err(),
             StoreError::NotFound(_)
         ));
     }
@@ -4186,12 +4249,59 @@ pub(crate) mod tests {
     fn delete_workspace_empty_succeeds_without_force() {
         let (_tmp, mut conn, _ws, _proj) = fresh_db();
         let empty = get_or_create_workspace(&mut conn, "orphan-ws").unwrap();
-        let summary = delete_workspace(&mut conn, &empty, false).unwrap();
+        let summary = delete_workspace(&mut conn, &empty, false, Compaction::Skip).unwrap();
         assert_eq!(summary.projects_deleted, 0);
         assert_eq!(summary.pages_deleted, 0);
         assert_eq!(summary.workstreams_deleted, 0);
         assert_eq!(summary.managed_runs_deleted, 0);
         assert!(summary.workstream_ids.is_empty());
+    }
+
+    /// #540: `delete-workspace` made the same "and all of its projects"
+    /// promise `purge-project` did. Both halves of the boundary, in one test
+    /// because the workspace path has no separate scope to keep alive — the
+    /// sibling here is a second workspace.
+    #[test]
+    fn delete_workspace_reclaims_only_when_asked() {
+        let bytes_after = |compaction: Compaction| -> (bool, bool, bool) {
+            let (tmp, mut conn, ws, proj) = fresh_db();
+            let db_path = tmp.path().join("test.sqlite");
+            let other_ws = get_or_create_workspace(&mut conn, "sibling").unwrap();
+            let other_proj = get_or_create_project(&mut conn, &other_ws, "keeper", None).unwrap();
+            seed_session(&mut conn, ws, proj, "target");
+            seed_session(&mut conn, other_ws, other_proj, "keep");
+            seed_workstream_event(&conn, ws, proj, "doomed-workspace-event");
+
+            let summary = delete_workspace(&mut conn, &ws, true, compaction).unwrap();
+            assert_eq!(summary.compacted, compaction == Compaction::Reclaim);
+
+            conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);").ok();
+            let raw = std::fs::read(&db_path).unwrap();
+            let hit = |needle: &str| raw.windows(needle.len()).any(|w| w == needle.as_bytes());
+            (
+                hit("obs-target"),
+                hit("doomed-workspace-event"),
+                hit("obs-keep"),
+            )
+        };
+
+        let (obs, event, sibling) = bytes_after(Compaction::Skip);
+        assert!(
+            obs && event,
+            "documented boundary: the default delete is logical. If this now \
+             fails, byte-level removal became the default and every operator- \
+             facing claim about delete-workspace needs revisiting."
+        );
+        assert!(sibling, "the sibling workspace is untouched");
+
+        let (obs, event, sibling) = bytes_after(Compaction::Reclaim);
+        assert!(!obs, "Reclaim removes the deleted workspace's observations");
+        assert!(
+            !event,
+            "and its managed-workstream events — the index a session purge \
+             never has to consider"
+        );
+        assert!(sibling, "the sibling workspace survives the VACUUM intact");
     }
 
     #[test]
@@ -4541,6 +4651,244 @@ pub(crate) mod tests {
         assert!(
             bytes.windows(8).any(|w| w == b"obs-keep"),
             "the surviving session's text is untouched by the compaction"
+        );
+    }
+
+    /// Rows in an FTS5 index's `%_data` shadow table. Drops when the index is
+    /// rebuilt and the deleted entries are dropped from its segments; an
+    /// ordinary delete leaves them behind.
+    fn fts_data_rows(conn: &Connection, index: &str) -> i64 {
+        conn.query_row(&format!("SELECT COUNT(*) FROM {index}_data"), [], |r| {
+            r.get(0)
+        })
+        .unwrap()
+    }
+
+    /// A managed workstream under `proj` with one event whose `content`
+    /// carries `marker`. Reachable from neither a session id nor a page, so
+    /// only a project- or workspace-wide delete ever removes it.
+    fn seed_workstream_event(conn: &Connection, ws: WorkspaceId, proj: ProjectId, marker: &str) {
+        let id = ai_memory_core::WorkstreamId::new();
+        let now = Timestamp::now().as_microsecond();
+        conn.execute(
+            "INSERT INTO workstreams (id, workspace_id, project_id, repo_fingerprint, \
+             worktree_fingerprint, name, cwd, created_at, selected_at, updated_at) \
+             VALUES (?1, ?2, ?3, 'repo', 'wt', ?4, '/tmp', ?5, ?5, ?5)",
+            rusqlite::params![
+                &id.as_bytes()[..],
+                &ws.as_bytes()[..],
+                &proj.as_bytes()[..],
+                marker,
+                now
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO workstream_events (workstream_id, sequence, event_id, agent_kind, \
+             native_session_id, kind, role, content, created_at) \
+             VALUES (?1, 1, ?2, 'claude-code', 'native-1', 'message', 'user', ?3, ?4)",
+            rusqlite::params![&id.as_bytes()[..], format!("{marker}-ev"), marker, now],
+        )
+        .unwrap();
+    }
+
+    /// The same boundary `purge_session_is_unsearchable_but_does_not_claim_byte_level_removal`
+    /// pins for one session, for the whole project. #540: the help text used
+    /// to promise "ALL its data", which this asserts is not what the default
+    /// does.
+    #[test]
+    fn purge_project_is_unsearchable_but_does_not_claim_byte_level_removal() {
+        let (tmp, mut conn, ws, proj) = fresh_db();
+        let db_path = tmp.path().join("test.sqlite");
+        let keep = get_or_create_project(&mut conn, &ws, "keeper", None).unwrap();
+        seed_session(&mut conn, ws, proj, "target");
+        seed_session(&mut conn, ws, keep, "keep");
+
+        let summary = purge_project(
+            &mut conn,
+            &ws,
+            &proj,
+            "default/scratch",
+            None,
+            false,
+            Compaction::Skip,
+        )
+        .unwrap();
+        assert!(!summary.compacted, "the default does not reclaim");
+
+        let matches = |c: &Connection, term: &str| -> i64 {
+            c.query_row(
+                "SELECT COUNT(*) FROM observations_fts WHERE observations_fts MATCH ?1",
+                rusqlite::params![format!("\"{term}\"")],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(
+            matches(&conn, "obs-target"),
+            0,
+            "the purged project is not searchable"
+        );
+        assert_eq!(
+            matches(&conn, "obs-keep"),
+            1,
+            "the sibling project still is"
+        );
+
+        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);").ok();
+        let bytes = std::fs::read(&db_path).unwrap();
+        assert!(
+            bytes.windows(10).any(|w| w == b"obs-target"),
+            "documented boundary: the default purge is a logical delete. If this \
+             now fails, byte-level removal became the default and the CLI help, \
+             the admin endpoint docs and docs/lifecycle-ops.md all need updating."
+        );
+    }
+
+    /// The opt-in half for a project. Paired with the test above, exactly as
+    /// #539 paired the two halves for a session.
+    #[test]
+    fn purge_project_with_reclaim_removes_the_bytes_from_the_file() {
+        let (tmp, mut conn, ws, proj) = fresh_db();
+        let db_path = tmp.path().join("test.sqlite");
+        let keep = get_or_create_project(&mut conn, &ws, "keeper", None).unwrap();
+        seed_session(&mut conn, ws, proj, "target");
+        seed_session(&mut conn, ws, keep, "keep");
+
+        let summary = purge_project(
+            &mut conn,
+            &ws,
+            &proj,
+            "default/scratch",
+            None,
+            false,
+            Compaction::Reclaim,
+        )
+        .unwrap();
+        assert!(summary.compacted, "the summary reports that VACUUM ran");
+
+        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);").ok();
+        let bytes = std::fs::read(&db_path).unwrap();
+        assert!(
+            !bytes.windows(10).any(|w| w == b"obs-target"),
+            "Reclaim must remove the purged text from the database file"
+        );
+        assert!(
+            bytes.windows(8).any(|w| w == b"obs-keep"),
+            "the surviving project's text is untouched by the compaction"
+        );
+    }
+
+    /// #540, the part a literal reuse of #539 gets wrong.
+    ///
+    /// `purge_session` rebuilds `observations_fts` and `pages_fts`, which is
+    /// exhaustive for a session. A project also cascades into `workstreams`
+    /// and from there into `workstream_events`, whose `content` is indexed by
+    /// a third FTS table that no session purge can reach. Reusing the session
+    /// set here would leave that index holding entries for rows that no
+    /// longer exist, silently, with the summary still reporting `compacted`.
+    ///
+    /// Asserted as "an explicit rebuild afterwards changes nothing", which
+    /// stays true however the reclaim is spelled, and is shown to have teeth
+    /// by the `Skip` half — where the same explicit rebuild does change it.
+    #[test]
+    fn purge_project_reclaim_rebuilds_the_workstream_event_index() {
+        let rows_after = |compaction: Compaction| -> (i64, i64, i64) {
+            let (_tmp, mut conn, ws, proj) = fresh_db();
+            let keep = get_or_create_project(&mut conn, &ws, "keeper", None).unwrap();
+            seed_workstream_event(&conn, ws, proj, "doomed-event-text");
+            seed_workstream_event(&conn, ws, keep, "surviving-event-text");
+
+            purge_project(
+                &mut conn,
+                &ws,
+                &proj,
+                "default/scratch",
+                None,
+                true,
+                compaction,
+            )
+            .unwrap();
+
+            let after = fts_data_rows(&conn, "workstream_events_fts");
+            conn.execute_batch(
+                "INSERT INTO workstream_events_fts(workstream_events_fts) VALUES('rebuild');",
+            )
+            .unwrap();
+            let after_explicit = fts_data_rows(&conn, "workstream_events_fts");
+
+            let survivor: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM workstream_events_fts \
+                     WHERE workstream_events_fts MATCH '\"surviving-event-text\"'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            (after, after_explicit, survivor)
+        };
+
+        let (reclaimed, reclaimed_then_rebuilt, survivor) = rows_after(Compaction::Reclaim);
+        assert_eq!(
+            reclaimed, reclaimed_then_rebuilt,
+            "Reclaim must already have rebuilt workstream_events_fts — an explicit \
+             rebuild afterwards found more to drop, so the purge left stale index \
+             entries behind for rows it deleted"
+        );
+        assert_eq!(
+            survivor, 1,
+            "the surviving project's events stay searchable"
+        );
+
+        let (skipped, skipped_then_rebuilt, _) = rows_after(Compaction::Skip);
+        assert!(
+            skipped > skipped_then_rebuilt,
+            "sanity: without Reclaim the index does hold droppable entries, so the \
+             assertion above is testing something"
+        );
+    }
+
+    /// Which FTS indexes a project or workspace purge must rebuild is not a
+    /// fact about today's schema that can be left implicit. Every FTS5 index
+    /// in the database currently sits over a table that cascades out of
+    /// `projects` or `workspaces`, so [`SCOPE_WIDE_FTS`] is all of them.
+    ///
+    /// A new index added later fails here, which is the point: whoever adds
+    /// it decides whether a scope-wide purge dirties it, rather than
+    /// discovering months later that `--compact` quietly skipped it.
+    #[test]
+    fn scope_wide_reclaim_covers_every_fts_index_in_the_schema() {
+        let (_tmp, conn, _ws, _proj) = fresh_db();
+        let mut stmt = conn
+            .prepare(
+                "SELECT name FROM sqlite_master \
+                 WHERE type = 'table' AND sql LIKE '%USING fts5%' ORDER BY name",
+            )
+            .unwrap();
+        let mut in_schema: Vec<String> = stmt
+            .query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        in_schema.sort();
+
+        let mut declared: Vec<String> = SCOPE_WIDE_FTS.iter().map(|s| (*s).to_owned()).collect();
+        declared.sort();
+
+        assert_eq!(
+            in_schema, declared,
+            "SCOPE_WIDE_FTS is out of date. Every FTS5 index over a table that \
+             cascades out of `projects` or `workspaces` must be listed, or \
+             `--compact` leaves it holding entries for deleted rows. If the new \
+             index is genuinely unreachable from a project or workspace delete, \
+             exclude it here deliberately and say why."
+        );
+
+        assert!(
+            SESSION_SCOPED_FTS
+                .iter()
+                .all(|t| SCOPE_WIDE_FTS.contains(t)),
+            "a session purge cannot dirty an index a project purge does not"
         );
     }
 
@@ -7746,8 +8094,16 @@ pub(crate) mod tests {
         let (_tmp, mut conn, ws, proj) = fresh_db();
         // Simulate the post-purge state: project row gone.
         // `purge_project` drives the cascading deletes we want here.
-        let _ = purge_project(&mut conn, &ws, &proj, "default/scratch", None, false)
-            .expect("purge of fresh project should succeed");
+        let _ = purge_project(
+            &mut conn,
+            &ws,
+            &proj,
+            "default/scratch",
+            None,
+            false,
+            Compaction::Skip,
+        )
+        .expect("purge of fresh project should succeed");
         // Now try to rename the project that no longer exists. The
         // pre-fix code returned `Ok(())` because `UPDATE` affected
         // zero rows. The fix returns `NotFound` so admin handlers
@@ -7808,6 +8164,7 @@ pub(crate) mod tests {
             "default/scratch",
             Some(author),
             false,
+            Compaction::Skip,
         )
         .expect("purge should succeed");
 
@@ -7855,8 +8212,16 @@ pub(crate) mod tests {
         let (_tmp, mut conn, ws, proj) = fresh_db();
         open_managed_run(&mut conn, &ws, &proj);
 
-        let err = purge_project(&mut conn, &ws, &proj, "default/scratch", None, false)
-            .expect_err("an active managed run must block the purge");
+        let err = purge_project(
+            &mut conn,
+            &ws,
+            &proj,
+            "default/scratch",
+            None,
+            false,
+            Compaction::Skip,
+        )
+        .expect_err("an active managed run must block the purge");
 
         match err {
             StoreError::ManagedRunActive { count, workstreams } => {
@@ -7888,8 +8253,16 @@ pub(crate) mod tests {
         let (_tmp, mut conn, ws, proj) = fresh_db();
         let prepared = open_managed_run(&mut conn, &ws, &proj);
 
-        let summary = purge_project(&mut conn, &ws, &proj, "default/scratch", None, true)
-            .expect("force purges regardless of the live lease");
+        let summary = purge_project(
+            &mut conn,
+            &ws,
+            &proj,
+            "default/scratch",
+            None,
+            true,
+            Compaction::Skip,
+        )
+        .expect("force purges regardless of the live lease");
 
         assert_eq!(summary.workstreams_deleted, 1);
         assert_eq!(summary.managed_runs_deleted, 1);
@@ -7916,8 +8289,16 @@ pub(crate) mod tests {
         )
         .unwrap();
 
-        let summary = purge_project(&mut conn, &ws, &proj, "default/scratch", None, false)
-            .expect("a lapsed lease is not a running agent");
+        let summary = purge_project(
+            &mut conn,
+            &ws,
+            &proj,
+            "default/scratch",
+            None,
+            false,
+            Compaction::Skip,
+        )
+        .expect("a lapsed lease is not a running agent");
 
         assert_eq!(summary.workstreams_deleted, 1);
         assert_eq!(summary.managed_runs_deleted, 1);

--- a/crates/ai-memory-store/src/writer.rs
+++ b/crates/ai-memory-store/src/writer.rs
@@ -290,6 +290,8 @@ pub(crate) enum WriteCmd {
         author_id: Option<ai_memory_core::UserId>,
         /// Purge even when a managed workstream still holds a live run lease.
         force: bool,
+        /// Whether to reclaim the freed bytes after the delete commits.
+        compaction: ops::Compaction,
         reply: oneshot::Sender<StoreResult<PurgeSummary>>,
     },
     /// Delete one session and everything derived from it, inside a single
@@ -309,6 +311,8 @@ pub(crate) enum WriteCmd {
     DeleteWorkspace {
         workspace_id: WorkspaceId,
         force: bool,
+        /// Whether to reclaim the freed bytes after the delete commits.
+        compaction: ops::Compaction,
         reply: oneshot::Sender<StoreResult<DeleteWorkspaceSummary>>,
     },
     /// Rename a workspace's `name` column (UUID-keyed dir doesn't move).
@@ -1215,6 +1219,7 @@ impl WriterHandle {
         label: impl Into<String>,
         author_id: Option<ai_memory_core::UserId>,
         force: bool,
+        compaction: ops::Compaction,
     ) -> StoreResult<PurgeSummary> {
         let (tx, rx) = oneshot::channel();
         self.send(WriteCmd::PurgeProject {
@@ -1223,6 +1228,7 @@ impl WriterHandle {
             label: label.into(),
             author_id,
             force,
+            compaction,
             reply: tx,
         })
         .await?;
@@ -1272,11 +1278,13 @@ impl WriterHandle {
         &self,
         workspace_id: WorkspaceId,
         force: bool,
+        compaction: ops::Compaction,
     ) -> StoreResult<DeleteWorkspaceSummary> {
         let (tx, rx) = oneshot::channel();
         self.send(WriteCmd::DeleteWorkspace {
             workspace_id,
             force,
+            compaction,
             reply: tx,
         })
         .await?;
@@ -2243,6 +2251,7 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
                 label,
                 author_id,
                 force,
+                compaction,
                 reply,
             } => {
                 let result = ops::purge_project(
@@ -2252,6 +2261,7 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
                     &label,
                     author_id,
                     force,
+                    compaction,
                 );
                 send_or_warn(reply, result, "purge_project");
             }
@@ -2276,9 +2286,10 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
             WriteCmd::DeleteWorkspace {
                 workspace_id,
                 force,
+                compaction,
                 reply,
             } => {
-                let result = ops::delete_workspace(&mut conn, &workspace_id, force);
+                let result = ops::delete_workspace(&mut conn, &workspace_id, force, compaction);
                 send_or_warn(reply, result, "delete_workspace");
             }
             WriteCmd::RenameWorkspace {

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -8,11 +8,11 @@ on a homelab box where mistakes are harder to undo.
 
 | Command | Safe with server **running**? | Wipes data? | Reversible? | Notes |
 |---|---|---|---|---|
-| `purge-project --confirm` | ✅ yes | the one project's data | no | Deletes the UUID-namespaced wiki root and raw workstream segments; sibling projects remain untouched. Refuses with `409` while a managed workstream under the project holds a live run lease — `--force` overrides. |
+| `purge-project --confirm` | ✅ yes | the one project's data | no | Deletes the UUID-namespaced wiki root and raw workstream segments; sibling projects remain untouched. Refuses with `409` while a managed workstream under the project holds a live run lease — `--force` overrides. Logical delete by default; `--compact` additionally rebuilds the FTS indexes and `VACUUM`s (see below). |
 | `purge-session --session-id --confirm` | ✅ yes | the one session's data | no | Deletes one session by UUID: its row, its observations, the handoffs it **authored**, its `sessions/<id>.md` page and every superseded version, their embeddings, and its auto-improve runs. Strictly scoped — a session that does not belong to the named workspace/project is a `404` and nothing is deleted. Handoffs the session only *accepted* are kept: that text belongs to the session that wrote it. Logical delete by default; `--compact` additionally rebuilds the FTS indexes and `VACUUM`s (see below). |
 | `rename-project --from --to` | ✅ yes | no | yes (rename back) | Column-only update on `projects.name`. The on-disk dir is keyed by `project_id` (UUID), so the rename never moves a file. |
 | `/admin/rename-workspace` | ✅ yes | no | yes (rename back) | Column-only update on `workspaces.name`; refreshes `_meta.md` scope manifests and checkpoints the wiki tree. |
-| `/admin/delete-workspace` | ✅ yes | the workspace and every child project | no | Runs `purge_workspace` admission first, deletes SQLite rows in one cascade, removes the UUID-keyed workspace directory and managed-workstream raw segments, reports filesystem partial failures, and dispatches mirror notification after durable work. |
+| `/admin/delete-workspace` | ✅ yes | the workspace and every child project | no | Runs `purge_workspace` admission first, deletes SQLite rows in one cascade, removes the UUID-keyed workspace directory and managed-workstream raw segments, reports filesystem partial failures, and dispatches mirror notification after durable work. Logical delete by default; `compact: true` additionally rebuilds the FTS indexes and `VACUUM`s (see below). |
 | `move-project --confirm` | ✅ yes | source only in the merge case (a `Reject`-policy `purge_project` webhook can still abort the source teardown leaving everything intact) | no | Fresh destination → lossless **true move** (re-stamp `workspace_id`, keep `project_id`, rename the dir): sessions/observations/handoffs + history all survive. Destination with a same-named project → **copy+purge merge**: only latest pages migrate. |
 | `move-session <id> --to --confirm` | ✅ yes | no | yes (move it back) | Re-stamps one session (or every session touching `--from-project`) into another project: `sessions`, `observations`, its `handoffs`, consolidation jobs, auto-improve runs/claims and its `sessions/<id>.md` page, one transaction per session; the page file moves with it (`--pages move`, default) or is retired for regeneration. Without `--confirm` it is a real dry run (rolled back). Refuses with `409` an open session or a pending consolidation job unless `--force`. |
 | `backup --to` | ✅ yes | no | n/a | Streams a gzipped tarball from the server's online `sqlite3 .backup` plus the wiki tree. Safe alongside the live writer. |
@@ -28,43 +28,62 @@ fundamentally cannot run while another process holds the SQLite WAL writer. See
 [CLAUDE.md §16](../CLAUDE.md) for the invariant.
 
 
-## `purge-session` and what "deleted" means
+## The destructive commands and what "deleted" means
 
-`purge-session` answers *"forget this conversation"*: after it runs, the
-session is gone from the API, from `status` counts and from search.
+Three commands delete rather than move: `purge-session` (one conversation),
+`purge-project` (one project), and `/admin/delete-workspace` (a workspace and
+everything under it). They differ in scope and in nothing else — all three are
+**logical deletes** by default, and all three take the same opt-in flag to go
+further.
 
 ```bash
 ai-memory purge-session \
   --workspace default --project my-app \
   --session-id 0199f3d2-1c4e-7a10-9f3b-2b0c5d8e7a11 \
   --confirm
+
+ai-memory purge-project --workspace default --project my-app --confirm --compact
+
+curl -X POST \
+  'http://127.0.0.1:49374/admin/delete-workspace' \
+  -H 'content-type: application/json' \
+  -d '{"workspace":"old","force":true,"compact":true}'
 ```
 
-It is a **logical delete**, and the distinction matters if you are answering a
-regulatory erasure request rather than tidying up:
+The distinction matters if you are answering a regulatory erasure request
+rather than tidying up:
 
-| | default | `--compact` |
+| | default | `--compact` / `compact: true` |
 |---|---|---|
 | Reachable through the API / MCP tools | no | no |
 | Returned by search (FTS) | no | no |
 | Bytes still present in `memory.sqlite` | **yes**, in free pages | no |
+| Stale entries left in the FTS index segments | **yes** | no |
 | Text still in the wiki git history | **yes** | **yes** |
 | Present in backups taken before the purge | **yes** | **yes** |
 | Cost | one transaction | rewrites the whole database |
 
-`--compact` rebuilds the affected FTS5 indexes — an ordinary delete leaves the
-tokens inside the index segments, which is why a rebuild rather than a
-`VACUUM` alone is what clears them — and then `VACUUM`s to release the freed
-pages. It needs free disk space of roughly the database's own size and takes
-minutes on a large store, which is why it is opt-in.
+Compaction rebuilds the FTS5 indexes the delete actually touched — an ordinary
+delete leaves the tokens inside the index segments, which is why a rebuild
+rather than a `VACUUM` alone is what clears them — and then `VACUUM`s to
+release the freed pages. It needs free disk space of roughly the database's
+own size and takes minutes on a large store, which is why it is opt-in.
 
-**`--compact` is not forensic erasure.** The wiki git repository stores page
+*Which* indexes those are depends on the scope. A session purge touches
+`observations_fts` and `pages_fts`. A project or workspace delete also cascades
+into `workstreams` and their `workstream_events`, so it rebuilds
+`workstream_events_fts` as well — a managed workstream's event ledger is
+reachable from neither a session id nor a page.
+
+**Compaction is not forensic erasure.** The wiki git repository stores page
 content in its objects *and its commit messages*, and any backup taken before
 the purge still contains everything. Removing the bytes from the live SQLite
 file is worth doing on its own terms; do not describe it to a user as a
-guarantee that the content is unrecoverable, because it is not.
+guarantee that the content is unrecoverable, because it is not. This is also
+why the commands' help text says what they delete rather than promising "all
+its data".
 
-### Scope containment
+### Scope containment (`purge-session`)
 
 The session id is never authority on its own. Every statement is filtered on
 `workspace_id` and `project_id` as well as `session_id`, the session must


### PR DESCRIPTION
Closes #540.

## What changed

- `ai-memory purge-project --compact` and `compact: true` on `POST /admin/delete-workspace` reclaim the freed bytes, reusing `Compaction::{Skip,Reclaim}` from #539.
- Both responses gained a `compacted` boolean, so a caller is told which of the two modes ran instead of assuming.
- **No default changed.** Absent, `false`, and the old request body all behave exactly as before: a logical delete. The new field is `#[serde(default)]` on both endpoints.
- The overstated claims are gone: `purge-project`'s help said "Permanently delete a project and ALL its data", and the admin module docs said "all its data" / "all of its projects". They now say what the commands remove.
- `docs/lifecycle-ops.md` carries the boundary table for the whole destructive family — `purge-session`, `purge-project`, `delete-workspace` — rather than for `purge-session` alone, with both matrix rows updated.

## Why

Your measurement on the issue: `PURGE_PROJECT shadow_rows=4 text_on_disk=true`. The rows are gone and the text is still in the file, because that is what any SQLite delete does. The defect is the claim, so this fixes the claim *and* the absence of a way to make it true.

## The part a literal reuse of #539 gets wrong

`purge_session` rebuilds `observations_fts` and `pages_fts`. Exhaustive for a session; not for a project or a workspace.

`workstreams.workspace_id` and `workstreams.project_id` are both `ON DELETE CASCADE` (`V31__managed_workstreams.sql:6-7`), `workstream_events.workstream_id` cascades out of those (`:69`), and `workstream_events_fts` is an external-content FTS5 index over `workstream_events.content` (`:92`). A managed workstream's event ledger is reachable from neither a session id nor a page, so a session purge never touches that index and a project or workspace purge always can.

Counting `*_fts_data` rows after each step, one purged project and one surviving project both holding a workstream with events:

| after | observations_fts | pages_fts | workstream_events_fts |
|---|---|---|---|
| delete only | 11 | 11 | 11 |
| + `VACUUM` | 11 | 11 | 11 |
| + the #539 batch | 3 | 3 | **11** |
| + `workstream_events_fts` rebuild | 3 | 3 | 3 |

Same shape at 4, 20 and 200 events per workstream. Rebuilding only the session's two would leave that index holding entries for rows that no longer exist, with the response still reporting `compacted: true`.

So `reclaim_after_commit` takes the index set explicitly and the two sets are named constants, rather than the correct set being a fact about today's schema that lives in one function's head.

## Enforced rather than asserted

Two tests carry the claim, because a comment saying "these are all of them" is exactly the thing that rots:

- `scope_wide_reclaim_covers_every_fts_index_in_the_schema` reads every `USING fts5` table out of `sqlite_master` and requires `SCOPE_WIDE_FTS` to equal it. An index added later fails here, routing whoever adds it into the decision instead of letting `--compact` silently skip it.
- `purge_project_reclaim_rebuilds_the_workstream_event_index` asserts *"an explicit rebuild afterwards changes nothing"*, which stays true however the reclaim is spelled, and shows the assertion has teeth by checking the `Skip` half — where the same explicit rebuild does change it.

I verified the second one fails for the right reason rather than trusting it: routing `purge_project` through `SESSION_SCOPED_FTS` produces

```
assertion `left == right` failed: Reclaim must already have rebuilt
workstream_events_fts — an explicit rebuild afterwards found more to drop,
so the purge left stale index entries behind for rows it deleted
```

then reverted.

## Scope decisions I made

- **The internal purges stay uncompacted.** `move-project`'s merge teardown and `merge-workspace`'s shell delete both call these functions, and both pass `Compaction::Skip`. Those are steps of a move, not an operator asking to reclaim bytes, and a `VACUUM` in the middle of a move is a surprise nobody requested. Say the word if you would rather they honour a flag.
- **`purge-project` keeps the paired boundary tests** — one asserting the default leaves the bytes, one asserting `--compact` removes them — mirroring how #539 paired them for `purge-session`, so the difference between what we promise and what we offer stays pinned from both sides.

## Drive-by

`purge_project`'s doc-comment was orphaned. #539 inserted `Compaction`, `PurgeSessionSummary` and `purge_session` between the block and its function, so it had been silently documenting the `Compaction` enum while `purge_project` had no docs at all. Moved back, since this change adds a paragraph to it. Nothing else in the move; only the "and all its data" phrase changed.

## One measurement of yours I could not reproduce

Raised on the issue and repeated here so it is not lost in the merge. Your table has `delete + VACUUM` still leaving the text in the file. In my harness `VACUUM` alone cleared the canary at every scale I tried — `delete only` recovers it, `+ VACUUM` does not — while the shadow rows sit unchanged. That matches your shadow-row column exactly and contradicts your text column.

It does not change this PR: the rebuild is required either way, for the stale index entries if nothing else, and the existing `purge_session_is_unsearchable_but_does_not_claim_byte_level_removal` only pins the `delete only` case, which we agree on. It does mean **the docs matrix row I wrote says "no" for bytes-in-file under `--compact` and "yes" under the default**, which is true in both our measurements — I deliberately did not write a row asserting anything about `delete + VACUUM` on its own. Happy to re-run against whatever shape you used if you want that row pinned too.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes — 70 suites, 0 failures
- [x] `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- [x] `bash scripts/check-changelog-frozen.sh upstream/main` — "no released section was modified"
- [x] Manual test: the negative verification above (routing `purge_project` through the session FTS set and confirming the regression test fails, then reverting), plus the `*_fts_data` measurement table, run against `f09382d`.

New tests: `purge_project_is_unsearchable_but_does_not_claim_byte_level_removal`, `purge_project_with_reclaim_removes_the_bytes_from_the_file`, `purge_project_reclaim_rebuilds_the_workstream_event_index`, `scope_wide_reclaim_covers_every_fts_index_in_the_schema`, `delete_workspace_reclaims_only_when_asked`, and one HTTP round-trip test per endpoint asserting `compacted` reports what actually ran across absent / `false` / `true`.

## Commit attribution

- [x] Verified: `Samir Hanna Verza <123646616+samirhvbr@users.noreply.github.com>`, the same identity as my merged commits.

## CHANGELOG (merge gate)

- [x] Added under `[Unreleased]` / `### Added`, alongside the #539 entry it extends.
- [x] No default changed — called out in "What changed" above.

## Notes for reviewers

The FTS set is the part worth your scrutiny. Everything else is mechanical plumbing of an existing enum through two more paths; that one is a judgement about what a scope-wide delete can dirty, and I would rather you check my reading of the `V31` cascades than take the test's word for it.
