### PR TITLE
fix(deny): check the all-features graph locally to match CI

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,7 +3,11 @@
 # and pin to the official crates.io registry.
 
 [graph]
-all-features = false
+# CI runs cargo-deny with --all-features (see .github/workflows/ci.yml), so build
+# the same graph here. This keeps the documented local gate `cargo deny check`
+# (AGENTS.md, CONTRIBUTING.md) checking the exact feature set CI enforces, instead
+# of the narrower default-features graph.
+all-features = true
 no-default-features = false
 
 [output]


### PR DESCRIPTION
## What changed

`deny.toml` sets `[graph] all-features = true` (was `false`).

Before: CI ran `cargo deny --all-features check` (`.github/workflows/ci.yml:211-215`)
while the documented local gate `cargo deny check` (`AGENTS.md:229`,
`CONTRIBUTING.md:52`) built the default-features graph, because a command-line
`--all-features` overrides the config value. The two checked different feature
graphs. After: the documented local command builds the same all-features graph
CI enforces.

## Why

Resolves #689. A license or advisory problem reachable only under a non-default
feature would pass the documented local gate and surface first in CI, so "green
locally" did not mean "green in CI".

This is one of the two mutually exclusive directions #689 lays out. I took the
one that keeps CI's coverage intact and widens the local check to match. The
trade-off: every other unflagged `cargo deny` invocation (a downstream consumer,
an ad-hoc run) now also widens to all features.

**The current setup may be intentional** — `all-features = false` as a
conservative default for unflagged runs, with CI deliberately wider. If so, the
correct fix is the opposite direction (drop `--all-features` from CI so it
matches the config and the docs), and this PR should be closed in favour of that.

Closes #689.

## Test plan

- [x] `git diff --check` passes
- [x] `cargo deny check` passes with the change: `advisories ok, bans ok,
      licenses ok, sources ok` (this is now the all-features graph)
- [x] Manual: confirmed `cargo deny check` and `cargo deny --all-features check`
      now build the same graph
- [ ] `cargo fmt` / `clippy` / `cargo tf`: not applicable — the change is a
      single TOML config value; no Rust is compiled or tested differently

## Commit attribution

- [x] I verified the name and email on the commit in this PR.

## Release impact

- [x] **Patch** — bug fix, no new surface. Contributor/CI tooling only.

## CHANGELOG (merge gate)

- [ ] No entry. `deny.toml` is contributor-facing CI/lint tooling, not
      user-visible behaviour, installation, platforms, deployment, product
      env/config, or a public tool surface — exempt per the AGENTS.md merge-gate
      rule ("internal refactors and test-only churn are exempt"). Happy to add
      one under `### Changed` if you read it as a changed default.
