### PR TITLE
fix(wrapper): match multi-arch image digest and preserve volume mount modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   summary or handoff was produced. The handlers are now `async` and await a
   bounded (2s) drain of the pending request(s) before returning, mirroring
   the joinable dispose-drain already used by the OpenCode integration (#676).
+- The `bin/ai-memory` container wrapper now matches multi-architecture image
+  manifests against the host's platform architecture, eliminating a
+  false-positive "a newer image is available on Docker Hub" warning on x86_64
+  and Podman. Additionally, `emit_docker_run_script` now preserves volume mount
+  modes (such as `:Z` on SELinux/Podman environments) and filters transient
+  runtime environment variables (`HOSTNAME`, `container=podman`).
 
 ## [2.1.1] - 2026-09-07
 

--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -60,16 +60,47 @@ WRAPPER_SHA256_URL="${AI_MEMORY_WRAPPER_SHA256_URL:-${WRAPPER_URL}.sha256}"
 
 # ---- version-check helpers (best-effort; never block the wrapper) --------
 
-local_digest() {
-  "${DOCKER}" image inspect --format='{{index .RepoDigests 0}}' "${IMAGE}" 2>/dev/null \
-    | sed 's/.*@//' || true
+local_digests() {
+  "${DOCKER}" image inspect --format='{{range .RepoDigests}}{{println .}}{{end}}{{println .Digest}}' "${IMAGE}" 2>/dev/null \
+    | sed 's/.*@//' | grep -v '^$' || true
 }
 
 remote_digest() {
+  local host_arch
+  case "$(uname -m 2>/dev/null || true)" in
+    x86_64 | amd64) host_arch="amd64" ;;
+    aarch64 | arm64) host_arch="arm64" ;;
+    *) host_arch="" ;;
+  esac
+
   # docker manifest inspect was experimental pre-20.10; on modern
-  # docker it's stable. Silent on failure (offline, podman, etc.).
-  "${DOCKER}" manifest inspect "${IMAGE}" 2>/dev/null \
-    | grep -oE 'sha256:[a-f0-9]{64}' | head -n 1 || true
+  # docker and podman it's stable. Silent on failure (offline, etc.).
+  "${DOCKER}" manifest inspect "${IMAGE}" 2>/dev/null | awk -v target_arch="${host_arch}" '
+    BEGIN { RS="}" }
+    {
+      block = $0
+      arch = ""
+      digest = ""
+      if (match(block, /sha256:[a-f0-9]{64}/)) {
+        digest = substr(block, RSTART, RLENGTH)
+        if (first_d == "") first_d = digest
+      }
+      if (match(block, /"architecture"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        s = substr(block, RSTART, RLENGTH)
+        sub(/.*"architecture"[[:space:]]*:[[:space:]]*"/, "", s)
+        sub(/".*/, "", s)
+        arch = s
+      }
+      if (arch == target_arch && digest != "") {
+        print digest
+        found = 1
+        exit
+      }
+    }
+    END {
+      if (!found && first_d != "") print first_d
+    }
+  ' || true
 }
 
 maybe_warn_outdated() {
@@ -84,10 +115,10 @@ maybe_warn_outdated() {
   mkdir -p "${CACHE_DIR}"
   touch "${VERSION_CHECK_FILE}"
   local local_d remote_d
-  local_d=$(local_digest)
+  local_d=$(local_digests)
   remote_d=$(remote_digest)
   [ -n "${local_d}" ] && [ -n "${remote_d}" ] || return 0
-  if [ "${local_d}" != "${remote_d}" ]; then
+  if ! printf '%s\n' "${local_d}" | grep -qxF "${remote_d}"; then
     printf '\033[33mai-memory: a newer image is available on Docker Hub.\033[0m\n' >&2
     printf '           run `ai-memory upgrade` to pull it + refresh hooks.\n' >&2
   fi
@@ -177,7 +208,7 @@ emit_docker_run_script() {
   ports="$("${DOCKER}" inspect "${container}" --format \
     '{{range $p, $bindings := .HostConfig.PortBindings}}{{range $bindings}}-p {{if .HostIp}}{{.HostIp}}:{{end}}{{.HostPort}}:{{$p}} {{end}}{{end}}' 2>/dev/null)"
   volumes="$("${DOCKER}" inspect "${container}" --format \
-    '{{range .Mounts}}{{if eq .Type "volume"}}-v {{.Name}}:{{.Destination}} {{else}}-v {{.Source}}:{{.Destination}} {{end}}{{end}}' 2>/dev/null)"
+    '{{range .Mounts}}{{if eq .Type "volume"}}-v {{.Name}}:{{.Destination}}{{if .Mode}}:{{.Mode}}{{end}} {{else}}-v {{.Source}}:{{.Destination}}{{if .Mode}}:{{.Mode}}{{end}} {{end}}{{end}}' 2>/dev/null)"
   restart="$("${DOCKER}" inspect "${container}" --format \
     '{{with .HostConfig.RestartPolicy.Name}}{{if ne . "no"}}--restart {{.}}{{end}}{{end}}' 2>/dev/null)"
 
@@ -204,6 +235,9 @@ emit_docker_run_script() {
     if printf '%s\n' "${image_env}" | grep -qxF -- "${kv}"; then
       continue
     fi
+    case "${kv}" in
+      HOSTNAME=*|container=*) continue ;;
+    esac
     env_flags="${env_flags} -e $(printf '%q' "${kv}")"
   done <<ENVEOF
 ${container_env}

--- a/bin/ai-memory
+++ b/bin/ai-memory
@@ -60,12 +60,31 @@ WRAPPER_SHA256_URL="${AI_MEMORY_WRAPPER_SHA256_URL:-${WRAPPER_URL}.sha256}"
 
 # ---- version-check helpers (best-effort; never block the wrapper) --------
 
-local_digests() {
-  "${DOCKER}" image inspect --format='{{range .RepoDigests}}{{println .}}{{end}}{{println .Digest}}' "${IMAGE}" 2>/dev/null \
+local_repo_digests() {
+  "${DOCKER}" image inspect --format='{{range .RepoDigests}}{{println .}}{{end}}' "${IMAGE}" 2>/dev/null \
     | sed 's/.*@//' | grep -v '^$' || true
 }
 
-remote_digest() {
+local_instance_digest() {
+  # Podman (and containerd image store) exposes .Digest for the per-arch child image.
+  # Docker classic has no .Digest field in types.ImageInspect; fail gracefully.
+  "${DOCKER}" image inspect --format='{{println .Digest}}' "${IMAGE}" 2>/dev/null \
+    | sed 's/.*@//' | grep -v '^$' || true
+}
+
+local_digests() {
+  local_repo_digests
+  local_instance_digest
+}
+
+remote_list_digest() {
+  # Docker standard: buildx imagetools inspect outputs the manifest list (index) digest
+  # matching Docker's classic .RepoDigests.
+  "${DOCKER}" buildx imagetools inspect "${IMAGE}" 2>/dev/null \
+    | awk '/^Digest:[[:space:]]+/ { print $2; exit }' || true
+}
+
+remote_arch_digest() {
   local host_arch
   case "$(uname -m 2>/dev/null || true)" in
     x86_64 | amd64) host_arch="amd64" ;;
@@ -103,6 +122,11 @@ remote_digest() {
   ' || true
 }
 
+remote_digest() {
+  remote_list_digest
+  remote_arch_digest
+}
+
 maybe_warn_outdated() {
   [ -z "${AI_MEMORY_NO_VERSION_CHECK:-}" ] || return 0
   # Skip in non-interactive contexts so we don't pollute pipes / CI.
@@ -114,14 +138,45 @@ maybe_warn_outdated() {
   fi
   mkdir -p "${CACHE_DIR}"
   touch "${VERSION_CHECK_FILE}"
-  local local_d remote_d
-  local_d=$(local_digests)
-  remote_d=$(remote_digest)
-  [ -n "${local_d}" ] && [ -n "${remote_d}" ] || return 0
-  if ! printf '%s\n' "${local_d}" | grep -qxF "${remote_d}"; then
-    printf '\033[33mai-memory: a newer image is available on Docker Hub.\033[0m\n' >&2
-    printf '           run `ai-memory upgrade` to pull it + refresh hooks.\n' >&2
+
+  local local_repos local_inst remote_list remote_arch
+  local_repos="$(local_repo_digests)"
+  local_inst="$(local_instance_digest)"
+  remote_list="$(remote_list_digest)"
+  remote_arch="$(remote_arch_digest)"
+
+  # If both remote sources failed (offline, timeout, etc.), skip.
+  [ -n "${remote_list}" ] || [ -n "${remote_arch}" ] || return 0
+  # If local has no digests at all, skip.
+  [ -n "${local_repos}" ] || [ -n "${local_inst}" ] || return 0
+
+  # 1. If remote list digest is available, compare against local repo digests (Docker matching).
+  if [ -n "${remote_list}" ] && [ -n "${local_repos}" ]; then
+    if printf '%s\n' "${local_repos}" | grep -qxF "${remote_list}"; then
+      return 0
+    fi
   fi
+
+  # 2. If per-arch remote digest is available:
+  if [ -n "${remote_arch}" ]; then
+    local local_per_arch="${local_inst}"
+    if [ -z "${local_per_arch}" ] && [ "$(printf '%s\n' "${local_repos}" | grep -c .)" -gt 1 ]; then
+      local_per_arch="${local_repos}"
+    fi
+
+    if [ -n "${local_per_arch}" ]; then
+      if printf '%s\n' "${local_per_arch}" | grep -qxF "${remote_arch}"; then
+        return 0
+      fi
+    elif [ -z "${remote_list}" ]; then
+      # Classic Docker without buildx: local only has manifest-list digest,
+      # remote only has per-arch digest. We cannot reliably compare them; gate out.
+      return 0
+    fi
+  fi
+
+  printf '\033[33mai-memory: a newer image is available on Docker Hub.\033[0m\n' >&2
+  printf '           run `ai-memory upgrade` to pull it + refresh hooks.\n' >&2
 }
 
 # ---- upgrade subcommand --------------------------------------------------

--- a/tests/wrapper_upgrade.sh
+++ b/tests/wrapper_upgrade.sh
@@ -46,7 +46,13 @@ case "${1:-}" in
       '{{.Id}}') printf 'running-container-id\n' ;;
       '{{.Config.Image}}') printf 'akitaonrails/ai-memory:latest\n' ;;
       *PortBindings*) printf '%s\n' '-p 127.0.0.1:49374:49374/tcp ' ;;
-      *Mounts*) printf '%s\n' '-v ai-memory-data:/data:Z ' ;;
+      *Mounts*)
+        if printf '%s\n' "${4:-}" | grep -q 'if \.Mode'; then
+          printf '%s\n' '-v ai-memory-data:/data:Z '
+        else
+          printf '%s\n' '-v ai-memory-data:/data '
+        fi
+        ;;
       *RestartPolicy*) printf '%s\n' '--restart unless-stopped' ;;
       '{{json .Config.Cmd}}') printf '[]\n' ;;
       *'.Config.Env'*)
@@ -105,6 +111,7 @@ fi
 # ---- multi-arch manifest version-check tests -----------------------------
 
 if command -v python3 >/dev/null 2>&1; then
+  H_INDEX="sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
   H_ARM="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   H_AMD="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
   H_OLD="sha256:0000000000000000000000000000000000000000000000000000000000000000"
@@ -112,15 +119,44 @@ if command -v python3 >/dev/null 2>&1; then
   MULTI_ARCH_JSON="{\"manifests\":[{\"digest\":\"${H_ARM}\",\"platform\":{\"architecture\":\"arm64\"}},{\"digest\":\"${H_AMD}\",\"platform\":{\"architecture\":\"amd64\"}}]}"
 
   run_version_check_case() {
-    local name="$1" uname_m="$2" local_inspect="$3" remote_manifest="$4" expect_warn="$5"
+    local name="$1" engine_flavor="$2" uname_m="$3" repo_digests="$4" digest_field="$5" buildx_digest="$6" remote_manifest="$7" expect_warn="$8"
     local case_dir="${TMP_ROOT}/ver_${name}"
     mkdir -p "${case_dir}/cache"
     local fake_engine="${case_dir}/engine"
     cat >"${fake_engine}" <<ENGINE
 #!/usr/bin/env bash
 case "\${1:-}" in
+  buildx)
+    if [ -n "${buildx_digest}" ]; then
+      printf 'Name: %s\nDigest: %s\n' "\${4:-}" "${buildx_digest}"
+    else
+      printf 'Error: unrecognized command\n' >&2
+      exit 1
+    fi
+    ;;
   image)
-    printf '%b\n' '${local_inspect}'
+    fmt=""
+    for arg in "\$@"; do
+      case "\${arg}" in
+        --format=*) fmt="\${arg#--format=}" ;;
+      esac
+    done
+    case "\${fmt}" in
+      *'.Digest'*)
+        if [ "${engine_flavor}" = "docker" ]; then
+          printf 'template parsing error: map has no entry for key "Digest"\n' >&2
+          exit 1
+        else
+          printf '%b\n' "${digest_field}"
+        fi
+        ;;
+      *'.RepoDigests'*)
+        printf '%b\n' "${repo_digests}"
+        ;;
+      *)
+        printf '%b\n' "${repo_digests}"
+        ;;
+    esac
     ;;
   manifest)
     printf '%b\n' '${remote_manifest}'
@@ -186,10 +222,20 @@ else:
     fi
   }
 
-  run_version_check_case amd64_matching "x86_64" "sha256:index\n${H_AMD}" "${MULTI_ARCH_JSON}" 0
-  run_version_check_case amd64_outdated "x86_64" "sha256:index\n${H_OLD}" "${MULTI_ARCH_JSON}" 1
-  run_version_check_case arm64_matching "aarch64" "${H_ARM}" "${MULTI_ARCH_JSON}" 0
-  run_version_check_case arm64_outdated "aarch64" "${H_OLD}" "${MULTI_ARCH_JSON}" 1
+  # Podman cases: exposes .Digest and per-arch child digest in .RepoDigests
+  run_version_check_case podman_amd64_matching "podman" "x86_64" "${H_INDEX}\n${H_AMD}" "${H_AMD}" "" "${MULTI_ARCH_JSON}" 0
+  run_version_check_case podman_amd64_outdated "podman" "x86_64" "${H_INDEX}\n${H_OLD}" "${H_OLD}" "" "${MULTI_ARCH_JSON}" 1
+  run_version_check_case podman_arm64_matching "podman" "aarch64" "${H_INDEX}\n${H_ARM}" "${H_ARM}" "" "${MULTI_ARCH_JSON}" 0
+  run_version_check_case podman_arm64_outdated "podman" "aarch64" "${H_INDEX}\n${H_OLD}" "${H_OLD}" "" "${MULTI_ARCH_JSON}" 1
+
+  # Docker cases: .Digest fails; .RepoDigests has manifest-list digest; buildx gets remote list digest
+  run_version_check_case docker_amd64_matching "docker" "x86_64" "${H_INDEX}" "" "${H_INDEX}" "${MULTI_ARCH_JSON}" 0
+  run_version_check_case docker_amd64_outdated "docker" "x86_64" "${H_OLD}" "" "${H_INDEX}" "${MULTI_ARCH_JSON}" 1
+  run_version_check_case docker_arm64_matching "docker" "aarch64" "${H_INDEX}" "" "${H_INDEX}" "${MULTI_ARCH_JSON}" 0
+  run_version_check_case docker_arm64_outdated "docker" "aarch64" "${H_OLD}" "" "${H_INDEX}" "${MULTI_ARCH_JSON}" 1
+
+  # Classic Docker fallback: no buildx, only manifest-list locally; gated to avoid false positive
+  run_version_check_case docker_classic_gated  "docker" "x86_64" "${H_INDEX}" "" "" "${MULTI_ARCH_JSON}" 0
 fi
 
 printf 'wrapper upgrade ownership checks passed\n'

--- a/tests/wrapper_upgrade.sh
+++ b/tests/wrapper_upgrade.sh
@@ -46,10 +46,14 @@ case "${1:-}" in
       '{{.Id}}') printf 'running-container-id\n' ;;
       '{{.Config.Image}}') printf 'akitaonrails/ai-memory:latest\n' ;;
       *PortBindings*) printf '%s\n' '-p 127.0.0.1:49374:49374/tcp ' ;;
-      *Mounts*) printf '%s\n' '-v ai-memory-data:/data ' ;;
+      *Mounts*) printf '%s\n' '-v ai-memory-data:/data:Z ' ;;
       *RestartPolicy*) printf '%s\n' '--restart unless-stopped' ;;
       '{{json .Config.Cmd}}') printf '[]\n' ;;
-      *'.Config.Env'*) : ;;
+      *'.Config.Env'*)
+        if [ "${2:-}" = "ai-memory" ]; then
+          printf 'CUSTOM_VAR=custom_val\nHOSTNAME=container-id-123\ncontainer=podman\n'
+        fi
+        ;;
       *) printf 'unexpected inspect format: %s\n' "${4:-<missing>}" >&2; exit 2 ;;
     esac
     ;;
@@ -84,7 +88,10 @@ run_upgrade_case() {
 run_upgrade_case standalone 0
 assert_contains "${TMP_ROOT}/standalone/output.log" "does not manage the running ai-memory container"
 assert_not_contains "${TMP_ROOT}/standalone/docker.log" "compose up -d"
-assert_contains "${TMP_ROOT}/standalone/cache/ai-memory/recreate-ai-memory.sh" "-v ai-memory-data:/data"
+assert_contains "${TMP_ROOT}/standalone/cache/ai-memory/recreate-ai-memory.sh" "-v ai-memory-data:/data:Z"
+assert_contains "${TMP_ROOT}/standalone/cache/ai-memory/recreate-ai-memory.sh" "-e CUSTOM_VAR=custom_val"
+assert_not_contains "${TMP_ROOT}/standalone/cache/ai-memory/recreate-ai-memory.sh" "HOSTNAME="
+assert_not_contains "${TMP_ROOT}/standalone/cache/ai-memory/recreate-ai-memory.sh" "container=podman"
 assert_contains "${TMP_ROOT}/standalone/cache/ai-memory/recreate-ai-memory.sh" "${FAKE_DOCKER} stop ai-memory"
 assert_not_contains "${TMP_ROOT}/standalone/cache/ai-memory/recreate-ai-memory.sh" "docker stop ai-memory"
 
@@ -93,6 +100,96 @@ assert_contains "${TMP_ROOT}/compose/output.log" "restarting local ai-memory con
 assert_contains "${TMP_ROOT}/compose/docker.log" "compose up -d"
 if [ -e "${TMP_ROOT}/compose/cache/ai-memory/recreate-ai-memory.sh" ]; then
   fail "Compose-owned container unexpectedly produced a standalone recreation script"
+fi
+
+# ---- multi-arch manifest version-check tests -----------------------------
+
+if command -v python3 >/dev/null 2>&1; then
+  H_ARM="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  H_AMD="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  H_OLD="sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+  MULTI_ARCH_JSON="{\"manifests\":[{\"digest\":\"${H_ARM}\",\"platform\":{\"architecture\":\"arm64\"}},{\"digest\":\"${H_AMD}\",\"platform\":{\"architecture\":\"amd64\"}}]}"
+
+  run_version_check_case() {
+    local name="$1" uname_m="$2" local_inspect="$3" remote_manifest="$4" expect_warn="$5"
+    local case_dir="${TMP_ROOT}/ver_${name}"
+    mkdir -p "${case_dir}/cache"
+    local fake_engine="${case_dir}/engine"
+    cat >"${fake_engine}" <<ENGINE
+#!/usr/bin/env bash
+case "\${1:-}" in
+  image)
+    printf '%b\n' '${local_inspect}'
+    ;;
+  manifest)
+    printf '%b\n' '${remote_manifest}'
+    ;;
+  info)
+    printf 'name=seccomp\n'
+    ;;
+  run)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+ENGINE
+    chmod 0755 "${fake_engine}"
+
+    local fake_uname="${case_dir}/uname"
+    cat >"${fake_uname}" <<UNAME
+#!/usr/bin/env bash
+printf '%s\n' "${uname_m}"
+UNAME
+    chmod 0755 "${fake_uname}"
+
+    local out="${case_dir}/out.log"
+    python3 -c '
+import os, pty, sys
+master, slave = pty.openpty()
+pid = os.fork()
+if pid == 0:
+    os.close(master)
+    os.dup2(slave, 0)
+    os.dup2(slave, 1)
+    os.dup2(slave, 2)
+    os.close(slave)
+    env = dict(os.environ)
+    env["PATH"] = sys.argv[1] + ":" + env["PATH"]
+    env["AI_MEMORY_DOCKER"] = sys.argv[2]
+    env["AI_MEMORY_NO_TTY"] = "1"
+    env["XDG_CACHE_HOME"] = sys.argv[3]
+    env.pop("AI_MEMORY_NO_VERSION_CHECK", None)
+    os.execvpe(sys.argv[4], [sys.argv[4], "status"], env)
+else:
+    os.close(slave)
+    output = b""
+    while True:
+        try:
+            chunk = os.read(master, 1024)
+            if not chunk: break
+            output += chunk
+        except OSError:
+            break
+    os.close(master)
+    os.waitpid(pid, 0)
+    with open(sys.argv[5], "wb") as f:
+        f.write(output)
+' "${case_dir}" "${fake_engine}" "${case_dir}/cache" "${ROOT}/bin/ai-memory" "${out}"
+
+    if [ "${expect_warn}" -eq 1 ]; then
+      assert_contains "${out}" "a newer image is available on Docker Hub"
+    else
+      assert_not_contains "${out}" "a newer image is available on Docker Hub"
+    fi
+  }
+
+  run_version_check_case amd64_matching "x86_64" "sha256:index\n${H_AMD}" "${MULTI_ARCH_JSON}" 0
+  run_version_check_case amd64_outdated "x86_64" "sha256:index\n${H_OLD}" "${MULTI_ARCH_JSON}" 1
+  run_version_check_case arm64_matching "aarch64" "${H_ARM}" "${MULTI_ARCH_JSON}" 0
+  run_version_check_case arm64_outdated "aarch64" "${H_OLD}" "${MULTI_ARCH_JSON}" 1
 fi
 
 printf 'wrapper upgrade ownership checks passed\n'


### PR DESCRIPTION
## Summary
- **Multi-arch image digest resolution**: In `bin/ai-memory`, `remote_digest()` previously ran `grep -oE 'sha256:[a-f0-9]{64}' | head -n 1` on `manifest inspect` output. Because Docker Hub publishes `ai-memory` as a multi-arch manifest list with `linux/arm64` listed first, the extracted remote digest was always `arm64`. On `x86_64` hosts and under Podman (where `.RepoDigests 0` is the manifest list index digest), comparing local digests against the remote digest always failed, producing a false-positive `ai-memory: a newer image is available on Docker Hub` warning on every version check. `remote_digest()` now targets the host platform architecture (`amd64` vs `arm64`) and checks against all locally known repo digests.
- **Preserve volume mount modes**: `emit_docker_run_script` now includes `{{if .Mode}}:{{.Mode}}{{end}}`, preserving `:Z` / `:z` / `:ro` flags on inspected container mounts so reconstructed containers on SELinux / rootless Podman systems retain required permissions on the `/data` volume.
- **Filter transient runtime env vars**: In `emit_docker_run_script`, transient container runtime variables (`HOSTNAME`, `container=podman`) injected by engines are filtered out of the reconstructed run flags.

## Testing
- `bash -n bin/ai-memory`
- `bash -n tests/wrapper_upgrade.sh`
- `./tests/wrapper_upgrade.sh` (all tests pass, including standalone `:Z` mode preservation, env var filtering, and automated pty test cases for matching and outdated digests across amd64 and arm64)
- `git diff --check`