### PR TITLE
feat(bootstrap): --resume reuses the chunks an interrupted run completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   snapshot.
 
 ### Added
+- `ai-memory bootstrap --resume` reuses the chunks an interrupted run already
+  completed instead of paying for their LLM calls again (#621). A multi-chunk
+  bootstrap holds every page in memory until one post-loop write, so a crash,
+  a server restart, or a chunk that fails past its retry budget discarded
+  every chunk paid for so far — on a nine-chunk run, up to eight LLM calls and
+  ~20 minutes, and the retry started from the first chunk. Each chunk's pages
+  are now recorded as they complete and cleared once the run writes, so the
+  wiki write stays atomic. Progress is keyed by a fingerprint of the pruned
+  source set plus the chunk budget: chunks are addressed by position and
+  sources are re-read from git and `docs/` at run time, so a new commit or a
+  different `--chunk-input-tokens` changes the hash and starts a fresh run
+  rather than resuming into a plan that has shifted underneath.
 - `ai-memory status` and the pre-migration backup log now report the data
   directory's **filesystem free space** (#629). The OKF-migration backup gate
   proves the archive is writable but said nothing about disk headroom — an

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -1144,6 +1144,12 @@ pub struct BootstrapArgs {
     /// the same project (the manifest is `wiki/bootstrap.md`).
     #[arg(long)]
     pub force: bool,
+    /// Reuse the chunks an interrupted run already completed instead of
+    /// paying for their LLM calls again. Progress is only reused when the
+    /// sources and chunk budget are unchanged; otherwise the run starts
+    /// over on its own.
+    #[arg(long)]
+    pub resume: bool,
 }
 
 /// Arguments for `setup-agent`.

--- a/crates/ai-memory-cli/src/commands/bootstrap.rs
+++ b/crates/ai-memory-cli/src/commands/bootstrap.rs
@@ -139,6 +139,7 @@ pub async fn run(config: &Config, args: BootstrapArgs) -> Result<()> {
         "chunk_input_tokens": args.chunk_input_tokens,
         "dry_run": args.dry_run,
         "force": args.force,
+        "resume": args.resume,
     });
     let outcome: BootstrapOutcome = post_json(&ep, "/admin/bootstrap", &body).await?;
 

--- a/crates/ai-memory-consolidate/src/bootstrap.rs
+++ b/crates/ai-memory-consolidate/src/bootstrap.rs
@@ -40,6 +40,7 @@ use ai_memory_wiki::{Wiki, WritePageRequest};
 use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 use tracing::{debug, info, warn};
 
@@ -277,6 +278,11 @@ pub struct BootstrapConfig {
     pub dry_run: bool,
     /// Allow re-running even when `wiki/bootstrap.md` already exists.
     pub force: bool,
+    /// Reuse the chunks a previous interrupted run already completed, instead
+    /// of paying for their LLM calls again. Only progress recorded under the
+    /// same source/budget fingerprint is eligible; anything else is ignored and
+    /// the run starts from the first chunk.
+    pub resume: bool,
 }
 
 /// Bootstrap driver. Holds the LLM provider + wiki handle + reader
@@ -331,7 +337,176 @@ async fn complete_chunk_with_retry(
     }
 }
 
+/// One chunk a resume can adopt instead of paying for it again.
+struct ReusedChunk {
+    /// One-based position in the chunk plan.
+    index: u32,
+    /// The pages that chunk produced.
+    pages: Vec<BootstrapPage>,
+    /// The rationale it reported, replayed into the manifest.
+    rationale: String,
+}
+
+/// Select the chunks a resume may reuse: the contiguous run starting at 1.
+///
+/// Later chunks are dropped even when they were recorded. Page dedup is
+/// first-write-wins in chunk order ([`insert_bootstrap_page`]), so adopting
+/// chunk 6 before re-running chunk 5 would let the later chunk keep a path the
+/// earlier one owns — a resumed run would then produce different pages than a
+/// clean one. A row whose pages will not parse ends the prefix for the same
+/// reason.
+fn reusable_prefix(recorded: Vec<ai_memory_store::BootstrapChunkProgress>) -> Vec<ReusedChunk> {
+    let mut out = Vec::new();
+    for (expected, entry) in (1_u32..).zip(recorded) {
+        if entry.chunk_index != expected {
+            debug!(
+                gap_at = expected,
+                found = entry.chunk_index,
+                "bootstrap --resume stopping at the first missing chunk",
+            );
+            break;
+        }
+        match serde_json::from_str::<Vec<BootstrapPage>>(&entry.pages_json) {
+            Ok(pages) => out.push(ReusedChunk {
+                index: entry.chunk_index,
+                pages,
+                rationale: entry.rationale,
+            }),
+            Err(error) => {
+                warn!(
+                    chunk = entry.chunk_index,
+                    %error,
+                    "unreadable bootstrap progress; re-running from that chunk",
+                );
+                break;
+            }
+        }
+    }
+    out
+}
+
+/// Hash the inputs that determine the chunk plan, for keying resumable
+/// progress (#621).
+///
+/// Recorded progress is addressed by chunk *position*, and `collect_sources`
+/// re-reads git and `docs/` at run time — so a stored `chunk_index` only refers
+/// to the same material while the planner's inputs are unchanged. Hashing the
+/// pruned source set together with the chunk budget makes that precise: equal
+/// fingerprints guarantee `plan_bootstrap_chunks` produces the same chunks, so
+/// skipping by index is sound; a new commit, an edited doc, or a different
+/// `--chunk-input-tokens` all change the hash and force a fresh run rather than
+/// silently resuming into a plan that has shifted underneath.
+///
+/// Order is part of the hash because the planner is order-sensitive: the same
+/// sources arranged differently chunk differently.
+fn bootstrap_fingerprint(sources: &[BootstrapSource], chunk_budget: usize) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"ai-memory bootstrap chunk plan v1\n");
+    hasher.update(chunk_budget.to_le_bytes());
+    hasher.update(
+        u64::try_from(sources.len())
+            .unwrap_or(u64::MAX)
+            .to_le_bytes(),
+    );
+    for source in sources {
+        // Length-prefix every field so that no rearrangement of the bytes can
+        // produce a colliding digest for a different source set. The kind's
+        // serde name is its stable identity — `drop_priority` would collide the
+        // moment two kinds shared a priority.
+        let kind = serde_json::to_string(&source.kind).unwrap_or_default();
+        hasher.update(u64::try_from(kind.len()).unwrap_or(u64::MAX).to_le_bytes());
+        hasher.update(kind.as_bytes());
+        hasher.update(
+            u64::try_from(source.label.len())
+                .unwrap_or(u64::MAX)
+                .to_le_bytes(),
+        );
+        hasher.update(source.label.as_bytes());
+        hasher.update(
+            u64::try_from(source.text.len())
+                .unwrap_or(u64::MAX)
+                .to_le_bytes(),
+        );
+        hasher.update(source.text.as_bytes());
+    }
+    format!("{:x}", hasher.finalize())
+}
+
 impl Bootstrap {
+    /// Read back the chunks a previous run recorded under this fingerprint.
+    ///
+    /// A store error here is not fatal to the run: the worst case is that the
+    /// chunks are processed again, which is exactly what would have happened
+    /// without `--resume`. Refusing to start because the optimisation is
+    /// unavailable would be the wrong trade.
+    async fn load_recorded_chunks(
+        &self,
+        fingerprint: &str,
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+    ) -> Result<Vec<ai_memory_store::BootstrapChunkProgress>, BootstrapError> {
+        let fingerprint = fingerprint.to_string();
+        let loaded = self
+            .reader
+            .with_conn(move |conn| {
+                ai_memory_store::load_bootstrap_progress(
+                    conn,
+                    &fingerprint,
+                    workspace_id,
+                    project_id,
+                )
+            })
+            .await;
+        match loaded {
+            Ok(rows) => Ok(rows),
+            Err(error) => {
+                warn!(%error, "could not read bootstrap progress; running every chunk");
+                Ok(Vec::new())
+            }
+        }
+    }
+
+    /// Persist one completed chunk so a later `--resume` can skip it.
+    ///
+    /// Recorded unconditionally, not only under `--resume`: a run cannot know
+    /// it is about to fail, so the progress has to already be there when the
+    /// next one asks for it. The cost is one small row per chunk, cleared when
+    /// the run writes its pages.
+    ///
+    /// Failing to record is logged and swallowed. The chunk itself succeeded,
+    /// and the only consequence is that a later resume pays for it again —
+    /// which is strictly better than discarding a run over bookkeeping.
+    async fn record_chunk_progress(
+        &self,
+        fingerprint: &str,
+        cfg: &BootstrapConfig,
+        chunk_no: u32,
+        batch: &BootstrapBatch,
+    ) {
+        let pages_json = match serde_json::to_string(&batch.pages) {
+            Ok(json) => json,
+            Err(error) => {
+                warn!(chunk = chunk_no, %error, "could not serialise chunk pages for resume");
+                return;
+            }
+        };
+        if let Err(error) = self
+            .wiki
+            .writer()
+            .record_bootstrap_chunk(
+                fingerprint.to_string(),
+                cfg.workspace_id,
+                cfg.project_id,
+                chunk_no,
+                pages_json,
+                batch.rationale.clone(),
+            )
+            .await
+        {
+            warn!(chunk = chunk_no, %error, "could not record bootstrap progress");
+        }
+    }
+
     /// Process pre-collected sources end-to-end: prune to budget,
     /// call the LLM, write pages, return the outcome. Server-side
     /// entry point — does NOT collect from disk.
@@ -398,6 +573,10 @@ impl Bootstrap {
         }
 
         // ---- LLM call(s) — chunked when over chunk_input_tokens ----
+        // Fingerprint before `kept` is consumed by the planner: it is the
+        // planner's own input, and it is what makes a stored chunk position
+        // meaningful on a later run.
+        let fingerprint = bootstrap_fingerprint(&kept, chunk_budget);
         let chunks = plan_bootstrap_chunks(kept, chunk_budget);
         let llm_chunks = chunks.len();
         info!(llm_chunks, chunk_budget, "bootstrap LLM chunk plan",);
@@ -405,7 +584,42 @@ impl Bootstrap {
         let mut pages_by_path = std::collections::BTreeMap::new();
         let mut rationales = Vec::with_capacity(llm_chunks);
 
+        // ---- resume: adopt whatever a previous run already paid for -------
+        let mut done: std::collections::BTreeMap<u32, String> = std::collections::BTreeMap::new();
+        if cfg.resume {
+            let recorded = self
+                .load_recorded_chunks(&fingerprint, cfg.workspace_id, cfg.project_id)
+                .await?;
+            for reused in reusable_prefix(recorded) {
+                for page in reused.pages {
+                    insert_bootstrap_page(
+                        &mut pages_by_path,
+                        page,
+                        usize::try_from(reused.index).unwrap_or(usize::MAX),
+                    );
+                }
+                done.insert(reused.index, reused.rationale);
+            }
+            if done.is_empty() {
+                info!(
+                    "bootstrap --resume found no reusable progress for these sources; \
+                     starting from the first chunk",
+                );
+            } else {
+                info!(
+                    reused = done.len(),
+                    total = llm_chunks,
+                    "bootstrap --resume reusing completed chunks",
+                );
+            }
+        }
+
         for (idx, chunk) in chunks.iter().enumerate() {
+            let chunk_no = u32::try_from(idx + 1).unwrap_or(u32::MAX);
+            if let Some(rationale) = done.get(&chunk_no) {
+                rationales.push(rationale.clone());
+                continue;
+            }
             let mut prior: Vec<String> = pages_by_path.keys().cloned().collect();
             prior.sort_unstable();
             let prior_refs: Vec<&str> = prior.iter().map(String::as_str).collect();
@@ -422,6 +636,10 @@ impl Bootstrap {
             );
             let batch: BootstrapBatch =
                 complete_chunk_with_retry(&*self.llm, request, BOOTSTRAP_CHUNK_RETRY_DELAY).await?;
+            // Record before merging: this chunk's own pages are what a resume
+            // needs, and `pages_by_path` has already absorbed the earlier ones.
+            self.record_chunk_progress(&fingerprint, cfg, chunk_no, &batch)
+                .await;
             rationales.push(batch.rationale);
             for page in batch.pages {
                 insert_bootstrap_page(&mut pages_by_path, page, idx + 1);
@@ -500,6 +718,18 @@ impl Bootstrap {
             "bootstrap: {llm_chunks} LLM chunk(s), ingested {collected} sources, wrote {} pages",
             written_paths.len() + 1,
         ));
+
+        // The pages are on disk, so the progress rows have nothing left to
+        // protect. Clearing by project also collects rows from earlier
+        // abandoned attempts whose fingerprints no longer match.
+        if let Err(error) = self
+            .wiki
+            .writer()
+            .clear_bootstrap_progress(cfg.workspace_id, cfg.project_id)
+            .await
+        {
+            warn!(%error, "could not clear bootstrap progress after a completed run");
+        }
 
         // Manifest is the last entry but conceptually first; list it.
         let mut out_paths = written_paths.clone();
@@ -1467,6 +1697,175 @@ mod tests {
             1,
             "a deterministic error must fail on the first call, no retries"
         );
+    }
+
+    fn src(kind: SourceKind, label: &str, text: &str) -> BootstrapSource {
+        BootstrapSource {
+            kind,
+            label: label.to_string(),
+            text: text.to_string(),
+        }
+    }
+
+    fn sample_sources() -> Vec<BootstrapSource> {
+        vec![
+            src(SourceKind::Readme, "README", "hello"),
+            src(SourceKind::DocFile, "docs/a.md", "world"),
+        ]
+    }
+
+    #[test]
+    fn fingerprint_is_stable_for_identical_inputs() {
+        // The whole resume guarantee rests on this: same sources and budget
+        // must produce the same key, or a resume can never match.
+        assert_eq!(
+            bootstrap_fingerprint(&sample_sources(), 24_000),
+            bootstrap_fingerprint(&sample_sources(), 24_000),
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_with_the_chunk_budget() {
+        // A different budget re-chunks the same sources, so stored chunk
+        // positions no longer refer to the same material.
+        assert_ne!(
+            bootstrap_fingerprint(&sample_sources(), 24_000),
+            bootstrap_fingerprint(&sample_sources(), 12_000),
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_when_a_source_changes() {
+        let mut edited = sample_sources();
+        edited[1].text = "world!".to_string();
+        assert_ne!(
+            bootstrap_fingerprint(&sample_sources(), 24_000),
+            bootstrap_fingerprint(&edited, 24_000),
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_when_a_source_is_added() {
+        let mut extra = sample_sources();
+        extra.push(src(SourceKind::GitCommit, "git: feat", "a commit"));
+        assert_ne!(
+            bootstrap_fingerprint(&sample_sources(), 24_000),
+            bootstrap_fingerprint(&extra, 24_000),
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_when_sources_are_reordered() {
+        // `plan_bootstrap_chunks` is order-sensitive, so the same sources in a
+        // different order are a different plan — and must not resume into one
+        // another.
+        let mut swapped = sample_sources();
+        swapped.reverse();
+        assert_ne!(
+            bootstrap_fingerprint(&sample_sources(), 24_000),
+            bootstrap_fingerprint(&swapped, 24_000),
+        );
+    }
+
+    #[test]
+    fn fingerprint_distinguishes_kind_from_identical_text() {
+        // Length-prefixing keeps a label/text boundary from being ambiguous,
+        // and the kind is part of the identity even when the text matches.
+        let a = vec![src(SourceKind::Readme, "x", "same")];
+        let b = vec![src(SourceKind::DocFile, "x", "same")];
+        assert_ne!(
+            bootstrap_fingerprint(&a, 24_000),
+            bootstrap_fingerprint(&b, 24_000),
+        );
+    }
+
+    #[test]
+    fn fingerprint_is_not_confused_by_shifting_a_field_boundary() {
+        // Without length prefixes, ("ab","c") and ("a","bc") would hash the
+        // same. This is the concatenation ambiguity the prefixes exist to stop.
+        let a = vec![src(SourceKind::Readme, "ab", "c")];
+        let b = vec![src(SourceKind::Readme, "a", "bc")];
+        assert_ne!(
+            bootstrap_fingerprint(&a, 24_000),
+            bootstrap_fingerprint(&b, 24_000),
+        );
+    }
+
+    fn progress(idx: u32, pages_json: &str) -> ai_memory_store::BootstrapChunkProgress {
+        ai_memory_store::BootstrapChunkProgress {
+            chunk_index: idx,
+            pages_json: pages_json.to_string(),
+            rationale: format!("chunk {idx}"),
+        }
+    }
+
+    const ONE_PAGE: &str = r#"[{"path":"a.md","title":"A","tags":[],"body_markdown":"x"}]"#;
+
+    #[test]
+    fn reusable_prefix_takes_a_complete_run_of_chunks() {
+        let taken = reusable_prefix(vec![
+            progress(1, ONE_PAGE),
+            progress(2, "[]"),
+            progress(3, "[]"),
+        ]);
+        assert_eq!(
+            taken.iter().map(|c| c.index).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn reusable_prefix_stops_at_the_first_gap() {
+        // The interrupted run failed on chunk 3 but had already recorded 4 and
+        // 5. Reusing those would let a later chunk win a page path that chunk 3
+        // owns, so a resumed run would differ from a clean one.
+        let taken = reusable_prefix(vec![
+            progress(1, "[]"),
+            progress(2, "[]"),
+            progress(4, "[]"),
+            progress(5, "[]"),
+        ]);
+        assert_eq!(
+            taken.iter().map(|c| c.index).collect::<Vec<_>>(),
+            vec![1, 2],
+            "everything from the gap onward must be re-run"
+        );
+    }
+
+    #[test]
+    fn reusable_prefix_is_empty_when_the_first_chunk_is_missing() {
+        let taken = reusable_prefix(vec![progress(2, "[]"), progress(3, "[]")]);
+        assert!(
+            taken.is_empty(),
+            "without chunk 1 there is no prefix to build on"
+        );
+    }
+
+    #[test]
+    fn reusable_prefix_stops_at_unreadable_pages() {
+        // Corrupt JSON ends the prefix rather than failing the run: the chunk
+        // is regenerable, and refusing here would strand a resume on data we
+        // can simply pay for again.
+        let taken = reusable_prefix(vec![
+            progress(1, "[]"),
+            progress(2, "{not json"),
+            progress(3, "[]"),
+        ]);
+        assert_eq!(taken.iter().map(|c| c.index).collect::<Vec<_>>(), vec![1]);
+    }
+
+    #[test]
+    fn reusable_prefix_carries_pages_and_rationale() {
+        let taken = reusable_prefix(vec![progress(1, ONE_PAGE)]);
+        assert_eq!(taken.len(), 1);
+        assert_eq!(taken[0].pages.len(), 1);
+        assert_eq!(taken[0].pages[0].path, "a.md");
+        assert_eq!(taken[0].rationale, "chunk 1");
+    }
+
+    #[test]
+    fn reusable_prefix_of_nothing_is_nothing() {
+        assert!(reusable_prefix(Vec::new()).is_empty());
     }
 
     fn make_repo(tmp: &Path) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -218,6 +218,9 @@ struct BootstrapRequest {
     /// Allow re-bootstrap when `wiki/bootstrap.md` already exists.
     #[serde(default)]
     force: bool,
+    /// Reuse chunks an interrupted run recorded for the same sources.
+    #[serde(default)]
+    resume: bool,
 }
 
 fn default_max_input_tokens() -> usize {
@@ -1789,6 +1792,7 @@ async fn handle_bootstrap(
         since: None,
         dry_run: req.dry_run,
         force: req.force,
+        resume: req.resume,
     };
 
     let bootstrap = Bootstrap {

--- a/crates/ai-memory-store/migrations/V59__bootstrap_chunk_progress.sql
+++ b/crates/ai-memory-store/migrations/V59__bootstrap_chunk_progress.sql
@@ -1,0 +1,25 @@
+-- Durable per-chunk progress so a crashed or hard-failed bootstrap does not
+-- discard the completed chunks' LLM work (#621). A multi-chunk run holds every
+-- page in memory until the single post-loop apply_batch, so losing the process
+-- loses every chunk paid for so far.
+--
+-- `fingerprint` is a hash of the pruned source set plus the chunk budget, not
+-- the project alone: chunks are addressed by position, and sources are re-read
+-- from git/docs at run time, so a stored chunk_index only means the same thing
+-- while those inputs are unchanged. A resume whose fingerprint differs is a
+-- different chunk plan and must start over rather than skip the wrong work.
+CREATE TABLE bootstrap_chunk_progress (
+    fingerprint  TEXT NOT NULL,
+    workspace_id BLOB NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    project_id   BLOB NOT NULL REFERENCES projects(id)   ON DELETE CASCADE,
+    chunk_index  INTEGER NOT NULL CHECK (chunk_index > 0),
+    pages_json   TEXT NOT NULL,
+    rationale    TEXT NOT NULL,
+    created_at   INTEGER NOT NULL,
+    PRIMARY KEY (fingerprint, chunk_index)
+) WITHOUT ROWID;
+
+-- Resume loads one fingerprint's chunks in order; the stale prune sweeps by
+-- age across fingerprints.
+CREATE INDEX idx_bootstrap_chunk_progress_sweep
+    ON bootstrap_chunk_progress (created_at);

--- a/crates/ai-memory-store/src/api_credentials.rs
+++ b/crates/ai-memory-store/src/api_credentials.rs
@@ -411,7 +411,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, 58, "update the pin when adding a migration");
+        assert_eq!(version, 59, "update the pin when adding a migration");
         let cols: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM pragma_table_info('users') WHERE name = 'token_hash'",

--- a/crates/ai-memory-store/src/bootstrap_progress.rs
+++ b/crates/ai-memory-store/src/bootstrap_progress.rs
@@ -1,0 +1,289 @@
+//! Durable per-chunk progress for a resumable bootstrap.
+//!
+//! Unlike [`crate::session_consolidation`], this table carries no lease or
+//! attempt state: `/admin/bootstrap` already serialises runs behind a lock, so
+//! there is never a second worker to arbitrate against. What survives here is
+//! only the expensive part — each completed chunk's pages — so a crash, a
+//! restart, or a chunk that fails past its retry budget does not discard the
+//! LLM calls already paid for.
+
+use ai_memory_core::{ProjectId, WorkspaceId};
+use jiff::Timestamp;
+use rusqlite::{Connection, params};
+
+use crate::error::StoreResult;
+
+/// One completed chunk's recorded output.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BootstrapChunkProgress {
+    /// One-based position of the chunk in the plan.
+    pub chunk_index: u32,
+    /// The chunk's pages, serialised as the JSON array the caller stored.
+    pub pages_json: String,
+    /// The model's stated reasoning for that chunk.
+    pub rationale: String,
+}
+
+/// Record one chunk's output, replacing any earlier row for the same position.
+///
+/// Replacing rather than ignoring matters when a resumed run re-processes a
+/// chunk it could not confirm: the newer output is the one the in-memory
+/// accumulator will hold, so the stored row has to agree with it.
+pub fn record_chunk(
+    conn: &mut Connection,
+    fingerprint: &str,
+    workspace_id: WorkspaceId,
+    project_id: ProjectId,
+    chunk_index: u32,
+    pages_json: &str,
+    rationale: &str,
+) -> StoreResult<()> {
+    conn.execute(
+        "INSERT OR REPLACE INTO bootstrap_chunk_progress \
+         (fingerprint, workspace_id, project_id, chunk_index, pages_json, rationale, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            fingerprint,
+            workspace_id.as_bytes(),
+            project_id.as_bytes(),
+            i64::from(chunk_index),
+            pages_json,
+            rationale,
+            Timestamp::now().as_microsecond(),
+        ],
+    )?;
+    Ok(())
+}
+
+/// Load every recorded chunk for one fingerprint, in plan order.
+///
+/// Scoping the read to the fingerprint is what makes a positional
+/// `chunk_index` safe to act on: a different pruned source set or chunk budget
+/// hashes differently, so its rows are never returned here and the run starts
+/// over instead of skipping work that no longer corresponds.
+pub fn load_progress(
+    conn: &Connection,
+    fingerprint: &str,
+    workspace_id: WorkspaceId,
+    project_id: ProjectId,
+) -> StoreResult<Vec<BootstrapChunkProgress>> {
+    let mut stmt = conn.prepare(
+        "SELECT chunk_index, pages_json, rationale \
+         FROM bootstrap_chunk_progress \
+         WHERE fingerprint = ?1 AND workspace_id = ?2 AND project_id = ?3 \
+         ORDER BY chunk_index",
+    )?;
+    let rows = stmt.query_map(
+        params![fingerprint, workspace_id.as_bytes(), project_id.as_bytes()],
+        |row| {
+            Ok(BootstrapChunkProgress {
+                chunk_index: u32::try_from(row.get::<_, i64>(0)?).unwrap_or(u32::MAX),
+                pages_json: row.get(1)?,
+                rationale: row.get(2)?,
+            })
+        },
+    )?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// Drop one project's recorded progress once the run has written its pages.
+///
+/// Clearing by project rather than by fingerprint also collects the rows of
+/// earlier abandoned attempts whose inputs have since changed, which would
+/// otherwise only be reachable by the age sweep.
+pub fn clear_progress(
+    conn: &mut Connection,
+    workspace_id: WorkspaceId,
+    project_id: ProjectId,
+) -> StoreResult<usize> {
+    let removed = conn.execute(
+        "DELETE FROM bootstrap_chunk_progress WHERE workspace_id = ?1 AND project_id = ?2",
+        params![workspace_id.as_bytes(), project_id.as_bytes()],
+    )?;
+    Ok(removed)
+}
+
+/// Delete progress rows older than `older_than`, whatever their fingerprint.
+///
+/// A run abandoned before its final write leaves rows no later run will match
+/// once the sources move on; without this sweep they would sit in the store
+/// until the project itself is deleted.
+pub fn prune_stale(conn: &mut Connection, older_than: i64) -> StoreResult<usize> {
+    let removed = conn.execute(
+        "DELETE FROM bootstrap_chunk_progress WHERE created_at < ?1",
+        params![older_than],
+    )?;
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Store;
+
+    async fn scoped_store() -> (tempfile::TempDir, Store, WorkspaceId, ProjectId) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let workspace_id = store
+            .writer
+            .get_or_create_workspace("default")
+            .await
+            .unwrap();
+        let project_id = store
+            .writer
+            .get_or_create_project(workspace_id, "project", None)
+            .await
+            .unwrap();
+        (tmp, store, workspace_id, project_id)
+    }
+
+    #[tokio::test]
+    async fn records_and_reloads_chunks_in_plan_order() {
+        let (_tmp, store, ws, proj) = scoped_store().await;
+        // Written out of order on purpose: resume seeds pages by chunk
+        // position, so the read has to impose the order, not the write.
+        for idx in [3_u32, 1, 2] {
+            store
+                .writer
+                .record_bootstrap_chunk(
+                    "fp".into(),
+                    ws,
+                    proj,
+                    idx,
+                    format!("[{{\"n\":{idx}}}]"),
+                    format!("chunk {idx}"),
+                )
+                .await
+                .unwrap();
+        }
+
+        let rows = store
+            .reader
+            .with_conn(move |conn| load_progress(conn, "fp", ws, proj))
+            .await
+            .unwrap();
+        let indices: Vec<u32> = rows.iter().map(|r| r.chunk_index).collect();
+        assert_eq!(indices, vec![1, 2, 3]);
+        assert_eq!(rows[0].pages_json, "[{\"n\":1}]");
+        assert_eq!(rows[2].rationale, "chunk 3");
+    }
+
+    #[tokio::test]
+    async fn a_different_fingerprint_is_not_visible() {
+        // The safety property: progress recorded for one source set must not
+        // be handed to a run whose sources have changed.
+        let (_tmp, store, ws, proj) = scoped_store().await;
+        store
+            .writer
+            .record_bootstrap_chunk("old".into(), ws, proj, 1, "[]".into(), "r".into())
+            .await
+            .unwrap();
+
+        let rows = store
+            .reader
+            .with_conn(move |conn| load_progress(conn, "new", ws, proj))
+            .await
+            .unwrap();
+        assert!(
+            rows.is_empty(),
+            "a run whose inputs changed must start over, not resume"
+        );
+    }
+
+    #[tokio::test]
+    async fn re_recording_a_chunk_replaces_it() {
+        let (_tmp, store, ws, proj) = scoped_store().await;
+        for rationale in ["first", "second"] {
+            store
+                .writer
+                .record_bootstrap_chunk("fp".into(), ws, proj, 1, "[]".into(), rationale.into())
+                .await
+                .unwrap();
+        }
+
+        let rows = store
+            .reader
+            .with_conn(move |conn| load_progress(conn, "fp", ws, proj))
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "one row per (fingerprint, chunk)");
+        assert_eq!(rows[0].rationale, "second");
+    }
+
+    #[tokio::test]
+    async fn clearing_drops_every_fingerprint_for_the_project() {
+        let (_tmp, store, ws, proj) = scoped_store().await;
+        for fp in ["abandoned", "current"] {
+            store
+                .writer
+                .record_bootstrap_chunk(fp.into(), ws, proj, 1, "[]".into(), "r".into())
+                .await
+                .unwrap();
+        }
+
+        let removed = store
+            .writer
+            .clear_bootstrap_progress(ws, proj)
+            .await
+            .unwrap();
+        assert_eq!(
+            removed, 2,
+            "a completed run also collects earlier abandoned attempts"
+        );
+        let rows = store
+            .reader
+            .with_conn(move |conn| load_progress(conn, "current", ws, proj))
+            .await
+            .unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn pruning_removes_only_rows_older_than_the_cutoff() {
+        let (_tmp, store, ws, proj) = scoped_store().await;
+        store
+            .writer
+            .record_bootstrap_chunk("fp".into(), ws, proj, 1, "[]".into(), "r".into())
+            .await
+            .unwrap();
+
+        // Anchor both cutoffs on the row's own timestamp rather than on a
+        // second clock reading: `record_bootstrap_chunk` stamps the row inside
+        // the writer, and a cutoff derived from a later `now()` can land in the
+        // same microsecond.
+        let written_at = store
+            .reader
+            .with_conn(|conn| {
+                let ts: i64 = conn.query_row(
+                    "SELECT created_at FROM bootstrap_chunk_progress",
+                    [],
+                    |row| row.get(0),
+                )?;
+                Ok(ts)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store
+                .writer
+                .prune_bootstrap_progress(written_at)
+                .await
+                .unwrap(),
+            0,
+            "the cutoff is exclusive: a row stamped exactly at it must survive"
+        );
+        assert_eq!(
+            store
+                .writer
+                .prune_bootstrap_progress(written_at + 1)
+                .await
+                .unwrap(),
+            1,
+        );
+    }
+}

--- a/crates/ai-memory-store/src/lib.rs
+++ b/crates/ai-memory-store/src/lib.rs
@@ -16,6 +16,7 @@ use rusqlite::Connection;
 
 mod api_credentials;
 mod auto_improve;
+mod bootstrap_progress;
 pub mod decay;
 mod error;
 mod fts_query;
@@ -42,6 +43,7 @@ pub use auto_improve::{
     OwnedAutoImproveProposalDetail, RejectAutoImproveProposal, SkippedProposal,
     StageAutoImproveRun, StagedAutoImproveRun, StagedAutoImproveRunReport, artifact_path_for,
 };
+pub use bootstrap_progress::{BootstrapChunkProgress, load_progress as load_bootstrap_progress};
 pub use decay::{
     DecayParams, SALIENCE_MAX, SALIENCE_MIN, SALIENCE_STEP, retention_score,
     retention_score_with_breadth, salience_after_feedback,

--- a/crates/ai-memory-store/src/writer.rs
+++ b/crates/ai-memory-store/src/writer.rs
@@ -190,6 +190,24 @@ pub(crate) enum WriteCmd {
         job: SessionConsolidationJob,
         reply: oneshot::Sender<StoreResult<()>>,
     },
+    RecordBootstrapChunk {
+        fingerprint: String,
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+        chunk_index: u32,
+        pages_json: String,
+        rationale: String,
+        reply: oneshot::Sender<StoreResult<()>>,
+    },
+    ClearBootstrapProgress {
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+        reply: oneshot::Sender<StoreResult<usize>>,
+    },
+    PruneBootstrapProgress {
+        older_than: i64,
+        reply: oneshot::Sender<StoreResult<usize>>,
+    },
     InsertHandoff {
         handoff: NewHandoff,
         reply: oneshot::Sender<StoreResult<HandoffId>>,
@@ -1037,6 +1055,67 @@ impl WriterHandle {
         let (tx, rx) = oneshot::channel();
         self.send(WriteCmd::ReleaseSessionConsolidation { job, reply: tx })
             .await?;
+        rx.await.map_err(|_| StoreError::WriterClosed)?
+    }
+
+    /// Record one completed bootstrap chunk so a later `--resume` can skip it.
+    ///
+    /// # Errors
+    /// Returns [`StoreError::WriterClosed`] or propagates SQL errors.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn record_bootstrap_chunk(
+        &self,
+        fingerprint: String,
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+        chunk_index: u32,
+        pages_json: String,
+        rationale: String,
+    ) -> StoreResult<()> {
+        let (tx, rx) = oneshot::channel();
+        self.send(WriteCmd::RecordBootstrapChunk {
+            fingerprint,
+            workspace_id,
+            project_id,
+            chunk_index,
+            pages_json,
+            rationale,
+            reply: tx,
+        })
+        .await?;
+        rx.await.map_err(|_| StoreError::WriterClosed)?
+    }
+
+    /// Drop a project's recorded bootstrap progress. Returns rows removed.
+    ///
+    /// # Errors
+    /// Returns [`StoreError::WriterClosed`] or propagates SQL errors.
+    pub async fn clear_bootstrap_progress(
+        &self,
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+    ) -> StoreResult<usize> {
+        let (tx, rx) = oneshot::channel();
+        self.send(WriteCmd::ClearBootstrapProgress {
+            workspace_id,
+            project_id,
+            reply: tx,
+        })
+        .await?;
+        rx.await.map_err(|_| StoreError::WriterClosed)?
+    }
+
+    /// Sweep bootstrap progress older than `older_than`. Returns rows removed.
+    ///
+    /// # Errors
+    /// Returns [`StoreError::WriterClosed`] or propagates SQL errors.
+    pub async fn prune_bootstrap_progress(&self, older_than: i64) -> StoreResult<usize> {
+        let (tx, rx) = oneshot::channel();
+        self.send(WriteCmd::PruneBootstrapProgress {
+            older_than,
+            reply: tx,
+        })
+        .await?;
         rx.await.map_err(|_| StoreError::WriterClosed)?
     }
 
@@ -2631,6 +2710,39 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
             WriteCmd::ReleaseSessionConsolidation { job, reply } => {
                 let result = crate::session_consolidation::release(&mut conn, &job);
                 send_or_warn(reply, result, "release_session_consolidation");
+            }
+            WriteCmd::RecordBootstrapChunk {
+                fingerprint,
+                workspace_id,
+                project_id,
+                chunk_index,
+                pages_json,
+                rationale,
+                reply,
+            } => {
+                let result = crate::bootstrap_progress::record_chunk(
+                    &mut conn,
+                    &fingerprint,
+                    workspace_id,
+                    project_id,
+                    chunk_index,
+                    &pages_json,
+                    &rationale,
+                );
+                send_or_warn(reply, result, "record_bootstrap_chunk");
+            }
+            WriteCmd::ClearBootstrapProgress {
+                workspace_id,
+                project_id,
+                reply,
+            } => {
+                let result =
+                    crate::bootstrap_progress::clear_progress(&mut conn, workspace_id, project_id);
+                send_or_warn(reply, result, "clear_bootstrap_progress");
+            }
+            WriteCmd::PruneBootstrapProgress { older_than, reply } => {
+                let result = crate::bootstrap_progress::prune_stale(&mut conn, older_than);
+                send_or_warn(reply, result, "prune_bootstrap_progress");
             }
             WriteCmd::InsertHandoff { handoff, reply } => {
                 let result = ops::insert_handoff(&mut conn, &handoff);

--- a/docs/install.md
+++ b/docs/install.md
@@ -1989,7 +1989,22 @@ remote or uses a custom host/port.
 --exclude-code             (skip Rust module headers)
 --dry-run                  (collect + estimate but don't call LLM or write)
 --force                    (re-bootstrap, overwrites the prior manifest)
+--resume                   (reuse the chunks an interrupted run completed)
 ```
+
+**Resuming an interrupted run.** A chunked bootstrap keeps every generated
+page in memory until one write at the end, so a crash, a server restart, or a
+chunk that fails past its retry budget used to discard the LLM calls already
+paid for. Each chunk is now recorded as it completes; `--resume` reuses those
+and only pays for the chunks that never finished.
+
+Progress is only reused when the sources and the chunk budget are unchanged —
+chunks are addressed by position, and sources are re-read from git and `docs/`
+on each run, so a new commit or a different `--chunk-input-tokens` starts a
+fresh run instead of resuming into a plan that has shifted. There is no
+failure mode where the wrong pages are reused; the worst case is paying for
+the run again. `--resume` on a project with nothing recorded is a normal full
+run, so it is safe to pass by default on a retry.
 
 **Cost.** With Kimi 2.6 via OpenRouter ($0.73/$3.49 per M):
 - 50k input tokens cap → ~$0.04 worst case input


### PR DESCRIPTION
## What changed

`ai-memory bootstrap` now records each chunk's pages as it completes, and a new `--resume` flag reuses them instead of paying for those LLM calls again.

Before: a multi-chunk run held every page in `pages_by_path` until one `apply_batch` after the loop, so a crash, a server restart, or a chunk that failed past its retry budget discarded every chunk already paid for. On a nine-chunk run that is up to eight LLM calls and ~20 minutes, and the retry restarted at chunk 1.

After: each chunk's output is written to a new `bootstrap_chunk_progress` table as it lands, and cleared once the run writes its pages. **The wiki write stays atomic** — nothing reaches the wiki until the run completes, so the manifest-gated `--force` guard holds as an invariant. Without `--resume` the observable behaviour is unchanged.

No default changes. Progress is recorded on every run (a run cannot know it is about to fail), but it is only *read* under `--resume`.

## Why

Closes #621. Follows #617, where the bounded transient retry fixed the common case; this covers the rarer crash / restart / past-retry-budget one.

**Fingerprint-guarded, per your design.** Chunks are addressed by position and `collect_sources` re-reads git and `docs/` at run time, so a naive index-resume is unsafe. Progress is keyed by a SHA-256 of the pruned source set plus the chunk budget — the planner's exact inputs, hashed before `plan_bootstrap_chunks` consumes `kept` at `bootstrap.rs:401`. `plan_bootstrap_chunks` is pure in those two, so an equal fingerprint guarantees an identical chunk plan; a new commit, an edited doc, or a different `--chunk-input-tokens` changes the hash and starts a fresh run.

**Three corrections to the issue's design, from the code:**

- The migration is **`V59`**, not `V60` — `V58__close_retired_entity_windows.sql` is the highest, and `api_credentials.rs:414` pins it.
- The per-chunk persistence point is **`bootstrap.rs:429`** (after `insert_bootstrap_page`), not ~L382.
- `apply_batch` is **`Wiki::apply_batch`** (`wiki.rs:1531`), called from `bootstrap.rs:498` — that is where the clear lands.

**One simplification**, flagged in the issue and carried through: the table has no lease, state, or attempt columns. `session_consolidation_jobs` needs those because workers race for jobs; `/admin/bootstrap` already serialises runs behind `bootstrap_lock` (`admin.rs:1759`). Stored state is just `(fingerprint, chunk_index) → pages_json, rationale`. Say the word and I'll widen it to mirror the queue shape.

**Only the contiguous prefix is reused.** This one is not obvious and I got it wrong first: `insert_bootstrap_page` is first-write-wins in chunk order, so if chunk 5 failed while 6-9 were already recorded, seeding 6-9 before re-running 5 would let a later chunk keep a path chunk 5 owns — a resumed run would produce different pages than a clean one. `reusable_prefix` stops at the first gap, and at a row whose JSON no longer parses.

Failures around the optimisation are logged and swallowed, never fatal: a store error while recording or reading progress just means the chunk is paid for again, which is what would have happened anyway.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p ai-memory-store -p ai-memory-consolidate --all-targets -- -D warnings` passes (both crates this touches; it caught an `explicit_counter_loop` I've fixed)
- [x] `cargo test -p ai-memory-store -p ai-memory-consolidate --lib` — **537 passed, 0 failed** (350 + 187), all 13 new tests green. Not the full `--workspace`; see "Notes for reviewers"
- [x] `cargo test -p ai-memory-store --lib` — **350 passed**, including the 5 new `bootstrap_progress` tests and the bumped `schema_top_version_is_pinned`
- [x] 13 new tests: 5 store (ordering, fingerprint isolation, replace-on-rerecord, clear-all-fingerprints, exclusive prune cutoff), 7 fingerprint (stability, budget/content/ordering/kind sensitivity, length-prefix ambiguity), 6 `reusable_prefix` (complete run, stops at gap, missing first chunk, unreadable JSON, payload carried, empty)

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected
      any unintended identity before requesting merge.

## Release impact

- [x] **Minor** — additive: a new `--resume` flag, a new POST field, a new table

## CHANGELOG (merge gate)

- [x] I added a `CHANGELOG.md` `[Unreleased]` entry under `### Added`
- [x] No default changed — without `--resume`, behaviour is unchanged

## Notes for reviewers

**On the test scope.** Both crates this touches run green: 350 in `ai-memory-store`, 187 in `ai-memory-consolidate`. I ran the second set on an x86_64 host rather than my own machine — on aarch64 the test binary cannot link, because `gemm-f16` fails with `error: instruction requires: fullfp16` (pulled in through `candle` via `ai-memory-llm`'s default `local-embeddings` feature). That was the gap in #615; this time I went and found a machine where it links. I have not run the full `--workspace`, so the crates this PR does not touch are still CI's word.

**Validated end-to-end on the reproduction repo**, against a real Anthropic provider (`claude-haiku-4-5`), in a throwaway container built from this branch:

| behaviour | observed |
|---|---|
| progress survives a hard kill | `docker kill` (SIGKILL) during chunk 8/9 left chunks 1-7 recorded, ~226 KB of pages |
| the wiki write stays atomic | after that crash: no pages, no manifest — the `--force` guard still holds |
| a changed source set is refused | resuming from a differently-cloned checkout (69 vs 70 sources, 8 vs 9 chunks) logged `--resume found no reusable progress for these sources; starting from the first chunk` and paid for the run again, rather than resuming into a shifted plan |
| fingerprints stay isolated | two fingerprints' rows coexisted in the table without either adopting the other's chunks |
| **resume skips paid chunks** | after a kill during chunk 4/8: `--resume reusing completed chunks reused=3 total=8`, and the first LLM call of the run was `chunk=4` |
| **progress is cleared on success** | the completed run emptied the table — including the orphaned rows from the earlier abandoned fingerprint |
| the run actually completes | 58 pages + `bootstrap.md` written |

Worth noting: that repository had **never** completed a bootstrap across four attempts during my pilot (the #614 bug, a `520`, a dropped connection). It completed on the resume.

**One thing I'd like your read on:** progress is recorded unconditionally, so every bootstrap now writes N small rows even when it will never resume. The alternative is recording only under `--resume`, but that flag is chosen *before* anyone knows the run will fail, which makes it useless exactly when it matters. Clearing on success plus the age sweep should keep the table empty in the common case.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
