### PR TITLE
fix(install-hooks): probe and stage under the data dir in use, not the platform default (#554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failing in isolation on `main`; it had passed in CI because the provider is
   process-global and another test happened to install it first.
 
+- `install-hooks` now probes for and stages the hook bundle under the data dir
+  actually in use, instead of the platform default (#554). With
+  `AI_MEMORY_DATA_DIR` (or `--data-dir`) set, the process logged one data dir
+  while `--apply` reported staging into another, quietly populating a directory
+  the operator was not using — and the probe could never find a bundle a
+  previous run, or docker `setup-agent`, had staged into the configured one.
+
+  Byte-identical for a default install: `default_data_dir()` *is*
+  `data_local_dir()/ai-memory`, so `<data_dir>/hooks/<agent>` resolves to the
+  same path the old `<data_local>/ai-memory/hooks/<agent>` produced. A test
+  pins that so the compatibility claim cannot rot.
+
+  Reported by @alvadorn alongside #546 and split out at their suggestion.
+
 ### Docs
 
 - `docs/windows.md` gains **Scenario E**, a persistent-server story for native

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -415,7 +415,8 @@ pub fn run(config: &Config, mut args: InstallHooksArgs) -> Result<()> {
             AgentChoice::Pi => apply_to_pi_extension(&server_url, auth, &args),
             AgentChoice::Omp => apply_to_omp_extension(&server_url, auth, &args),
             AgentChoice::ClaudeCode => {
-                let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+                let hooks_dir =
+                    resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
                 apply_to_claude_code_settings(
                     &hooks_dir,
                     &server_url,
@@ -425,11 +426,13 @@ pub fn run(config: &Config, mut args: InstallHooksArgs) -> Result<()> {
                 )
             }
             AgentChoice::Codex => {
-                let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+                let hooks_dir =
+                    resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
                 apply_to_codex_settings(&hooks_dir, &server_url, auth, &config.data_dir, &args)
             }
             AgentChoice::CommandCode => {
-                let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+                let hooks_dir =
+                    resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
                 apply_to_command_code_settings(
                     &hooks_dir,
                     &server_url,
@@ -439,15 +442,18 @@ pub fn run(config: &Config, mut args: InstallHooksArgs) -> Result<()> {
                 )
             }
             AgentChoice::Cursor => {
-                let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+                let hooks_dir =
+                    resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
                 apply_to_cursor_settings(&hooks_dir, &server_url, auth, &config.data_dir, &args)
             }
             AgentChoice::GeminiCli => {
-                let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+                let hooks_dir =
+                    resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
                 apply_to_gemini_settings(&hooks_dir, &server_url, auth, &config.data_dir, &args)
             }
             AgentChoice::AntigravityCli => {
-                let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+                let hooks_dir =
+                    resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
                 apply_to_antigravity_settings(
                     &hooks_dir,
                     &server_url,
@@ -457,22 +463,26 @@ pub fn run(config: &Config, mut args: InstallHooksArgs) -> Result<()> {
                 )
             }
             AgentChoice::Grok => {
-                let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+                let hooks_dir =
+                    resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
                 apply_to_grok_settings(&hooks_dir, &server_url, auth, &config.data_dir, &args)
             }
             AgentChoice::Zero => apply_to_zero_hooks(&server_url, auth, &config.data_dir, &args),
             AgentChoice::Zcode => apply_to_zcode_hooks(&server_url, auth, &config.data_dir, &args),
             AgentChoice::Devin => {
-                let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+                let hooks_dir =
+                    resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
                 apply_to_devin_settings(&hooks_dir, &server_url, auth, &config.data_dir, &args)
             }
             AgentChoice::Openclaw => openclaw_plugin::apply(&server_url, auth, &args),
             AgentChoice::KimiCode => {
-                let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+                let hooks_dir =
+                    resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
                 apply_to_kimi_code_config(&hooks_dir, &server_url, auth, &config.data_dir, &args)
             }
             AgentChoice::KiroCli => {
-                let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+                let hooks_dir =
+                    resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
                 apply_to_kiro_cli_agent_configs(
                     &hooks_dir,
                     &server_url,
@@ -482,11 +492,13 @@ pub fn run(config: &Config, mut args: InstallHooksArgs) -> Result<()> {
                 )
             }
             AgentChoice::KiroCliV3 => {
-                let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+                let hooks_dir =
+                    resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
                 apply_to_kiro_cli_v3_hooks(&hooks_dir, &server_url, auth, &config.data_dir, &args)
             }
             AgentChoice::Pool => {
-                let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+                let hooks_dir =
+                    resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
                 apply_to_pool(&hooks_dir, &server_url, auth, &config.data_dir, &args)
             }
         };
@@ -499,7 +511,8 @@ pub fn run(config: &Config, mut args: InstallHooksArgs) -> Result<()> {
             render_omp_extension(&server_url, auth, strategy, args.profile.as_deref())
         }
         AgentChoice::ClaudeCode => {
-            let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+            let hooks_dir =
+                resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
             let settings_path = match &args.config_file {
                 Some(p) => p.clone(),
                 None => claude_settings_path()?,
@@ -518,7 +531,8 @@ pub fn run(config: &Config, mut args: InstallHooksArgs) -> Result<()> {
             )
         }
         AgentChoice::Codex => {
-            let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+            let hooks_dir =
+                resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
             render_agent(
                 "codex",
                 &hooks_dir,
@@ -529,7 +543,8 @@ pub fn run(config: &Config, mut args: InstallHooksArgs) -> Result<()> {
             )
         }
         AgentChoice::CommandCode => {
-            let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+            let hooks_dir =
+                resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
             render_agent(
                 "command-code",
                 &hooks_dir,
@@ -540,7 +555,8 @@ pub fn run(config: &Config, mut args: InstallHooksArgs) -> Result<()> {
             )
         }
         AgentChoice::Cursor => {
-            let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+            let hooks_dir =
+                resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
             render_agent(
                 "cursor",
                 &hooks_dir,
@@ -551,7 +567,8 @@ pub fn run(config: &Config, mut args: InstallHooksArgs) -> Result<()> {
             )
         }
         AgentChoice::GeminiCli => {
-            let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+            let hooks_dir =
+                resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
             render_agent(
                 "gemini-cli",
                 &hooks_dir,
@@ -562,7 +579,8 @@ pub fn run(config: &Config, mut args: InstallHooksArgs) -> Result<()> {
             )
         }
         AgentChoice::AntigravityCli => {
-            let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+            let hooks_dir =
+                resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
             render_agent(
                 "antigravity-cli",
                 &hooks_dir,
@@ -573,13 +591,15 @@ pub fn run(config: &Config, mut args: InstallHooksArgs) -> Result<()> {
             )
         }
         AgentChoice::Grok => {
-            let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+            let hooks_dir =
+                resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
             render_grok(&hooks_dir, &server_url, auth, &config.data_dir, strategy)
         }
         AgentChoice::Zero => render_zero(&server_url, auth, &config.data_dir, strategy),
         AgentChoice::Zcode => render_zcode(&server_url, auth, &config.data_dir, strategy),
         AgentChoice::Devin => {
-            let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+            let hooks_dir =
+                resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
             render_devin(&hooks_dir, &server_url, auth, &config.data_dir, strategy)
         }
         AgentChoice::Openclaw => {
@@ -587,19 +607,23 @@ pub fn run(config: &Config, mut args: InstallHooksArgs) -> Result<()> {
             Ok(())
         }
         AgentChoice::KimiCode => {
-            let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+            let hooks_dir =
+                resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
             render_kimi_code(&hooks_dir, &server_url, auth, &config.data_dir, strategy)
         }
         AgentChoice::KiroCli => {
-            let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+            let hooks_dir =
+                resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
             render_kiro_cli(&hooks_dir, &server_url, auth, &config.data_dir, strategy)
         }
         AgentChoice::KiroCliV3 => {
-            let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+            let hooks_dir =
+                resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
             render_kiro_cli_v3(&hooks_dir, &server_url, auth, &config.data_dir, strategy)
         }
         AgentChoice::Pool => {
-            let hooks_dir = resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent)?;
+            let hooks_dir =
+                resolve_hooks_dir(args.hooks_dir.as_deref(), args.agent, &config.data_dir)?;
             render_pool(&hooks_dir, &server_url, auth, &config.data_dir, strategy)
         }
     }
@@ -1391,7 +1415,7 @@ fn apply_to_claude_code_settings(
     data_dir: &Path,
     args: &InstallHooksArgs,
 ) -> Result<()> {
-    let staged = stage_hook_scripts(hooks_dir, "claude-code")?;
+    let staged = stage_hook_scripts(hooks_dir, "claude-code", data_dir)?;
     apply_to_claude_code_settings_with_staged(&staged, server_url, auth_token, data_dir, args)
 }
 
@@ -1510,7 +1534,7 @@ fn apply_to_grok_settings(
         Some(p) => p.clone(),
         None => grok_hooks_path()?,
     };
-    let staged = stage_hook_scripts(hooks_dir, "grok")?;
+    let staged = stage_hook_scripts(hooks_dir, "grok", data_dir)?;
     let command_dir = staged_command_dir(&staged, "grok");
     let strategy = args.project_strategy.and_then(ProjectStrategyArg::baked);
     let payload = build_grok_payload_with_data_dir(
@@ -1562,7 +1586,7 @@ fn apply_to_devin_settings(
     data_dir: &Path,
     args: &InstallHooksArgs,
 ) -> Result<()> {
-    let staged = stage_hook_scripts(hooks_dir, "devin")?;
+    let staged = stage_hook_scripts(hooks_dir, "devin", data_dir)?;
     apply_to_devin_settings_with_staged(&staged, server_url, auth_token, data_dir, args)
 }
 
@@ -1652,7 +1676,7 @@ fn apply_to_command_code_settings(
     data_dir: &Path,
     args: &InstallHooksArgs,
 ) -> Result<()> {
-    let staged = stage_hook_scripts(hooks_dir, "command-code")?;
+    let staged = stage_hook_scripts(hooks_dir, "command-code", data_dir)?;
     apply_to_command_code_settings_with_staged(&staged, server_url, auth_token, data_dir, args)
 }
 
@@ -1768,7 +1792,7 @@ fn apply_to_codex_settings(
     data_dir: &Path,
     args: &InstallHooksArgs,
 ) -> Result<()> {
-    let staged = stage_hook_scripts(hooks_dir, "codex")?;
+    let staged = stage_hook_scripts(hooks_dir, "codex", data_dir)?;
     apply_to_codex_settings_with_staged(&staged, server_url, auth_token, data_dir, args)
 }
 
@@ -1929,7 +1953,7 @@ fn apply_to_cursor_settings(
         Some(p) => p.clone(),
         None => cursor_hooks_path()?,
     };
-    let staged = stage_hook_scripts(hooks_dir, "cursor")?;
+    let staged = stage_hook_scripts(hooks_dir, "cursor", data_dir)?;
     let command_dir = staged_command_dir(&staged, "cursor");
     let strategy = args.project_strategy.and_then(ProjectStrategyArg::baked);
     let outcome = merge_cursor_hooks(
@@ -2021,7 +2045,7 @@ fn apply_to_gemini_settings(
         Some(p) => p.clone(),
         None => gemini_settings_path()?,
     };
-    let staged = stage_hook_scripts(hooks_dir, "gemini-cli")?;
+    let staged = stage_hook_scripts(hooks_dir, "gemini-cli", data_dir)?;
     let command_dir = staged_command_dir(&staged, "gemini-cli");
     let strategy = args.project_strategy.and_then(ProjectStrategyArg::baked);
     let outcome = merge_gemini_hooks(
@@ -2105,7 +2129,7 @@ fn apply_to_antigravity_settings(
         Some(p) => p.clone(),
         None => antigravity_hooks_path()?,
     };
-    let staged = stage_hook_scripts(hooks_dir, "antigravity-cli")?;
+    let staged = stage_hook_scripts(hooks_dir, "antigravity-cli", data_dir)?;
     let command_dir = staged_command_dir(&staged, "antigravity-cli");
     let strategy = args.project_strategy.and_then(ProjectStrategyArg::baked);
     let outcome = merge_antigravity_hooks(
@@ -2195,7 +2219,7 @@ fn apply_to_kimi_code_config(
         Some(p) => p.clone(),
         None => kimi_code_config_path()?,
     };
-    let staged = stage_hook_scripts(hooks_dir, "kimi-code")?;
+    let staged = stage_hook_scripts(hooks_dir, "kimi-code", data_dir)?;
     let command_dir = staged_command_dir(&staged, "kimi-code");
     let strategy = args.project_strategy.and_then(ProjectStrategyArg::baked);
     let outcome = merge_kimi_code_hooks(
@@ -2337,7 +2361,7 @@ fn apply_to_kiro_cli_agent_configs(
         args.project_strategy,
     )?;
 
-    let staged = stage_hook_scripts(hooks_dir, "kiro-cli")?;
+    let staged = stage_hook_scripts(hooks_dir, "kiro-cli", data_dir)?;
     let command_dir = staged_command_dir(&staged, "kiro-cli");
     for (path, strategy) in prepared {
         let outcome = merge_kiro_cli_agent_hooks(
@@ -2475,7 +2499,7 @@ fn apply_to_kiro_cli_v3_hooks(
         &existing, hooks_dir, server_url, auth_token, data_dir, strategy, &path,
     )?;
 
-    let staged = stage_hook_scripts(hooks_dir, "kiro-cli")?;
+    let staged = stage_hook_scripts(hooks_dir, "kiro-cli", data_dir)?;
     let command_dir = staged_command_dir(&staged, "kiro-cli");
     let outcome = merge_kiro_cli_v3_hooks(
         &command_dir,
@@ -3991,21 +4015,17 @@ fn manual_agent_project_strategy_instruction(project_strategy: Option<&str>) -> 
 ///
 /// Errors propagate when source is missing, the staging dir
 /// can't be created, or any file copy fails.
-fn stage_hook_scripts(source_dir: &Path, agent_label: &str) -> Result<PathBuf> {
-    let data_dir = dirs::data_local_dir()
-        .context("could not locate the user data-local directory (e.g. ~/.local/share)")?;
-    stage_hook_scripts_in(source_dir, agent_label, &data_dir)
+fn stage_hook_scripts(source_dir: &Path, agent_label: &str, data_dir: &Path) -> Result<PathBuf> {
+    stage_hook_scripts_in(source_dir, agent_label, data_dir)
 }
 
-fn stage_hook_scripts_in(
-    source_dir: &Path,
-    agent_label: &str,
-    data_local_dir: &Path,
-) -> Result<PathBuf> {
-    let dest_root = data_local_dir
-        .join("ai-memory")
-        .join("hooks")
-        .join(agent_label);
+fn stage_hook_scripts_in(source_dir: &Path, agent_label: &str, data_dir: &Path) -> Result<PathBuf> {
+    // `<data_dir>/hooks/<agent>`, not `<platform default>/ai-memory/hooks/…`.
+    // Byte-identical for a default install, since `default_data_dir()` *is*
+    // `data_local_dir()/ai-memory` — but it now follows `--data-dir` and
+    // `AI_MEMORY_DATA_DIR` instead of populating a directory the operator is
+    // not using (#554).
+    let dest_root = data_dir.join("hooks").join(agent_label);
 
     fs::create_dir_all(&dest_root)
         .with_context(|| format!("creating staging dir {}", dest_root.display()))?;
@@ -4159,7 +4179,11 @@ fn is_hook_script_file(path: &Path) -> bool {
     )
 }
 
-fn resolve_hooks_dir(explicit: Option<&Path>, agent: AgentChoice) -> Result<PathBuf> {
+fn resolve_hooks_dir(
+    explicit: Option<&Path>,
+    agent: AgentChoice,
+    data_dir: &Path,
+) -> Result<PathBuf> {
     let Some(sub) = agent.script_hook_subdir() else {
         anyhow::bail!("{agent:?} uses a generated integration, not a hook script directory")
     };
@@ -4176,7 +4200,7 @@ fn resolve_hooks_dir(explicit: Option<&Path>, agent: AgentChoice) -> Result<Path
         sub,
         repo_root_guess(),
         exe_dir_guess(),
-        dirs::data_local_dir(),
+        Some(data_dir.to_path_buf()),
     );
     for path in &candidates {
         if !path.as_os_str().is_empty() && path.is_dir() {
@@ -4193,7 +4217,7 @@ fn hook_source_candidates(
     sub: &str,
     repo_root: Option<PathBuf>,
     exe_dir: Option<PathBuf>,
-    data_local_dir: Option<PathBuf>,
+    data_dir: Option<PathBuf>,
 ) -> Vec<PathBuf> {
     let mut candidates = Vec::with_capacity(5);
     // Cargo-run from the repo.
@@ -4212,9 +4236,10 @@ fn hook_source_candidates(
     )));
     // Native Linux packages install hook sources under /usr/share.
     candidates.push(PathBuf::from(format!("/usr/share/ai-memory/hooks/{sub}")));
-    // Local install honourable mention.
-    if let Some(dir) = data_local_dir {
-        candidates.push(dir.join("ai-memory/hooks").join(sub));
+    // Local install honourable mention: the bundle a previous `--apply`, or
+    // docker `setup-agent`, staged under the data dir actually in use.
+    if let Some(dir) = data_dir {
+        candidates.push(dir.join("hooks").join(sub));
     }
     candidates
 }
@@ -4935,7 +4960,7 @@ fn apply_to_pool(
     data_dir: &Path,
     args: &InstallHooksArgs,
 ) -> Result<()> {
-    let staged = stage_hook_scripts(hooks_dir, "pool")?;
+    let staged = stage_hook_scripts(hooks_dir, "pool", data_dir)?;
     let command_dir = staged_command_dir(&staged, "pool");
     let strategy = args.project_strategy.and_then(ProjectStrategyArg::baked);
     print!(
@@ -5173,7 +5198,10 @@ mod tests {
                 "stop.sh",
             ],
         );
-        let staging = TempDir::new().unwrap();
+        let staging_root = TempDir::new().unwrap();
+        // A real data dir ends in `ai-memory`; the entry-matching below keys
+        // off that, so inject a realistic one rather than a bare temp path.
+        let staging = staging_root.path().join("ai-memory");
         let config_dir = TempDir::new().unwrap();
         let config_path = config_dir.path().join("settings.json");
         fs::write(
@@ -5200,7 +5228,7 @@ mod tests {
             "http://memory:49374",
             Some("token"),
             config_dir.path(),
-            staging.path(),
+            &staging,
             &args,
         )
         .unwrap();
@@ -5210,7 +5238,7 @@ mod tests {
             "http://memory:49374",
             Some("token"),
             config_dir.path(),
-            staging.path(),
+            &staging,
             &args,
         )
         .unwrap();
@@ -5803,7 +5831,7 @@ command = "AI_MEMORY_HOOK_URL=http://h AI_MEMORY_PROJECT_STRATEGY=repo-root /x/a
         fs::create_dir_all(tmp.path().join("grok")).unwrap();
         fs::create_dir_all(tmp.path().join("claude-code")).unwrap();
 
-        let resolved = resolve_hooks_dir(Some(tmp.path()), AgentChoice::Grok).unwrap();
+        let resolved = resolve_hooks_dir(Some(tmp.path()), AgentChoice::Grok, tmp.path()).unwrap();
         assert_eq!(resolved, tmp.path().join("grok"));
     }
 
@@ -5813,7 +5841,7 @@ command = "AI_MEMORY_HOOK_URL=http://h AI_MEMORY_PROJECT_STRATEGY=repo-root /x/a
         fs::create_dir_all(tmp.path().join("pool")).unwrap();
         fs::create_dir_all(tmp.path().join("claude-code")).unwrap();
 
-        let resolved = resolve_hooks_dir(Some(tmp.path()), AgentChoice::Pool).unwrap();
+        let resolved = resolve_hooks_dir(Some(tmp.path()), AgentChoice::Pool, tmp.path()).unwrap();
         assert_eq!(resolved, tmp.path().join("pool"));
     }
 
@@ -6205,7 +6233,7 @@ command = "AI_MEMORY_HOOK_URL=http://h AI_MEMORY_PROJECT_STRATEGY=repo-root /x/a
         fs::create_dir_all(tmp.path().join("devin")).unwrap();
         fs::create_dir_all(tmp.path().join("claude-code")).unwrap();
 
-        let resolved = resolve_hooks_dir(Some(tmp.path()), AgentChoice::Devin).unwrap();
+        let resolved = resolve_hooks_dir(Some(tmp.path()), AgentChoice::Devin, tmp.path()).unwrap();
         assert_eq!(resolved, tmp.path().join("devin"));
     }
 
@@ -6627,9 +6655,9 @@ model = "gpt-5"
         let tmp = TempDir::new().unwrap();
         let data_dir = tmp.path().join("data");
         let agent_label = "stage-in-place";
-        // Simulate "scripts already extracted into the data-local
-        // hooks dir by a prior `setup-agent` run".
-        let in_place = data_dir.join("ai-memory/hooks").join(agent_label);
+        // Simulate "scripts already extracted into the data dir's hooks
+        // dir by a prior `setup-agent` run".
+        let in_place = data_dir.join("hooks").join(agent_label);
         fs::create_dir_all(&in_place).unwrap();
         stub_scripts(&in_place, &["session-start.sh", "post-tool-use.sh"]);
 
@@ -6695,13 +6723,67 @@ model = "gpt-5"
         assert!(format!("{err:#}").contains("no hook scripts"));
     }
 
+    /// #554: with `AI_MEMORY_DATA_DIR` set, `install-hooks` probed and staged
+    /// under the *platform default* instead of the data dir in use — so the
+    /// server logged one path while `--apply` reported staging into another,
+    /// silently populating a directory the operator was not using.
+    #[test]
+    fn a_configured_data_dir_is_where_the_bundle_is_probed_and_staged() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("custom-data");
+        let source = tmp.path().join("bundle");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("session-start.sh"), b"#!/bin/sh\n").unwrap();
+
+        // Staged into the configured dir…
+        let staged = stage_hook_scripts_in(&source, "claude-code", &data_dir).unwrap();
+        assert_eq!(staged, data_dir.join("hooks").join("claude-code"));
+        assert!(staged.join("session-start.sh").is_file());
+        assert!(
+            !tmp.path().join("ai-memory").exists(),
+            "nothing may be written under a platform-default path"
+        );
+
+        // …and the probe looks in the same place, so the two halves agree.
+        let candidates = hook_source_candidates("claude-code", None, None, Some(data_dir.clone()));
+        assert!(
+            candidates.contains(&data_dir.join("hooks").join("claude-code")),
+            "the configured data dir must be probed; got {candidates:?}"
+        );
+    }
+
+    /// The default install must be byte-identical to the old behaviour:
+    /// `default_data_dir()` is `data_local_dir()/ai-memory`, so
+    /// `<data_dir>/hooks/<agent>` is the same path the previous
+    /// `<data_local>/ai-memory/hooks/<agent>` produced.
+    #[test]
+    fn the_default_data_dir_stages_to_the_same_path_as_before() {
+        let tmp = TempDir::new().unwrap();
+        let data_local = tmp.path().join(".local").join("share");
+        let default_data_dir = data_local.join("ai-memory");
+        let source = tmp.path().join("bundle");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("session-start.sh"), b"#!/bin/sh\n").unwrap();
+
+        let staged = stage_hook_scripts_in(&source, "claude-code", &default_data_dir).unwrap();
+        assert_eq!(
+            staged,
+            data_local
+                .join("ai-memory")
+                .join("hooks")
+                .join("claude-code"),
+            "existing installs must keep staging exactly where they did"
+        );
+    }
+
     #[test]
     fn hook_source_candidates_include_native_package_dir() {
         let candidates = hook_source_candidates(
             "claude-code",
             Some(PathBuf::from("/repo")),
             Some(PathBuf::from("/opt/ai-memory")),
-            Some(PathBuf::from("/home/alice/.local/share")),
+            // The resolved data dir, not the platform data-local root (#554).
+            Some(PathBuf::from("/home/alice/.local/share/ai-memory")),
         );
 
         assert_eq!(candidates[0], PathBuf::from("/repo/hooks/claude-code"));
@@ -7696,7 +7778,6 @@ model = "gpt-5"
 
         let staged_script = staging_tmp
             .path()
-            .join("ai-memory")
             .join("hooks")
             .join("codex")
             .join("session-start.sh");
@@ -8183,7 +8264,6 @@ command = "AI_MEMORY_HOOK_URL=http://old:1 /old/ai-memory/hooks/kimi-code/sessio
 
         let staged_script = staging_tmp
             .path()
-            .join("ai-memory")
             .join("hooks")
             .join("claude-code")
             .join("session-start.sh");


### PR DESCRIPTION
Closes #554. Reported by @alvadorn alongside #546 and split out at their suggestion.

## The defect

`resolve_hooks_dir` passed `dirs::data_local_dir()` as its last candidate, and `stage_hook_scripts` derived its destination the same way. Both ignored `--data-dir` and `AI_MEMORY_DATA_DIR`.

With a custom data dir the process logs one path while `--apply` reports staging into another — quietly populating a directory the operator is not using. The two halves also disagreed with each other: the probe could never find a bundle that a previous run, or docker `setup-agent` (which extracts into the data dir), had staged into the configured one.

## Compatibility

**Byte-identical for a default install.** `default_data_dir()` *is* `data_local_dir()/ai-memory`, so `<data_dir>/hooks/<agent>` resolves to exactly the path the old `<data_local>/ai-memory/hooks/<agent>` produced. `the_default_data_dir_stages_to_the_same_path_as_before` pins that, so the claim cannot rot into a silent relocation of everyone's staged scripts.

## Tests, with controls

`a_configured_data_dir_is_where_the_bundle_is_probed_and_staged` covers both halves — staged into the configured dir, *and* probed there, so they cannot drift apart again. It also asserts nothing is written under a platform-default path.

| control | result |
|---|---|
| restore the old path shape (`<data_dir>/ai-memory/hooks/…`) | ✅ fails |
| drop the data-dir probe candidate | ✅ fails |

Both controls stay rooted at the test's **injected** temp dir. That is deliberate: an earlier version of the first control substituted `dirs::data_local_dir()` for the injected parameter, which made the test write to the real user data directory and wipe the live staged hook scripts. A control may break logic; it must not redirect a destination.

## Four existing tests updated

They asserted the old shape against an injected *data-local root*; that parameter is now the data dir itself.

One is worth calling out: `command_code_apply_uses_only_stable_events_and_preserves_user_settings` found "our" hook entry by searching the serialised JSON for the substring `ai-memory`, which had been arriving incidentally from the staged path. Rather than weaken the assertion I gave the test a realistic data dir — a real one ends in `ai-memory` — so it now matches for the right reason instead of by accident.

## Gate

`fmt` ✅ · `clippy -D warnings` ✅ · **2716 tests, 0 failures** ✅ · both changelog guards ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDbhmszrjG9s5MrPrTuNtm