### PR TITLE
docs(cli): correct the process_guard inventory of guarded commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,8 +277,11 @@ prior-art bug (see `docs/ARCHITECTURE.md` and `docs/issues-*.md`):
    wrapper libraries.
 8. **`{provider, model, dim}` denormalized next to every embedding**;
    stale vectors are warned about and ignored on config mismatch.
-9. **Live-process check before destructive ops** (`reset`, `backup`,
-   `restore` consult `sysinfo`).
+9. **Live-process check before direct-disk lifecycle ops.** `reset`, `restore`,
+   `reindex`, and `uninstall --purge-data` consult `sysinfo`; the uninstall
+   guard is conditional on `--purge-data`. `backup` stays online: its thin HTTP
+   client asks the server to snapshot SQLite with the online backup API while
+   the writer remains live.
 10. **Atomic file writes** (tmp + rename + fsync); the watcher ignores
     its own writes by filename prefix.
 11. **Absolute canonical data dir**, logged loudly at startup.

--- a/crates/ai-memory-cli/src/process_guard.rs
+++ b/crates/ai-memory-cli/src/process_guard.rs
@@ -1,7 +1,10 @@
 //! Shared "is another ai-memory process alive?" check.
 //!
-//! Used by every destructive command (`reset`, `backup`, `restore`) so
-//! we never race a live writer (lesson from basic-memory #765).
+//! Used by direct-disk lifecycle operations that must not race a live writer:
+//! `reset`, `restore`, `reindex`, and `uninstall` when `--purge-data` is set
+//! (lesson from basic-memory #765). `backup` is intentionally excluded: it is a
+//! thin HTTP client, and the server snapshots SQLite through its online backup
+//! API while the writer stays live.
 
 use std::ffi::OsStr;
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -511,8 +511,11 @@ that touch the relevant area.
 8. **`{provider, model, dim}` denormalised next to every embedding.**
    Warn and ignore stale vectors on mismatch until re-embedding completes.
    (agentmemory #469.)
-9. **Live-process check before destructive ops.** `ai-memory reset`,
-   `backup`, `restore` all consult `sysinfo`. (basic-memory #765.)
+9. **Live-process check before direct-disk lifecycle ops.** `ai-memory reset`,
+   `restore`, `reindex`, and `uninstall --purge-data` consult `sysinfo`; the
+   uninstall guard is conditional on `--purge-data`. `backup` is a thin HTTP
+   client instead: the server snapshots SQLite with its online backup API while
+   the writer remains live. (basic-memory #765.)
 10. **Atomic file writes** (tmp + rename + fsync). Watcher ignores
     own writes by filename prefix.
 11. **Absolute canonical data dir** default; logged loudly on


### PR DESCRIPTION
## What changed

- Correct the `process_guard` module inventory to list the actual guarded direct-disk paths: `reset`, `restore`, `reindex`, and `uninstall --purge-data`.
- Align the same invariant in `AGENTS.md` and `docs/ARCHITECTURE.md`.
- Document why `backup` is intentionally excluded: it is a thin HTTP client, and the server uses SQLite's online backup API while the writer remains live.

## Why

`docs/ARCHITECTURE.md` contradicted itself: the backup description says the source remains writable, while the process-guard invariant said backup refused a live process. History explains the drift: `abf1c8a7` introduced guarded local backup, `46bc071f` moved backup behind `/admin/backup`, `2c2f9453` added the conditional uninstall purge guard, and `e622f331` added the reindex guard. The original inventory was never updated. Runtime behavior is unchanged.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- [x] `TAILWIND_SKIP=1 cargo test --workspace -- --test-threads=1`
- [x] `cargo deny check`
- [x] `git diff --check`
- [x] Manually verified every `sibling_processes` and `busy_message` call via `git grep` and direct caller reading; verified that backup reaches server-side `ReaderPool::snapshot_to`.

## CHANGELOG (merge gate)

- [x] No entry required: this documentation-only correction changes no flag, environment variable, endpoint, MCP tool, marker key, behavior, or default;
- [x] No default changed.

## Notes for reviewers

- No runtime behavior changes.
- `docs/lifecycle-ops.md` already says backup is safe with a live writer. Its missing uninstall purge row was deliberately left out because additive lifecycle coverage is separate from correcting this frozen inventory.
