### PR TITLE
fix(store): say "does not exist" when the project id is dangling

### DIFF
--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -532,6 +532,15 @@ pub fn ensure_project_with_id(
 /// Wiki writes call this before touching the filesystem so a stale hook/cache
 /// carrying the old workspace for a moved project fails before it can create an
 /// orphan file. The pairing INSERT triggers are still the final SQL backstop.
+///
+/// The two ways this fails need different words, because they send a reader
+/// looking in different places. A project that moved workspaces is a stale
+/// pairing: the row exists, and the caller's copy of its scope is out of date.
+/// A project id with no row at all is a dangling reference — nothing moved,
+/// and there is no scoping question to answer. Reporting the second as "does
+/// not belong to workspace X" costs whoever reads that line a hunt for a
+/// workspace/project mismatch that does not exist. The disambiguating query
+/// runs only on the failure path, so the common case still pays one lookup.
 pub fn ensure_project_workspace(
     conn: &Connection,
     workspace_id: &WorkspaceId,
@@ -545,12 +554,23 @@ pub fn ensure_project_workspace(
         )
         .optional()?;
     if found.is_some() {
-        Ok(())
-    } else {
-        Err(StoreError::NotFound(format!(
-            "project {project_id} does not belong to workspace {workspace_id}"
-        )))
+        return Ok(());
     }
+    let owner: Option<Vec<u8>> = conn
+        .query_row(
+            "SELECT workspace_id FROM projects WHERE id = ?1",
+            params![project_id.as_bytes()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Err(StoreError::NotFound(match owner {
+        Some(owner) => format!(
+            "project {project_id} does not belong to workspace {workspace_id}; \
+             it belongs to {}",
+            WorkspaceId::from_slice(&owner)?
+        ),
+        None => format!("project {project_id} does not exist"),
+    }))
 }
 
 /// Upsert a batch of pages inside one transaction. Either *all* pages
@@ -8060,6 +8080,38 @@ pub(crate) mod tests {
                 Err(StoreError::NotFound(_))
             ),
             "a stale workspace/project pair must fail before wiki writes touch disk"
+        );
+    }
+
+    #[test]
+    fn ensure_project_workspace_separates_a_moved_project_from_a_missing_one() {
+        let (_tmp, conn, ws, proj) = fresh_db();
+        let other_ws = WorkspaceId::new();
+        let ghost = ProjectId::new();
+
+        // The project exists, but the caller carries a stale workspace: the
+        // message has to name where it actually lives, or the reader cannot
+        // tell a stale cache from a corrupt one.
+        let moved = ensure_project_workspace(&conn, &other_ws, &proj).unwrap_err();
+        let moved = moved.to_string();
+        assert!(
+            moved.contains(&ws.to_string()) && moved.contains(&other_ws.to_string()),
+            "a moved project must name both the real and the supplied workspace, got: {moved}"
+        );
+
+        // No row at all. Saying this "does not belong to workspace X" sends
+        // the reader hunting a scoping bug that is not there — the id is
+        // simply dangling.
+        let missing = ensure_project_workspace(&conn, &ws, &ghost)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            missing.contains("does not exist"),
+            "a dangling project id must be reported as missing, got: {missing}"
+        );
+        assert!(
+            !missing.contains("does not belong to workspace"),
+            "a dangling project id must not be described as a workspace mismatch, got: {missing}"
         );
     }
 


### PR DESCRIPTION
Split out of #613 — this is the small, self-contained half of it.

## The defect

`ensure_project_workspace` has two failure modes and one sentence for both:

```rust
"SELECT 1 FROM projects WHERE id = ?1 AND workspace_id = ?2"
// ...
Err(StoreError::NotFound(format!(
    "project {project_id} does not belong to workspace {workspace_id}"
)))
```

A single predicate over both columns cannot distinguish *the project moved* from *the project was never there*, so both are reported as a workspace mismatch.

The two send a reader to different places. A moved project is a stale pairing — the row exists, and the caller's copy of its scope is out of date; the doc-comment says that is the case the check was written for. A dangling id has no row at all: nothing moved, and there is no scoping question to answer. Told the second in the first's words, whoever reads that line goes hunting a workspace/project mismatch that does not exist.

## How it showed up

On a production instance, 77 wiki directories whose project rows were gone made the watcher emit this line ~600 times every two minutes, each naming a workspace that had nothing to do with the problem. I started the diagnosis at the wrong end because of the wording, and only found the real shape — dangling ids, not misfiled ones — after querying the database by hand.

## The change

A second query, on the failure path only, separates them:

- no row → `project X does not exist`
- row elsewhere → `project X does not belong to workspace Y; it belongs to Z`

The success path still pays one lookup. The moved case deliberately keeps the original phrase so `admin_move::true_move_stale_source_write_fails_before_creating_file` goes on asserting exactly what it asserted before — no upstream expectation was rewritten to fit this patch — and gains the destination, which is the part a reader actually needs.

## Verification

- New test `ensure_project_workspace_separates_a_moved_project_from_a_missing_one`, checked both ways: it **fails** against the old message and passes against this one.
- `cargo test -p ai-memory-store --lib` — 341 passed.
- `cargo test -p ai-memory-mcp --test admin_move` — 32 passed.
- `cargo fmt --check` and `cargo clippy --all-features` clean.
