### PR TITLE
fix(watcher): apply the orphan skip to directory events too

### DIFF
--- a/crates/ai-memory-wiki/src/watcher.rs
+++ b/crates/ai-memory-wiki/src/watcher.rs
@@ -244,21 +244,39 @@ async fn handle_event(wiki: &Wiki, event: notify_debouncer_full::DebouncedEvent)
     }
 }
 
+/// Returns `false` when the directory was skipped because the store has no
+/// row for it — the same orphan case `reconcile` counts as `skipped_orphans`,
+/// surfaced here so the skip is testable on this path too.
 async fn reindex_project_dir(
     wiki: &Wiki,
     ws: WorkspaceId,
     proj: ProjectId,
     proj_root: std::path::PathBuf,
-) {
+) -> bool {
+    // Same orphan guard `reconcile` applies (#613), for the other way a
+    // project directory reaches the indexer. A filesystem event on a rowless
+    // directory would otherwise walk it and warn once per page, which is the
+    // behaviour that pass was about — quieter here only because it needs an
+    // event rather than firing every 30s. Checking once per directory also
+    // saves walking a tree whose every page is going to fail scope resolution.
+    if let Err(e) = wiki.ensure_project_workspace(ws, proj).await {
+        debug!(
+            workspace = %ws,
+            project = %proj,
+            error = %e,
+            "skipping directory event for a project directory with no store row",
+        );
+        return false;
+    }
     let pages = match tokio::task::spawn_blocking(move || walk_markdown(&proj_root)).await {
         Ok(Ok(pages)) => pages,
         Ok(Err(e)) => {
             warn!(error = %e, "watcher directory walk failed");
-            return;
+            return true;
         }
         Err(e) => {
             warn!(error = %e, "watcher directory walk task failed");
-            return;
+            return true;
         }
     };
 
@@ -268,6 +286,7 @@ async fn reindex_project_dir(
             Err(e) => warn!(path = %path, error = %e, "watcher directory reindex failed"),
         }
     }
+    true
 }
 
 /// Outcome of one reconciliation pass, for the caller's telemetry and tests.
@@ -826,6 +845,40 @@ mod tests {
         assert!(
             stranded.is_empty(),
             "an orphan directory's page must not be indexed"
+        );
+    }
+
+    /// The sibling of `reconcile_skips_project_dirs_with_no_store_row` (#613):
+    /// a directory event reaches the indexer through `reindex_project_dir`,
+    /// which had no orphan guard. Rarer than the 30s pass, same defect.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn directory_events_skip_project_dirs_with_no_store_row() {
+        let (tmp, store, wiki, ws, _proj) = setup().await;
+        let wiki_root = tmp.path().join("wiki");
+
+        let orphan = ProjectId::new();
+        let orphan_dir = wiki_root.join(ws.to_string()).join(orphan.to_string());
+        std::fs::create_dir_all(&orphan_dir).unwrap();
+        std::fs::write(orphan_dir.join("index.md"), "seeded shell\n").unwrap();
+        std::fs::write(orphan_dir.join("stale.md"), "eventtoken content\n").unwrap();
+
+        // Exactly what a Create/Modify event on the directory triggers.
+        let indexed = reindex_project_dir(&wiki, ws, orphan, orphan_dir).await;
+        assert!(
+            !indexed,
+            "a rowless directory must be skipped before the walk, not walked \
+             and failed page by page"
+        );
+
+        let stranded = store
+            .reader
+            .search_pages("eventtoken".into(), 5)
+            .await
+            .unwrap();
+        assert!(
+            stranded.is_empty(),
+            "a rowless directory must not index through a directory event, got {}",
+            stranded.len()
         );
     }
 


### PR DESCRIPTION
Follow-up to 249c616b (#613). Small and deliberately narrow — please read the "what this is not" section before weighing it.

## The gap

`reconcile` got the orphan guard: check the project scope once per directory, skip a rowless one wholesale at `debug`. A project directory reaches the indexer by a second route, and it kept the old behaviour:

```rust
if ft.is_dir() {
    let Some((ws, proj, proj_root)) = extract_project_dir_ids(wiki.root(), raw_path) else { continue; };
    reindex_project_dir(wiki, ws, proj, proj_root).await;   // no scope check
    continue;
}
```

`reindex_project_dir` walks the tree and lets every page fail scope resolution on its own — one `warn` each — which is the behaviour that pass was about.

## What this is not

**It is not a second incident, and the functional outcome does not change.** `reindex_page` makes the same `ensure_project_workspace` call, so no page from a rowless directory was ever indexed by this path either. What changes is one `debug` line instead of one warning per page, and not walking a tree whose every entry is going to fail.

It is also far quieter than what #613 reported: it needs a filesystem event on that specific directory rather than firing every 30 seconds, so it could never have produced the flood that buried the 22-hour outage on our host. I am sending it as consistency in the sibling function, not as a bug — if you would rather leave the event path alone, that is a reasonable call and no argument from me.

## On the return value

`reindex_project_dir` now returns whether it indexed. Same reasoning you gave for `ReconcileStats`: the skip has to be observable to be testable. The caller ignores it; if you prefer it folded into the caller as a counter, or a `ReconcileStats`-shaped type instead of a `bool`, say so and I will change it.

## Verification

- New test `directory_events_skip_project_dirs_with_no_store_row`, checked both ways: **fails** without the guard, passes with it.
- Worth mentioning because it nearly shipped wrong: my first version asserted the orphan page was absent from the store, and **passed with and without the guard** — the store is precisely what does not differ between the two. Asserting on the skip is what makes it a regression test rather than a decoration.
- `directory_event_reindexes_project_markdown` (the resolvable-directory case) still passes, so the legitimate path is untouched.
- `cargo test -p ai-memory-wiki` — 142 passed. `cargo fmt --check` and `cargo clippy --all-features` clean.