### PR TITLE
fix(bootstrap): tolerate a chunk that returns no pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `bootstrap` no longer aborts the whole multi-chunk run when one chunk
+  returns no `pages` key (#614). Later chunks are told which paths
+  earlier ones wrote, so a model that judges the material already
+  covered legitimately answers with a rationale and no pages; because
+  Anthropic's `tool_use` schema does not enforce required fields the way
+  OpenAI's `strict: true` does, that answer reached serde and failed
+  deserialisation with `missing field 'pages'`. Since pages are only
+  written after every chunk completes, the error discarded the work of
+  all preceding chunks. `pages` now defaults to empty.
 - `install-hooks --agent antigravity-cli` on native Windows now emits
   an unquoted hook `command` (#611). The native-binary rendering wrapped
   the executable, `--data-dir`, and `--server-url` in double quotes, but

--- a/crates/ai-memory-consolidate/src/bootstrap.rs
+++ b/crates/ai-memory-consolidate/src/bootstrap.rs
@@ -160,6 +160,15 @@ pub struct BootstrapPage {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct BootstrapBatch {
     /// Pages to create.
+    ///
+    /// Defaulted because a chunk legitimately has nothing to add: later
+    /// chunks receive the paths earlier ones already wrote, so a model
+    /// that judges the material covered answers with a rationale and no
+    /// `pages` key. Anthropic's `tool_use` schema does not enforce
+    /// required fields the way OpenAI's `strict: true` does, so that
+    /// answer reaches serde — and without a default it aborts the whole
+    /// multi-chunk run, discarding every page the earlier chunks paid for.
+    #[serde(default)]
     pub pages: Vec<BootstrapPage>,
     /// Brief one-paragraph note about what was processed, surfaced
     /// in the wiki/bootstrap.md manifest + the auto-commit message.
@@ -1554,6 +1563,16 @@ mod tests {
         assert_eq!(collected, 27_873);
         assert_eq!(sent, 1);
         assert_eq!(dropped, 27_872);
+    }
+
+    #[test]
+    fn batch_without_pages_key_deserialises_as_empty() {
+        let batch: BootstrapBatch =
+            serde_json::from_str(r#"{"rationale":"already covered by earlier chunks"}"#)
+                .expect("a chunk that adds no pages must not fail the whole run");
+
+        assert!(batch.pages.is_empty());
+        assert_eq!(batch.rationale, "already covered by earlier chunks");
     }
 
     #[test]


### PR DESCRIPTION
## What changed

`BootstrapBatch::pages` is now `#[serde(default)]`.

Before: a chunk answering `{"rationale": "..."}` with no `pages` key failed deserialisation with `missing field 'pages'`, and because that error propagates out of the chunk loop before any page is written, the whole run was discarded — including every page the earlier chunks had produced.

After: that answer deserialises as an empty batch, the chunk contributes nothing, and the run continues to the next one.

No default changes: a batch that *does* carry `pages` behaves exactly as before.

## Why

Fixes #614.

Later chunks are handed the paths earlier ones already wrote, so "the remaining material is already covered" is a correct answer for a model to give — particularly on repositories whose sources are documentation rather than commits, where a handful of dense files can be fully described by the first few chunks. Anthropic's `tool_use` schema (`crates/ai-memory-llm/src/anthropic.rs:255-260`) is advisory rather than enforcing, unlike OpenAI's `strict: true`, so that answer reaches serde.

The rest of the pipeline already tolerates an empty batch — `insert_bootstrap_page` is simply never called and `merged_pages` ends up shorter. Only the deserialisation step objected.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` — **not run locally**, see "Notes for reviewers"
- [x] Manual test: reproduced on a docs-only repository (70 sources collected / 36 kept, 0 git commits, 33 doc files, `llm_chunks=9`) against `claude-haiku-4-5`. The unpatched server failed with `502 {"error":"serde: missing field 'pages'"}` on 2 of 4 attempts, each time discarding a ~20-minute run. Added `batch_without_pages_key_deserialises_as_empty` to cover the payload shape directly.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected
      any unintended identity before requesting merge.

## Release impact

- [x] **Patch** — bug fix, no new surface

## CHANGELOG (merge gate)

- [x] I added a `CHANGELOG.md` `[Unreleased]` entry
- [x] Any changed **default** is called out explicitly in "What changed" above (none — behaviour for batches that carry `pages` is unchanged)

## Notes for reviewers

**On the missing `cargo test --workspace`:** I could not run the full suite locally. On aarch64 the build fails in `gemm-f16` (`error: instruction requires: fullfp16`) pulled in through `candle`, and the x86_64 path under emulation was too slow to finish. `fmt` and `clippy` both pass on aarch64. The change is one attribute plus one test that only exercises `serde_json::from_str`, so I am relying on CI here — please bounce this back if you would rather see a green local run first.

**On scope:** I deliberately kept this to the deserialisation fix. The larger issue — that *any* single-chunk failure discards the entire run, because pages are only written after the loop at `bootstrap.rs:390` — is a design question (write incrementally per chunk, or persist progress for a `--resume`, along the lines of the durable queue from #260). I did not want to presume a direction in a PR. Happy to open a separate issue or take a stab at it if you have a preference.
