### PR TITLE
fix(cli): name the request method and path in server error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- CLI server errors now name the request. A non-2xx response from the
+  configured server printed only `server returned 404 Not Found: <body>`,
+  so a failure gave no clue which endpoint answered. The message now leads
+  with the request method and path: `GET /admin/open-sessions: server
+  returned 404 Not Found: <body>`. The error keeps the path only, so a
+  token in the URL userinfo or query string never reaches a log line.
 - Wiki auto-commits stage what the wiki wrote instead of walking the
   whole tree, keep the repository open between commits, and no longer
   drop the commit when another session is writing a file at the same

--- a/crates/ai-memory-cli/src/http_client.rs
+++ b/crates/ai-memory-cli/src/http_client.rs
@@ -26,6 +26,8 @@ use ai_memory_web::normalize_prefix;
 /// Non-success response returned by the configured ai-memory server.
 #[derive(Debug)]
 pub(crate) struct ServerResponseError {
+    method: reqwest::Method,
+    path: String,
     status: reqwest::StatusCode,
     body: String,
 }
@@ -44,14 +46,48 @@ impl ServerResponseError {
 
 impl fmt::Display for ServerResponseError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(formatter, "server returned {}: {}", self.status, self.body)
+        write!(
+            formatter,
+            "{} {}: server returned {}: {}",
+            self.method, self.path, self.status, self.body
+        )
     }
 }
 
 impl std::error::Error for ServerResponseError {}
 
-fn server_response_error(status: reqwest::StatusCode, body: String) -> anyhow::Error {
-    ServerResponseError { status, body }.into()
+fn server_response_error(
+    method: reqwest::Method,
+    url: &reqwest::Url,
+    status: reqwest::StatusCode,
+    body: String,
+) -> anyhow::Error {
+    ServerResponseError {
+        method,
+        path: url.path().to_owned(),
+        status,
+        body,
+    }
+    .into()
+}
+
+/// Pass a 2xx response through, else consume the body into a
+/// [`ServerResponseError`].
+///
+/// Only the request path reaches the error, so userinfo and query
+/// credentials in the URL never land in a message. `reqwest` does not carry
+/// the request method on the response, so callers supply it.
+async fn require_success(
+    method: reqwest::Method,
+    resp: reqwest::Response,
+) -> Result<reqwest::Response> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp);
+    }
+    let url = resp.url().clone();
+    let body = resp.text().await.unwrap_or_default();
+    Err(server_response_error(method, &url, status, body))
 }
 
 /// Resolved server target — origin URL + base-path prefix + optional bearer token.
@@ -227,11 +263,7 @@ pub async fn get_json<T: DeserializeOwned>(
         .send()
         .await
         .map_err(|e| augment_connect_error(e, endpoint, &url))?;
-    let status = resp.status();
-    if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        return Err(server_response_error(status, body));
-    }
+    let resp = require_success(reqwest::Method::GET, resp).await?;
     resp.json::<T>()
         .await
         .with_context(|| format!("parsing JSON body from GET {url}"))
@@ -253,11 +285,7 @@ pub async fn patch_json<B: Serialize, T: DeserializeOwned>(
         .send()
         .await
         .map_err(|e| augment_connect_error(e, endpoint, &url))?;
-    let status = resp.status();
-    if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        return Err(server_response_error(status, body));
-    }
+    let resp = require_success(reqwest::Method::PATCH, resp).await?;
     resp.json::<T>()
         .await
         .with_context(|| format!("parsing JSON body from PATCH {url}"))
@@ -288,11 +316,7 @@ pub async fn post_json_no_content<B: Serialize>(
         .send()
         .await
         .map_err(|e| augment_connect_error(e, endpoint, &url))?;
-    let status = resp.status();
-    if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        return Err(server_response_error(status, body));
-    }
+    require_success(reqwest::Method::POST, resp).await?;
     Ok(())
 }
 
@@ -305,11 +329,7 @@ pub async fn post_empty(endpoint: &ServerEndpoint, path: &str) -> Result<()> {
         .send()
         .await
         .map_err(|e| augment_connect_error(e, endpoint, &url))?;
-    let status = resp.status();
-    if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        return Err(server_response_error(status, body));
-    }
+    require_success(reqwest::Method::POST, resp).await?;
     Ok(())
 }
 
@@ -331,11 +351,7 @@ pub async fn post_json_with_query<B: Serialize, T: DeserializeOwned>(
         .send()
         .await
         .map_err(|e| augment_connect_error(e, endpoint, &url))?;
-    let status = resp.status();
-    if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        return Err(server_response_error(status, body));
-    }
+    let resp = require_success(reqwest::Method::POST, resp).await?;
     resp.json::<T>()
         .await
         .with_context(|| format!("parsing JSON body from POST {url}"))
@@ -417,15 +433,11 @@ pub async fn post_to_file(endpoint: &ServerEndpoint, path: &str, dest: &Path) ->
     let client = reqwest::Client::new();
     let url = endpoint.build_url(path);
     let req = endpoint.authenticate(client.post(&url));
-    let mut resp = req
+    let resp = req
         .send()
         .await
         .map_err(|e| augment_connect_error(e, endpoint, &url))?;
-    let status = resp.status();
-    if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        return Err(server_response_error(status, body));
-    }
+    let mut resp = require_success(reqwest::Method::POST, resp).await?;
     let file = private_output_file(dest)
         .with_context(|| format!("creating output file {}", dest.display()))?;
     let mut writer = BufWriter::new(file);
@@ -473,6 +485,34 @@ mod tests {
             std::fs::metadata(output).unwrap().permissions().mode() & 0o777,
             0o600
         );
+    }
+
+    #[test]
+    fn response_errors_include_method_and_credential_free_path() {
+        let url = reqwest::Url::parse(
+            "https://username:password@example.test/workstream/runs?access_token=secret",
+        )
+        .expect("test URL parses");
+        let error = server_response_error(
+            reqwest::Method::POST,
+            &url,
+            reqwest::StatusCode::NOT_FOUND,
+            "missing".to_owned(),
+        );
+
+        assert_eq!(
+            error.to_string(),
+            "POST /workstream/runs: server returned 404 Not Found: missing"
+        );
+        let structured = error
+            .downcast_ref::<ServerResponseError>()
+            .expect("response errors retain their structured type");
+        assert_eq!(structured.status(), reqwest::StatusCode::NOT_FOUND);
+        assert_eq!(structured.body(), "missing");
+        assert!(!error.to_string().contains("username"));
+        assert!(!error.to_string().contains("password"));
+        assert!(!error.to_string().contains("access_token"));
+        assert!(!error.to_string().contains("secret"));
     }
 
     // ----------------------------------------------------------------


### PR DESCRIPTION
## What changed

- A non-2xx response from the configured server printed only
  `server returned 404 Not Found: <body>`. The message named no endpoint. A
  failed CLI subcommand gave no clue which request failed.
- `ServerResponseError` now carries the request method and the URL path. The
  error prints `GET /admin/open-sessions: server returned 404 Not Found:
  <body>`.
- The error keeps the path only. A token in the URL userinfo or query string
  never reaches a log line. A test asserts this.
- The six subcommand helpers repeated the same status check. One
  `require_success` helper replaces them.

No default changes. The only observable change is the text of the error.

## Why

A CLI subcommand runs several requests. `finalize_session` and `run` each call
three or more endpoints. When one returned a non-2xx status, the message named
the status and the body but not the request. A user had to guess the endpoint,
or read the source.

The path is enough to identify the request. The full URL is not safe to print,
because `ServerEndpoint` can hold a bearer token, and a caller can put
credentials in the URL userinfo or the query string. `require_success` reads
the path from `resp.url()`, so no call site can pass a raw URL by mistake.

`run.rs` and `finalize_session.rs` downcast to `ServerResponseError` to read
`status()` and `body()`. Both keep the same behaviour.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `git diff --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo tf` (or `cargo test --workspace --all-targets`) passes
- [x] Manual test: added
      `http_client::tests::response_errors_include_method_and_credential_free_path`.
      It builds the error from
      `https://username:password@example.test/workstream/runs?access_token=secret`
      and asserts the message is
      `POST /workstream/runs: server returned 404 Not Found: missing`. It also
      asserts the message holds none of `username`, `password`,
      `access_token`, `secret`, and that the error still downcasts to
      `ServerResponseError` with the original status and body.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected
      any unintended identity before requesting merge. See
      [commit attribution guidance](https://github.com/akitaonrails/ai-memory/blob/main/CONTRIBUTING.md#commit-attribution).

## Release impact

- [x] **Patch** — bug fix, no new surface
- [ ] **Minor** — additive: new flag/subcommand/MCP tool/config key,
      new agent harness or provider
- [ ] **Major (breaking)** — on-disk format, removed/renamed surface,
      breaking MCP schema change — called out in "What changed" above

## CHANGELOG (merge gate)

- [x] I added a `CHANGELOG.md` `[Unreleased]` entry — **required** for any
      user-facing change: new flag / env var / endpoint / MCP tool / marker
      key, changed behaviour, or an observable bug fix. (Exempt only for
      internal refactors, dead-code removal, and test-only churn.)
- [x] Any changed **default** (flag behaviour, config default, env var,
      response shape) is called out explicitly in "What changed" above.

## Notes for reviewers

**Question: can `flake.lock` be committed?** `flake.nix` is tracked, but
`flake.lock` is not, and `.gitignore` does not list it. An untracked lock file
means each contributor resolves a different toolchain from the same
`flake.nix`. I kept `flake.lock` out of this PR, because the choice belongs to
the maintainers and not to this fix. Tell me the answer and I open a separate
PR:

- Commit it, so `nix develop` gives every contributor and CI the same
  toolchain.
- Add it to `.gitignore`, so the current state is deliberate and `git status`
  stays clean.

Two design points to check:

1. `require_success` takes the method as an argument. `reqwest::Response` does
   not carry the request method, so the call site supplies it. A wrong method
   at a call site produces a wrong label, and no test catches it.
2. The error holds `url.path()`. It drops the query string. A route that
   depends on a query parameter is harder to identify from the message alone.
   I chose this because the query string can hold a token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uuoo7H5ZdDTZBAsGkE5VJS
