### PR TITLE
refactor(auth): drop the per-username login window nothing reads

### DIFF
--- a/crates/ai-memory-mcp/src/human_auth.rs
+++ b/crates/ai-memory-mcp/src/human_auth.rs
@@ -119,11 +119,10 @@ impl Cidr {
     }
 }
 
-/// Bounded per-IP and per-username login attempt windows.
+/// Bounded per-IP login attempt windows.
 #[derive(Debug, Default)]
 pub struct LoginLimiter {
     ip: Mutex<HashMap<IpAddr, VecDeque<Instant>>>,
-    user: Mutex<HashMap<[u8; 32], VecDeque<Instant>>>,
 }
 
 impl LoginLimiter {
@@ -181,14 +180,6 @@ impl LoginLimiter {
         let now = Instant::now();
         let mut map = self.ip.lock().unwrap_or_else(|e| e.into_inner());
         Self::record_failure(&mut map, ip, now);
-    }
-
-    /// Record a username failure in a fixed-size, bounded key space.
-    pub fn record_username_failure(&self, username: &str) {
-        let now = Instant::now();
-        let key = hash_session_secret(username);
-        let mut map = self.user.lock().unwrap_or_else(|e| e.into_inner());
-        Self::record_failure(&mut map, key, now);
     }
 }
 
@@ -559,12 +550,7 @@ async fn issue_cookies(
     Ok((secret, csrf, issued.expires_at))
 }
 
-async fn dummy_login_failure(
-    runtime: &HumanAuthRuntime,
-    ip: IpAddr,
-    username: &str,
-    password: String,
-) -> Response {
+async fn dummy_login_failure(runtime: &HumanAuthRuntime, ip: IpAddr, password: String) -> Response {
     match ai_memory_store::password::dummy_verify(password).await {
         Err(ai_memory_store::StoreError::InvalidState(msg)) if msg.contains("saturated") => {
             json_err(StatusCode::TOO_MANY_REQUESTS, "kdf saturated")
@@ -578,7 +564,6 @@ async fn dummy_login_failure(
         }
         Ok(()) => {
             runtime.limiter.record_ip_failure(ip);
-            runtime.limiter.record_username_failure(username);
             json_err(StatusCode::UNAUTHORIZED, "invalid credentials")
         }
     }
@@ -617,18 +602,17 @@ async fn handle_login(
 
     let fail = || {
         runtime.limiter.record_ip_failure(ip);
-        runtime.limiter.record_username_failure(&username);
         json_err(StatusCode::UNAUTHORIZED, "invalid credentials")
     };
 
     let Some(login) = login else {
-        return dummy_login_failure(runtime, ip, &username, password).await;
+        return dummy_login_failure(runtime, ip, password).await;
     };
     if login.user.disabled_at.is_some() {
-        return dummy_login_failure(runtime, ip, &username, password).await;
+        return dummy_login_failure(runtime, ip, password).await;
     }
     let Some(phc) = login.password_hash.clone() else {
-        return dummy_login_failure(runtime, ip, &username, password).await;
+        return dummy_login_failure(runtime, ip, password).await;
     };
     let ok = match ai_memory_store::password::verify_password(password, phc.clone()).await {
         Ok(v) => v,
@@ -1239,13 +1223,9 @@ mod tests {
         let limiter = LoginLimiter::default();
         for n in 0..(LOGIN_LIMITER_MAX_KEYS + 50) {
             limiter.record_ip_failure(IpAddr::V6(std::net::Ipv6Addr::from(n as u128)));
-            limiter.record_username_failure(&format!("attacker-controlled-{n}"));
         }
         assert!(
             limiter.ip.lock().unwrap_or_else(|e| e.into_inner()).len() <= LOGIN_LIMITER_MAX_KEYS
-        );
-        assert!(
-            limiter.user.lock().unwrap_or_else(|e| e.into_inner()).len() <= LOGIN_LIMITER_MAX_KEYS
         );
     }
 


### PR DESCRIPTION
## What changed

`LoginLimiter` documented "bounded per-IP **and per-username** login attempt windows", and `record_username_failure` was called on every failed login, but no code ever read the username map back. This drops the map, the recorder, its two call sites, and the now-unused `username` parameter of `dummy_login_failure`. The per-IP half is untouched, so login behaviour is identical; the struct doc now says per-IP only.

This is option 3 from the issue. Options 1 (enforce) and 2 (observe) both need a threshold / alerting policy call that the issue deliberately leaves to you, and either is easy to add back on the same seam if you want it — the eviction helper `record_failure` is still shared by the IP map.

## Why

As the issue lays out, the current state carries the cost of both other designs with the effect of neither: every failed login pays a SHA-256 of the username plus the eviction scan under `LOGIN_LIMITER_MAX_KEYS`, and none of it gates anything. Your AGENTS.md rule 2 ("no dead code, no half-built features") reads this as not intended. And leaving the doc comment claiming username throttling is the worst option for anyone auditing the auth path, since they'd reasonably conclude per-username blocking exists.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (77 test binaries, 0 failures)
- [x] Manual: no new test because there is nothing observable to assert — the deleted map gated nothing, so any login-success or IP-block test passes identically on the pre-change tree. The existing `login_limiter_state_has_a_hard_global_cap` and `login_unknown_disabled_and_wrong_password_share_generic_shape` still cover the surviving behavior.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected
      any unintended identity before requesting merge. See
      [commit attribution guidance](https://github.com/akitaonrails/ai-memory/blob/main/CONTRIBUTING.md#commit-attribution).

## Release impact

- [x] **Patch** — bug fix, no new surface

Internal removal only: no flag/env/endpoint/tool change, no observable behaviour change.

## CHANGELOG (merge gate)

- [x] Exempt — internal dead-code removal (per CONTRIBUTING.md's exemption list: "Internal refactors, dead-code removal, and test-only churn are exempt").

## Notes for reviewers

The per-username map arrived with #533 and never had a reader. If you'd rather have option 1 or 2 from the issue, say the word and I'll rework this — the two halves are independent enough that either can land on the same seam.
