### PR TITLE
test(store): stop a subscriberless thread blinding the warning captures (#558)

### DIFF
--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -4367,7 +4367,70 @@ pub(crate) mod tests {
         }
     }
 
+    /// A subscriber that exists only to be counted (#558).
+    ///
+    /// `tracing` resolves a callsite's interest **once**, on first execution,
+    /// and caches the answer process-globally. While only one `Dispatch` is
+    /// alive — which `WARNING_CAPTURE_LOCK` guarantees, since it serialises the
+    /// captures — `tracing-core` takes a fast path that resolves that answer
+    /// from the *registering thread's own* default subscriber
+    /// (`callsite.rs`: `if has_just_one { … dispatcher::get_default(f) }`).
+    /// A thread without one resolves to `Interest::never()`, and every later
+    /// capture of that callsite goes blind.
+    ///
+    /// Keeping a second `Dispatch` alive for the life of the test binary
+    /// defeats that: with more than one registered, resolution consults every
+    /// live dispatcher instead of only the current thread's, so the capture's
+    /// own subscriber counts no matter which thread registers first.
+    ///
+    /// **Being counted is the whole contribution.** It is never installed as
+    /// anyone's default and never receives an event. Verified by control: see
+    /// `a_subscriberless_thread_must_not_disable_a_callsite_the_capture_needs`,
+    /// which fails when this pin is removed and passes with it, whatever this
+    /// subscriber answers.
+    ///
+    /// The two ways it could stop being invisible are not symmetric, and the
+    /// difference is easy to get backwards:
+    ///
+    /// - **Interest is not a maximum.** `Interest::and` keeps the value when
+    ///   two dispatchers agree and collapses to `sometimes()` when they differ.
+    ///   This pin answers `never` (its `enabled` is false, and the default
+    ///   `register_callsite` follows that), so pairing it with a capture that
+    ///   answers `always` yields `sometimes` — a per-event `enabled()` call,
+    ///   answered by whichever subscriber is actually in scope. That is why an
+    ///   inert pin cannot silence a callsite someone else wants.
+    /// - **The level hint *is* a maximum**, and a `None` hint is read as
+    ///   `TRACE`. Hence the explicit `Some(OFF)` below.
+    struct RegistryPin;
+
+    impl tracing::Subscriber for RegistryPin {
+        /// Explicit, and load-bearing — see
+        /// `the_registry_pin_stays_invisible_to_the_global_max_level`.
+        fn max_level_hint(&self) -> Option<tracing::level_filters::LevelFilter> {
+            Some(tracing::level_filters::LevelFilter::OFF)
+        }
+
+        fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+            false
+        }
+
+        fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+
+        fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+        fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+        fn event(&self, _: &tracing::Event<'_>) {}
+        fn enter(&self, _: &tracing::span::Id) {}
+        fn exit(&self, _: &tracing::span::Id) {}
+    }
+
+    /// Holds the second dispatcher alive. Constructing a `Dispatch` is what
+    /// registers it, so simply keeping this initialised is the mechanism.
+    static REGISTRY_PIN: std::sync::OnceLock<tracing::Dispatch> = std::sync::OnceLock::new();
+
     fn capture_warnings(run: impl FnOnce()) -> String {
+        REGISTRY_PIN.get_or_init(|| tracing::Dispatch::new(RegistryPin));
         let _guard = WARNING_CAPTURE_LOCK.lock().unwrap();
         let logs = CapturedLogs::default();
         let subscriber = tracing_subscriber::fmt()
@@ -4377,6 +4440,84 @@ pub(crate) mod tests {
             .finish();
         tracing::subscriber::with_default(subscriber, run);
         String::from_utf8(logs.0.lock().unwrap().clone()).unwrap()
+    }
+
+    /// Guards the `max_level_hint` override on [`RegistryPin`] against being
+    /// removed as apparent dead code.
+    ///
+    /// The pin has to be *registered* to do its job, and every registered
+    /// dispatcher feeds `tracing`'s global max level — which `rebuild_interest`
+    /// computes as the maximum across live dispatchers, reading a `None` hint
+    /// as `TRACE`. Dropping the override therefore raises this binary's global
+    /// level from `OFF` to `TRACE` for good after the first capture. Measured
+    /// both ways: with `Some(OFF)` the level follows exactly the `OFF -> WARN`
+    /// path it follows with no pin at all; without the override it goes to
+    /// `TRACE` and stays there.
+    ///
+    /// Nothing observable breaks when that happens, which is precisely why it
+    /// wants a guard rather than a comment — every `trace!` and `debug!`
+    /// callsite in the crate would quietly start being evaluated instead of
+    /// short-circuiting.
+    #[test]
+    fn the_registry_pin_stays_invisible_to_the_global_max_level() {
+        use tracing::Subscriber as _;
+
+        assert_eq!(
+            RegistryPin.max_level_hint(),
+            Some(tracing::level_filters::LevelFilter::OFF),
+            "a None hint is read as TRACE, which would raise the whole binary's \
+             global max level as a side effect of pinning the dispatcher"
+        );
+    }
+
+    /// A `warn!` callsite reachable from nowhere but the control test below.
+    ///
+    /// The defect being reproduced is in `tracing`'s **one-shot** callsite
+    /// registration, so the callsite has to still be unregistered when the
+    /// control runs. Any second caller would register it first and make the
+    /// control vacuous.
+    fn control_only_warn() {
+        tracing::warn!("control-callsite-canary");
+    }
+
+    /// #558: a thread with no subscriber must not be able to disable a
+    /// callsite that a concurrent capture depends on.
+    ///
+    /// The flake is `Interest::never()` cached **globally** for a callsite,
+    /// resolved from whichever thread happens to register it first:
+    ///
+    /// - `tracing`'s event macro gates on the global max level *before*
+    ///   consulting the callsite's interest. With no other subscriber in this
+    ///   binary that level starts at `OFF`, so a subscriberless thread normally
+    ///   short-circuits and never registers anything.
+    /// - While a capture holds a live `Dispatch`, the level is `WARN`, and now
+    ///   a subscriberless thread *does* reach the registration.
+    /// - With a single live dispatcher, registration resolves interest from the
+    ///   registering thread's own default — `NoSubscriber` — writing
+    ///   `Interest::never()` into a process-global cache.
+    ///
+    /// The capturing thread then skips its `warn!` entirely and the capture
+    /// comes back **empty**, which is the reported symptom. Under `--workspace`
+    /// the foreign thread is real: the homonym `warn!` in this module is also
+    /// driven by the `ai-memory-writer` thread and by other libtest threads,
+    /// none of which hold a subscriber.
+    ///
+    /// Ordering, not luck, reproduces it: register from the foreign thread
+    /// first, then ask the capture to observe the same callsite.
+    #[test]
+    fn a_subscriberless_thread_must_not_disable_a_callsite_the_capture_needs() {
+        let logs = capture_warnings(|| {
+            std::thread::spawn(control_only_warn)
+                .join()
+                .expect("control thread panicked");
+            control_only_warn();
+        });
+
+        assert!(
+            logs.contains("control-callsite-canary"),
+            "a subscriberless thread registered this callsite as Interest::never() \
+             and the capture went blind: {logs:?}"
+        );
     }
 
     fn handoff_acceptance(


### PR DESCRIPTION
Closes #558.

## What changed

One file, entirely inside `#[cfg(test)]`. No production code, no behaviour change, no CHANGELOG entry (test-only churn, exempt per CONTRIBUTING).

- A control test that reproduces the flake **deterministically**, by ordering rather than by luck.
- `RegistryPin`: one inert `Subscriber` held alive in a `OnceLock<tracing::Dispatch>` for the life of the test binary, initialised from `capture_warnings`.

## Your hypothesis (c) was right. Your control couldn't fire.

You wrote that callsite `Interest` being cached as `never` "is not the explanation" because your control passed. It *is* the explanation — the control was testing a path it never reached, for a reason that is genuinely hard to see.

`tracing`'s event macro has **two** process-global gates, and the level gate comes first (`tracing-0.1.44/src/macros.rs:2805`):

```rust
if $crate::level_enabled!($lvl)                                   // global MAX_LEVEL
    && { interest = __CALLSITE.interest(); !interest.is_never() } // global per-callsite cache
    && $crate::__macro_support::__is_enabled(__CALLSITE.metadata(), interest)
```

`LevelFilter::current()` reads `static MAX_LEVEL: AtomicUsize`, **initialised to `OFF`** (`tracing-core-0.1.36/src/metadata.rs:245`). This binary installs no global subscriber, so that level is `OFF` except while a capture's `Dispatch` is alive.

Your control pre-evaluated the callsite under `NoSubscriber`, then captured. But at pre-evaluation time `MAX_LEVEL` was `OFF`, so `level_enabled!` short-circuited **before** `__CALLSITE.interest()` — registration never happened, so there was nothing to poison. It passed for the wrong reason, which is exactly why discarding your replacement was the right call even though the diagnosis underneath it was sound.

## The mechanism

1. While a capture holds a live `Dispatch`, the global level is `WARN`. A thread with no subscriber now **does** reach the one-shot callsite registration.
2. `tracing-core` resolves a callsite's interest exactly once, and with a single live dispatcher it takes a fast path that reads the **registering thread's own default** — `callsite.rs`: `if has_just_one { … dispatcher::get_default(f) }`.
3. That thread has no subscriber, so `Interest::never()` goes into a process-global cache. The capturing thread then skips its `warn!` entirely.

Empty capture, not wrong content. Rare — the one-shot registration has to land inside a capture window. Self-healing — the next `capture_warnings` registers a dispatch, taking the thread-agnostic `Rebuilder::Write` path that rebuilds every callsite. Which is why it passes alone, and passes on rerun.

**The irony worth naming:** `WARNING_CAPTURE_LOCK` — the thing that correctly ruled out your hypothesis (b) — is what keeps at most one `Dispatch` alive, holds `has_just_one` true, and so keeps that thread-local fast path armed.

**The foreign thread is real, not theoretical.** `ops.rs`'s homonym `warn!` is a single callsite shared by `get_or_create_project` and `ensure_project_with_id`, and it is also driven uncaptured by the **`ai-memory-writer` thread** (from `scope.rs` and `reader.rs`) and by libtest threads outside the capture lock. None of them holds a subscriber. Under `--workspace` there are simply more of them running at once.

## The fix, and what is actually load-bearing

Keep one inert `Dispatch` alive. With more than one registered, `has_just_one` is false and interest resolution consults every live dispatcher instead of the registering thread's default — so the capture's own subscriber counts no matter who registers first. It is never installed as anyone's default and never receives an event; being counted is its whole contribution.

| variant | control |
|---|---|
| pin removed entirely | ❌ **fails** — `capture went blind: ""` |
| pin + `register_callsite -> Interest::never()` | ✅ passes |
| pin + `max_level_hint -> Some(LevelFilter::OFF)` | ✅ passes |
| pin present (shipped) | ✅ passes |

Only the pin's **existence** makes the control pass. But *"therefore the pin is invisible"* does not follow, and I had it wrong at first — an earlier revision of this PR asserted that interest and level are both combined by taking the maximum, so an inert pin could not affect anything. Half of that is false, and the false half ships a side effect. The two axes behave differently:

- **Interest is not a maximum.** `Interest::and` (`tracing-core-0.1.36/src/subscriber.rs:658`) keeps the value when two dispatchers agree and collapses to `sometimes()` when they differ:

  ```rust
  pub(crate) fn and(self, rhs: Interest) -> Self {
      if self.0 == rhs.0 { self } else { Interest::sometimes() }
  }
  ```

  So this pin answering `never` alongside a capture answering `always` yields `sometimes` — a per-event `enabled()` call, answered by whichever subscriber is actually in scope. *That* is why an inert pin cannot silence a callsite someone else wants. It happens to be safe, but not for the reason I first gave.

- **The level hint *is* a maximum**, and a `None` hint is read as `TRACE` (`callsite.rs`: `dispatch.max_level_hint().unwrap_or(LevelFilter::TRACE)`). Leaving `max_level_hint` to the default therefore raises this binary's global max level from `OFF` to `TRACE`, permanently, after the first capture. Measured three ways:

  | | global max level |
  |---|---|
  | no pin at all | `OFF` → `WARN` |
  | pin, no `max_level_hint` override | `OFF` → **`TRACE`**, and stays there |
  | pin, `Some(LevelFilter::OFF)` (shipped) | `OFF` → `WARN` — identical to no pin |

  Nothing observable breaks when that happens, which is exactly why it is worth catching: every `trace!` and `debug!` callsite in the crate would quietly start being evaluated instead of short-circuiting. A test-capture fix has no business changing that.

  So the override is explicit and carries `the_registry_pin_stays_invisible_to_the_global_max_level` — a guard against it being removed later as apparent dead code, since removing it breaks nothing that any test would notice.

I also rejected a *global default* subscriber: it works, but only because it is also a second registered dispatcher — strictly more invasive, changing what every thread in the binary resolves to, for no additional guarantee.

## Why the control isn't vacuous

The defect is in **one-shot** registration, so a callsite that any other test touches first would make the control meaningless — the trap the previous attempt fell into. So the control gets its own private `warn!`, reachable from nothing else, and registers it from a subscriberless thread *inside* the capture window:

```rust
let logs = capture_warnings(|| {
    std::thread::spawn(control_only_warn).join().unwrap();
    control_only_warn();
});
```

Without the pin that assertion fails with `""` — the exact reported symptom.

## Why not assert on a value instead

There is no non-log signal: `get_or_create_project` returns only a `ProjectId`, `ensure_project_with_id` returns `()`, and `also_in` / `created` are locals. The *predicate* is already covered by value (`get_or_create_project_flags_homonym_across_workspaces` asserts directly on `project_name_in_other_workspaces`). What the capture tests uniquely pin is the **wiring** — that creation actually calls the warn helper with the right data. Deleting the log assertion would lose real coverage, so the capture had to be made reliable rather than removed.

`#[serial]` would have been worse than useless: serialising the captures is precisely what keeps the buggy fast path armed.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — **75 suites, 2857 tests, 0 failures** on the rebased head
- [x] `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- [x] `check-changelog-sections.sh` and `check-changelog-frozen.sh` both pass
- [x] Manual test: the control table above, each variant run against the shipped code and reverted; the negative control re-run on the rebased head
- [x] All five `capture_warnings` tests pass, including `ensure_project_with_id_does_not_warn_when_validation_fails` — the pin must not make an absent warning appear, and does not

**On reproducing it naturally:** I took your suggestion first and ran `cargo test --workspace` in a loop under CPU load — **10 iterations, all clean**. It did not reproduce. Saying so plainly because the deterministic control is the evidence here, not the loop.

## One observation, not a diagnosis

During an earlier session I saw `31 passed; 1 failed` in `crates/ai-memory-mcp/tests/admin_move.rs`. That was under three concurrent full-workspace runs of my own making, and the shell was SIGKILLed before the log survived. It is a different test binary from the one this PR touches and it does not reproduce in a clean run. Flagging it in case it matches something you have seen; I am not claiming it is related, and this PR does not address it.

## Commit attribution

- [x] Verified: `Samir Hanna Verza <123646616+samirhvbr@users.noreply.github.com>`, the identity on my merged commits.

## CHANGELOG (merge gate)

- [x] Deliberately none — test-only churn, which CONTRIBUTING exempts. Both guards run and pass.
- [x] No default changed.

## Notes for reviewers

Two follow-ups I did **not** bundle:

1. `crates/ai-memory-consolidate/src/auto_improve_schedule.rs` carries an independent hand-rolled copy of the same `CapturedLogs` helper, with the same exposure and **without** a mutex. Different binary, deserves its own review — happy to send it separately.
2. This looks like a `tracing-core` sharp edge in its own right: a one-shot, process-global interest decision resolved from whichever thread happens to arrive first. Worth raising upstream; out of scope here.
