### PR TITLE
fix(wiki): exclude .serve.lock from OKF pre-migration backup (fixes #593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so historical `as_of` is correct. Broad tags don't distort ranking
   (the entity stream is inverse-frequency weighted), and a store already
   written through the current path is a no-op. See `docs/temporal.md`.
+- The OKF v0.2 pre-migration backup walk now skips the `.serve.lock`
+  single-instance lock and its `.serve.lock.holder` sidecar. On Windows
+  the exclusive `LockFileEx` is mandatory, so the same `serve` process
+  that runs the migration also holds `.serve.lock` and could not read it
+  back while creating the backup — the walk aborted with `os error 33`
+  and the server crash-looped on every `2.0.x` upgrade from a 1.x store
+  (#593). Linux/macOS were immune because POSIX locks are advisory.
 - The Windows PowerShell wrapper (`ai-memory.ps1`) no longer crashes with
   `git.exe : fatal: not a git repository … NativeCommandError` when run
   outside a git repository — which broke `ai-memory status` and every

--- a/crates/ai-memory-wiki/src/backup.rs
+++ b/crates/ai-memory-wiki/src/backup.rs
@@ -166,10 +166,17 @@ fn create_pre_migration_backup_inner(
                     }
                     stack.push(path);
                 } else if ft.is_file() {
+                    let file_name = path.file_name().and_then(|n| n.to_str());
                     if path == archive_path
-                        || path
-                            .file_name()
-                            .is_some_and(|n| n == "pre-migration-backup.json.tmp")
+                        || file_name == Some("pre-migration-backup.json.tmp")
+                        // The single-instance serve lock and its holder-info
+                        // sidecar. On Windows the exclusive LockFileEx is
+                        // mandatory, so the same serve process that owns the
+                        // migration also holds `.serve.lock` and cannot read
+                        // it back from the walk (os error 33). Keep in sync
+                        // with crates/ai-memory-cli/src/commands/serve.rs
+                        // `SERVE_LOCK_FILE`.
+                        || file_name.is_some_and(|n| n.starts_with(".serve.lock"))
                     {
                         continue;
                     }
@@ -332,5 +339,41 @@ mod tests {
         let receipt = create_pre_migration_backup(data.path(), "test", Some(dest.path())).unwrap();
         std::fs::remove_file(&receipt.archive_path).unwrap();
         assert!(!receipt.archive_present());
+    }
+
+    /// The pre-migration backup runs in the same process as `serve`, which
+    /// holds `.serve.lock` under an exclusive LockFileEx. On Windows that
+    /// lock is mandatory, so the walk cannot read the file back. The walk
+    /// must skip `.serve.lock` and its `.serve.lock.holder` sidecar by name,
+    /// exactly as it already skips the archive and the receipt tmp. Simulated
+    /// here on all platforms because the skip is by name, independent of OS
+    /// lock semantics; a Windows CI running the real lock would hit the same
+    /// path after this guard.
+    #[test]
+    fn the_backup_skips_the_serve_lock_and_its_holder_sidecar() {
+        let data = data_dir_with_content();
+        std::fs::write(data.path().join(".serve.lock"), b"").unwrap();
+        std::fs::write(data.path().join(".serve.lock.holder"), b"pid=1").unwrap();
+        let dest = TempDir::new().unwrap();
+        let receipt = create_pre_migration_backup(data.path(), "test", Some(dest.path())).unwrap();
+        assert_eq!(
+            receipt.entries, 2,
+            "only the two data files; serve lock and holder never archived"
+        );
+        let file = std::fs::File::open(&receipt.archive_path).unwrap();
+        let dec = flate2::read::GzDecoder::new(file);
+        let mut ar = tar::Archive::new(dec);
+        for entry in ar.entries().unwrap() {
+            let name = entry
+                .unwrap()
+                .path()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned();
+            assert!(
+                !name.starts_with(".serve.lock"),
+                "archive must not contain serve lock entry: {name:?}"
+            );
+        }
     }
 }

--- a/docs/MIGRATION-2.0.md
+++ b/docs/MIGRATION-2.0.md
@@ -19,9 +19,18 @@ one-shot wiki migration runs before the server accepts any traffic:
 
    Set `AI_MEMORY_BACKUP_DIR=/somewhere/else` before starting if your
    home is small; the destination must be outside the data directory.
-   The archive is re-opened and verified after writing. **If the backup
-   cannot be written or verified, the migration aborts and the server
-   refuses to start** — your data is untouched and the error says why.
+The archive is re-opened and verified after writing. **If the backup
+    cannot be written or verified, the migration aborts and the server
+    refuses to start** — your data is untouched and the error says why.
+
+    The walk skips the runtime `.serve.lock` file (and its
+    `.serve.lock.holder` sidecar) so the initial-start abort seen on
+    Windows — where the same `serve` process holds that lock under a
+    mandatory exclusive `LockFileEx`, making the backup read fail with
+    `os error 33` — cannot happen. If you are on 2.0.0/2.0.1 and still
+    hit it, dropping the container/process (or using a byte-range decoy
+    lock above the first 64 KiB with `serve --force`) unblocks the
+    one-time migration; a later patch releases these notes.
 
 2. The wiki git history gets a `pre-okf-migration checkpoint` commit.
 


### PR DESCRIPTION
## Summary

Windows native upgrades from `1.x` to `2.0.0/2.0.1` crash-loop on every start because the OKF v0.2 pre-migration backup gated migration could not read `.serve.lock`.

`serve` runs the migration in the same process that already holds `<data_dir>/.serve.lock` (`SERVE_LOCK_FILE`) under an exclusive `LockFileEx`. On Windows that lock is **mandatory**: opening a second handle to read the locked bytes fails with `ERROR_LOCK_VIOLATION` (`os error 33`). `.serve.lock` sorts first on NTFS, so the backup walk aborts on its very first file entry, the migration can't proceed, and the server never boots (SQL refinery migrations already applied, wiki not conformed). Linux/macOS were immune because POSIX locks are advisory. Fresh installs never hit it (the backup gate skips fresh stores); only real upgrades were affected (#593).

## Fix

The backup walk already excludes the archive itself and the receipt tmp. This adds `.serve.lock` and its `.serve.lock.holder` sidecar to that exclusion, by exact name prefix — the same mechanism `serve.rs` already relies on to keep the lock out of other handles' way, and the treatment the issue reporter suggested.

## Validation

- New unit test `the_backup_skips_the_serve_lock_and_its_holder_sidecar` — simulated on all platforms (the skip is by name, independent of OS lock semantics) — verifies neither `.serve.lock` nor `.serve.lock.holder` lands in the archive while `wiki/a.md` + `db.sqlite` do.
- `cargo test -p ai-memory-wiki backup` — 12/12 pass.
- `cargo clippy --workspace` + `cargo fmt --check` — clean.
- `CHANGELOG.md` entry added under `## [Unreleased] / ### Fixed`.
- `docs/MIGRATION-2.0.md` note added so the Windows workaround is clearly marked as superseded once this ships.

Closes #593
