### PR TITLE
chore(ci): fast Linux gate per merge, full macOS/Windows matrix pre-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  # Manual full run (macOS legs included) — dispatch on the
+  # release-candidate SHA right before a release.
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -40,9 +44,11 @@ jobs:
       fail-fast: false
       matrix:
         # macOS catches stat / SELinux / case-sensitivity assumptions
-        # that wouldn't show up on a Linux-only matrix. Stays in step
-        # with the homelab deploy which is Linux.
-        os: [ubuntu-latest, macos-latest]
+        # that wouldn't show up on a Linux-only matrix. It costs most of
+        # the wall clock, so during iteration only Linux runs; the macOS
+        # leg joins on a `full-ci` PR label or a manual dispatch, and is
+        # MANDATORY right before a release (see AGENTS.md).
+        os: ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'full-ci')) && fromJSON('["ubuntu-latest", "macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -88,15 +94,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # Keep Linux on Debian bookworm so the prebuilt binary matches the
-          # Docker runtime image. macOS entries mirror the release assets.
-          - artifact: linux-x86_64
-            runner: ubuntu-22.04
-          - artifact: macos-aarch64
-            runner: macos-15
-          - artifact: macos-x86_64
-            runner: macos-15-intel
+        # Keep Linux on Debian bookworm so the prebuilt binary matches the
+        # Docker runtime image. macOS entries mirror the release assets;
+        # they run only on `full-ci` / dispatch (mandatory pre-release),
+        # like the macOS test leg above.
+        include: ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'full-ci')) && fromJSON('[{"artifact": "linux-x86_64", "runner": "ubuntu-22.04"}, {"artifact": "macos-aarch64", "runner": "macos-15"}, {"artifact": "macos-x86_64", "runner": "macos-15-intel"}]') || fromJSON('[{"artifact": "linux-x86_64", "runner": "ubuntu-22.04"}]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,11 @@ jobs:
         # the wall clock, so during iteration only Linux runs; the macOS
         # leg joins on a `full-ci` PR label or a manual dispatch, and is
         # MANDATORY right before a release (see AGENTS.md).
-        os: ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'full-ci')) && fromJSON('["ubuntu-latest", "macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        os: >-
+          ${{ (github.event_name == 'workflow_dispatch' ||
+               contains(github.event.pull_request.labels.*.name, 'full-ci'))
+              && fromJSON('["ubuntu-latest", "macos-latest"]')
+              || fromJSON('["ubuntu-latest"]') }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -98,7 +102,13 @@ jobs:
         # Docker runtime image. macOS entries mirror the release assets;
         # they run only on `full-ci` / dispatch (mandatory pre-release),
         # like the macOS test leg above.
-        include: ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'full-ci')) && fromJSON('[{"artifact": "linux-x86_64", "runner": "ubuntu-22.04"}, {"artifact": "macos-aarch64", "runner": "macos-15"}, {"artifact": "macos-x86_64", "runner": "macos-15-intel"}]') || fromJSON('[{"artifact": "linux-x86_64", "runner": "ubuntu-22.04"}]') }}
+        include: >-
+          ${{ (github.event_name == 'workflow_dispatch' ||
+               contains(github.event.pull_request.labels.*.name, 'full-ci'))
+              && fromJSON('[{"artifact": "linux-x86_64", "runner": "ubuntu-22.04"},
+                            {"artifact": "macos-aarch64", "runner": "macos-15"},
+                            {"artifact": "macos-x86_64", "runner": "macos-15-intel"}]')
+              || fromJSON('[{"artifact": "linux-x86_64", "runner": "ubuntu-22.04"}]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,9 +29,11 @@ name: windows
 #
 # If you are changing any of those areas, add the `windows` label to the
 # pull request rather than finding out after the merge.
+# During feature iteration this workflow no longer runs on every push to
+# main: fast Linux CI gates each merge, and the full Windows suite runs
+# nightly, on demand, and MANDATORILY right before a release (dispatch it
+# on the release-candidate SHA and wait for green — see AGENTS.md).
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, labeled]
   schedule:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -392,6 +392,13 @@ Additional boundary rules:
   `Added`/`Changed`/`Fixed` heading, past-tense, trailing `(#NNN)`
   reference) and update the relevant README/docs references in the same
   commit. Internal refactors and test-only churn are exempt.
+- **CI pacing: fast per merge, full matrix before release.** Every
+  implementation merge gates on the fast Linux jobs only. The slow
+  macOS/Windows legs run on a `full-ci` PR label, nightly (windows), or
+  manual dispatch — and running them is **mandatory right before a
+  release**: dispatch `ci` (macOS legs) and `windows` on the exact
+  release-candidate SHA and wait for green before tagging. Never tag a
+  release whose SHA lacks a green full matrix.
 - **No version bumps or release tags without explicit user approval.**
   Do not bump crate/package versions automatically.
 - **PR evaluation:** report pros, cons, and recommended fix, then ask for

--- a/crates/ai-memory-cli/tests/packaging.rs
+++ b/crates/ai-memory-cli/tests/packaging.rs
@@ -205,11 +205,18 @@ fn docker_publish_jobs_use_prebuilt_binaries() {
 
     let ci = read_repo(".github/workflows/ci.yml");
     assert!(ci.contains("ci-ai-memory-${{ matrix.artifact }}"));
-    assert!(ci.contains("artifact: linux-x86_64"));
-    assert!(ci.contains("artifact: macos-aarch64"));
-    assert!(ci.contains("artifact: macos-x86_64"));
-    assert!(ci.contains("runner: macos-15"));
-    assert!(ci.contains("runner: macos-15-intel"));
+    // The release-build matrix is a conditional expression since the
+    // fast-CI split: Linux always, the macOS legs on full-ci/dispatch.
+    // The full branch must keep every release artifact and runner.
+    assert!(ci.contains(r#"{"artifact": "linux-x86_64", "runner": "ubuntu-22.04"}"#));
+    assert!(ci.contains(r#"{"artifact": "macos-aarch64", "runner": "macos-15"}"#));
+    assert!(ci.contains(r#"{"artifact": "macos-x86_64", "runner": "macos-15-intel"}"#));
+    // and the reduced branch still builds the Linux artifact docker uses
+    assert!(
+        ci.matches(r#"{"artifact": "linux-x86_64", "runner": "ubuntu-22.04"}"#)
+            .count()
+            >= 2
+    );
     assert!(ci.contains("--target runtime-prebuilt-amd64"));
 }
 

--- a/docs/ROADMAP-2.0.md
+++ b/docs/ROADMAP-2.0.md
@@ -176,8 +176,10 @@ for. Most speculative, therefore last - and shaped by whatever items
 ```
 
 Each lands on main individually gated (fmt, clippy -D warnings, full
-tests, changelog guards, harness numbers where retrieval is touched).
-2.0 is cut when:
+tests, changelog guards, harness numbers where retrieval is touched) —
+**fast Linux CI only per item**; the slow macOS/Windows matrix runs
+once, mandatorily, on the release-candidate SHA before the cut (see
+AGENTS.md "CI pacing"). 2.0 is cut when:
 
 - all six items (or an explicitly-decided subset - item 6 may justifiably
   drop) are merged with docs;
@@ -185,7 +187,11 @@ tests, changelog guards, harness numbers where retrieval is touched).
   exercised against a copy of a real 1.x data dir, **including a full
   restore drill from the pre-migration backup archive**;
 - README/ARCHITECTURE reflect 2.0 reality;
-- the eval numbers are re-run and published for the final tree.
+- the eval numbers are re-run and published for the final tree;
+- the full macOS/Windows CI matrix is green on the release-candidate
+  SHA (dispatched, not assumed), and **the user has reviewed the summary
+  of everything done and explicitly approved the release** — 2.0 is
+  never cut automatically.
 
 Deploy/live-test follows the same v1.39 pipeline: exact-main gates,
 hosted CI, `compose pull` (never `bin/deploy`), health + status + a


### PR DESCRIPTION
Per-merge CI now runs the fast Linux jobs only; slow legs are opt-in and mandatory pre-release:

- `ci.yml`: macOS test leg + macOS release builds run only with a `full-ci` PR label or `workflow_dispatch` (added); Linux legs unchanged.
- `windows.yml`: drops the push-to-main trigger; keeps nightly schedule, `windows` label, and dispatch.
- AGENTS.md gains a **CI pacing** rule: before any release, dispatch `ci` (full) and `windows` on the exact release-candidate SHA and wait for green — never tag without a green full matrix.
- `docs/ROADMAP-2.0.md` cut criteria updated accordingly, and made explicit that 2.0 is cut only after user review and approval.

This PR itself demonstrates the effect: its own run should skip the macOS legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDbhmszrjG9s5MrPrTuNtm