### PR TITLE
fix(wiki): serialize session purge with page mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now uses the import instead of a prose pointer (#680).
 
 ### Fixed
-- `purge-session` held the wiki mutation guard across database deletion and file
-  cleanup, preventing an in-flight watcher reindex from restoring deleted rows
-  or a concurrent page write from losing its file during cleanup (#653).
+- `purge-session` took the wiki mutation guard only for the file cleanup, after
+  the database deletion had already committed. A watcher reindex could reinsert
+  the still-present page in that gap and keep only the row, and a concurrent page
+  write could lose its file to the cleanup. The purge now holds the guard across
+  both steps, so reindexes, page writes and wiki moves finish before it starts
+  and wait until it is done (#696, follow-up to #653).
 - The from-source AUR `PKGBUILD` now builds and tests on constrained AUR
   builders. Release LTO was disabled (`options=('!debug' '!lto')`) so the
   final link no longer gets OOM-killed on low-memory build hosts, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now uses the import instead of a prose pointer (#680).
 
 ### Fixed
+- `purge-session` held the wiki mutation guard across database deletion and file
+  cleanup, preventing an in-flight watcher reindex from restoring deleted rows
+  or a concurrent page write from losing its file during cleanup (#653).
 - The from-source AUR `PKGBUILD` now builds and tests on constrained AUR
   builders. Release LTO was disabled (`options=('!debug' '!lto')`) so the
   final link no longer gets OOM-killed on low-memory build hosts, and the

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -3673,7 +3673,7 @@ async fn handle_purge_session(
     {
         Ok(s) => s,
         // Absent from this scope (or already purged) is a 404, not a fault.
-        Err(e @ StoreError::NotFound(_)) => {
+        Err(WikiError::Store(e @ StoreError::NotFound(_))) => {
             return (
                 StatusCode::NOT_FOUND,
                 Json(serde_json::json!({ "error": e.to_string() })),

--- a/crates/ai-memory-mcp/src/admin.rs
+++ b/crates/ai-memory-mcp/src/admin.rs
@@ -3598,38 +3598,6 @@ pub struct PurgeSessionReport {
     pub checkpoint: Option<String>,
 }
 
-async fn remove_purged_session_storage(
-    state: &AdminState,
-    workspace_id: WorkspaceId,
-    project_id: ProjectId,
-    removed_paths: &[PagePath],
-) -> (Vec<PagePath>, Vec<PagePath>) {
-    let mut files_deleted = Vec::with_capacity(removed_paths.len());
-    let mut files_failed = Vec::new();
-
-    for path in removed_paths {
-        match state
-            .wiki
-            .remove_page_file(workspace_id, project_id, path)
-            .await
-        {
-            Ok(true) => files_deleted.push(path.clone()),
-            Ok(false) => {}
-            Err(error) => {
-                warn!(
-                    operation = "purge-session",
-                    path = path.as_str(),
-                    error = %error,
-                    "session purge failed to remove wiki page file"
-                );
-                files_failed.push(path.clone());
-            }
-        }
-    }
-
-    (files_deleted, files_failed)
-}
-
 /// `POST /admin/purge-session` — delete one session and everything derived
 /// from it, inside a single workspace/project scope.
 async fn handle_purge_session(
@@ -3698,8 +3666,8 @@ async fn handle_purge_session(
         ai_memory_store::Compaction::Skip
     };
 
-    let summary = match state
-        .writer
+    let outcome = match state
+        .wiki
         .purge_session(ws_id, proj_id, session_id, author_id, compaction)
         .await
     {
@@ -3714,8 +3682,11 @@ async fn handle_purge_session(
         Err(e) => return internal_err(e.to_string()),
     };
 
-    let (files_deleted, files_failed) =
-        remove_purged_session_storage(&state, ws_id, proj_id, &summary.removed_paths).await;
+    let ai_memory_wiki::PurgeSessionOutcome {
+        summary,
+        files_deleted,
+        files_failed,
+    } = outcome;
     if !files_failed.is_empty()
         && let Some(ref mut ctx) = dispatch_ctx
     {

--- a/crates/ai-memory-store/src/writer.rs
+++ b/crates/ai-memory-store/src/writer.rs
@@ -1535,6 +1535,11 @@ impl WriterHandle {
     /// deleted. See [`ops::purge_session`] for what is and is not removed —
     /// in particular, handoffs this session *accepted* are left alone.
     ///
+    /// Server callers must go through `Wiki::purge_session` instead, which
+    /// holds the wiki mutation guard across this deletion and the page-file
+    /// cleanup. Calling this directly commits the rows with no guard, so a
+    /// watcher reindex can reinsert the page before the file is removed (#653).
+    ///
     /// # Errors
     /// [`StoreError::NotFound`] when the session is absent from that scope,
     /// [`StoreError::WriterClosed`], or a propagated SQL error.

--- a/crates/ai-memory-wiki/src/lib.rs
+++ b/crates/ai-memory-wiki/src/lib.rs
@@ -26,7 +26,7 @@ pub use git::{COMMIT_AUTHOR_EMAIL, COMMIT_AUTHOR_NAME, GitAdapter};
 pub use markdown::{Markdown, derive_title, emit, parse};
 pub use migrations::run_pending as run_wiki_migrations;
 pub use watcher::{DEBOUNCE_WINDOW, RECONCILE_INTERVAL, WatcherHandle};
-pub use wiki::{MoveSessionOutcome, SessionPageFile, Wiki, WritePageRequest};
+pub use wiki::{MoveSessionOutcome, PurgeSessionOutcome, SessionPageFile, Wiki, WritePageRequest};
 
 // Integration tests compile into this crate's test harness instead of a
 // separate binary: every test binary is another link and, on macOS and

--- a/crates/ai-memory-wiki/src/wiki.rs
+++ b/crates/ai-memory-wiki/src/wiki.rs
@@ -11,8 +11,8 @@ use ai_memory_core::{
 use ai_memory_llm::Embedder;
 use ai_memory_store::{
     ApproveAutoImproveProposal, ApproveAutoImproveProposalResult, AutoImproveProposalDetail,
-    FailAutoImproveProposal, MoveSessionSummary, MoveSummary, PagesMode, ReaderPool, WriterHandle,
-    artifact_path_for, f32_vec_to_bytes,
+    FailAutoImproveProposal, MoveSessionSummary, MoveSummary, PagesMode, PurgeSessionSummary,
+    ReaderPool, WriterHandle, artifact_path_for, f32_vec_to_bytes,
 };
 use tokio::sync::RwLock;
 
@@ -23,9 +23,10 @@ use crate::markdown::{Markdown, derive_title, emit, parse};
 use crate::watcher::is_pending_path;
 
 /// Store deletion and best-effort file cleanup from [`Wiki::purge_session`].
+#[derive(Debug, Clone)]
 pub struct PurgeSessionOutcome {
     /// Committed database deletion counts and paths.
-    pub summary: ai_memory_store::PurgeSessionSummary,
+    pub summary: PurgeSessionSummary,
     /// Paths successfully removed from disk.
     pub files_deleted: Vec<PagePath>,
     /// Paths whose file cleanup failed after the database committed.
@@ -1223,7 +1224,8 @@ impl Wiki {
     /// page write or project move from landing between SQL and file cleanup.
     ///
     /// # Errors
-    /// Returns the store error without removing files if the database purge fails.
+    /// Returns [`WikiError::Store`] without removing files if the database
+    /// purge fails.
     pub async fn purge_session(
         &self,
         workspace_id: WorkspaceId,
@@ -1231,13 +1233,13 @@ impl Wiki {
         session_id: SessionId,
         author_id: Option<UserId>,
         compaction: ai_memory_store::Compaction,
-    ) -> ai_memory_store::StoreResult<PurgeSessionOutcome> {
+    ) -> WikiResult<PurgeSessionOutcome> {
         let _guard = self.mutation_lock.write().await;
         let summary = self
             .writer
             .purge_session(workspace_id, project_id, session_id, author_id, compaction)
             .await?;
-        let mut files_deleted = Vec::new();
+        let mut files_deleted = Vec::with_capacity(summary.removed_paths.len());
         let mut files_failed = Vec::new();
         for path in &summary.removed_paths {
             let abs = self.abs_path(workspace_id, project_id, path);
@@ -1248,8 +1250,12 @@ impl Wiki {
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
                 Err(error) => {
-                    tracing::warn!(operation = "purge-session", path = path.as_str(),
-                        error = %error, "session purge failed to remove wiki page file");
+                    tracing::warn!(
+                        operation = "purge-session",
+                        path = path.as_str(),
+                        error = %error,
+                        "session purge failed to remove wiki page file",
+                    );
                     files_failed.push(path.clone());
                 }
             }
@@ -5177,7 +5183,7 @@ mod tests {
         tokio::pin!(purge);
         tokio::select! {
             biased;
-            result = &mut purge => panic!("purge bypassed an active reader: {}", result.is_ok()),
+            result = &mut purge => panic!("purge bypassed an active reader: {result:?}"),
             () = std::future::ready(()) => {}
         }
         store
@@ -5222,6 +5228,56 @@ mod tests {
         );
     }
 
+    /// The writer's half of the same claim. `purge_session` holds the
+    /// exclusive guard across SQL and cleanup — proved by
+    /// `purge_session_waits_for_in_flight_reindex_before_deleting_rows` — and
+    /// `write_page` takes the shared one, so a write cannot install its file
+    /// while a purge owns the guard and would otherwise delete it during
+    /// cleanup. Removing the shared guard from `write_page` makes this fail.
+    #[tokio::test]
+    async fn page_write_cannot_land_while_the_purge_guard_is_held() {
+        let tmp = TempDir::new().unwrap();
+        let (store, wiki, ws, proj, _, _sid, _path) = session_with_page(&tmp).await;
+        let target = PagePath::new("decisions/keep.md").unwrap();
+        let abs = wiki.abs_path(ws, proj, &target);
+
+        let purge_guard = wiki.mutation_lock.write().await;
+        let write = wiki.write_page(req(
+            ws,
+            proj,
+            target.as_str(),
+            "kept body",
+            serde_json::json!({ "title": "Keep" }),
+        ));
+        tokio::pin!(write);
+        // A single poll would only prove the write did not finish in one
+        // step, which is true even without the guard: `write_page` parks on
+        // the writer queue before it touches disk. Give it real time instead.
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(250), &mut write)
+                .await
+                .is_err(),
+            "the page write must not complete while a purge owns the guard"
+        );
+        assert!(
+            !abs.exists(),
+            "no page file may be installed while a purge owns the guard"
+        );
+
+        drop(purge_guard);
+        write.await.unwrap();
+        assert!(abs.exists(), "the write completes once the purge releases");
+        assert!(
+            !store
+                .reader
+                .search_pages("kept".into(), 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "disk and index agree after the guard is released"
+        );
+    }
+
     #[tokio::test]
     async fn purge_session_store_failure_preserves_page_file() {
         let tmp = TempDir::new().unwrap();
@@ -5233,7 +5289,7 @@ mod tests {
             .await;
         assert!(matches!(
             result,
-            Err(ai_memory_store::StoreError::NotFound(_))
+            Err(WikiError::Store(ai_memory_store::StoreError::NotFound(_)))
         ));
         assert_eq!(std::fs::read(&abs).unwrap(), before);
         assert!(

--- a/crates/ai-memory-wiki/src/wiki.rs
+++ b/crates/ai-memory-wiki/src/wiki.rs
@@ -22,6 +22,16 @@ use crate::git::{Checkpoint, GitAdapter};
 use crate::markdown::{Markdown, derive_title, emit, parse};
 use crate::watcher::is_pending_path;
 
+/// Store deletion and best-effort file cleanup from [`Wiki::purge_session`].
+pub struct PurgeSessionOutcome {
+    /// Committed database deletion counts and paths.
+    pub summary: ai_memory_store::PurgeSessionSummary,
+    /// Paths successfully removed from disk.
+    pub files_deleted: Vec<PagePath>,
+    /// Paths whose file cleanup failed after the database committed.
+    pub files_failed: Vec<PagePath>,
+}
+
 /// Summary of a [`Wiki::reindex_all`] run.
 #[derive(Debug, Default, Clone)]
 pub struct ReindexSummary {
@@ -1206,30 +1216,49 @@ impl Wiki {
         }
     }
 
-    /// Remove one on-disk page file without touching the store.
-    ///
-    /// Used after a scoped store purge has already deleted the authoritative
-    /// rows and returned the affected paths. A missing file is treated as
-    /// already removed; any other filesystem error is reported to the caller.
+    /// Purge a session and its page files under one exclusive mutation guard.
+    /// Admission must run before this call. File failures do not roll back the
+    /// committed database purge and are returned for partial-failure reporting.
+    /// Holding the guard before submitting SQL prevents a watcher reindex,
+    /// page write or project move from landing between SQL and file cleanup.
     ///
     /// # Errors
-    /// Returns [`WikiError::Io`] on filesystem errors other than NotFound.
-    pub async fn remove_page_file(
+    /// Returns the store error without removing files if the database purge fails.
+    pub async fn purge_session(
         &self,
         workspace_id: WorkspaceId,
         project_id: ProjectId,
-        path: &PagePath,
-    ) -> WikiResult<bool> {
+        session_id: SessionId,
+        author_id: Option<UserId>,
+        compaction: ai_memory_store::Compaction,
+    ) -> ai_memory_store::StoreResult<PurgeSessionOutcome> {
         let _guard = self.mutation_lock.write().await;
-        let abs = self.abs_path(workspace_id, project_id, path);
-        match self.git.remove_file(&abs) {
-            Ok(()) => {
-                sync_parent_best_effort(&abs);
-                Ok(true)
+        let summary = self
+            .writer
+            .purge_session(workspace_id, project_id, session_id, author_id, compaction)
+            .await?;
+        let mut files_deleted = Vec::new();
+        let mut files_failed = Vec::new();
+        for path in &summary.removed_paths {
+            let abs = self.abs_path(workspace_id, project_id, path);
+            match self.git.remove_file(&abs) {
+                Ok(()) => {
+                    sync_parent_best_effort(&abs);
+                    files_deleted.push(path.clone());
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    tracing::warn!(operation = "purge-session", path = path.as_str(),
+                        error = %error, "session purge failed to remove wiki page file");
+                    files_failed.push(path.clone());
+                }
             }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
-            Err(e) => Err(crate::WikiError::Io(e)),
         }
+        Ok(PurgeSessionOutcome {
+            summary,
+            files_deleted,
+            files_failed,
+        })
     }
 
     /// Dispatch non-blocking purge webhooks after the caller's purge has
@@ -5131,6 +5160,90 @@ mod tests {
         .await
         .unwrap();
         (store, wiki, ws, src, dst, sid, path)
+    }
+
+    #[tokio::test]
+    async fn purge_session_waits_for_in_flight_reindex_before_deleting_rows() {
+        let tmp = TempDir::new().unwrap();
+        let (store, wiki, ws, proj, _, sid, path) = session_with_page(&tmp).await;
+        let page_id = wiki.reindex_page(ws, proj, path.clone()).await.unwrap();
+        store.writer.end_session(sid, Some(page_id)).await.unwrap();
+
+        // Model a watcher that has acquired the shared guard but has not
+        // indexed its file yet. Poll the purge once, then fence the writer
+        // queue: any SQL it submitted must finish before this command replies.
+        let reader_guard = wiki.mutation_lock.read().await;
+        let purge = wiki.purge_session(ws, proj, sid, None, ai_memory_store::Compaction::Skip);
+        tokio::pin!(purge);
+        tokio::select! {
+            biased;
+            result = &mut purge => panic!("purge bypassed an active reader: {}", result.is_ok()),
+            () = std::future::ready(()) => {}
+        }
+        store
+            .writer
+            .get_or_create_workspace("queue-fence")
+            .await
+            .unwrap();
+        assert!(
+            store
+                .reader
+                .find_session_scope(sid)
+                .await
+                .unwrap()
+                .is_some(),
+            "purge must wait for the wiki guard before deleting SQL rows"
+        );
+        // Finish the already-admitted reindex without recursively locking.
+        wiki.reindex_page_locked(ws, proj, path.clone())
+            .await
+            .unwrap();
+        drop(reader_guard);
+        let outcome = purge.await.unwrap();
+        assert_eq!(outcome.files_deleted, vec![path.clone()]);
+        assert!(outcome.files_failed.is_empty());
+        assert!(
+            store
+                .reader
+                .find_session_scope(sid)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(!wiki.abs_path(ws, proj, &path).exists());
+        assert!(wiki.reindex_page(ws, proj, path).await.is_err());
+        assert!(
+            store
+                .reader
+                .search_pages("consolidated".into(), 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn purge_session_store_failure_preserves_page_file() {
+        let tmp = TempDir::new().unwrap();
+        let (store, wiki, ws, proj, other, sid, path) = session_with_page(&tmp).await;
+        let abs = wiki.abs_path(ws, proj, &path);
+        let before = std::fs::read(&abs).unwrap();
+        let result = wiki
+            .purge_session(ws, other, sid, None, ai_memory_store::Compaction::Skip)
+            .await;
+        assert!(matches!(
+            result,
+            Err(ai_memory_store::StoreError::NotFound(_))
+        ));
+        assert_eq!(std::fs::read(&abs).unwrap(), before);
+        assert!(
+            store
+                .reader
+                .find_session_scope(sid)
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 
     fn leftover_tempfiles(dir: &Path) -> Vec<String> {

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -96,6 +96,13 @@ purge with wiki project/session moves. Admission webhooks run before this guard.
 File cleanup failures still leave the database purge committed and are reported
 in `files_failed`; this coordination does not provide crash-atomic rollback.
 
+The guard is taken before the purge is submitted to the writer actor, so it also
+covers the wait for whatever that single queue is already draining, and — with
+`compact: true` — the `VACUUM` that runs after the delete commits. A purge on a
+busy server therefore holds up wiki mutations for longer than the delete itself.
+The git checkpoints taken before and after the purge sit outside the guard: they
+bracket it, they do not snapshot it.
+
 ### Scope containment
 
 The session id is never authority on its own. Every statement is filtered on

--- a/docs/lifecycle-ops.md
+++ b/docs/lifecycle-ops.md
@@ -89,6 +89,13 @@ purge needs. Rebuilding only the indexes a given caller "should" have touched
 is what leaves a managed agent's transcript text in the file after an operator
 asked for it to be reclaimed.
 
+Session purges hold the wiki mutation guard across the database deletion and
+file cleanup. In-flight page writes and watcher reindexes finish before the
+purge starts; new ones wait until cleanup completes. This also serializes the
+purge with wiki project/session moves. Admission webhooks run before this guard.
+File cleanup failures still leave the database purge committed and are reported
+in `files_failed`; this coordination does not provide crash-atomic rollback.
+
 ### Scope containment
 
 The session id is never authority on its own. Every statement is filtered on


### PR DESCRIPTION
## What changed

`purge-session` now acquires the wiki's exclusive mutation guard before submitting the SQL purge and holds it through page-file cleanup. The admin handler delegates both steps to `Wiki::purge_session`. HTTP fields, authorization, admission and partial-failure reporting are unchanged.

## Why

Follow-up to #653 / #654. Previously the database purge completed before file removal acquired the guard. A watcher already holding a shared guard could reinsert the still-existing page between those steps; cleanup would then remove only the file. A concurrent page write or wiki move could also interleave with cleanup.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets`
- [x] `cargo deny --all-features check`
- Manual validation: no live-server test. A deterministic regression holds the watcher's shared guard, polls the purge, fences the writer queue, and verifies SQL has not deleted the session. It then finishes reindexing, releases the guard and verifies purge removes both the file and searchable page. Moving lock acquisition after SQL makes this test fail.
- A second regression verifies a wrong-project store error preserves the page file. Existing admin tests cover cleanup failures and sibling-project isolation.

## Commit attribution

- [x] Verified author name and GitHub noreply email.

## Release impact

- [x] **Patch** — bug fix, no new operator surface
- [ ] **Minor**
- [ ] **Major (breaking)**

## CHANGELOG (merge gate)

- [x] Added a `[Unreleased]` / `Fixed` entry and lifecycle documentation.
- [x] No defaults or response shape changed.

## Notes for reviewers

The shared-project invariant is enforced by using the same guard as page writes, reindexing and wiki moves. Admission stays outside the lock. SQL failure removes no files; filesystem failure still leaves the SQL purge committed and reports `files_failed`. This is process-local coordination, not crash-atomic rollback. The exclusive guard also covers optional SQL compaction, so a compacting purge can hold up wiki mutations longer.

Maintainer action: please add the `windows` label for the locking change. The author account lacks permission to apply it.
