### PR TITLE
fix(mcp-bridge): install the crypto provider in the transport constructor path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enable. The workspace-client half of #492 landed in #496; this is the MCP
   transport, which is a second, independent copy of reqwest ([#497]).
 
+- `ai-memory mcp-bridge` no longer risks a panic when building its HTTP
+  transport. #497 moved the bridge onto reqwest's `rustls-no-provider`, which
+  **panics** inside `ClientBuilder` when no rustls crypto provider is
+  installed — not an error a caller can handle, a crash. The install ran in
+  `run` only, leaving `StreamableHttpClientTransport::from_config` reachable
+  without one.
+
+  Moved into `upstream_config`, which every transport in that module is built
+  from. Caught by `stdio_bridge_forwards_tools_and_session_header_in_both_http_modes`
+  failing in isolation on `main`; it had passed in CI because the provider is
+  process-global and another test happened to install it first.
+
 ### Docs
 
 - `docs/windows.md` gains **Scenario E**, a persistent-server story for native

--- a/crates/ai-memory-cli/src/commands/mcp_bridge.rs
+++ b/crates/ai-memory-cli/src/commands/mcp_bridge.rs
@@ -64,6 +64,13 @@ fn upstream_config(
     session_id: &str,
     auth_token: Option<&str>,
 ) -> Result<StreamableHttpClientTransportConfig> {
+    // Every transport in this module is built from a config this function
+    // produced, so installing here covers each of them. Doing it only in
+    // `run` left `StreamableHttpClientTransport::from_config` reachable
+    // without a provider, and reqwest 0.13 under `rustls-no-provider`
+    // *panics* rather than erroring when one is missing.
+    install_crypto_provider()?;
+
     let mut headers = HashMap::new();
     headers.insert(
         ACTOR_SESSION_HEADER,
@@ -117,8 +124,6 @@ pub async fn run(config: &Config, args: McpBridgeArgs) -> Result<()> {
         .as_deref()
         .map(mcp_server_url_from_base)
         .unwrap_or_else(|| mcp_server_url_from_base(&config.server_url));
-    install_crypto_provider()?;
-
     let transport = StreamableHttpClientTransport::from_config(upstream_config(
         &server_url,
         session_id,
@@ -155,6 +160,29 @@ pub async fn run(config: &Config, args: McpBridgeArgs) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    /// Building the transport must never depend on a caller having installed
+    /// a provider first. reqwest 0.13 under `rustls-no-provider` **panics**
+    /// inside `ClientBuilder` when none is present, so a missing install is a
+    /// crash rather than an error a caller could handle.
+    ///
+    /// The install lives in `upstream_config` for that reason: every transport
+    /// in this module is built from a config it produced.
+    ///
+    /// Note what this test cannot do. The provider is process-global, so once
+    /// any test installs one this assertion would hold even with the install
+    /// removed. The structural guarantee — install in the constructor path,
+    /// not at one call site — is what actually prevents the panic; this pins
+    /// the contract so the call is not quietly deleted.
+    #[test]
+    fn upstream_config_leaves_a_crypto_provider_installed() {
+        let config = upstream_config("http://127.0.0.1:1/mcp", "session-for-provider", None);
+        assert!(config.is_ok(), "config build must succeed");
+        assert!(
+            rustls::crypto::CryptoProvider::get_default().is_some(),
+            "upstream_config must guarantee a provider before any client is built"
+        );
+    }
 
     #[test]
     fn install_crypto_provider_is_idempotent_and_leaves_a_default() {


### PR DESCRIPTION
A regression from #497, found while working #554. **`main` is currently affected.**

## The defect

#497 moved the bridge onto reqwest's `rustls-no-provider`, which supplies the platform verifier without pinning a crypto provider. Without one installed, reqwest 0.13 does not return an error — it **panics** inside `ClientBuilder`:

```
No rustls crypto provider is configured. When using the `rustls-no-provider`
feature you must install a crypto provider before building a Client.
```

The install ran in `run()` only, so `StreamableHttpClientTransport::from_config` stayed reachable without one.

## Why CI missed it, and why I did

`stdio_bridge_forwards_tools_and_session_header_in_both_http_modes` fails **in isolation on clean `main`**. It passed in CI because the provider is process-global: whichever test installs it first covers every test that follows. So the breakage was order-dependent rather than absent, and a green suite said nothing about whether the path was safe.

That is the part worth keeping: I audited #497 on the strength of a green full-suite run and the feature-resolution evidence, and neither could see this. A panic reachable from a constructor is not something a passing aggregate catches when the guard it depends on is global mutable state.

## The fix

Install in `upstream_config`, which every transport in the module is built from, rather than at one call site. No construction path can miss it.

## Tests

The existing bridge test is the real regression guard — it fails without this change when run alone, which is how I found it.

I added `upstream_config_leaves_a_crypto_provider_installed` to pin the contract, and its doc comment says plainly what it cannot do: the provider is process-global, so once any test installs one the assertion holds even with the install deleted. The structural guarantee — install in the constructor path — is what prevents the panic; the test stops the call being quietly removed.

## Gate

`fmt` ✅ · `clippy -D warnings` ✅ · **2705 tests, 0 failures** ✅ · both changelog guards ✅
Previously-failing test, run alone: ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDbhmszrjG9s5MrPrTuNtm