### PR TITLE
fix(config): scope the ambient LLM_BASE_URL to operator-supplied endpoints (#691)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now uses the import instead of a prose pointer (#680).
 
 ### Fixed
+- A bare `LLM_BASE_URL` in the environment no longer redirects providers that
+  talk to a fixed vendor endpoint. The variable is a cross-tool convention an
+  operator exports once for a local Ollama, and ai-memory fed it to every
+  provider: a `gemini` server then POSTed to
+  `http://localhost:11434/v1beta/models/<model>:generateContent` and got Ollama's
+  plain-text `404 page not found`, surfacing as
+  `502 Bad Gateway: {"error":"provider error 404: 404 page not found"}` on
+  bootstrap and consolidation. It now reaches only the dialects whose endpoint
+  the operator supplies anyway — `openai-compat`, which has none without it, and
+  `opencode`, whose Zen catalogue is an override — and is ignored elsewhere with
+  a startup `warn!` naming the provider and the URL. An explicit `llm_base_url`
+  (or `AI_MEMORY_LLM_BASE_URL`) still configures any provider, so proxying a
+  vendor endpoint on purpose is unchanged. `ai-memory llm-test` resolves the base
+  URL the same way, so it reproduces what `serve` will do instead of inheriting
+  the same ambient override (#691).
 - The from-source AUR `PKGBUILD` now builds and tests on constrained AUR
   builders. Release LTO was disabled (`options=('!debug' '!lto')`) so the
   final link no longer gets OOM-killed on low-memory build hosts, and the

--- a/crates/ai-memory-cli/src/commands/llm_test.rs
+++ b/crates/ai-memory-cli/src/commands/llm_test.rs
@@ -22,7 +22,7 @@ pub async fn run(config: &Config, args: LlmTestArgs) -> Result<()> {
         provider,
         model: args.model,
         auth: config.provider_auth(provider, api_key_override),
-        base_url: args.base_url.or_else(|| config.llm_test_base_url()),
+        base_url: args.base_url.or_else(|| config.llm_test_base_url(provider)),
         compat_strict: config.llm_compat_strict,
         request_timeout_secs: config.llm_timeout_secs,
         reasoning_effort: config.llm_reasoning_effort,

--- a/crates/ai-memory-cli/src/config.rs
+++ b/crates/ai-memory-cli/src/config.rs
@@ -1199,13 +1199,7 @@ impl Config {
             provider,
             model,
             auth: self.provider_auth(provider, None),
-            // base_url falls back to the runtime env (LLM_BASE_URL), mirroring
-            // how auth is sourced — otherwise openai-compat is only
-            // configurable via config.toml even though the key comes from env.
-            base_url: self
-                .llm_base_url
-                .clone()
-                .or_else(|| self.runtime_env.llm_base_url.clone()),
+            base_url: self.resolve_base_url(provider),
             compat_strict: self.llm_compat_strict,
             request_timeout_secs: self.llm_timeout_secs,
             reasoning_effort: self.llm_reasoning_effort,
@@ -1576,14 +1570,44 @@ impl Config {
         }
     }
 
+    /// Base URL for `provider`, from the two sources that can supply one.
+    ///
+    /// An explicit ai-memory setting (`llm_base_url` in `config.toml`, or
+    /// `AI_MEMORY_LLM_BASE_URL`) configures any provider: naming ai-memory is
+    /// how an operator says they mean it, and proxying a vendor endpoint is a
+    /// legitimate deployment.
+    ///
+    /// The bare `LLM_BASE_URL` is different in kind — a cross-tool convention
+    /// an operator exports once for a local Ollama and forgets. It reaches
+    /// only the providers whose endpoint is theirs to choose anyway; sending
+    /// it to a vendor-fixed endpoint silently rewrites every request onto a
+    /// host that does not speak the dialect (#691), so it is ignored and the
+    /// reason is logged rather than left for a 404 to explain.
+    fn resolve_base_url(&self, provider: ProviderChoice) -> Option<String> {
+        if let Some(explicit) = non_empty(self.llm_base_url.as_deref()) {
+            return Some(explicit.to_string());
+        }
+        let ambient = non_empty(self.runtime_env.llm_base_url.as_deref())?;
+        if provider.endpoint_is_operator_chosen() {
+            return Some(ambient.to_string());
+        }
+        tracing::warn!(
+            provider = provider.name(),
+            base_url = ambient,
+            "ignoring ambient LLM_BASE_URL: this provider talks to a fixed vendor \
+             endpoint. Set llm_base_url (or AI_MEMORY_LLM_BASE_URL) to point it \
+             somewhere else on purpose."
+        );
+        None
+    }
+
     /// Base URL fallback for `llm-test`. Resolves exactly as
     /// [`Self::provider_config`] does, so `llm-test` exercises the endpoint
-    /// `serve` will use — including an `opencode` override onto Zen.
+    /// `serve` will use — including an `opencode` override onto Zen, and the
+    /// same refusal to inherit an ambient `LLM_BASE_URL`.
     #[must_use]
-    pub fn llm_test_base_url(&self) -> Option<String> {
-        self.llm_base_url
-            .clone()
-            .or_else(|| self.runtime_env.llm_base_url.clone())
+    pub fn llm_test_base_url(&self, provider: ProviderChoice) -> Option<String> {
+        self.resolve_base_url(provider)
     }
 }
 
@@ -3147,4 +3171,113 @@ fn llm_provider_config_gemini_uses_default_base_url_when_none_provided() {
     let provider = cfg.llm_provider_config().unwrap().unwrap();
     assert_eq!(provider.provider, ProviderChoice::Gemini);
     assert_eq!(provider.base_url, None);
+}
+
+// #691: `LLM_BASE_URL` is an ambient, cross-tool convention — an operator who
+// once pointed it at Ollama for `openai-compat` keeps it exported. Feeding it
+// to Gemini builds `http://localhost:11434/v1beta/models/<model>:generateContent`,
+// which Ollama answers with a plain-text `404 page not found`; the bootstrap
+// surfaces that as a 502 with no server-side log line to explain it.
+#[test]
+fn ambient_llm_base_url_does_not_override_gemini() {
+    let cfg = Config {
+        llm_provider: Some("gemini".into()),
+        llm_base_url: None,
+        runtime_env: RuntimeEnv {
+            gemini_api_key: Some(SecretString::from("dummy")),
+            llm_base_url: Some("http://localhost:11434".into()),
+            ..RuntimeEnv::default()
+        },
+        ..Config::default()
+    };
+    let provider = cfg.llm_provider_config().unwrap().unwrap();
+    assert_eq!(provider.provider, ProviderChoice::Gemini);
+    assert_eq!(provider.base_url, None);
+}
+
+// The other half of #691: the ambient fallback exists *for* the dialects whose
+// endpoint the operator supplies, and narrowing it must not take that away.
+// `openai-compat` has no endpoint at all without one.
+#[test]
+fn ambient_llm_base_url_still_configures_openai_compat() {
+    let cfg = Config {
+        llm_provider: Some("openai-compat".into()),
+        llm_model: Some("gemma4:26b-mlx".into()),
+        llm_base_url: None,
+        runtime_env: RuntimeEnv {
+            llm_base_url: Some("http://localhost:11434/v1".into()),
+            ..RuntimeEnv::default()
+        },
+        ..Config::default()
+    };
+    let provider = cfg.llm_provider_config().unwrap().unwrap();
+    assert_eq!(provider.provider, ProviderChoice::OpenAiCompat);
+    assert_eq!(
+        provider.base_url.as_deref(),
+        Some("http://localhost:11434/v1")
+    );
+}
+
+// `opencode` defaults to Go and reaches Zen's general catalogue only through an
+// override, so it is operator-chosen too.
+#[test]
+fn ambient_llm_base_url_still_configures_opencode() {
+    let cfg = Config {
+        llm_provider: Some("opencode".into()),
+        runtime_env: RuntimeEnv {
+            opencode_api_key: Some(SecretString::from("dummy")),
+            llm_base_url: Some("https://opencode.ai/zen/v1".into()),
+            ..RuntimeEnv::default()
+        },
+        ..Config::default()
+    };
+    let provider = cfg.llm_provider_config().unwrap().unwrap();
+    assert_eq!(provider.provider, ProviderChoice::OpenCode);
+    assert_eq!(
+        provider.base_url.as_deref(),
+        Some("https://opencode.ai/zen/v1")
+    );
+}
+
+// Naming ai-memory is how an operator says they mean it: proxying Gemini stays
+// possible, and the explicit setting outranks an ambient one that disagrees.
+#[test]
+fn explicit_llm_base_url_still_overrides_gemini_over_an_ambient_one() {
+    let cfg = Config {
+        llm_provider: Some("gemini".into()),
+        llm_base_url: Some("https://gemini-proxy.internal".into()),
+        runtime_env: RuntimeEnv {
+            gemini_api_key: Some(SecretString::from("dummy")),
+            llm_base_url: Some("http://localhost:11434".into()),
+            ..RuntimeEnv::default()
+        },
+        ..Config::default()
+    };
+    let provider = cfg.llm_provider_config().unwrap().unwrap();
+    assert_eq!(
+        provider.base_url.as_deref(),
+        Some("https://gemini-proxy.internal")
+    );
+}
+
+// `llm-test` is the tool an operator reaches for to reproduce what `serve`
+// does. It resolved base_url through its own copy of the old chain, so before
+// this fix it hit the ambient endpoint too — and agreed with the broken server
+// instead of exposing it.
+#[test]
+fn llm_test_base_url_resolves_per_provider_like_serve_does() {
+    let cfg = Config {
+        llm_base_url: None,
+        runtime_env: RuntimeEnv {
+            llm_base_url: Some("http://localhost:11434".into()),
+            ..RuntimeEnv::default()
+        },
+        ..Config::default()
+    };
+    assert_eq!(cfg.llm_test_base_url(ProviderChoice::Gemini), None);
+    assert_eq!(
+        cfg.llm_test_base_url(ProviderChoice::OpenAiCompat)
+            .as_deref(),
+        Some("http://localhost:11434")
+    );
 }

--- a/crates/ai-memory-llm/src/factory.rs
+++ b/crates/ai-memory-llm/src/factory.rs
@@ -82,6 +82,22 @@ impl ProviderChoice {
             },
         }
     }
+
+    /// Whether the operator, rather than the vendor, decides where this
+    /// provider's endpoint lives.
+    ///
+    /// True for the self-hosted / aggregator dialects: `openai-compat` has
+    /// no endpoint at all without one, and `opencode` reaches Zen's general
+    /// catalogue only through an override. Every other provider talks to a
+    /// fixed vendor host, and a base URL aimed elsewhere does not speak its
+    /// dialect — a Gemini request against an Ollama host is a 404, not a
+    /// degraded answer. Callers use this to decide whether an *ambient*
+    /// base URL (the cross-tool `LLM_BASE_URL` convention) may configure the
+    /// provider; an explicit ai-memory setting always may.
+    #[must_use]
+    pub const fn endpoint_is_operator_chosen(self) -> bool {
+        matches!(self, Self::OpenAiCompat | Self::OpenCode)
+    }
 }
 
 /// All settings needed to construct one LLM provider instance.
@@ -388,6 +404,33 @@ pub fn build_provider(config: ProviderConfig) -> LlmResult<Arc<dyn LlmProvider>>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Exhaustive on purpose: adding a provider must be a decision about whose
+    // endpoint it is, not a default inherited from whichever arm was copied.
+    #[test]
+    fn only_the_operator_supplied_dialects_accept_an_ambient_base_url() {
+        for choice in [ProviderChoice::OpenAiCompat, ProviderChoice::OpenCode] {
+            assert!(
+                choice.endpoint_is_operator_chosen(),
+                "{} has no endpoint without an operator-supplied one",
+                choice.name()
+            );
+        }
+        for choice in [
+            ProviderChoice::Anthropic,
+            ProviderChoice::OpenAi,
+            ProviderChoice::Gemini,
+            ProviderChoice::OpenAiOAuth,
+            ProviderChoice::Copilot,
+            ProviderChoice::AnthropicOAuth,
+        ] {
+            assert!(
+                !choice.endpoint_is_operator_chosen(),
+                "{} talks to a fixed vendor host",
+                choice.name()
+            );
+        }
+    }
 
     #[test]
     fn provider_choices_declare_current_auth_requirements() {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -598,7 +598,15 @@ AI_MEMORY_LLM_MODEL        optional when the provider has a default; e.g. claude
 ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY / LLM_API_KEY
 AI_MEMORY_LLM_BASE_URL     required for openai-compat (Ollama, vLLM); optional override for
                            opencode (defaults to the Go endpoint, set
-                           https://opencode.ai/zen/v1 for Zen's catalogue)
+                           https://opencode.ai/zen/v1 for Zen's catalogue).
+                           Applies to any provider: naming ai-memory is how an
+                           operator says a vendor endpoint is proxied on purpose
+LLM_BASE_URL               the unprefixed cross-tool convention, accepted for
+                           openai-compat and opencode only. Providers with a
+                           fixed vendor endpoint (anthropic, openai, gemini,
+                           the OAuth backends, copilot) ignore it and log why —
+                           an operator's leftover Ollama URL must not silently
+                           rewrite every Gemini request into a 404
 AI_MEMORY_LLM_COMPAT_STRICT true by default; false disables response_format=json_schema
 AI_MEMORY_LLM_TIMEOUT_SECS  per-request timeout for chat providers; 300 by default
 AI_MEMORY_LLM_REASONING_EFFORT  optional reasoning/thinking effort


### PR DESCRIPTION
Fixes #691.

## The failure

`LLM_BASE_URL` is a cross-tool convention — an operator exports it once for a local Ollama and forgets. ai-memory fed it to *every* provider, so a `gemini` server POSTed to `http://localhost:11434/v1beta/models/<model>:generateContent`. Ollama is a Go server and answers with a plain-text `404 page not found`, which reached the operator as:

```
Error: server returned 502 Bad Gateway: {"error":"provider error 404: 404 page not found"}
```

Every bootstrap, consolidation and auto-improve tick against that provider failed the same way.

## The fix

The unprefixed variable now reaches only the dialects whose endpoint the operator supplies anyway: `openai-compat`, which has no endpoint without one, and `opencode`, whose Zen catalogue is an override. Elsewhere it is ignored and a startup `warn!` names the provider and the URL.

Which providers those are is a property of the provider, so it lives on `ProviderChoice::endpoint_is_operator_chosen` rather than in the CLI.

An explicit `llm_base_url` / `AI_MEMORY_LLM_BASE_URL` still configures any provider — naming ai-memory is how an operator says a vendor endpoint is proxied on purpose, and the existing test asserting that for Gemini is unchanged.

`llm_test_base_url` now takes the provider and resolves through the same helper. It previously carried its own copy of the old chain, so `ai-memory llm-test` inherited the ambient override too and agreed with the broken server instead of exposing it.

`docs/ARCHITECTURE.md` documents the unprefixed variable for the first time. Its absence from the env reference was part of why this was hard to find.

## Verification

Built binary, against the real Gemini API, with the exact environment that produced the bug:

```console
$ LLM_BASE_URL=http://localhost:11434 GEMINI_API_KEY=… \
    ai-memory llm-test --provider gemini --model gemini-3.5-flash-lite --prompt 'responda apenas: ok'
WARN ai_memory_cli::config: ignoring ambient LLM_BASE_URL: this provider talks to a
  fixed vendor endpoint. Set llm_base_url (or AI_MEMORY_LLM_BASE_URL) to point it
  somewhere else on purpose. provider="gemini" base_url="http://localhost:11434"
--- model: gemini-3.5-flash-lite ---
--- usage: in=6 out=1 ---
ok
```

And the path that must not have been taken away, against a local Ollama:

```console
$ LLM_BASE_URL=http://localhost:11434/v1 \
    ai-memory llm-test --provider openai-compat --model gemma4:e4b --prompt 'responda apenas: ok'
--- model: gemma4:e4b ---
ok
```

No warning for `openai-compat`, and it reached the endpoint.

## Tests

Written test-first; the first run failed with `left: Some("http://localhost:11434")`, `right: None`.

- `ambient_llm_base_url_does_not_override_gemini` — the bug
- `ambient_llm_base_url_still_configures_openai_compat` / `..._opencode` — the fallback's reason for existing, preserved
- `explicit_llm_base_url_still_overrides_gemini_over_an_ambient_one` — deliberate proxying, and precedence between the two sources
- `llm_test_base_url_resolves_per_provider_like_serve_does` — the diagnostic tool matches the server
- `only_the_operator_supplied_dialects_accept_an_ambient_base_url` — exhaustive over all eight providers, so adding one is a decision rather than an inheritance

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace --all-targets` are green. Four `packaging::slow::*` failures on this machine (docker/podman/SELinux) reproduce on a clean `origin/main` and are unrelated.

## Note for the reviewer

The `[Unreleased]` entry will conflict with #692's if both are merged; whichever lands second needs the trivial resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDaxUG5YY7Kx9UmoC3aLkn
