### PR TITLE
fix(tests): stop fixture git commits failing when the developer signs commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,12 @@ Additional boundary rules:
   Parsers, ID derivation, and retention/decay math especially.
 - Filesystem tests use temp dirs or injected roots (`tempfile`); never
   depend on the real user home directory being writable.
+- Tests that build throwaway git repos must not inherit the contributor's
+  machine config: pass `--no-gpg-sign` on every fixture commit (a global
+  `commit.gpgsign = true` otherwise signs as the fixture's fake identity and
+  fails), and build `git2` signatures with a fixed `Signature::now(...)`,
+  never `repo.signature()`. CI cannot catch either — its runners have no
+  global gitconfig, so the breakage only ever shows up on a developer's box.
 - PRs touching scope resolution need table-driven tests for partial
   scope, missing explicit scope, active-project precedence, and
   cross-workspace isolation.

--- a/crates/ai-memory-cli/src/commands/hook_capture.rs
+++ b/crates/ai-memory-cli/src/commands/hook_capture.rs
@@ -893,6 +893,9 @@ drop_subagent_captures = "true"
                 .unwrap()
                 .success()
         );
+        // The commit exists only because `git worktree add` refuses a repo with
+        // no commits. --no-gpg-sign: a global `commit.gpgsign = true` would
+        // otherwise make git sign as this throwaway identity, and fail.
         assert!(
             std::process::Command::new("git")
                 .arg("-C")
@@ -904,6 +907,7 @@ drop_subagent_captures = "true"
                     "user.name=t",
                     "commit",
                     "-q",
+                    "--no-gpg-sign",
                     "--allow-empty",
                     "-m",
                     "init",

--- a/crates/ai-memory-consolidate/src/bootstrap.rs
+++ b/crates/ai-memory-consolidate/src/bootstrap.rs
@@ -1336,15 +1336,19 @@ mod tests {
         run(&["init", "-q", "-b", "main"])?;
         run(&["config", "user.email", "test@example.com"])?;
         run(&["config", "user.name", "Test"])?;
+        // --no-gpg-sign throughout: a global `commit.gpgsign = true` would make
+        // git sign as this fixture's throwaway identity, and fail.
         run(&[
             "commit",
+            "--no-gpg-sign",
             "--allow-empty",
             "-m",
             "feat: initial scaffolding for storage substrate with WAL + supersession chain",
         ])?;
-        run(&["commit", "--allow-empty", "-m", "typo"])?;
+        run(&["commit", "--no-gpg-sign", "--allow-empty", "-m", "typo"])?;
         run(&[
             "commit",
+            "--no-gpg-sign",
             "--allow-empty",
             "-m",
             "design: choose Karpathy compile-not-retrieve model over RAG for capture",
@@ -1683,10 +1687,9 @@ mod tests {
             assert!(status.success(), "git {args:?} failed");
             Ok(())
         };
+        // `git init` alone is enough: MainRepoRoot resolves through
+        // `Repository::discover` + `commondir()`, which never reads HEAD.
         run(&["init", "-q", "-b", "main"]).unwrap();
-        run(&["config", "user.email", "t@t"]).unwrap();
-        run(&["config", "user.name", "t"]).unwrap();
-        run(&["commit", "--allow-empty", "-m", "init"]).unwrap();
 
         let from_sub = repo.join("sub").join("dir");
         let (name, root) =

--- a/crates/ai-memory-hooks/src/router.rs
+++ b/crates/ai-memory-hooks/src/router.rs
@@ -3730,9 +3730,10 @@ mod tests {
     fn init_repo_with_commit(path: &std::path::Path) -> git2::Repository {
         std::fs::create_dir_all(path).unwrap();
         let repo = git2::Repository::init(path).unwrap();
-        let sig = repo
-            .signature()
-            .unwrap_or_else(|_| git2::Signature::now("test", "test@test.com").unwrap());
+        // Fixed identity, not `repo.signature()`: that reads the machine's global
+        // user.name/user.email, so these commits would be authored by whoever ran
+        // the suite. Unrelated to signing — libgit2 never signs commits.
+        let sig = git2::Signature::now("test", "test@test.com").unwrap();
         let tree_id = repo.index().unwrap().write_tree().unwrap();
         {
             let tree = repo.find_tree(tree_id).unwrap();
@@ -3766,7 +3767,9 @@ mod tests {
         commit
             .arg("-C")
             .arg(path)
-            .args(["commit", "--allow-empty", "-m", "initial"]);
+            // --no-gpg-sign: a global `commit.gpgsign = true` would make git
+            // sign as this fixture's throwaway identity, and fail.
+            .args(["commit", "--no-gpg-sign", "--allow-empty", "-m", "initial"]);
         assert_command_success(commit);
     }
 

--- a/scripts/managed-workstream-acceptance.sh
+++ b/scripts/managed-workstream-acceptance.sh
@@ -47,7 +47,7 @@ git -C "$REPO" config user.name "ai-memory acceptance"
 git -C "$REPO" config user.email "acceptance@localhost"
 printf '# Managed workstream acceptance\n' >"$REPO/README.md"
 git -C "$REPO" add README.md
-git -C "$REPO" commit -qm "acceptance fixture"
+git -C "$REPO" commit -q --no-gpg-sign -m "acceptance fixture"
 
 TOKEN="managed-acceptance-$(date +%s)-$$"
 PORT=${AI_MEMORY_ACCEPTANCE_PORT:-$((52000 + ($$ % 10000)))}
@@ -1235,7 +1235,7 @@ git -C "$OTHER_REPO" config user.name "ai-memory acceptance"
 git -C "$OTHER_REPO" config user.email "acceptance@localhost"
 printf '# elsewhere\n' >"$OTHER_REPO/README.md"
 git -C "$OTHER_REPO" add README.md
-git -C "$OTHER_REPO" commit -qm "acceptance fixture"
+git -C "$OTHER_REPO" commit -q --no-gpg-sign -m "acceptance fixture"
 other_json=$(cd "$OTHER_REPO" && "$BIN" --data-dir "$DATA" workstreams \
   --project "$(basename "$REPO")" --json)
 jq -e 'length == 0' <<<"$other_json" >/dev/null || {

--- a/tests/hooks/test_lib.sh
+++ b/tests/hooks/test_lib.sh
@@ -181,7 +181,7 @@ if command -v git >/dev/null 2>&1; then
     mkdir -p "$REPO"
     git init -q "$REPO"
     git -C "$REPO" -c user.email=t@example.com -c user.name=t \
-        commit -q --allow-empty -m init
+        commit -q --no-gpg-sign --allow-empty -m init
 
     # A subdirectory of the main checkout collapses to the repo basename
     # (not the subdir name) when the marker selects repo-root and pins no


### PR DESCRIPTION
## What changed

Some tests need a real git repo to run against. One example is the test that checks a detached worktree resolves to the repo name, not the worktree folder name. Those tests make a throwaway repo in a temp dir with `git init`, make a commit, then check the result.

The commit step was failing. Here is the chain:

1. The fixtures commit with a fake identity passed inline, `-c user.email=t@example.com -c user.name=t`.
2. `-c` sets those two keys, but every other config key is still read as normal, including `commit.gpgsign` from the developer's `~/.gitconfig`.
3. If that is `true`, git tries to sign the commit, and it picks the signing key based on the committer identity, which here is `t@example.com`.
4. There is no key for a made-up address, so gpg (or gpgsm when `gpg.format = x509`) fails, and git gives up on the commit.

The fix adds `--no-gpg-sign` to each commit call. It turns off `commit.gpgsign` for that one command, and does nothing at all if you were not signing anyway. Eight places: 1 in `hook_capture.rs`, 3 in `bootstrap.rs`, 1 in `router.rs` (Windows arm), 1 in `tests/hooks/test_lib.sh`, 2 in `scripts/managed-workstream-acceptance.sh`.

Two other things came out of the same sweep.

`router.rs` built its commit author with `repo.signature()`. That reads `user.name` and `user.email` through libgit2's config chain, which includes the developer's global config. So fixture commits were authored by whoever ran the suite, and the `Signature::now("test", ...)` fallback right next to it could never run on a machine with git set up. It now always uses a fixed identity. This is about making the fixture deterministic, not about signing: libgit2 does not sign commits at all, so this fixture was never hit by the failure above.

`bootstrap.rs` made a commit and set two `git config` values that nothing needed. The test calls `derive_project_name(.., MainRepoRoot)`, which goes through `Repository::discover()` and `commondir()` and never reads HEAD, so an empty repo is enough. It now just runs `git init`. That drops three subprocess calls and one more place you would have to remember the flag.

No production code is touched, and nothing changes for users.

## Why

`commit.gpgsign = true` in a developer's `~/.gitconfig` applies to every repo on that machine, including the temp ones a test run creates. You get a confusing failure at a step the test is not even about:

```
error: gpg failed to sign the data
fatal: failed to write commit object
```

This lasted so long because CI cannot see it. GitHub Actions runners start with no global git config, so signing is off and all these tests pass there. It only shows up on a developer machine, and it looks like a broken test rather than a config problem.

I tried a bigger fix first: a helper that wiped out the whole global config (`GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM`) for every test git call. It came to about 150 lines copied across three crates to do what one git flag does, so I dropped it.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (native Windows 11, Git 2.52; passes both with and without a scoped `commit.gpgsign = true`)
- [x] Manual: with signing on globally, `ai-memory-cli` went from 1 failure to 0, and `ai-memory-consolidate` from 2 to 0. I removed the unnecessary commit and re-ran `derive_project_name_main_repo_root_collapses_subdirs` to check nothing depended on it. Ran `bash -n` on the shell edits.

## Commit attribution

- [x] Verified name and email on every commit

## Release impact

- [x] **Patch**

## CHANGELOG

- [ ] Skipped. This is test-only churn plus one line of contributor docs, which the template exempts. Happy to add an entry if you want one.
- [x] No changed defaults.

