### PR TITLE
docs(routing): CLAUDE.md must import AGENTS.md to load it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,11 @@ Many projects use CLAUDE.md for Claude Code and
 AGENTS.md for Codex / OpenCode / OpenCode 2 / Cursor / Gemini CLI / Grok Build CLI / Kimi Code / Kiro CLI / Command Code,
 but if the project says one file is canonical, use that file.
 
+Claude Code loads `CLAUDE.md` and does not read `AGENTS.md`. In a project
+where `AGENTS.md` is canonical, give `CLAUDE.md` a bare `@AGENTS.md` import
+line. Without it a rule written to `AGENTS.md` is absent from context at
+session start and reaches Claude Code only if the agent opens the file.
+
 If the rule is a standing *user/team* preference that should apply to
 every project (tech choices, code style, personal conventions), save it
 to ai-memory's reserved global scope instead — the durable-pages skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The managed routing snippet now states that Claude Code loads `CLAUDE.md` and
+  does not read `AGENTS.md`: a project whose canonical instruction file is
+  `AGENTS.md` needs a bare `@AGENTS.md` import line in `CLAUDE.md`, or the rules
+  written there are absent from context at session start and reach the agent only
+  if it opens the file. `docs/install.md` and `docs/usage.md` carry the same note
+  beside the `--target AGENTS.md` guidance, and this repository's own `CLAUDE.md`
+  now uses the import instead of a prose pointer (#680).
+
 ### Fixed
 - Wiki auto-commits stage what the wiki wrote instead of walking the
   whole tree, keep the repository open between commits, and no longer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,14 @@
-# Claude Code Instructions
+@AGENTS.md
 
-Read and follow [`AGENTS.md`](AGENTS.md). This repository keeps a single
-canonical agent instruction file for Claude Code, OpenCode, Codex, Cursor,
-Gemini CLI, and other AGENTS-aware harnesses.
+<!--
+Claude Code reads CLAUDE.md and does not read AGENTS.md, so the import on the
+first line is what loads this repository's canonical instruction file into a
+Claude Code session: https://code.claude.com/docs/en/memory#agents-md
 
-Do not duplicate project rules here. Update `AGENTS.md` instead.
+A prose "read AGENTS.md" pointer loads nothing at session start; it asks the
+agent to open the file, which leaves adherence to whether it does.
+
+Do not duplicate project rules here. Update AGENTS.md instead. Add content
+below the import only when it is specific to Claude Code and has no AGENTS.md
+counterpart.
+-->

--- a/crates/ai-memory-core/src/routing_snippet.rs
+++ b/crates/ai-memory-core/src/routing_snippet.rs
@@ -98,6 +98,11 @@ Many projects use CLAUDE.md for Claude Code and
 AGENTS.md for Codex / OpenCode / OpenCode 2 / Cursor / Gemini CLI / Grok Build CLI / Kimi Code / Kiro CLI / Command Code,
 but if the project says one file is canonical, use that file.
 
+Claude Code loads `CLAUDE.md` and does not read `AGENTS.md`. In a project
+where `AGENTS.md` is canonical, give `CLAUDE.md` a bare `@AGENTS.md` import
+line. Without it a rule written to `AGENTS.md` is absent from context at
+session start and reaches Claude Code only if the agent opens the file.
+
 If the rule is a standing *user/team* preference that should apply to
 every project (tech choices, code style, personal conventions), save it
 to ai-memory's reserved global scope instead — the durable-pages skill
@@ -228,7 +233,8 @@ mod tests {
     /// (`ai-memory install-instructions --target AGENTS.md`) and committed
     /// separately, so nothing forces it to track [`SNIPPET_BODY`]. This guard
     /// fails when the two drift — regenerate to fix it. Only `AGENTS.md` is
-    /// checked (root `CLAUDE.md` is a pointer; `README.md` is prose).
+    /// checked (root `CLAUDE.md` imports it with `@AGENTS.md` and carries no
+    /// block of its own; `README.md` is prose).
     #[test]
     fn committed_agents_md_matches_snippet_body() {
         // From `crates/ai-memory-core` up to the repo root.

--- a/docs/install.md
+++ b/docs/install.md
@@ -124,6 +124,12 @@ legacy long snippets between `<!-- ai-memory:start -->` /
 `<!-- ai-memory:end -->` are replaced in place with the slim snippet, and
 managed Agent Skills are installed or updated alongside it.
 
+If you install into `AGENTS.md` and the project is also used from Claude Code,
+make `CLAUDE.md` import it with a bare `@AGENTS.md` first line. Claude Code
+loads `CLAUDE.md` and does not read `AGENTS.md`, so without that import the
+installed block is absent from context at session start. See
+[Claude Code memory](https://code.claude.com/docs/en/memory#agents-md).
+
 ---
 
 ## Configuring the CLI URL and auth

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -229,6 +229,15 @@ instruction target unless you override it: `CLAUDE.md` implies
 both skill roots. For Grok Build CLI, select `--skills-agent grok` so skills
 install under its `.grok/skills` root.
 
+When a project keeps `AGENTS.md` as its canonical instruction file, give it a
+`CLAUDE.md` whose first line is a bare `@AGENTS.md` import. Claude Code loads
+`CLAUDE.md` and does not read `AGENTS.md`, so without that import a block
+installed with `--target AGENTS.md`, along with every project rule in the same
+file, is absent from context at session start. A prose "read AGENTS.md" pointer
+does not load the file; it asks the agent to open it, which leaves adherence to
+whether the agent does. See
+[Claude Code memory](https://code.claude.com/docs/en/memory#agents-md).
+
 To refresh only the managed Agent Skills:
 
 ```bash


### PR DESCRIPTION
Fixes #680.

## What changed

Before: the managed routing snippet directs agents to write durable project rules
into "the project's canonical agent instruction file", and the CLI hint plus the
docs steer that file toward `AGENTS.md`, with nothing stating that Claude Code
does not read `AGENTS.md`. A project following that recommendation keeps its
canonical rules out of context at session start. This repository was in exactly
that state: `CLAUDE.md` was a prose pointer, so its 529-line `AGENTS.md` never
loaded for Claude Code.

After: the snippet names the precondition, the docs repeat it beside the
`--target AGENTS.md` guidance, and this repository's own `CLAUDE.md` imports the
canonical file instead of describing it.

| File | Change |
|-|-|
| `crates/ai-memory-core/src/routing_snippet.rs` | `SNIPPET_BODY` states the precondition; the guard test's doc comment no longer describes root `CLAUDE.md` as a prose pointer |
| `AGENTS.md` | committed managed block regenerated to mirror `SNIPPET_BODY` |
| `docs/install.md`, `docs/usage.md` | the same note beside the `--target AGENTS.md` guidance |
| `CLAUDE.md` | switched from a prose pointer to `@AGENTS.md`, with the maintainer note kept in an HTML comment, which Claude Code strips before injecting context |
| `CHANGELOG.md` | `[Unreleased]` → `### Changed` |

No default changes. No new flag, env var, endpoint, MCP tool, or marker key.

## Why

Fixes #680. The snippet does not merely omit a caveat; it actively directs the
agent to write rules to the canonical file, so a project that follows ai-memory's
own guidance inherits a silent gap.

To be precise about the claim, since the issue was revised on this point: the
rules are not unreachable. An agent that acts on a prose "read AGENTS.md" pointer
opens the file with a read tool, and the content is in context from that point.
The defect is that a file the project designates as canonical loads
conditionally, on the agent noticing a sentence and acting on it, where a
one-line import loads it at every session start.

Claude Code documents both the constraint and the fix:
<https://code.claude.com/docs/en/memory#agents-md>.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `git diff --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo tf` (or `cargo test --workspace --all-targets`) passes
- [x] Manual test: see below

Run on `a091c6c8` against `main` at `195be4e5`:

```
cargo fmt --all -- --check                              pass
git diff --check                                        pass
cargo clippy --workspace --all-targets -- -D warnings   pass
cargo test --workspace --all-targets                    pass (3,146 tests, 0 failed)
cargo deny check                                        pass (advisories, bans, licenses, sources)
cargo deny --all-features check                         pass (advisories, bans, licenses, sources)
```

`cargo tf` itself was unavailable because nextest is not installed on the machine
this ran on, so the CONTRIBUTING-named equivalent was used, which is also what CI
runs.

**Manual test.** Both halves were checked with `/context` in Claude Code sessions
at the repo root.

Before the change, **Memory files** listed `~/.claude/CLAUDE.md` and this repo's
7-line `CLAUDE.md`, and nothing else. `AGENTS.md` was absent from context, and
its rules arrived only after an explicit file read, mid-session.

After the change, opening a new session and running `/context` lists `AGENTS.md`
under **Memory files**, pulled in by the first-line import, so its rules are
present from the first turn. The same one-line `@AGENTS.md` pattern is already in
production in two other `AGENTS.md`-canonical repositories on this machine, which
is where the shape came from.

That is the whole check, and it is one command for a reviewer to repeat.

The gate most likely to trip on this change is
`committed_agents_md_matches_snippet_body`, which compares the block committed in
`AGENTS.md` against `SNIPPET_BODY` byte for byte. It passes; the block was
regenerated in the same commit.

## Commit attribution

- [x] I verified the name and email on every commit in this PR and corrected any
      unintended identity before requesting merge.

Single commit `a091c6c8`, authored by `Felipe Neves Ricardo
<felipe.nevesricardo@gmail.com>`.

## Release impact

- [x] **Patch** — bug fix, no new surface
- [ ] **Minor**
- [ ] **Major (breaking)**

Filed as patch because nothing is added to the CLI, MCP, config, or marker
surface; shipped guidance text is corrected. The CHANGELOG entry sits under
`### Changed` to match the closest precedent, the 2.1.1 entry for #671, which was
the same shape of snippet-content change. If you would rather the release
mapping in AGENTS.md drive it strictly (only `### Fixed` → patch), say so and I
will move the entry to `### Fixed`.

## CHANGELOG (merge gate)

- [x] I added a `CHANGELOG.md` `[Unreleased]` entry.
- [x] No default changed, so there is nothing to call out on that count.

## Notes for reviewers

**Trade-off worth stating.** The import loads all 534 lines of `AGENTS.md` (529
today, plus the five this PR adds) into every Claude Code session. Claude Code's
documentation targets CLAUDE.md files under 200 lines and notes that imports do
not reduce context, since imported files load at launch. This trades context
budget for reliability. Splitting the file into path-scoped `.claude/rules/`
would avoid the cost and is a refactor well outside this change; happy to follow
up separately if you would rather go that way.

**Unrelated observation, filed separately as #683.** Running the dependency gate
for this PR turned up that `AGENTS.md:465` quotes it as `cargo deny check
--all-features`, which exits 2 on cargo-deny 0.20.2 because the flag is global
there. CI is unaffected: the action composes `--all-features` before the
subcommand, so it runs the correct form. Kept out of this branch to hold this PR
to one change, and written up in #683 with the CI run log that explains why
nothing went red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqE9rQpsjqNK5mmpqmggL7
