### PR TITLE
docs(macos): clarify PATH resolution across install scenarios

### DIFF
--- a/docs/macos.md
+++ b/docs/macos.md
@@ -64,14 +64,37 @@ cd ~/Applications/ai-memory
 ./ai-memory install-mcp --client claude-code --apply
 ```
 
+Optionally, once hooks are wired, put the binary on `PATH` so later commands
+(`ai-memory status`, a fresh terminal tab, the checklist below) don't need
+`cd`/`./`:
+
+```bash
+sudo ln -sf ~/Applications/ai-memory/ai-memory /usr/local/bin/ai-memory
+```
+
+Do this *after* `install-hooks`, not before: on macOS `install-hooks`
+auto-discovers the sibling `hooks/` directory by walking up from the running
+binary's own path, and that walk does not currently resolve through a
+symlink (tracked in [#546](https://github.com/akitaonrails/ai-memory/issues/546)).
+Running `install-hooks` through the `/usr/local/bin` symlink instead of the
+extracted `./ai-memory` sends discovery to the wrong parent directories. On a
+machine with no prior ai-memory install this fails outright; on a machine
+that already has a hooks cache under `~/Library/Application Support/ai-memory`
+from an earlier run, discovery can silently fall back to *that* — reporting
+success while wiring whatever hook version happens to be cached there,
+possibly not the one you just extracted. `ai-memory serve`/`status`/etc. are
+unaffected either way.
+
 Notes:
 
 - The MCP endpoint, capture hooks, and `ai-memory status` work without a token
   in this single-user loopback setup. If you explicitly configure
   `AI_MEMORY_AUTH_TOKEN` for the server, pass the same token with `--auth-token`
   or export it for CLI commands.
-- Keep the extracted `ai-memory` at a stable path; the hook commands reference
-  it. Re-run `install-hooks` if you move it.
+- Keep the extracted `ai-memory` at a stable path; the hook commands (and the
+  symlink, if you made one) reference it. Re-run `install-hooks` — via the
+  extracted path, per the caution above — and re-point the symlink if you move
+  it.
 
 ## Scenario B: Source Build
 
@@ -96,12 +119,27 @@ automatically (no `--source` needed from the repo root):
 ./target/release/ai-memory install-mcp   --client claude-code --apply
 ```
 
+If you symlink the built binary onto `PATH` for convenience (e.g.
+`ln -sf "$(pwd)/target/release/ai-memory" ~/.local/bin/ai-memory`), do it
+*after* the `install-hooks` call above, not before — see the `install-hooks`
+symlink caution in Scenario A
+([#546](https://github.com/akitaonrails/ai-memory/issues/546)); it applies
+here too and is the exact layout that bug was filed against.
+
 ## Scenario C: Docker Wrapper
 
 Use this when you want the server data in a Docker volume while the agent still
 runs as a native macOS process. The wrapper renders host-side agent config with
 `http://127.0.0.1:49374`, but its own thin-client commands reach the server from
 inside a helper container via Docker Desktop's `host.docker.internal` alias.
+
+This assumes the `ai-memory` thin-client wrapper is already on `PATH`; if
+`ai-memory --version` doesn't resolve yet, install it first via the
+[README Docker quick-start](../README.md#docker) (downloads a small shell
+script to `~/.local/bin/ai-memory`). On a stock macOS Terminal `~/.local/bin`
+is **not** on `PATH` by default — add
+`export PATH="$HOME/.local/bin:$PATH"` to `~/.zshrc` if `which ai-memory`
+comes up empty after installing the wrapper.
 
 ```bash
 # Start the server. The image default allowlist includes host.docker.internal so
@@ -114,6 +152,9 @@ docker run -d --name ai-memory --restart unless-stopped \
 ai-memory install-mcp   --client claude-code --apply
 ai-memory install-hooks --agent  claude-code --apply
 ```
+
+The wrapper is a shell script, not the native binary, so the `install-hooks`
+symlink caution above (#546) does not apply here.
 
 The published Docker image includes both `linux/amd64` and `linux/arm64`, so
 Apple Silicon pulls the native arm64 image without `--platform linux/amd64`.
@@ -149,10 +190,27 @@ wrapper's `posix` shell-script path does not. Re-run `install-hooks --agent
   `hooks/` directory automatically.
 - **Platform-mismatch warning on Apple Silicon:** update to a current Docker
   tag. Tagged releases publish a multi-arch manifest with `linux/arm64`.
+- **`ai-memory: command not found` in a new terminal tab:** Scenario A/B's
+  `./ai-memory`/`./target/release/ai-memory` is a relative path, so it only
+  resolves from inside the install/build directory. Either keep `cd`-ing there
+  first, or symlink the binary onto `PATH` once you're done wiring hooks (see
+  the Scenario A/B notes above) so plain `ai-memory` works everywhere.
+- **`install-hooks` wires the wrong (or no) `hooks/` bundle even though the
+  tarball was extracted whole:** if the binary is reached through a symlink
+  (e.g. you put it on `PATH` before running `install-hooks`), macOS discovery
+  does not resolve the symlink and searches the wrong parent directories —
+  see [#546](https://github.com/akitaonrails/ai-memory/issues/546). On a
+  clean machine this fails outright; if a hooks cache from an earlier install
+  already exists under `~/Library/Application Support/ai-memory`, it can
+  silently reuse that stale copy instead and report success. Run
+  `install-hooks` via the real extracted/built path instead of the symlink
+  until that's fixed.
 
 ## Suggested Test Checklist
 
-1. `ai-memory serve --bind 127.0.0.1:49374` starts and logs `bind=127.0.0.1:49374`.
+1. `ai-memory serve --bind 127.0.0.1:49374` starts and logs `bind=127.0.0.1:49374`
+   (`./ai-memory serve …`, or `./target/release/ai-memory serve …` for
+   Scenario B, if you haven't put it on `PATH` yet).
 2. `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:49374/mcp` returns
    `405` (reachable; GET not allowed), confirming the loopback server is up.
 3. `install-hooks --agent claude-code --apply` writes hook commands that

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -78,12 +78,20 @@ binary's own path, and that walk does not currently resolve through a
 symlink (tracked in [#546](https://github.com/akitaonrails/ai-memory/issues/546)).
 Running `install-hooks` through the `/usr/local/bin` symlink instead of the
 extracted `./ai-memory` sends discovery to the wrong parent directories. On a
-machine with no prior ai-memory install this fails outright; on a machine
-that already has a hooks cache under `~/Library/Application Support/ai-memory`
-from an earlier run, discovery can silently fall back to *that* — reporting
-success while wiring whatever hook version happens to be cached there,
-possibly not the one you just extracted. `ai-memory serve`/`status`/etc. are
-unaffected either way.
+machine with no prior ai-memory install (verified with a clean `$HOME`) this
+fails outright:
+
+```
+Error: could not locate hooks directory. Tried: ["/…/hooks/claude-code",
+"/usr/local/share/ai-memory/hooks/claude-code", "/usr/share/ai-memory/hooks/claude-code",
+"…/Library/Application Support/ai-memory/hooks/claude-code"]
+```
+
+On a machine that already has a hooks cache under
+`~/Library/Application Support/ai-memory` from an earlier run, discovery can
+instead silently fall back to *that* — reporting success while wiring
+whatever hook version happens to be cached there, possibly not the one you
+just extracted. `ai-memory serve`/`status`/etc. are unaffected either way.
 
 Notes:
 
@@ -200,10 +208,11 @@ wrapper's `posix` shell-script path does not. Re-run `install-hooks --agent
   (e.g. you put it on `PATH` before running `install-hooks`), macOS discovery
   does not resolve the symlink and searches the wrong parent directories —
   see [#546](https://github.com/akitaonrails/ai-memory/issues/546). On a
-  clean machine this fails outright; if a hooks cache from an earlier install
-  already exists under `~/Library/Application Support/ai-memory`, it can
-  silently reuse that stale copy instead and report success. Run
-  `install-hooks` via the real extracted/built path instead of the symlink
+  clean machine this fails outright with `Error: could not locate hooks
+  directory. Tried: [...]`; if a hooks cache from an earlier install already
+  exists under `~/Library/Application Support/ai-memory`, it can silently
+  reuse that stale copy instead and report success. Run `install-hooks` via
+  the real extracted/built path instead of the symlink
   until that's fixed.
 
 ## Suggested Test Checklist

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -72,14 +72,14 @@ Optionally, once hooks are wired, put the binary on `PATH` so later commands
 sudo ln -sf ~/Applications/ai-memory/ai-memory /usr/local/bin/ai-memory
 ```
 
-Do this *after* `install-hooks`, not before: on macOS `install-hooks`
-auto-discovers the sibling `hooks/` directory by walking up from the running
-binary's own path, and that walk does not currently resolve through a
-symlink (tracked in [#546](https://github.com/akitaonrails/ai-memory/issues/546)).
-Running `install-hooks` through the `/usr/local/bin` symlink instead of the
-extracted `./ai-memory` sends discovery to the wrong parent directories. On a
-machine with no prior ai-memory install (verified with a clean `$HOME`) this
-fails outright:
+As of v1.39.0, running `install-hooks` through the symlink works: hook
+discovery canonicalises the running binary's path before walking up to
+the sibling `hooks/` directory
+([#546](https://github.com/akitaonrails/ai-memory/issues/546), fixed in
+v1.39.0). **On v1.38.x or older**, the walk did not resolve through a
+symlink — running `install-hooks` via `/usr/local/bin/ai-memory` sent
+discovery to the wrong parent directories, failing outright on a clean
+machine:
 
 ```
 Error: could not locate hooks directory. Tried: ["/…/hooks/claude-code",
@@ -87,11 +87,10 @@ Error: could not locate hooks directory. Tried: ["/…/hooks/claude-code",
 "…/Library/Application Support/ai-memory/hooks/claude-code"]
 ```
 
-On a machine that already has a hooks cache under
-`~/Library/Application Support/ai-memory` from an earlier run, discovery can
-instead silently fall back to *that* — reporting success while wiring
-whatever hook version happens to be cached there, possibly not the one you
-just extracted. `ai-memory serve`/`status`/etc. are unaffected either way.
+— or, worse, silently wiring a stale hooks cache from
+`~/Library/Application Support/ai-memory` on a machine with an earlier
+install. If you are on an older release, run `install-hooks` via the
+extracted `./ai-memory` path (or upgrade).
 
 Notes:
 
@@ -100,9 +99,8 @@ Notes:
   `AI_MEMORY_AUTH_TOKEN` for the server, pass the same token with `--auth-token`
   or export it for CLI commands.
 - Keep the extracted `ai-memory` at a stable path; the hook commands (and the
-  symlink, if you made one) reference it. Re-run `install-hooks` — via the
-  extracted path, per the caution above — and re-point the symlink if you move
-  it.
+  symlink, if you made one) reference it. Re-run `install-hooks` and re-point
+  the symlink if you move it.
 
 ## Scenario B: Source Build
 


### PR DESCRIPTION
## The gap

`docs/macos.md` Scenario A/B tell you to always invoke the binary via a relative path (`./ai-memory` / `./target/release/ai-memory`), but the same doc's Notes section and Suggested Test Checklist already assume a bare `ai-memory` on `PATH` — literally following either scenario leaves you unable to run the doc's own checklist, or anything from a second terminal tab, without `command not found`. Scenario C has a related gap: it jumps straight to `ai-memory install-mcp` right after `docker run` without ever showing how the thin-client wrapper reaches `PATH` on macOS — that step only exists in the README's Docker quick-start, and its "most distros put `~/.local/bin` on `PATH` automatically" comment doesn't hold for a stock macOS Terminal.

## The symlink trap

Putting the binary on `PATH` via a symlink is the obvious fix, but doing it *before* `install-hooks` walks into an existing bug: on macOS, hooks/ discovery walks up from the binary's own path via `current_exe()`, which returns the unresolved symlink path there (unlike Linux) — sending discovery to the wrong parent directories (#546, filed but not yet released).

Verified two ways against the current v1.38.0 release binary, neither touching real config:

**Sandbox with `AI_MEMORY_DATA_DIR` overridden but real `$HOME` intact:** `install-hooks --agent claude-code` (no `--apply`, stdout preview only) via the direct extracted path correctly printed `# Hook scripts: $SANDBOX/install/hooks/claude-code`. The same command via a `PATH` symlink instead printed `# Hook scripts: /Users/.../Library/Application Support/ai-memory/hooks/claude-code` — a completely different, unrelated directory that happened to already have a matching hooks cache from a prior real install on that machine, so `--apply` silently "succeeded" by coincidence.

**Genuinely clean `$HOME`** (fresh `mktemp -d`, confirmed empty — no prior ai-memory install anywhere in it, `env -i HOME=$FAKE_HOME PATH=... bash`): extract → `init` → symlink onto `PATH` *before* ever running `install-hooks` → both the preview and `--apply` fail hard, exit 1:

```
Error: could not locate hooks directory. Tried: ["/…/hooks/claude-code",
"/usr/local/share/ai-memory/hooks/claude-code", "/usr/share/ai-memory/hooks/claude-code",
"…/Library/Application Support/ai-memory/hooks/claude-code"]
```

A same-machine baseline run of `install-hooks --agent claude-code --apply` via the direct extracted path (no symlink) succeeded and staged 18 hook scripts correctly, confirming the failure is specific to symlink invocation. So the real behavior is bimodal: hard failure on a clean machine, silent stale-cache reuse on one with prior state — neither is what a reader following Scenario A/B for the first time should hit, so the doc now tells them to order the symlink step after `install-hooks`, not before, either way.

## What changed

- Scenario A/B: add the PATH-symlink step, placed after hook wiring, with the caution above.
- Scenario C: link the README's wrapper-install step and correct the PATH assumption for macOS.
- Troubleshooting: two new entries — plain `command not found`, and the silent-fallback/hard-fail `install-hooks` case.
- Suggested Test Checklist: item 1 now notes the relative-path fallback for readers who haven't symlinked yet.

## Not fixed here

`install-hooks --apply` ignores `AI_MEMORY_DATA_DIR`/`--data-dir` for the hook-script staging step itself — it always writes to the real `~/Library/Application Support/ai-memory/hooks/<agent>` regardless of those overrides (confirmed via `diff -rq` during the sandbox testing above, harmless here because content was already identical, but it means that step can't currently be sandboxed via a data-dir override alone). Outside a docs PR's scope; filed as #573 rather than folding a code fix in here.

Refs #546, #573.

Docs-only.

---

Ran the sandbox and clean-`$HOME` testing above with Claude (Sonnet) in a Claude Code session — it's also what caught that the two symlink outcomes differ (hard fail vs. silent stale reuse) instead of just one, which is why the doc calls out both. Happy to paste the full command transcript if anyone wants to double-check before merging.
