### PR TITLE
fix(reindex): identify missing scope manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `ai-memory reindex` now names the exact missing or unreadable scope
+  `_meta.md` path instead of collapsing the filesystem error to a bare `No such
+  file or directory (os error 2)`. This makes the existing startup-backfill
+  workaround discoverable when a scope was first created during the server's
+  last run. (#643)
+
 ## [2.0.3] - 2026-09-04
 
 ### Changed

--- a/crates/ai-memory-wiki/src/wiki.rs
+++ b/crates/ai-memory-wiki/src/wiki.rs
@@ -1351,14 +1351,29 @@ impl Wiki {
     /// Read a `_meta.md` scope-manifest's frontmatter from `dir`.
     fn read_scope_meta(dir: &Path) -> WikiResult<serde_json::Value> {
         let path = dir.join("_meta.md");
-        let meta = std::fs::symlink_metadata(&path)?;
+        let meta = std::fs::symlink_metadata(&path).map_err(|error| {
+            let message = if error.kind() == std::io::ErrorKind::NotFound {
+                format!("scope manifest {} is missing", path.display())
+            } else {
+                format!(
+                    "could not inspect scope manifest {}: {error}",
+                    path.display()
+                )
+            };
+            WikiError::Io(std::io::Error::new(error.kind(), message))
+        })?;
         if meta.file_type().is_symlink() {
             return Err(WikiError::Io(std::io::Error::other(format!(
                 "refusing to read symlinked scope manifest {}",
                 path.display()
             ))));
         }
-        let raw = std::fs::read_to_string(path)?;
+        let raw = std::fs::read_to_string(&path).map_err(|error| {
+            WikiError::Io(std::io::Error::new(
+                error.kind(),
+                format!("could not read scope manifest {}: {error}", path.display()),
+            ))
+        })?;
         Ok(parse(&raw)?.frontmatter)
     }
 
@@ -4402,6 +4417,50 @@ mod tests {
         assert_eq!(wiki.backfill_scope_manifests().await.unwrap(), 1);
         let healed = std::fs::read_to_string(&meta_path).unwrap();
         assert!(healed.contains("type: Scope Manifest"), "{healed}");
+    }
+
+    #[tokio::test]
+    async fn reindex_names_a_missing_workspace_manifest() {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
+        let ws = WorkspaceId::new();
+        let proj = ProjectId::new();
+        let ws_dir = tmp.path().join("wiki").join(ws.to_string());
+        let missing = ws_dir.join("_meta.md");
+        std::fs::create_dir_all(ws_dir.join(proj.to_string())).unwrap();
+
+        let err = wiki.reindex_all().await.unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            format!("scope manifest {} is missing", missing.display())
+        );
+    }
+
+    #[tokio::test]
+    async fn reindex_names_a_missing_project_manifest() {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
+        let ws = WorkspaceId::new();
+        let proj = ProjectId::new();
+        let ws_dir = tmp.path().join("wiki").join(ws.to_string());
+        let proj_dir = ws_dir.join(proj.to_string());
+        let missing = proj_dir.join("_meta.md");
+        std::fs::create_dir_all(&proj_dir).unwrap();
+        std::fs::write(
+            ws_dir.join("_meta.md"),
+            "---\nworkspace: acme\ntype: Scope Manifest\n---\n",
+        )
+        .unwrap();
+
+        let err = wiki.reindex_all().await.unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            format!("scope manifest {} is missing", missing.display())
+        );
     }
 
     #[cfg(any(unix, windows))]

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -731,6 +731,10 @@ volume.
 ai-memory reindex --data-dir <path>
 ```
 
+If reindex reports a missing scope `_meta.md`, the error includes its exact
+path. Restore the original DB, start and stop the current server once so its
+startup backfill writes missing manifests, then retry against a clean DB.
+
 Direct-disk lifecycle operation. Refuses if any sibling `ai-memory` process is
 alive, and also refuses if SQLite already contains rows. `reindex` is a
 rebuild-from-files path, not an in-place dirty-index repair.


### PR DESCRIPTION
## What changed

- preserve the exact `_meta.md` path when scope-manifest inspection or reading fails
- report a missing manifest as `scope manifest <path> is missing` instead of a bare `No such file or directory (os error 2)`
- add `reindex_all` regressions for both a missing workspace manifest and a missing project manifest
- document the existing startup-backfill recovery procedure

This implements the first, independently reviewable step in #643. It intentionally does not claim to close the separate lifecycle window where a newly materialized scope lacks a manifest until the next server start.

## Why

A reindex is usually run during recovery, after the derived DB has been moved aside. The previous error discarded the only actionable fact—the affected scope path—so the operator could neither identify the broken directory nor discover the existing backfill workaround.

The change keeps the original `io::ErrorKind`, changes no reindex decisions, and does not touch wiki files or SQLite rows.

Refs #643

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo test -p ai-memory-wiki reindex_names_a_missing -j 2` — 2 passed
- [x] `cargo test -p ai-memory-wiki -j 2` — 133 unit + 17 admission tests passed
- [x] `cargo clippy -p ai-memory-wiki --all-targets -j 2 -- -D warnings`
- [ ] `cargo test --workspace` — attempted twice on Windows; rustc exhausted the host page file while compiling unrelated `ai-memory-cli` / `ai-memory-web` test targets, once at `-j 2` and once at `-j 1`. No test assertion failed; the affected crate's full suite passed as listed above. CI remains authoritative for the workspace-wide run.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected an unintended local identity before pushing.

## Release impact

- [x] **Patch** — diagnostic bug fix, no new surface
- [ ] **Minor** — additive surface
- [ ] **Major (breaking)** — breaking change

## CHANGELOG (merge gate)

- [x] Added an `[Unreleased]` `Fixed` entry.
- [x] No default, file format, database, or API behavior changed.

## Notes for reviewers

The second suggestion in #643—writing manifests at scope creation—is deliberately left separate. It crosses the hook ledger's direct append path, ordinary and batch page writes, and mutation-lock semantics; combining it with this diagnostic fix would make a two-line I/O-boundary change carry unrelated write/concurrency risk.

Suggested label: `windows` (path rendering regressions run on this host too).
