### PR TITLE
docs(ci): align Windows coverage claims with workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
       - run: cargo test --workspace --all-targets
 
   # Native Windows coverage lives in `.github/workflows/windows.yml`: it
-  # runs on every push to main, nightly, on demand, and on any pull request
-  # carrying the `windows` label. It was ~1000s here against ~250s for the
+  # runs nightly, on demand, and on any pull request carrying the `windows`
+  # label. It was ~1000s here against ~250s for the
   # same tests on Linux, which meant every pull request waited roughly
   # seventeen minutes when every gating job below finishes in about eight —
   # and it was `continue-on-error`, so those extra minutes gated nothing.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,23 +14,20 @@ name: windows
 # `continue-on-error` and therefore blocked nothing. Linux and macOS are
 # the priority platforms and now set the pull-request feedback time.
 #
-# Moving it here makes the coverage *stronger*, not weaker:
+# Keeping it separate preserves deliberate Windows coverage without adding it
+# to every merge:
 #
-#   * it runs on every push to `main`, so every merge is checked;
-#   * it no longer carries `continue-on-error`, so a real Windows break is
-#     a red run instead of a yellow one nobody reads. It cannot block a
-#     Linux/macOS merge from here, which was the original reason for the
-#     override;
 #   * a nightly run catches toolchain and dependency drift that no code
 #     change would trigger;
 #   * `workflow_dispatch` and the `windows` label give a pull request that
 #     touches platform-sensitive code — path handling, file locking, git
-#     plumbing — a way to opt in *before* merging.
+#     plumbing — a way to opt in before merging;
+#   * the job no longer carries `continue-on-error`, so failures in those
+#     scheduled, labelled, and manual runs are red rather than advisory.
 #
 # If you are changing any of those areas, add the `windows` label to the
-# pull request rather than finding out after the merge.
-# During feature iteration this workflow no longer runs on every push to
-# main: fast Linux CI gates each merge, and the full Windows suite runs
+# pull request. During feature iteration this workflow does not run on pushes
+# to main: fast Linux CI gates each merge, and the full Windows suite runs
 # nightly, on demand, and MANDATORILY right before a release (dispatch it
 # on the release-candidate SHA and wait for green — see AGENTS.md).
 on:
@@ -58,8 +55,8 @@ env:
 jobs:
   test:
     name: test (windows-latest)
-    # On a pull request, only when explicitly opted in. Pushes to main,
-    # the schedule, and manual dispatch always run.
+    # On a pull request, only when explicitly opted in. The schedule and
+    # manual dispatch always run.
     if: >-
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'windows')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,9 +225,9 @@ cargo deny check                                          # dependency policy (i
   `.github/workflows/secret-scan.yml` runs the separate weekly/manual
   full-history gitleaks scan.
 - **Windows runs in its own workflow** (`.github/workflows/windows.yml`):
-  every push to `main`, nightly, on demand, and on any PR labelled
-  `windows`. It is the only place `#[cfg(windows)]` tests compile, and it
-  is ~4x slower than the same tests on Linux — keeping it out of `ci.yml`
+  nightly, on demand, and on any PR labelled `windows`. It is the only place
+  `#[cfg(windows)]` tests compile, and it is ~4x slower than the same tests on
+  Linux — keeping it out of `ci.yml`
   is what holds PR feedback near the eight minutes the gating jobs take.
   **Add the `windows` label** to a PR touching path handling, file
   locking, or git plumbing, so the check runs before the merge rather


### PR DESCRIPTION
## What changed

Updated the Windows workflow comments, the main CI workflow comments, and the contributor guide to describe the triggers that are actually configured: labelled pull requests, the nightly schedule, and manual dispatch.

## Why

PR #575 deliberately removed the `push` trigger from the Windows workflow as part of the fast-per-merge/full-pre-release CI policy. Older comments still claimed that every push to `main` ran Windows tests, which could give contributors false confidence about post-merge Windows coverage.

## Test plan

- [x] `git diff --check` passes
- [x] Manually compared every updated statement with `.github/workflows/windows.yml`'s `on` block and job condition
- [x] Confirmed the diff changes comments and documentation only; workflow behavior is unchanged

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected any unintended identity before requesting merge.

## Release impact

- [x] **Patch** — documentation correction, no new surface or runtime behavior

## CHANGELOG

- [x] No entry required: this corrects internal CI documentation and comments without changing behavior, defaults, or a user-facing surface.

## Notes for reviewers

The newer CI pacing rule in `AGENTS.md` already states the intended policy: fast Linux jobs per merge, with Windows nightly, on demand, by PR label, and mandatory on the release-candidate SHA before tagging.
