### PR TITLE
fix(auth): ignore stale bearer when auth is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Authentication-disabled HTTP servers now ignore stale or unexpected Bearer
+  headers and preserve anonymous access. Previously, a client retaining an old
+  `AI_MEMORY_AUTH_TOKEN` received `401 Unauthorized` even though the server
+  reported `auth=false`; invalid Bearers remain rejected whenever static or
+  human authentication is enabled. (#639)
+
 ## [2.0.3] - 2026-09-04
 
 ### Changed

--- a/crates/ai-memory-mcp/src/auth.rs
+++ b/crates/ai-memory-mcp/src/auth.rs
@@ -406,7 +406,11 @@ pub async fn require_bearer(
     match authenticate_bearer(&state, &mut req).await {
         Ok(BearerAuth::Authenticated) => next.run(req).await,
         Err(resp) => resp,
-        Ok(BearerAuth::Absent) if !state.enabled() => {
+        Ok(BearerAuth::Absent | BearerAuth::Rejected) if !state.enabled() => {
+            // With no configured authority the wire gate is disabled. A
+            // client may still carry a stale bearer from an older secured
+            // deployment; treat it like an anonymous request instead of
+            // making the no-auth server stricter than an absent header.
             req.extensions_mut().insert(ActorContext::anonymous());
             req.extensions_mut().insert(AuthLevel::Anonymous);
             next.run(req).await
@@ -543,6 +547,22 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri("/probe")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn no_token_configured_ignores_an_unexpected_bearer() {
+        let r = router_with_auth(None);
+        let resp = r
+            .oneshot(
+                Request::builder()
+                    .uri("/probe")
+                    .header("Authorization", "Bearer stale-client-token")
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/crates/ai-memory-mcp/src/human_auth.rs
+++ b/crates/ai-memory-mcp/src/human_auth.rs
@@ -1019,22 +1019,22 @@ pub async fn require_dual_auth(
     mut req: Request<axum::body::Body>,
     next: Next,
 ) -> Response {
-    match crate::auth::authenticate_bearer(&state, &mut req).await {
+    let bearer = match crate::auth::authenticate_bearer(&state, &mut req).await {
         Ok(crate::auth::BearerAuth::Authenticated) => {
             req.extensions_mut().insert(state.clone());
             return next.run(req).await;
         }
         Err(resp) => return resp,
-        Ok(crate::auth::BearerAuth::Rejected) => {
-            return crate::auth::unauthorized_bearer();
-        }
-        Ok(crate::auth::BearerAuth::Absent) => {}
-    }
+        Ok(outcome) => outcome,
+    };
 
     let human_configured = match human_auth_configured(&state).await {
         Ok(configured) => configured,
         Err(response) => return response,
     };
+    if bearer == crate::auth::BearerAuth::Rejected && (state.enabled() || human_configured) {
+        return crate::auth::unauthorized_bearer();
+    }
     if !human_configured {
         if !state.enabled() {
             req.extensions_mut().insert(ActorContext::anonymous());
@@ -1370,6 +1370,23 @@ mod tests {
                 state.clone(),
                 require_dual_auth,
             ))
+    }
+
+    #[tokio::test]
+    async fn dual_auth_ignores_an_unexpected_bearer_when_auth_is_disabled() {
+        let resp = dual_router(Arc::new(AuthState::new(None)))
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/probe")
+                    .header("authorization", "Bearer stale-client-token")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        assert_eq!(&body[..], b"anonymous");
     }
 
     async fn json_error(resp: axum::http::Response<axum::body::Body>) -> serde_json::Value {


### PR DESCRIPTION
## What changed

- Treats a stale or unexpected Bearer header as anonymous when neither static
  nor human authentication is configured.
- Keeps the secure default unchanged: an invalid Bearer still returns `401`
  whenever static or human authentication is enabled.
- Adds focused regression coverage for both HTTP authentication middleware
  paths.

## Why

A client may retain an old `AI_MEMORY_AUTH_TOKEN` after a server is switched to
no-auth mode. Before this change, the resulting Bearer header caused the server
to return `401 Unauthorized: auth required` even though it reported
`auth=false`.

Closes #639.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Manual test: reproduced `401` with v2.0.3, then verified the patched
      no-auth server returns `200`; an auth-enabled server still returns `401`
      for the wrong token and `200` for the configured token.

The GitHub Actions `test (ubuntu-latest)` workspace run passed, including both
new authentication regression tests. All required CI checks completed
successfully.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected
      any unintended identity before requesting merge. See
      [commit attribution guidance](https://github.com/akitaonrails/ai-memory/blob/main/CONTRIBUTING.md#commit-attribution).

## Release impact

- [x] **Patch** — bug fix, no new surface
- [ ] **Minor** — additive: new flag/subcommand/MCP tool/config key,
      new agent harness or provider
- [ ] **Major (breaking)** — on-disk format, removed/renamed surface,
      breaking MCP schema change — called out in "What changed" above

## CHANGELOG (merge gate)

- [x] I added a `CHANGELOG.md` `[Unreleased]` entry — **required** for any
      user-facing change: new flag / env var / endpoint / MCP tool / marker
      key, changed behaviour, or an observable bug fix. (Exempt only for
      internal refactors, dead-code removal, and test-only churn.)
- [x] Any changed **default** (flag behaviour, config default, env var,
      response shape) is called out explicitly in "What changed" above.

## Notes for reviewers

The patch changes only `CHANGELOG.md` and the two authentication middleware
modules. It does not modify `.github/`, GitHub Actions workflows, or existing
tests.
