### PR TITLE
fix(wiki): drop a leading BOM on a page with no frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-event disposition runs. The install-time "enforced"/"NOT in force"
   messaging is corrected to match: a script-fallback install is now the
   only path flagged as unenforced. (#661)
+- A UTF-8 BOM on a hand-edited wiki page that has no frontmatter no longer
+  rides into the page body. `markdown::parse` stripped the mark before looking
+  for the frontmatter fence, but the no-frontmatter path returned the untouched
+  input as the body, so the mark stayed in front of the first line. Two things
+  followed from that: `derive_title` no longer read the leading `# ` as a
+  heading, so the page was indexed under its filename instead of its title, and
+  the OKF v0.2 file pass (which conforms frontmatter and leaves the body alone)
+  re-emitted the mark after the closing `---` fence, where it is a stray
+  zero-width no-break space rather than a byte-order mark. Both paths now drop
+  the leading BOM, which is what the frontmatter path already did. (#663)
 
 ## [2.1.0] - 2026-09-06
 

--- a/crates/ai-memory-wiki/src/markdown.rs
+++ b/crates/ai-memory-wiki/src/markdown.rs
@@ -28,6 +28,12 @@ pub struct Markdown {
 /// Recognises only the canonical `---\n<yaml>\n---\n` block at the very
 /// start of the document. Anything else is treated as body.
 ///
+/// A leading UTF-8 BOM is dropped either way. It only means "this file is
+/// UTF-8" while it sits at offset zero; carried into `body` it is a
+/// zero-width no-break space in front of the first line, which hides an H1
+/// from [`derive_title`] and rides into the body a later re-emit writes
+/// back after the frontmatter fence.
+///
 /// # Errors
 /// Returns [`WikiError::Yaml`] if the frontmatter block exists but does
 /// not parse as YAML.
@@ -47,7 +53,7 @@ pub fn parse(input: &str) -> WikiResult<Markdown> {
     }
     Ok(Markdown {
         frontmatter: serde_json::Value::Null,
-        body: input.to_string(),
+        body: trimmed.to_string(),
     })
 }
 
@@ -549,6 +555,26 @@ mod tests {
         let md = parse(src).unwrap();
         assert_eq!(md.frontmatter["title"], "Hello");
         assert_eq!(md.body, "Body\n");
+    }
+
+    /// A page a Windows editor saved with a UTF-8 BOM and no frontmatter:
+    /// the mark belongs to the file, not to the first line. Left in `body`
+    /// it sits in front of the `#`, so the H1 stops being a heading and the
+    /// page is indexed under its filename instead of its title.
+    #[test]
+    fn parses_bom_prefixed_body_without_frontmatter() {
+        let src = "\u{FEFF}# Hand written\n\nBody.\n";
+        let md = parse(src).unwrap();
+        assert!(md.frontmatter.is_null());
+        assert_eq!(md.body, "# Hand written\n\nBody.\n");
+        assert_eq!(
+            derive_title(
+                &md.frontmatter,
+                &md.body,
+                &PagePath::new("notes/hand-written.md").unwrap(),
+            ),
+            "Hand written"
+        );
     }
 
     #[test]

--- a/crates/ai-memory-wiki/src/migrations/m2026_09_okf_conformance.rs
+++ b/crates/ai-memory-wiki/src/migrations/m2026_09_okf_conformance.rs
@@ -542,6 +542,34 @@ mod tests {
         assert!(crate::backup::BackupReceipt::load(tmp.path()).is_none());
     }
 
+    /// The file pass leaves the body untouched, and a UTF-8 BOM is not part
+    /// of the body: it means "this file is UTF-8" only at offset zero. A
+    /// hand-edited page a Windows editor saved with one and no frontmatter
+    /// used to come back through `parse` with the mark still on the front of
+    /// the body, so this pass wrote it out AFTER the frontmatter fence, where
+    /// it is a stray zero-width no-break space ahead of the H1.
+    #[test]
+    fn conforming_a_bom_prefixed_page_does_not_move_the_mark_into_the_body() {
+        let tmp = TempDir::new().unwrap();
+        let rel = Path::new("w/p/notes/hand-written.md");
+        let abs = tmp.path().join(rel);
+        std::fs::create_dir_all(abs.parent().unwrap()).unwrap();
+        std::fs::write(&abs, "\u{FEFF}# Hand written\n\nBody.\n").unwrap();
+
+        conform_file(tmp.path(), rel, &std::collections::HashMap::new()).unwrap();
+
+        let conformed = std::fs::read_to_string(&abs).unwrap();
+        assert!(
+            !conformed.contains('\u{FEFF}'),
+            "the mark survived the file pass: {conformed:?}"
+        );
+        assert!(
+            conformed.ends_with("---\n# Hand written\n\nBody.\n"),
+            "the body must reach disk exactly as it was authored: {conformed:?}"
+        );
+        assert_eq!(parse(&conformed).unwrap().frontmatter["type"], "Note");
+    }
+
     // ---- #633: the safety archive must be taken BEFORE the DB migration ----
 
     /// The core assertion for #633: the pre-open snapshot captures the DB as it


### PR DESCRIPTION
## What changed

`markdown::parse` strips a leading UTF-8 BOM before it looks for the frontmatter fence, but the no-frontmatter path returned the untouched `input` as the body instead of the stripped `trimmed` (`crates/ai-memory-wiki/src/markdown.rs:34-52`). A page with a BOM and no frontmatter therefore kept the mark in front of its first line, where it is not a byte-order mark any more. It now returns `trimmed` on both paths, which is what the frontmatter path already did.

Before: `parse("\u{FEFF}# Hand written\n\nBody.\n").body == "\u{FEFF}# Hand written\n\nBody.\n"`. After: `"# Hand written\n\nBody.\n"`. A page that already had frontmatter is unchanged, and so is every page with no BOM.

## Why

Two observable consequences.

`derive_title` picks a title by scanning body lines for a `# ` prefix. With the mark sitting in front of the `#` the H1 stops matching, so `reindex_page` and `restore_page_from_checkpoint` index the page under its filename stem rather than its heading. A hand-edited `notes/hand-written.md` starting `# Hand written` came back as "hand-written".

The OKF v0.2 file pass is worse, because it writes. Its contract is "conform every wiki `.md` in place (body untouched)" (`crates/ai-memory-wiki/src/migrations/m2026_09_okf_conformance.rs:8`), and `conform_file` implements that by parsing, filling the frontmatter, and writing `emit(&md)` back through an atomic rename. Fed a BOM-prefixed page with no frontmatter it produced:

```
---
type: Note
generated:
  by: process:ai-memory/2.1.0
  at: 2026-09-06T22:38:30Z
---
\u{feff}# Hand written

Body.
```

The mark is now after the closing fence, inside the body, where it is a stray zero-width no-break space ahead of the H1 rather than a byte-order mark. That is a permanent edit to the source of truth, and the migration is one-shot.

The wiki is meant to be hand-editable and the project supports Windows, where a BOM is what several editors and PowerShell write by default. The CLI hook path already handles this deliberately (`crates/ai-memory-cli/src/commands/hook.rs:822`, `docs/windows.md:512`); this is the same class of input reaching the wiki parser.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `git diff --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --all-targets` passes
- [x] Manual test: the workspace run is 3108 passed / 0 failed across 15 test binaries, `ai-memory-wiki` 158 of them. With the two new tests kept and the one-word fix reverted, `parses_bom_prefixed_body_without_frontmatter` fails with `left: "\u{feff}# Hand written\n\nBody.\n"` and `conforming_a_bom_prefixed_page_does_not_move_the_mark_into_the_body` fails printing the conformed file with the mark after the fence. The pre-existing `parses_bom_prefixed_frontmatter` passes either way, so the frontmatter path is untouched.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected any unintended identity before requesting merge. See [commit attribution guidance](https://github.com/akitaonrails/ai-memory/blob/main/CONTRIBUTING.md#commit-attribution).

## Release impact

- [x] **Patch**: bug fix, no new surface
- [ ] **Minor**: additive: new flag/subcommand/MCP tool/config key, new agent harness or provider
- [ ] **Major (breaking)**: on-disk format, removed/renamed surface, breaking MCP schema change

## CHANGELOG (merge gate)

- [x] I added a `CHANGELOG.md` `[Unreleased]` entry under `### Fixed`.
- [x] Any changed **default** is called out in "What changed" above. Nothing configurable changed; the only behaviour difference is on input that carries a leading BOM.

## Notes for reviewers

The tests live in the two modules that own the two symptoms: the parse-boundary one next to the existing `parses_bom_prefixed_frontmatter` in `markdown.rs`, and the file-pass one in the migration's own test module, calling `conform_file` directly rather than standing up a store.

One knock-on worth naming: a store that already indexed a BOM-prefixed frontmatter-less page will supersede it once on the next reindex, because the body sha256 changes when the mark leaves. That is the fix landing, and it corrects the title on the same pass.

I did not touch the `---\r\n` case. A CRLF file is not recognised as having frontmatter at all today, which is a separate decision about what "the canonical `---\n<yaml>\n---\n` block" means, and it would change what parses rather than what a parsed body contains.
