### PR TITLE
fix(windows): backup walk skips .serve.lock so 2.0 migration survives (#593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- The OKF v0.2 pre-migration backup no longer aborts on Windows when
+  upgrading a store with existing data from 1.x to 2.0.x (#593). The
+  backup walks the whole data dir and archived every file, including the
+  `.serve.lock` single-instance lock (#563) — which the same `serve`
+  process holds under a *mandatory* exclusive lock on Windows, so the
+  first read faulted with `ERROR_LOCK_VIOLATION` (os error 33), the
+  backup gate failed, and the server refused to start on either version.
+  The walk now skips `.serve.lock` and its `.holder` sidecar (neither
+  carries durable state); the lock file name is shared from
+  `ai-memory-core`. Unix was immune (advisory locks). Once on the fixed
+  binary a half-migrated store recovers by restarting — the failed wiki
+  migration was never recorded and simply retries.
 - `as_of` time-travel queries and the entity retrieval stream now work
   on real stores. Both read the entity index, which was populated only
   from an LLM consolidator's `entities:` frontmatter — absent on the

--- a/crates/ai-memory-cli/src/commands/serve.rs
+++ b/crates/ai-memory-cli/src/commands/serve.rs
@@ -11,7 +11,7 @@ use ai_memory_consolidate::{
     ScheduledAutoImproveSettings, run_auto_improve_scheduler_tick, run_embedding_backfill,
     run_lint, run_sweep_with_options,
 };
-use ai_memory_core::{ActiveProject, ProjectId, Sanitizer, WorkspaceId};
+use ai_memory_core::{ActiveProject, ProjectId, SERVE_LOCK_FILE, Sanitizer, WorkspaceId};
 use ai_memory_hooks::{
     DEFAULT_HOOK_INGEST_MAX_IN_FLIGHT, HookState, ProjectCacheStore, WorkstreamState, hook_router,
     workstream_router,
@@ -67,9 +67,6 @@ const SESSION_CONSOLIDATION_POLL_INTERVAL: Duration = Duration::from_secs(15);
 /// requests are expected to finish well inside this lease.
 const SESSION_CONSOLIDATION_LEASE: Duration = Duration::from_secs(10 * 60);
 
-/// Lock file guarding a data dir against a second `ai-memory serve` (#563).
-const SERVE_LOCK_FILE: &str = ".serve.lock";
-
 /// The single-instance guard for `ai-memory serve`: an exclusive `flock` on
 /// `<data-dir>/.serve.lock` held for the process lifetime. The OS releases it
 /// when the process exits, so a crashed server never locks the operator out of
@@ -83,7 +80,7 @@ struct ServeLock {
 /// lock file because Windows' exclusive lock blocks reads of the locked
 /// file from other handles; informational only, rewritten by each holder.
 fn holder_info_path(data_dir: &Path) -> std::path::PathBuf {
-    data_dir.join(".serve.lock.holder")
+    data_dir.join(format!("{SERVE_LOCK_FILE}.holder"))
 }
 
 /// Take the single-instance serve lock for `data_dir`.

--- a/crates/ai-memory-core/src/lib.rs
+++ b/crates/ai-memory-core/src/lib.rs
@@ -40,6 +40,14 @@ pub const DEFAULT_PROJECT_NAME: &str = "scratch";
 /// event capture to it.
 pub const GLOBAL_SCOPE_PROJECT: &str = "_global";
 
+/// Name of the single-instance lock file `ai-memory serve` holds for its
+/// process lifetime (#563), directly under the data dir. It carries no
+/// durable state. On Windows the process holds a *mandatory* exclusive lock
+/// on it, so any code that walks the data dir (pre-migration backups,
+/// restores) must skip this name and its `.holder` sidecar — otherwise the
+/// read faults with `ERROR_LOCK_VIOLATION` and aborts the walk (#593).
+pub const SERVE_LOCK_FILE: &str = ".serve.lock";
+
 pub use active_project::{
     ActiveProject, ActiveProjectLookup, ActiveProjectMode, ActorKey, DEFAULT_MAX_ENTRIES,
     DEFAULT_PER_KEY_TTL, MidSessionRouting,

--- a/crates/ai-memory-wiki/src/backup.rs
+++ b/crates/ai-memory-wiki/src/backup.rs
@@ -11,6 +11,7 @@ use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::{Path, PathBuf};
 
+use ai_memory_core::SERVE_LOCK_FILE;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{WikiError, WikiResult};
@@ -166,11 +167,19 @@ fn create_pre_migration_backup_inner(
                     }
                     stack.push(path);
                 } else if ft.is_file() {
-                    if path == archive_path
-                        || path
-                            .file_name()
-                            .is_some_and(|n| n == "pre-migration-backup.json.tmp")
-                    {
+                    // Skip, before any `File::open`: the half-written archive,
+                    // the receipt's temp file, and the serve single-instance
+                    // lock. The lock (`.serve.lock` and its `.holder` sidecar)
+                    // is held under a *mandatory* exclusive lock on Windows,
+                    // so merely opening it to read faults with
+                    // `ERROR_LOCK_VIOLATION` and aborts the whole backup —
+                    // which broke every 1.x -> 2.0 upgrade on Windows (#593).
+                    // It carries no durable state, so dropping it from the
+                    // archive loses nothing.
+                    let skip_by_name = path.file_name().and_then(|n| n.to_str()).is_some_and(|n| {
+                        n == "pre-migration-backup.json.tmp" || n.starts_with(SERVE_LOCK_FILE)
+                    });
+                    if path == archive_path || skip_by_name {
                         continue;
                     }
                     tar.append_path_with_name(&path, rel)?;
@@ -230,6 +239,23 @@ mod tests {
         std::fs::write(tmp.path().join("wiki/ws/proj/notes/a.md"), "---\n---\nbody").unwrap();
         std::fs::write(tmp.path().join("db.sqlite"), b"not really a db").unwrap();
         tmp
+    }
+
+    /// Relative names of every entry in a backup archive, `/`-separated.
+    fn archived_names(archive: &Path) -> Vec<String> {
+        let file = BufReader::new(File::open(archive).unwrap());
+        let dec = flate2::read::GzDecoder::new(file);
+        let mut ar = tar::Archive::new(dec);
+        ar.entries()
+            .unwrap()
+            .map(|e| {
+                e.unwrap()
+                    .path()
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect()
     }
 
     #[test]
@@ -316,6 +342,59 @@ mod tests {
             second.entries, 3,
             "data files + first receipt, never the archive"
         );
+    }
+
+    /// #593: `ai-memory serve` holds `.serve.lock` (and rewrites a
+    /// `.serve.lock.holder` sidecar) directly under the data dir, and the
+    /// migration that takes this backup runs in that same process. The walk
+    /// must skip both — on Windows the lock is mandatory and merely opening
+    /// the file to archive it faults the whole backup with
+    /// `ERROR_LOCK_VIOLATION`. Neither file carries durable state, so they
+    /// are simply absent from the archive.
+    #[test]
+    fn the_backup_walk_skips_the_serve_lock_and_its_sidecar() {
+        let data = data_dir_with_content();
+        std::fs::write(data.path().join(".serve.lock"), b"").unwrap();
+        std::fs::write(data.path().join(".serve.lock.holder"), b"pid=1234\n").unwrap();
+        let dest = TempDir::new().unwrap();
+        let receipt = create_pre_migration_backup(data.path(), "test", Some(dest.path())).unwrap();
+
+        // Still only the two real data files — the lock pair was dropped.
+        assert_eq!(receipt.entries, 2);
+        let names = archived_names(&receipt.archive_path);
+        assert!(
+            !names.iter().any(|n| n.contains(".serve.lock")),
+            "the serve lock must never land in the archive: {names:?}"
+        );
+        assert!(names.iter().any(|n| n.ends_with("wiki/ws/proj/notes/a.md")));
+    }
+
+    /// #593 on the platform that actually breaks: hold an exclusive lock on
+    /// `.serve.lock` exactly as `acquire_serve_lock` does, then run the
+    /// backup. Before the fix the walk's `File::open` on the locked file
+    /// faulted with `ERROR_LOCK_VIOLATION` (os error 33) and aborted the
+    /// migration; now the walk skips it and the backup completes.
+    #[cfg(windows)]
+    #[test]
+    fn a_held_serve_lock_does_not_fault_the_backup_on_windows() {
+        let data = data_dir_with_content();
+        let lock = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(data.path().join(".serve.lock"))
+            .unwrap();
+        // Exactly what `acquire_serve_lock` holds for the process lifetime.
+        lock.lock().unwrap();
+
+        let dest = TempDir::new().unwrap();
+        let receipt = create_pre_migration_backup(data.path(), "test", Some(dest.path()))
+            .expect("backup must survive a held serve lock (#593)");
+        assert_eq!(receipt.entries, 2);
+        assert!(receipt.archive_present());
+
+        lock.unlock().unwrap();
     }
 
     #[test]

--- a/docs/MIGRATION-2.0.md
+++ b/docs/MIGRATION-2.0.md
@@ -125,6 +125,39 @@ directory and will tolerate the extra frontmatter, but new writes from
 1.x will not carry the OKF keys — avoid mixing; restore the archive if
 you need to stay on 1.x.)
 
+## Windows: backup fails with `os error 33` (fixed in 2.0.2+)
+
+On **ai-memory 2.0.0 and 2.0.1**, upgrading a Windows store that already
+has data aborts the pre-migration backup with:
+
+```text
+ERROR ai_memory_wiki::migrations::runner: wiki migration failed — server cannot start until this is resolved
+  error=... (os error 33)
+```
+
+`os error 33` is `ERROR_LOCK_VIOLATION`; the localised text varies by
+Windows display language (`O processo não pode acessar o arquivo…` on a
+Portuguese install). The backup walk tried to archive the `.serve.lock`
+file while the same process held a mandatory exclusive lock on it (#593).
+Fresh installs are unaffected.
+
+**Fix:** upgrade to **2.0.2 or later** and restart. The failed migration
+was never recorded, so it simply retries and completes — no manual
+recovery needed.
+
+**Stuck on 2.0.0 / 2.0.1 and cannot upgrade yet?** Hold a byte-range
+lock on `.serve.lock` above the first 64 KB from another process, then
+start `serve --force` (which then runs without taking the whole-file
+lock itself, so the backup can read the 0-byte lock file):
+
+```powershell
+$fs = [IO.File]::Open("$DataDir\.serve.lock", 'OpenOrCreate', 'ReadWrite', 'ReadWrite')
+$fs.Lock(1048576, 1); Start-Sleep 240; $fs.Unlock(1048576, 1); $fs.Dispose()
+```
+
+Restart normally (without `--force`) once the migration completes to
+restore the single-instance guard.
+
 ## Sharing bundles
 
 Post-migration, each project directory *is* an OKF v0.2 bundle. Hand a


### PR DESCRIPTION
## What changed

**Before:** on Windows, upgrading a store with existing data from 1.x to 2.0.x
aborted the OKF v0.2 pre-migration backup with `os error 33`
(`ERROR_LOCK_VIOLATION`). The backup gate then failed, the migration aborted,
and the server refused to start on either version — the store was left
half-migrated (refinery v57/v58 applied, wiki not conformed). Fresh installs
were unaffected (the gate skips them).

**After:** the backup walk skips `.serve.lock` and its `.holder` sidecar before
any `File::open`, the same way it already skips the half-written archive and
the receipt tmp file. The migration completes; a store already stuck recovers
by restarting on the fixed binary (the failed wiki migration is never recorded,
so it simply retries). No default changes.

Fixes #593.

## Why

Bug fix. `create_pre_migration_backup` (`crates/ai-memory-wiki/src/backup.rs`)
tars every file under the data dir, excluding only the archive and the receipt
tmp. `.serve.lock` — the single-instance guard (#563) that the *same* `serve`
process holds under an exclusive lock — was not excluded. On Windows
`LockFileEx` locks are mandatory: opening the locked file on another handle to
read it into the tar faults with `ERROR_LOCK_VIOLATION`, and `read_dir` yields
`.serve.lock` first (leading `.` sorts ahead on NTFS), so the walk died on its
first entry. Unix is immune (advisory locks don't fault reads), which is why
the Unix-only CI matrix never caught it.

The lock file name moves to `ai-memory-core` as `SERVE_LOCK_FILE`, shared by
`serve` and the wiki crate; `holder_info_path` derives the sidecar name from
it.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes — on `x86_64-pc-windows-msvc`, Rust 1.95,
      including the `#[cfg(windows)]` test
- [x] `cargo deny check` passes (`advisories ok, bans ok, licenses ok, sources
      ok`) — and `Cargo.lock` is unchanged by this PR anyway (the fix uses
      `std`'s file locking, no new crate)
- [x] Manual test: negative control — reverted the walk guard and ran the two
      new tests. `a_held_serve_lock_does_not_fault_the_backup_on_windows` panics
      with `Os { code: 33, kind: Uncategorized }` (`ERROR_LOCK_VIOLATION`);
      `the_backup_walk_skips_the_serve_lock_and_its_sidecar` fails with
      `entries` = 4 instead of 2. Both green with the fix.

New regression tests in `backup.rs`:

- `the_backup_walk_skips_the_serve_lock_and_its_sidecar` (all platforms)
- `a_held_serve_lock_does_not_fault_the_backup_on_windows` (`#[cfg(windows)]`) —
  holds an exclusive lock on `.serve.lock` exactly as `acquire_serve_lock` does

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected
      any unintended identity before requesting merge.
      (`rafaelkenedy <k.rafaelalves@gmail.com>`, linked to the GitHub account.)

## Release impact

- [x] **Patch** — bug fix, no new surface
- [ ] **Minor**
- [ ] **Major (breaking)**

## CHANGELOG (merge gate)

- [x] Added a `CHANGELOG.md` `[Unreleased]` → `### Fixed` entry.
- [x] No changed default.

## Notes for reviewers

- Please add the **`windows`** label so `windows.yml` runs before merge — this
  touches file locking and path handling. (I can't set labels from a fork.)
- `SERVE_LOCK_FILE` lands in `ai-memory-core`, whose crate doc says "free of
  platform concerns" — it's a plain `&str` filename; the doc-comment notes the
  Windows hazard only to tell callers why they must skip it. Happy to move it
  to `ai-memory-store` or inline the literal in `backup.rs` if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
