### PR TITLE
fix(hooks): write the capture-mode opt-in atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/okf.md` and `docs/MIGRATION-2.0.md`.
 
 ### Fixed
+- `install-hooks` now writes the capture-mode opt-in atomically. It was
+  written in place, and every reader maps an unrecognised value onto
+  `denylist` — the less private mode — so a crash, a full disk or a killed
+  `ai-memory upgrade` mid-write left a truncated file that silently reverted
+  an `--capture-mode allowlist` opt-in to capture-by-default, which is exactly
+  what `persist_capture_mode` documents it must never do. The fallback itself
+  is correct and stays; the torn write that triggered it is gone. Now routed
+  through the same `write_atomic` (tmp + fsync + rename) the rest of the CLI
+  already uses, per the project's atomic-writes invariant.
 - `status` no longer overstates missing embeddings: empty-body pages —
   which no embedder can ever cover and the backfill skips by rule — are
   excluded from the "latest pages missing" figure and reported on their

--- a/crates/ai-memory-cli/src/commands/install_hooks.rs
+++ b/crates/ai-memory-cli/src/commands/install_hooks.rs
@@ -703,7 +703,11 @@ fn persist_capture_mode(data_dir: &Path, requested: Option<CaptureModeArg>) -> R
     };
     fs::create_dir_all(data_dir)
         .with_context(|| format!("creating data dir {}", data_dir.display()))?;
-    fs::write(&path, format!("{value}\n"))
+    // Atomically, because every reader maps an unrecognised value onto
+    // `denylist`: a torn write would not corrupt the opt-in, it would silently
+    // revert it to capture-by-default (`CONTRIBUTING.md`, "Atomic file writes
+    // only").
+    ai_memory_wiki::write_atomic(&path, format!("{value}\n").as_bytes())
         .with_context(|| format!("writing {}", path.display()))?;
     Ok(value.to_string())
 }
@@ -5022,6 +5026,52 @@ mod tests {
                 .unwrap()
                 .trim(),
             "allowlist"
+        );
+    }
+
+    /// #446's opt-in is stored as a bare word, and every reader maps anything
+    /// it does not recognise onto `denylist` — the *less* private mode. That
+    /// fallback is deliberate and tested
+    /// (`hook.rs`: `unreadable_or_unknown_mode_falls_back_to_denylist_not_allowlist`);
+    /// what must never happen is the truncated file that triggers it. An
+    /// in-place write truncates before it writes, so a crash, a full disk or a
+    /// killed `upgrade` mid-write leaves exactly that — and the next hook run
+    /// reads it as capture-by-default, silently undoing the opt-in the doc
+    /// comment on `persist_capture_mode` promises to preserve.
+    ///
+    /// Replacement rather than truncation is the property that rules the window
+    /// out, and it is observable: a rename gives the path a new inode, an
+    /// in-place rewrite keeps the old one. This fails against `fs::write`.
+    #[cfg(unix)]
+    #[test]
+    fn rewriting_the_capture_mode_replaces_the_file_rather_than_truncating_it() {
+        use std::os::unix::fs::MetadataExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(crate::commands::hook::CAPTURE_MODE_FILE);
+
+        persist_capture_mode(tmp.path(), Some(CaptureModeArg::Allowlist)).unwrap();
+        let before = fs::metadata(&path).unwrap().ino();
+
+        persist_capture_mode(tmp.path(), Some(CaptureModeArg::Denylist)).unwrap();
+        let after = fs::metadata(&path).unwrap().ino();
+
+        assert_ne!(
+            before, after,
+            "the capture mode must be replaced by rename, not rewritten in \
+             place: an in-place write is observable truncated, and a truncated \
+             file reads back as denylist"
+        );
+
+        let leftovers: Vec<String> = fs::read_dir(tmp.path())
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with(".ai-memory-tmp."))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "the staging tempfile must not survive the write: {leftovers:?}"
         );
     }
 


### PR DESCRIPTION
## What changed

`persist_capture_mode` writes `<data_dir>/capture-mode` through `ai_memory_wiki::write_atomic` instead of `fs::write`. One line, plus a control test and a CHANGELOG entry.

No behaviour change on the happy path: same file, same content, same reads. What changes is that the file is now replaced by rename rather than truncated and rewritten.

## Why

`persist_capture_mode`'s own doc comment states the requirement:

> Omitting the flag *reads* the stored value rather than defaulting to it, so a bare `--apply` — including the auto-refresh inside `ai-memory upgrade` — can never quietly downgrade an existing opt-in back to capture-by-default.

An in-place write is the one way it can. `fs::write` truncates before it writes, and every reader maps anything it does not recognise onto `denylist` — the *less* private mode:

```rust
Ok(text) if text.trim().eq_ignore_ascii_case("allowlist") => CaptureMode::Allowlist,
_ => CaptureMode::Denylist,
```

That fallback is deliberate, already tested by `unreadable_or_unknown_mode_falls_back_to_denylist_not_allowlist`, and **stays** — it is the right answer for a file whose content cannot be trusted. This PR does not touch it.

What must not exist is the truncated file that triggers it. A crash, a full disk, or a killed `upgrade` landing between truncate and write leaves a zero-length `capture-mode`, and the next hook run reads it as capture-by-default. Nobody is told, because from the reader's side a truncated file is indistinguishable from never having opted in — a privacy protection that disappears silently, which is the failure mode #446 was written to prevent.

`CONTRIBUTING.md` and `AGENTS.md` both carry this as an invariant:

> Atomic file writes only: tmp + rename + fsync; never write in-place.

## The control

Crash-tearing is not directly testable without an FS shim, and mocking one would test the shim rather than the fix. But the property that closes the window *is* observable: replacement rather than truncation. A rename gives the path a new inode; an in-place rewrite keeps the old one.

`rewriting_the_capture_mode_replaces_the_file_rather_than_truncating_it` asserts the inode changes across two writes. Against `fs::write` it fails:

```
assertion `left != right` failed: the capture mode must be replaced by rename,
not rewritten in place: an in-place write is observable truncated, and a
truncated file reads back as denylist
  left: 214605
 right: 214605
```

It also asserts no `.ai-memory-tmp.*` staging file survives the write. Unix-only, since the signal is an inode — `#[cfg(unix)]`, so the Windows job compiles unaffected.

## Two small judgement calls

- **`create_dir_all` is now redundant and I kept it.** `write_atomic` creates the parent itself. Keeping the explicit call preserves the `"creating data dir …"` context instead of surfacing a rename error against a missing directory, and removing it would widen a one-line change for no gain. Happy to drop it if you'd rather.
- **`write_atomic` over a local helper.** `ai-memory-cli` already depends on `ai-memory-wiki` and already calls this in three places (`project_registry.rs`, `apply_shared.rs`, `show.rs`); the call style here copies `project_registry.rs`. No new helper, no manifest change.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `TAILWIND_SKIP=1 cargo clippy --workspace --all-targets -- -D warnings`
- [x] `TAILWIND_SKIP=1 cargo test --workspace` — **77 suites, 2870 tests, 0 failures**
- [x] `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- [x] `check-changelog-sections.sh` and `check-changelog-frozen.sh` both pass
- [x] Manual test: `install-hooks --apply --capture-mode allowlist` followed by a bare `--apply` still reports and stores `allowlist`; the three pre-existing capture-mode tests and the four `hook.rs` reader tests pass unchanged
- [x] Control verified in both directions: fails against `fs::write` (output above), passes after the change

## Commit attribution

- [x] Verified: `Samir Hanna Verza <123646616+samirhvbr@users.noreply.github.com>`, the identity on my merged commits.

## CHANGELOG (merge gate)

- [x] Added under `[Unreleased]` / `### Fixed` — an observable bug fix.
- [x] No default changed; the `denylist` fallback is untouched.

## Notes for reviewers

Two neighbours I deliberately left alone rather than widening this PR:

1. `hook.rs` `store_session_id` is also an in-place write, and its error is discarded — same class, different blast radius, worth its own look.
2. `hook.rs` `mark_briefed` writes an empty file. Nothing to tear, so probably fine as is.

Neither is touched here.
