### PR TITLE
test(auth): pin the login window's expiry, which nothing observed

### DIFF
--- a/crates/ai-memory-mcp/src/human_auth.rs
+++ b/crates/ai-memory-mcp/src/human_auth.rs
@@ -163,7 +163,26 @@ impl LoginLimiter {
     /// True when this IP has already spent its window. Call before Argon2.
     #[must_use]
     pub fn ip_blocked(&self, ip: IpAddr) -> bool {
-        let now = Instant::now();
+        self.ip_blocked_at(ip, Instant::now())
+    }
+
+    /// Record an IP failure.
+    pub fn record_ip_failure(&self, ip: IpAddr) {
+        self.record_ip_failure_at(ip, Instant::now());
+    }
+
+    /// Record a username failure in a fixed-size, bounded key space.
+    pub fn record_username_failure(&self, username: &str) {
+        self.record_username_failure_at(username, Instant::now());
+    }
+
+    // The `_at` forms take the reading instead of sampling it, because the
+    // window is 60s and a test that waits it out is not a test anyone runs.
+    // Without them `prune` is unobservable: delete its body and the suite
+    // stays green, while a spent window would stop reopening and one minute
+    // of failures would lock the account out until the process restarts.
+
+    fn ip_blocked_at(&self, ip: IpAddr, now: Instant) -> bool {
         let mut map = self.ip.lock().unwrap_or_else(|e| e.into_inner());
         let Some(q) = map.get_mut(&ip) else {
             return false;
@@ -176,16 +195,12 @@ impl LoginLimiter {
         blocked
     }
 
-    /// Record an IP failure.
-    pub fn record_ip_failure(&self, ip: IpAddr) {
-        let now = Instant::now();
+    fn record_ip_failure_at(&self, ip: IpAddr, now: Instant) {
         let mut map = self.ip.lock().unwrap_or_else(|e| e.into_inner());
         Self::record_failure(&mut map, ip, now);
     }
 
-    /// Record a username failure in a fixed-size, bounded key space.
-    pub fn record_username_failure(&self, username: &str) {
-        let now = Instant::now();
+    fn record_username_failure_at(&self, username: &str, now: Instant) {
         let key = hash_session_secret(username);
         let mut map = self.user.lock().unwrap_or_else(|e| e.into_inner());
         Self::record_failure(&mut map, key, now);
@@ -1232,6 +1247,68 @@ mod tests {
             peer_ip(&headers, &extensions, &trusted),
             "10.0.0.4".parse::<IpAddr>().unwrap()
         );
+    }
+
+    #[test]
+    fn login_window_reopens_once_the_attempts_age_out() {
+        // `prune` is what makes this a *sliding* window rather than a
+        // permanent ban. Gut its body and every other test in this crate
+        // still passes, so the failure mode it guards -- a legitimate user
+        // locked out until the process restarts -- would ship unnoticed.
+        let limiter = LoginLimiter::default();
+        let ip = "198.51.100.7".parse::<IpAddr>().unwrap();
+        let t0 = Instant::now();
+
+        for _ in 0..LOGIN_IP_LIMIT {
+            limiter.record_ip_failure_at(ip, t0);
+        }
+        assert!(limiter.ip_blocked_at(ip, t0), "the limit must bite at all");
+
+        assert!(
+            !limiter.ip_blocked_at(ip, t0 + LOGIN_WINDOW + Duration::from_secs(1)),
+            "a spent window must reopen"
+        );
+    }
+
+    #[test]
+    fn login_window_holds_right_up_to_its_edge() {
+        let limiter = LoginLimiter::default();
+        let ip = "198.51.100.8".parse::<IpAddr>().unwrap();
+        let t0 = Instant::now();
+        for _ in 0..LOGIN_IP_LIMIT {
+            limiter.record_ip_failure_at(ip, t0);
+        }
+
+        // Non-vacuity for the test above: it would also pass against a
+        // limiter that forgot everything immediately. `prune` drops an
+        // attempt only once it is *strictly* older than the window, so the
+        // exact boundary still blocks.
+        assert!(limiter.ip_blocked_at(ip, t0 + LOGIN_WINDOW - Duration::from_millis(1)));
+        assert!(limiter.ip_blocked_at(ip, t0 + LOGIN_WINDOW));
+        assert!(!limiter.ip_blocked_at(ip, t0 + LOGIN_WINDOW + Duration::from_millis(1)));
+    }
+
+    #[test]
+    fn login_window_ages_out_one_attempt_at_a_time() {
+        // A window that reopened wholesale on expiry would pass the two
+        // tests above. Attempts must expire individually: ten spread across
+        // the window means the block lifts as the oldest ages out, not in
+        // one step.
+        let limiter = LoginLimiter::default();
+        let ip = "198.51.100.9".parse::<IpAddr>().unwrap();
+        let t0 = Instant::now();
+        for n in 0..LOGIN_IP_LIMIT {
+            limiter.record_ip_failure_at(ip, t0 + Duration::from_secs(n as u64));
+        }
+        assert!(limiter.ip_blocked_at(ip, t0 + Duration::from_secs(9)));
+
+        // Just past the first attempt's expiry, and only that one: the
+        // second is still 59s old. Nine left, under the limit, so the caller
+        // gets exactly one attempt back -- not the whole window.
+        let after_first_expires = t0 + LOGIN_WINDOW + Duration::from_millis(1);
+        assert!(!limiter.ip_blocked_at(ip, after_first_expires));
+        limiter.record_ip_failure_at(ip, after_first_expires);
+        assert!(limiter.ip_blocked_at(ip, after_first_expires));
     }
 
     #[test]


### PR DESCRIPTION
## What

`LoginLimiter::prune` is the whole reason the login limiter is a *sliding* window and not a permanent ban, and no test reached it. Replacing its entire body with a no-op leaves **all 258 tests in `ai-memory-mcp` green**:

```rust
fn prune(q: &mut VecDeque<Instant>, now: Instant) {
    let _ = (q, now);          // every test still passes
}
```

`LOGIN_WINDOW` appears exactly twice in the file — its definition and that one comparison. The three existing limiter tests cover per-IP isolation, blocking at the limit, and the global key cap; none of them advances time, so none can tell a window that reopens from one that never does.

The symptom if it regressed isn't a weakened limiter, it's the opposite: ten failures in a minute and that IP is refused **until the process restarts**. A self-inflicted lockout is the kind of thing that looks like a network problem for an afternoon.

## Why it was unobservable, and the smallest fix for that

The public methods sampled `Instant::now()` internally, and the window is 60 seconds — so the only test that could observe expiry is one nobody would ever run. Each public method is now a thin sampler over a private `_at` form that takes the reading:

```rust
pub fn ip_blocked(&self, ip: IpAddr) -> bool {
    self.ip_blocked_at(ip, Instant::now())
}
```

**No public API change and no behaviour change** — the sampled path is exactly what it was, and the `_at` forms are private, so this is a test-only seam rather than new surface. That's also why there's no CHANGELOG entry: nothing user-facing moved, which puts it under the "internal refactors and test-only churn are exempt" line in CONTRIBUTING. Happy to add one if you read it differently.

## The tests, and the mutation each one kills

| mutation | result |
|---|---|
| body of `prune` removed | **all three fail** |
| `>` relaxed to `>=` | the boundary test alone fails |
| whole queue cleared on expiry instead of per attempt | the ageing test alone fails |

The third is the one I'd argue hardest for keeping. A limiter that dropped the entire queue once its oldest entry expired would pass both simpler tests, while handing an attacker the full ten-attempt budget back every sixty seconds instead of one attempt at a time. `login_window_ages_out_one_attempt_at_a_time` is what separates those, and it's the shape a plausible "simplification" of `prune` would take.

The boundary test also does non-vacuity duty for the first: a limiter that forgot everything immediately would satisfy "the window reopens", so the exact edge is asserted in both directions — `prune` drops an attempt only once it is *strictly* older than the window.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — **2989 passed, 0 failed** across 77 test binaries
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok` (no dependency changes either; `Cargo.toml` / `Cargo.lock` are untouched)

## One thing I found next door, filed separately

Chasing this I noticed `LoginLimiter`'s username half is **written and never read** — `record_username_failure` maintains the map, and the only read of `self.user` outside that write is a test asserting the key cap. There is no `username_blocked` anywhere in the workspace. That's a design question rather than a bug (blocking on username invites a lockout DoS against a named account), so I've kept it out of this PR and written it up in its own issue.
