### PR TITLE
fix: scope the OKF pending exclusion to project roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now uses the import instead of a prose pointer (#680).
 
 ### Fixed
+- Limited the OKF migration's `_pending/` exclusion to project roots, so
+  ordinary nested pages such as `notes/_pending/legacy.md` still trigger a
+  safety backup and migrate. Project-root proposal sidecars remain excluded
+  (#695).
 - The Docker wrapper (`bin/ai-memory`) now forwards `GEMINI_API_KEY` and
   `GOOGLE_API_KEY` into the container. Every other provider credential was on
   the `-e` forwarding allowlist, but these two were missing, so

--- a/crates/ai-memory-wiki/src/migrations/m2026_09_okf_conformance.rs
+++ b/crates/ai-memory-wiki/src/migrations/m2026_09_okf_conformance.rs
@@ -212,9 +212,14 @@ fn nonconformant_files(wiki_root: &Path) -> WikiResult<Vec<PathBuf>> {
                 // every boot, and since this scan feeds the pre-migration
                 // backup gate, that re-archives the whole data dir each time
                 // once the receipt's archive is gone (#695, same class as the
-                // ledger skip for #669). Skip the subtree, matching the
-                // watcher indexer's own `_pending/` exclusion.
-                if path.file_name().is_some_and(|n| n == "_pending") {
+                // ledger skip for #669). Only the project-root subtree is
+                // reserved, matching the watcher indexer's `_pending/` rule;
+                // a nested path like notes/_pending still contains pages.
+                if path.file_name().is_some_and(|n| n == "_pending")
+                    && path
+                        .strip_prefix(wiki_root)
+                        .is_ok_and(|relative| relative.components().count() == 3)
+                {
                     continue;
                 }
                 stack.push(path);
@@ -826,6 +831,26 @@ mod tests {
             std::fs::read_dir(dest.path()).unwrap().count(),
             0,
             "the ledger caused a full data-dir archive"
+        );
+    }
+
+    #[test]
+    fn a_nested_pending_directory_still_requires_a_migration_backup() {
+        let tmp = TempDir::new().unwrap();
+        let wiki_root = tmp.path().join("wiki");
+        let relative = PathBuf::from("w/p/notes/_pending/legacy.md");
+        let path = wiki_root.join(&relative);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, "# Ordinary old page\n").unwrap();
+        let page = PagePath::new("notes/_pending/legacy.md").unwrap();
+        assert!(!crate::watcher::is_pending_path(&page));
+        assert_eq!(nonconformant_files(&wiki_root).unwrap(), vec![relative]);
+        let dest = TempDir::new().unwrap();
+        assert!(
+            snapshot_before_db_migration(tmp.path(), Some(dest.path()))
+                .unwrap()
+                .is_some(),
+            "ordinary legacy pages still require a pre-migration backup"
         );
     }
 

--- a/docs/auto-improvement-loop.md
+++ b/docs/auto-improvement-loop.md
@@ -515,6 +515,10 @@ non-indexed sidecars plus SQLite rows, with list/diff/approve/reject commands
 and audit rows. Approval applies through the existing wiki mutation boundaries
 with the `auto_improve` actor preserved in proposal provenance.
 
+Only the project-root `_pending/` directory is reserved proposal storage and
+excluded from the OKF migration scan. A nested path such as
+`notes/_pending/legacy.md` remains an ordinary wiki page and must still migrate.
+
 Tests:
 
 1. Pending proposals survive restart.


### PR DESCRIPTION
## What changed

I limited the OKF scanner's `_pending` directory exclusion to project roots. A normal page such as `notes/_pending/legacy.md` now remains eligible for the safety backup and file migration, while project-root proposal sidecars stay excluded.

## Why

This follows up on #695 and commit `a727ade`. The watcher reserves only a page path starting with `_pending/`, but the new migration scan skips any directory named `_pending`, including nested ordinary-page directories. The regression fixture demonstrates a valid, non-reserved `PagePath` that the current scanner misses, then verifies that its legacy contents require a pre-migration backup.

The original #695 sidecar regression remains unchanged and must still pass.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo deny check` — advisories, bans, licenses, and sources passed.
- [x] `cargo test --workspace --all-targets -- --test-threads=2` — **3,136 passed, 0 failed, 11 ignored** across 15 test binaries on Windows with Rust 1.95 MSVC.

The final run used commit `2fadb61bce743923e5c985b618026d0ce3606866` based on `a727ade`. Both the existing project-root sidecar regression and the new nested-page regression pass.

Local setup: with the target directory outside the checkout, I placed the unchanged `hooks/` bundle beside the test executable, matching the supported release archive layout. I used two test threads after an earlier default-parallel run hit an existing one-second shell-startup deadline; that unchanged test passes in isolation and in the final complete run. No test thresholds or assertions were relaxed.

The new regression fails on `a727ade`: the scanner returns an empty list instead of `w/p/notes/_pending/legacy.md`. Validation uses isolated temporary stores, not an installed user's data directory.

## Commit attribution

- [x] I verified the name and GitHub-provided email on the contribution commit.

## Release impact

- [x] **Patch** — bug fix, no new surface.

## CHANGELOG (merge gate)

- [x] Added a `[Unreleased]` fix entry and clarified the project-root boundary in the pending-storage documentation.
- [x] No configuration defaults or public interfaces changed.

## Notes for reviewers

Please apply the `windows` label for the repository's path-handling CI workflow. The change retains the directory pruning from #695 and only limits it to `wiki/<workspace>/<project>/_pending`.
