### PR TITLE
run: accept claude*-prefixed harness names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `ai-memory run` now accepts any `claude*`-prefixed harness name
+  (`claude-corp`, `claude-personal`, ...), all resolving to the same
+  `ManagedHarness::Claude`/`AgentKind::ClaudeCode` — no new session store,
+  migration, or agent kind. This is for callers juggling more than one
+  Claude account (e.g. Corporate and Personal): name each account's `PATH`
+  wrapper script `claude-<account>` and pair it with `--executable
+  claude-<account>` (bare names already resolve through `PATH`) so
+  `ai-memory run claude-corp --executable claude-corp` and `ai-memory run
+  claude-personal --executable claude-personal` each launch the right
+  binary while reading clearly in shell history (#1).
+
 ### Changed
 - The managed routing snippet now states that Claude Code loads `CLAUDE.md` and
   does not read `AGENTS.md`: a project whose canonical instruction file is

--- a/crates/ai-memory-cli/src/cli.rs
+++ b/crates/ai-memory-cli/src/cli.rs
@@ -244,8 +244,10 @@ pub struct RunArgs {
     #[arg(long)]
     pub fresh: bool,
     /// Agent harness to launch. When omitted, continue the newest managed or
-    /// checkout-local session among the auto-detected harnesses.
-    #[arg(value_enum)]
+    /// checkout-local session among the auto-detected harnesses. Any value
+    /// starting with `claude` (e.g. `claude-corp`, `claude-personal`) also
+    /// selects the Claude harness — see `parse_run_harness_choice`.
+    #[arg(value_parser = parse_run_harness_choice)]
     pub harness: Option<RunHarnessChoice>,
     /// Native harness arguments, forwarded byte-for-byte and in order.
     #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
@@ -255,7 +257,9 @@ pub struct RunArgs {
 /// Harnesses supported by managed workstreams.
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 pub enum RunHarnessChoice {
-    /// Anthropic Claude Code (`claude`).
+    /// Anthropic Claude Code (`claude`). Any `claude*`-prefixed name (e.g.
+    /// `claude-corp`, `claude-personal`) also selects this harness — see
+    /// `parse_run_harness_choice`.
     #[value(alias = "claude-code")]
     Claude,
     /// OpenAI Codex CLI.
@@ -293,6 +297,40 @@ pub enum RunHarnessChoice {
     /// Google Antigravity CLI (`agy`).
     #[value(name = "antigravity", alias = "antigravity-cli", alias = "agy")]
     Antigravity,
+}
+
+/// Parses the `run` harness positional, additionally wildcarding every
+/// `claude*` spelling onto [`RunHarnessChoice::Claude`].
+///
+/// Callers who juggle more than one Claude account (e.g. Corporate and
+/// Personal) commonly resolve `claude` to different accounts through a
+/// `PATH`-visible wrapper script per account (a plain shell `alias` is
+/// invisible to us — `ai-memory run` execs directly, without going through
+/// an interactive shell). Naming those wrappers `claude-corp` /
+/// `claude-personal` and then passing `--executable claude-corp` (bare names
+/// resolve through `PATH` just like the default) already selects the right
+/// binary; this parser just stops the harness argument itself from being
+/// rejected as an unknown value, so `ai-memory run claude-corp --executable
+/// claude-corp` (or any other `claude*` spelling used consistently) reads
+/// naturally instead of forcing every account onto the literal `claude`
+/// token.
+fn parse_run_harness_choice(value: &str) -> Result<RunHarnessChoice, String> {
+    use clap::ValueEnum as _;
+    if let Ok(choice) = RunHarnessChoice::from_str(value, true) {
+        return Ok(choice);
+    }
+    if value.len() > "claude".len() && value.to_ascii_lowercase().starts_with("claude") {
+        return Ok(RunHarnessChoice::Claude);
+    }
+    let known = RunHarnessChoice::value_variants()
+        .iter()
+        .filter_map(clap::ValueEnum::to_possible_value)
+        .map(|value| value.get_name().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(format!(
+        "invalid value '{value}' for harness; expected one of: {known}, or any `claude*` spelling"
+    ))
 }
 
 /// Arguments for `show`.
@@ -2879,6 +2917,42 @@ mod tests {
             };
             assert!(matches!(args.harness, Some(RunHarnessChoice::OpenCode2)));
         }
+    }
+
+    #[test]
+    fn claude_wildcard_names_parse_to_the_claude_harness() {
+        // A caller juggling several Claude accounts (Corporate, Personal, ...)
+        // names each account's PATH wrapper `claude-<account>`; every such
+        // spelling must resolve to the Claude harness rather than being
+        // rejected as an unknown value. Case is not significant, and this
+        // covers both the fixed `claude`/`claude-code` names and the
+        // `claude*` wildcard fallback so there is one alias mechanism, not
+        // two overlapping ones.
+        for name in [
+            "claude",
+            "claude-code",
+            "claude-corp",
+            "claude-personal",
+            "CLAUDE-WORK",
+            "claudex",
+        ] {
+            let cli = Cli::try_parse_from(["ai-memory", "run", name])
+                .unwrap_or_else(|error| panic!("failed to parse run {name}: {error}"));
+            let Command::Run(args) = cli.command else {
+                panic!("expected run for claude wildcard name {name}");
+            };
+            assert!(matches!(args.harness, Some(RunHarnessChoice::Claude)));
+        }
+    }
+
+    #[test]
+    fn non_claude_unknown_harness_is_still_rejected() {
+        let error = Cli::try_parse_from(["ai-memory", "run", "banana"])
+            .expect_err("unknown non-claude harness must still be rejected");
+        assert!(
+            error.to_string().contains("expected one of"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/docs/managed-workstreams.md
+++ b/docs/managed-workstreams.md
@@ -7,6 +7,33 @@ keep their existing ai-memory behavior. There is no global mode toggle and no
 `switch` command: using `run` selects the current workstream and transparently
 creates or resumes the correct native session for the requested harness.
 
+The launcher resolves its executable name through `PATH` directly — it does
+not go through an interactive shell, so a `claude` defined only as a shell
+`alias` in `.bashrc`/`.zshrc` is invisible to it. If you switch Claude
+accounts by alias, put a same-named script or shim earlier on `PATH` instead
+(or pass `--executable PATH`, which also resolves a bare name through
+`PATH`), so the resolved `claude` process actually is the one you meant.
+
+**Multiple Claude accounts (e.g. Corporate and Personal).** Any harness name
+starting with `claude` is accepted (`claude-corp`, `claude-personal`, ...)
+and always selects the Claude harness — the exact spelling never changes
+the agent kind, session store, or transcript import.
+Combine that wildcard with `--executable` to launch the right account's
+binary while keeping each account's managed workstream distinguishable in
+your shell history:
+
+```bash
+# ~/bin/claude-corp and ~/bin/claude-personal are wrapper scripts (earlier on
+# PATH than the bare `claude`) that each exec the real claude binary with
+# that account's config/credentials directory.
+ai-memory run claude-corp --executable claude-corp --model opus
+ai-memory run claude-personal --executable claude-personal
+```
+
+Only the `--executable` value matters for which binary actually runs; the
+positional name is free-form as long as it starts with `claude`, so pick
+whatever reads clearly to you.
+
 ```bash
 cd /path/to/project
 
@@ -15,6 +42,8 @@ ai-memory run claude
 ai-memory run codex --yolo
 # return to Claude Code later; ai-memory supplies Claude's native --resume
 ai-memory run claude --model opus
+# any `claude*` name is accepted (see "Multiple Claude accounts" above)
+ai-memory run claude-corp
 # Kimi Code installs `kimi`; `kimi-cli` is accepted as a launcher alias
 ai-memory run kimi-cli
 # Command Code uses `command-code` on Unix and `cmdc` on native Windows
@@ -42,7 +71,7 @@ file, and the current checkout remain authoritative.
 ai-memory run [--workspace NAME] [--project NAME]
               [--workstream NAME | --new NAME] [--executable PATH]
               [--yolo] [--fresh]
-              [claude|codex|opencode|opencode2|pi|crush|omp|kimi|command-code|kiro|grok|antigravity]
+              [claude|claude*|codex|opencode|opencode2|pi|crush|omp|kimi|command-code|kiro|grok|antigravity]
               [native arguments...]
 ```
 


### PR DESCRIPTION
## Summary
- `ai-memory run` now accepts **any harness name starting with `claude`** (`claude-corp`, `claude-personal`, `claudex`, ...) — all resolving to the same `ManagedHarness::Claude` / `AgentKind::ClaudeCode`. No new harness variant, agent kind, or session-store migration.
- Unknown, non-`claude*` values are still rejected exactly as before (`invalid value ... expected one of: ...`).
- Documents that `PATH` resolution bypasses shell-only aliases (`Command::new` does not go through an interactive shell), so a `claude` defined only via `.bashrc`/`.zshrc` `alias` won't be picked up — a `PATH`-visible shim/wrapper script or `--executable PATH` is needed instead.

## Use case: more than one Claude account

If you switch between Corporate and Personal Claude accounts, name each account's `PATH` wrapper script `claude-<account>` (earlier on `PATH` than the bare `claude`) and pair it with a matching `--executable`:

```bash
# ~/bin/claude-corp and ~/bin/claude-personal each exec the real `claude`
# binary with that account's config/credentials directory.
ai-memory run claude-corp --executable claude-corp --model opus
ai-memory run claude-personal --executable claude-personal
```

Only the `--executable` value determines which binary actually runs; the positional harness name just has to start with `claude` so it isn't rejected as an unknown value, and different spellings share nothing else (same agent kind, same session store, same transcript import) — pick whatever name reads clearly to you in shell history.

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no issues found
- [x] `cargo test --workspace --all-targets` — 3150 passed, 11 ignored, 0 failed (includes `claude_wildcard_names_parse_to_the_claude_harness`, `non_claude_unknown_harness_is_still_rejected`)

All run locally (rustup + pinned 1.95 toolchain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)