### PR TITLE
feat(packaging): add a launchd user agent for macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,9 +144,10 @@ jobs:
           TAILWIND_SKIP: "1"
         run: cargo build --release -p ai-memory-cli
 
-      # Mirrors the Linux tarball, minus Linux-only service assets
-      # (packaging/systemd|sysusers|tmpfiles|env). macOS users get the binary,
-      # hooks bundle, default config template, and the docs a macOS user needs
+      # Mirrors the Linux tarball, swapping the Linux-only service assets
+      # (packaging/systemd|sysusers|tmpfiles|env) for the macOS-only
+      # packaging/launchd agent. macOS users get the binary, hooks bundle,
+      # default config template, and the docs a macOS user needs
       # (install.md + macos.md).
       - name: Create release tarball
         env:
@@ -157,6 +158,8 @@ jobs:
           mkdir -p "dist/$artifact"
           cp target/release/ai-memory "dist/$artifact/ai-memory"
           cp -a hooks "dist/$artifact/hooks"
+          mkdir -p "dist/$artifact/packaging"
+          cp -a packaging/launchd "dist/$artifact/packaging/launchd"
           mkdir -p "dist/$artifact/crates/ai-memory-cli/templates"
           cp crates/ai-memory-cli/templates/config.default.toml \
             "dist/$artifact/crates/ai-memory-cli/templates/config.default.toml"
@@ -179,6 +182,7 @@ jobs:
           "$smoke/ai-memory" --version
           for path in \
             hooks \
+            packaging/launchd/com.github.akitaonrails.ai-memory.plist \
             crates/ai-memory-cli/templates/config.default.toml \
             docs/install.md \
             docs/macos.md \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of the systemd user unit, shipped in both macOS release tarballs and
   documented in [`docs/macos.md`](docs/macos.md). Until now macOS had no
   documented way to keep the server running once the terminal that started it
-  closed, which silently stopped hook delivery.
+  closed, which silently stopped hook delivery. (#569)
 
   launchd expands nothing, so the template carries explicit
   `__AI_MEMORY_BIN__` / `__HOME__` placeholders rather than a home specifier,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added a per-user launchd agent for macOS at
+  `packaging/launchd/com.github.akitaonrails.ai-memory.plist`, the counterpart
+  of the systemd user unit, shipped in both macOS release tarballs and
+  documented in [`docs/macos.md`](docs/macos.md). Until now macOS had no
+  documented way to keep the server running once the terminal that started it
+  closed, which silently stopped hook delivery.
+
+  launchd expands nothing, so the template carries explicit
+  `__AI_MEMORY_BIN__` / `__HOME__` placeholders rather than a home specifier,
+  and passes neither `--data-dir` nor `--config` — both already resolve to the
+  macOS platform defaults. `ProcessType` is pinned to `Interactive` because
+  leaving it unset makes launchd throttle the job's CPU and I/O bandwidth,
+  which the hook ingress budget cannot absorb. A bearer token, if one is
+  configured at all, goes in the rendered plist's `EnvironmentVariables`:
+  launchd has no `EnvironmentFile` equivalent.
+
 - Added `ai-memory resume`, an interactive picker for recent managed
   workstreams from the current checkout and validated client-local links. It
   launches the selected named workstream with the established automatic harness

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 | Area | Status | Notes |
 |---|---|---|
 | Linux | Supported | Primary Docker/server target and CI platform. Published Docker images support `linux/amd64` and `linux/arm64`. Native Arch/AUR packages include system and user systemd units. |
-| macOS | Supported | Workspace tests run in CI; tagged releases publish native `ai-memory-macos-aarch64.tar.gz` and `ai-memory-macos-x86_64.tar.gz` binaries. The native binary is the recommended path on Apple Silicon. See [`docs/macos.md`](docs/macos.md). |
+| macOS | Supported | Workspace tests run in CI; tagged releases publish native `ai-memory-macos-aarch64.tar.gz` and `ai-memory-macos-x86_64.tar.gz` binaries, which include a per-user launchd agent. The native binary is the recommended path on Apple Silicon. See [`docs/macos.md`](docs/macos.md). |
 | Windows via WSL2 | Supported | Use the Linux install path inside WSL2 when the agent runs there. |
 | Native Windows | Experimental | Tagged releases publish `ai-memory-windows-x86_64.zip` with `ai-memory.exe`; Docker Desktop wrapper and source builds are also available. Local supported profiles default to host-native hook commands; Claude Code may use its Windows exec form, while other agents use native single command strings matching their hook schema. PowerShell/Git Bash scripts are compatibility fallbacks. See [`docs/windows.md`](docs/windows.md). |
 | Claude Code | Supported | MCP config + lifecycle hooks; native commands enforce capture exclusions. `install-mcp --session-aware` optionally enables per-session auto-scope isolation through a local stdio bridge. Optionally captures the assistant's final turn on `Stop` when installed with `--capture-assistant` and the server enables `capture_assistant` (double opt-in, off by default). |

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -122,6 +122,75 @@ fn systemd_units_use_explicit_native_paths() {
     assert!(!user.contains("/var/lib/ai-memory"));
 }
 
+const LAUNCHD_AGENT_PLIST: &str = "packaging/launchd/com.github.akitaonrails.ai-memory.plist";
+
+#[test]
+fn launchd_agent_plist_is_home_independent_and_unthrottled() {
+    let agent = read_repo(LAUNCHD_AGENT_PLIST);
+
+    // launchd expands nothing: no %h, no $HOME, no ~. Every path in a plist is
+    // a literal, so the two the template cannot know stay placeholders.
+    assert!(agent.contains("__AI_MEMORY_BIN__"));
+    assert!(agent.contains("__HOME__/Library/Logs/ai-memory/"));
+    for unexpandable in ["%h", "$HOME", "${HOME}", "~/"] {
+        assert!(
+            !agent.contains(unexpandable),
+            "launchd would take {unexpandable} literally instead of expanding it"
+        );
+    }
+
+    // The macOS data dir and the config file inside it are already the binary's
+    // defaults, so passing them would only reintroduce a home-dependent path.
+    assert!(!agent.contains("--data-dir"));
+    assert!(!agent.contains("--config"));
+
+    // An unset ProcessType makes launchd throttle CPU and I/O bandwidth, which
+    // the hook ingress budget cannot absorb. Adaptive keys off XPC
+    // transactions, which ai-memory never opens, so it decays to Background.
+    assert!(agent.contains("<key>ProcessType</key>\n  <string>Interactive</string>"));
+
+    assert!(agent.contains("<key>RunAtLoad</key>\n  <true/>"));
+    assert!(agent.contains("<key>KeepAlive</key>\n  <true/>"));
+
+    // launchctl addresses the job by Label, so a Label that disagrees with the
+    // filename silently invalidates every bootout/kickstart command we publish.
+    let label = Path::new(LAUNCHD_AGENT_PLIST)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .expect("the plist path has a file stem");
+    assert!(agent.contains(&format!("<key>Label</key>\n  <string>{label}</string>")));
+}
+
+// Substring assertions cannot see malformed XML, and a plist launchd refuses to
+// parse fails at bootstrap time with no useful diagnostic.
+#[cfg(target_os = "macos")]
+#[test]
+fn launchd_agent_plist_is_a_valid_property_list() {
+    let path = repo_root().join(LAUNCHD_AGENT_PLIST);
+    let output = Command::new("plutil")
+        .arg("-lint")
+        .arg(&path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "plutil -lint rejected {}: {}{}",
+        path.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn macos_release_tarball_ships_the_launchd_agent_plist() {
+    let release = read_repo(".github/workflows/release.yml");
+    assert!(release.contains("cp -a packaging/launchd \"dist/$artifact/packaging/launchd\""));
+    assert!(
+        release.contains(LAUNCHD_AGENT_PLIST),
+        "the macOS tarball smoke test must prove the plist actually shipped"
+    );
+}
+
 #[test]
 fn aur_packages_install_all_native_assets() {
     for path in ["packaging/aur/PKGBUILD", "packaging/aur/PKGBUILD-bin"] {

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -210,6 +210,22 @@ rm ~/Library/LaunchAgents/com.github.akitaonrails.ai-memory.plist
 Nothing rotates the two log files; they grow without bound. Add a
 `newsyslog.d` entry or truncate them periodically if that matters to you.
 
+> **Validated on** macOS 26.6.2 (build 25G83, Apple Silicon) with ai-memory
+> v1.38.0 installed per Scenario A, and separately with v1.21.0 to confirm the
+> agent does not depend on a recently added flag. Confirmed: `launchctl
+> bootstrap`; the job `running` with `last exit code = (never exited)` rather
+> than crash-looping; the launchd child (`PPID 1`) owning `127.0.0.1:49374`, so
+> the reply came from the agent rather than a foreground server left over on the
+> same port; `~/Library/Application Support/ai-memory` resolved and logged as
+> the data dir with no `--data-dir` passed; `405` from `GET /mcp` on the bound
+> port; `KeepAlive` — the served process was `SIGKILL`ed and a replacement was
+> answering about a second later, with `runs` incrementing; and a clean
+> `launchctl bootout`. Start-at-login was configured but not independently
+> exercised, since that needs a logout. `ThrottleInterval` is left at its 10s
+> default, so a crash within 10s of startup is respawned after that delay rather
+> than immediately. Corrections from anyone on a different macOS version are
+> welcome.
+
 ## Hook Platform on macOS
 
 `AI_MEMORY_HOOK_PLATFORM` selects how hook commands are rendered. On macOS the

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -118,6 +118,98 @@ ai-memory install-hooks --agent  claude-code --apply
 The published Docker image includes both `linux/amd64` and `linux/arm64`, so
 Apple Silicon pulls the native arm64 image without `--platform linux/amd64`.
 
+## Run as a Login Service (launchd)
+
+Every scenario above leaves the server in the foreground: close that terminal
+and capture stops. The macOS counterpart of a systemd user unit is a
+**LaunchAgent** — a plist in `~/Library/LaunchAgents/` that the per-user
+launchd domain starts at login and restarts on failure. The repo ships one at
+`packaging/launchd/com.github.akitaonrails.ai-memory.plist`, and the macOS
+release tarballs include it.
+
+launchd expands nothing. A plist has no home specifier and no
+`EnvironmentFile`, so every path in it is a literal and the template carries
+two placeholders you substitute at install time. Run this from the extracted
+tarball (Scenario A) or the repo root (Scenario B):
+
+```bash
+# launchd creates the log files but not their parent directory, and a missing
+# one is a silent redirect failure.
+mkdir -p ~/Library/Logs/ai-memory
+
+# Wherever you keep the binary: ~/Applications/ai-memory/ai-memory for a
+# release tarball, ./target/release/ai-memory for a source build.
+AI_MEMORY_BIN=~/Applications/ai-memory/ai-memory
+
+sed -e "s|__AI_MEMORY_BIN__|$AI_MEMORY_BIN|" \
+    -e "s|__HOME__|$HOME|" \
+    packaging/launchd/com.github.akitaonrails.ai-memory.plist \
+    > ~/Library/LaunchAgents/com.github.akitaonrails.ai-memory.plist
+
+launchctl bootstrap gui/$(id -u) \
+    ~/Library/LaunchAgents/com.github.akitaonrails.ai-memory.plist
+```
+
+The agent runs `ai-memory serve --transport http --enable-web` and passes
+neither `--data-dir` nor `--config`: on macOS the binary already defaults to
+`~/Library/Application Support/ai-memory` with the config file inside it, so
+naming them would only add two more paths to substitute. `bind` comes from that
+config, defaulting to `127.0.0.1:49374`. Re-render and reload the plist if you
+move the binary.
+
+Verify it came up:
+
+```bash
+launchctl print gui/$(id -u)/com.github.akitaonrails.ai-memory | grep state
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:49374/mcp   # 405
+tail -f ~/Library/Logs/ai-memory/stderr.log
+```
+
+### Coming from systemd
+
+| systemd `--user` | launchd (per-user domain) |
+|---|---|
+| `systemctl --user enable --now ai-memory` | `launchctl bootstrap gui/$(id -u) <plist>` |
+| `systemctl --user disable --now ai-memory` | `launchctl bootout gui/$(id -u)/<label>` |
+| `systemctl --user status ai-memory` | `launchctl print gui/$(id -u)/<label>` |
+| `systemctl --user restart ai-memory` | `launchctl kickstart -k gui/$(id -u)/<label>` |
+| `journalctl --user -u ai-memory -f` | `tail -f ~/Library/Logs/ai-memory/stderr.log` |
+| `loginctl enable-linger $USER` | no equivalent — a LaunchAgent stops at logout |
+| `EnvironmentFile=` | no equivalent — see the token note below |
+
+`<label>` is `com.github.akitaonrails.ai-memory`. After editing the plist,
+`bootout` then `bootstrap` again; `kickstart -k` only restarts the process and
+does not re-read the definition.
+
+### If you configure a bearer token
+
+`AI_MEMORY_AUTH_TOKEN` is read from the process environment only — it is not a
+`config.toml` key, and launchd has no `EnvironmentFile`. A single-user loopback
+setup needs no token at all. If you do set one, add it to your rendered plist
+and tighten the file, because `~/Library/LaunchAgents` is not private:
+
+```xml
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AI_MEMORY_AUTH_TOKEN</key>
+    <string>…</string>
+  </dict>
+```
+
+```bash
+chmod 600 ~/Library/LaunchAgents/com.github.akitaonrails.ai-memory.plist
+```
+
+### Removing the agent
+
+```bash
+launchctl bootout gui/$(id -u)/com.github.akitaonrails.ai-memory
+rm ~/Library/LaunchAgents/com.github.akitaonrails.ai-memory.plist
+```
+
+Nothing rotates the two log files; they grow without bound. Add a
+`newsyslog.d` entry or truncate them periodically if that matters to you.
+
 ## Hook Platform on macOS
 
 `AI_MEMORY_HOOK_PLATFORM` selects how hook commands are rendered. On macOS the

--- a/packaging/launchd/com.github.akitaonrails.ai-memory.plist
+++ b/packaging/launchd/com.github.akitaonrails.ai-memory.plist
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Per-user LaunchAgent for ai-memory, the macOS counterpart of
+  packaging/systemd/ai-memory-user.service.
+
+  launchd expands nothing: it has no systemd-style home specifier and no
+  EnvironmentFile, so both placeholders below must be substituted before the
+  file is installed into the user's LaunchAgents directory. See docs/macos.md
+  for the render command.
+
+    __AI_MEMORY_BIN__  absolute path to the ai-memory binary
+    __HOME__           absolute path to the user's home directory
+
+  The data dir and its config file are deliberately not passed: on macOS the
+  binary already defaults to Library/Application Support/ai-memory under the
+  user's home, so spelling them out would only add two more paths to
+  substitute.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.github.akitaonrails.ai-memory</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__AI_MEMORY_BIN__</string>
+    <string>serve</string>
+    <string>--transport</string>
+    <string>http</string>
+    <string>--enable-web</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+
+  <!-- Left unset, launchd throttles the job's CPU and I/O bandwidth, which the
+       hook ingress budget cannot absorb. Adaptive keys off XPC transactions
+       ai-memory never opens, so it would decay to Background. -->
+  <key>ProcessType</key>
+  <string>Interactive</string>
+
+  <!-- launchd creates these files but not their parent directory. -->
+  <key>StandardOutPath</key>
+  <string>__HOME__/Library/Logs/ai-memory/stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>__HOME__/Library/Logs/ai-memory/stderr.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## What changed

Adds `packaging/launchd/com.github.akitaonrails.ai-memory.plist`, the macOS
counterpart of `packaging/systemd/ai-memory-user.service`. Both macOS release
tarballs now ship it, and `docs/macos.md` gains a "Run as a Login Service"
section covering the render-and-bootstrap flow plus a systemd-to-launchd
command mapping.

No code changes: packaging asset, docs, and regression tests only.

## Why

Every scenario in `docs/macos.md` ends at `ai-memory serve` in a foreground
terminal. Close it and the server stops, so hook delivery silently stops with
it. Linux has a documented user service; macOS had none.

This follows the direction settled in #530: document the platform's own
supervisor rather than teach the binary to register itself. macOS needs no
third-party wrapper for it, since launchd is native.

Three details are non-obvious enough that the tests pin them:

- **launchd expands nothing.** No home specifier, no `EnvironmentFile`. The
  template carries `__AI_MEMORY_BIN__` / `__HOME__` placeholders, and a test
  rejects `%h`, `$HOME` and `~/` anywhere in the file.
- **`ProcessType` is not optional.** Left unset, `man launchd.plist` says the
  system throttles the job's CPU and I/O bandwidth - which the <=200 ms hook
  ingress budget cannot absorb. `Adaptive` keys off XPC transactions ai-memory
  never opens, so it decays to `Background`; `Interactive` is the honest value.
- **No `--data-dir` / `--config`.** Both already resolve to the macOS platform
  defaults, so naming them would only add two more paths to substitute.

A bearer token, if configured at all, goes in the rendered plist's
`EnvironmentVariables` with the file mode tightened - documented, since launchd
has no `EnvironmentFile` equivalent.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Manual test: ran the documented flow end to end on macOS 26.6.2 (build
      25G83, Apple Silicon) with ai-memory v1.38.0, and separately with v1.21.0
      to confirm the agent does not depend on a recently added flag. Confirmed
      `launchctl bootstrap`; the job `running` with `last exit code = (never
      exited)` rather than crash-looping; the launchd child (`PPID 1`) owning
      `127.0.0.1:49374`, so the reply came from the agent and not a foreground
      server left over on the same port; the macOS default data dir resolved and
      logged with no `--data-dir` passed; `405` from `GET /mcp`; `KeepAlive` -
      the served process was `SIGKILL`ed and a replacement answered about a
      second later with `runs` incrementing; and a clean `launchctl bootout`.
      Start-at-login was configured but not independently exercised (needs a
      logout); that limit is recorded in the doc rather than left implied.

      Three new tests in `crates/ai-memory-cli/tests/packaging.rs`: the
      content/placeholder assertions, a macOS-gated `plutil -lint`, and one
      proving the release workflow ships the asset.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected
      any unintended identity before requesting merge.

## CHANGELOG (merge gate)

- [x] I added a `CHANGELOG.md` `[Unreleased]` entry
- [x] No changed defaults - this adds an opt-in packaging asset and does not
      alter existing behaviour.