### PR TITLE
docs(agents): fix cargo-deny invocation in security section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -462,7 +462,7 @@ Additional boundary rules:
 - **Auth ladder:** static root bearer token → DB-user tokens
   (attribution only, no admin) → OIDC device tokens at the hook edge.
   `/admin/*` becomes root-only the moment the first DB user exists.
-- **Dependency policy:** `cargo deny check --all-features` and
+- **Dependency policy:** `cargo deny --all-features check` and
   `cargo audit` run in CI; do not add dependencies without checking the
   project doesn't already have the capability, and match existing
   versions/idioms.


### PR DESCRIPTION
Fixes #683.

## What changed

One line in `AGENTS.md`, in the Security considerations section.

```diff
-- **Dependency policy:** `cargo deny check --all-features` and
+- **Dependency policy:** `cargo deny --all-features check` and
```

Before, the quoted command did not run. On cargo-deny 0.20.2 `--all-features` is
a global option, listed in `cargo deny --help` and absent from `cargo deny check
--help`, so the quoted form exits 2:

```
$ cargo deny check --all-features
error: unexpected argument '--all-features' found
  tip: to pass '--all-features' as a value, use '-- --all-features'

$ cargo deny --all-features check
advisories ok, bans ok, licenses ok, sources ok
```

No behaviour changes, no default changes, no surface changes.

## Why

CI was never affected, and that is the reason the line could drift without
anything going red. The `cargo-deny-action` composes its `arguments` input
*before* its `command` input, so it already runs the correct form. From the
`cargo-deny` job of the `ci` run on `195be4e5`:

```
docker run ... "--log-level" "warn" "--manifest-path" "./Cargo.toml" "--all-features" "check" ""
advisories ok, bans ok, licenses ok, sources ok
```

The prose transcribed the two parts in the order they appear in the workflow
YAML, where `command` is listed above `arguments`, rather than the order the
action passes them. Only a person typing the line would have caught it, which is
how it surfaced: running the dependency gate for #681.

The two runnable command lists, the gate block at `AGENTS.md:224` and
`CONTRIBUTING.md:52`, both write plain `cargo deny check` with no flag. Both run
correctly and are untouched here.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `git diff --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` unaffected (no Rust changed)
- [x] `cargo test -p ai-memory-core routing_snippet` passes, including
      `committed_agents_md_matches_snippet_body`
- [x] Manual test: both invocations run, with the output quoted above

The guard test matters here because it reads `AGENTS.md` through `include_str!`.
The edited line sits well outside the `<!-- ai-memory:start -->` block it
compares, so the managed region is byte-identical and the test passes.

## Commit attribution

- [x] Verified. Single commit `e4a253f4`, authored by `Felipe Neves Ricardo
      <felipe.nevesricardo@gmail.com>`.

## Release impact

- [x] **Patch** — bug fix, no new surface
- [ ] **Minor**
- [ ] **Major (breaking)**

## CHANGELOG (merge gate)

No entry added. This is contributor-facing documentation with no user-visible
effect: no flag, env var, endpoint, MCP tool, marker key, changed default, or
observable bug fix. That reads as exempt under the CONTRIBUTING carve-out for
internal churn. Say the word if you would rather have an entry anyway and I will
add one.

## Notes for reviewers

I did not touch the workflow. `arguments: --all-features` alongside
`command: check` is correct for the action as it composes them, so the YAML is
fine as written and only the prose describing it was wrong.

Worth a second opinion on one thing I deliberately left alone: `deny.toml` sets
`[graph] all-features = false` while CI passes `--all-features` on the command
line. I did not investigate which wins or whether that is intentional, and it is
outside this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqE9rQpsjqNK5mmpqmggL7
