### PR TITLE
fix(wiki): stop reindexing the page of a purged session (#701)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now uses the import instead of a prose pointer (#680).
 
 ### Fixed
+- A `purge-session` whose page-file cleanup failed was undone by the next
+  watcher pass. The cleanup failure is reported in `files_failed` and leaves
+  the database rows deleted while `sessions/<id>.md` is still on disk; nothing
+  on the reindex path consulted the `purged_sessions` tombstone, so the
+  reconcile tick 30 seconds later indexed the leftover file and the purged
+  session's body was searchable again. The wiki reindex now skips a page whose
+  session is tombstoned, the way it already skips a tombstoned scope, loading
+  the tombstones once per directory per pass rather than once per page. The
+  pass reports them as `skipped_purged_sessions` (#701).
 - The Docker wrapper (`bin/ai-memory`) now forwards `GEMINI_API_KEY` and
   `GOOGLE_API_KEY` into the container. Every other provider credential was on
   the `-e` forwarding allowlist, but these two were missing, so

--- a/crates/ai-memory-store/src/ops.rs
+++ b/crates/ai-memory-store/src/ops.rs
@@ -3660,6 +3660,36 @@ pub fn scope_is_purged(
     Ok(found.is_some())
 }
 
+/// Session ids tombstoned by `purge_session` in one scope.
+///
+/// The scope-level twin of [`scope_is_purged`], read the same way and for the
+/// same reason: a purge whose page-file removal did not complete leaves the
+/// markdown on disk, and the wiki reindex must not put it back (#701). Loaded
+/// once per directory per reindex pass rather than once per page — a purged
+/// scope is one row, but a project accumulates one purged session per purge.
+///
+/// # Errors
+/// Propagates SQL errors.
+pub fn purged_session_ids(
+    conn: &Connection,
+    workspace_id: &WorkspaceId,
+    project_id: &ProjectId,
+) -> StoreResult<Vec<SessionId>> {
+    let mut stmt = conn.prepare(
+        "SELECT session_id FROM purged_sessions \
+         WHERE workspace_id = ?1 AND project_id = ?2",
+    )?;
+    let rows = stmt.query_map(
+        rusqlite::params![workspace_id.as_bytes(), project_id.as_bytes()],
+        |row| row.get::<_, Vec<u8>>(0),
+    )?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(SessionId::from_slice(&row?)?);
+    }
+    Ok(out)
+}
+
 /// One recorded bootstrap chunk, as loaded by [`load_bootstrap_progress`].
 #[derive(Debug, Clone)]
 pub struct BootstrapChunkRecord {

--- a/crates/ai-memory-store/src/writer.rs
+++ b/crates/ai-memory-store/src/writer.rs
@@ -82,6 +82,11 @@ pub(crate) enum WriteCmd {
         project_id: ProjectId,
         reply: oneshot::Sender<StoreResult<bool>>,
     },
+    PurgedSessionIds {
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+        reply: oneshot::Sender<StoreResult<Vec<SessionId>>>,
+    },
     RecordBootstrapChunk {
         fingerprint: String,
         chunk_index: u32,
@@ -760,6 +765,29 @@ impl WriterHandle {
     ) -> StoreResult<bool> {
         let (tx, rx) = oneshot::channel();
         self.send(WriteCmd::ScopeIsPurged {
+            workspace_id,
+            project_id,
+            reply: tx,
+        })
+        .await?;
+        rx.await.map_err(|_| StoreError::WriterClosed)?
+    }
+
+    /// Session ids tombstoned by `purge_session` in this scope. The wiki
+    /// reindex consults these so a purge whose page-file removal did not
+    /// complete cannot be undone by the next pass (#701). Loaded once per
+    /// directory per pass, not once per page. Routed through the writer actor
+    /// for the same reason [`Self::scope_is_purged`] is.
+    ///
+    /// # Errors
+    /// Returns [`StoreError::WriterClosed`] or propagates SQL errors.
+    pub async fn purged_session_ids(
+        &self,
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+    ) -> StoreResult<Vec<SessionId>> {
+        let (tx, rx) = oneshot::channel();
+        self.send(WriteCmd::PurgedSessionIds {
             workspace_id,
             project_id,
             reply: tx,
@@ -2555,6 +2583,14 @@ fn worker_loop(mut conn: Connection, mut rx: mpsc::Receiver<WriteCmd>) {
             } => {
                 let result = ops::scope_is_purged(&conn, &workspace_id, &project_id);
                 send_or_warn(reply, result, "scope_is_purged");
+            }
+            WriteCmd::PurgedSessionIds {
+                workspace_id,
+                project_id,
+                reply,
+            } => {
+                let result = ops::purged_session_ids(&conn, &workspace_id, &project_id);
+                send_or_warn(reply, result, "purged_session_ids");
             }
             WriteCmd::RecordBootstrapChunk {
                 fingerprint,

--- a/crates/ai-memory-wiki/src/watcher.rs
+++ b/crates/ai-memory-wiki/src/watcher.rs
@@ -255,6 +255,16 @@ async fn handle_event(wiki: &Wiki, event: notify_debouncer_full::DebouncedEvent)
         if is_reserved_page_file(raw_path, &page_path) {
             continue;
         }
+        // A tombstoned session's page must not come back from a file its
+        // purge could not remove (#701). One query, for one event.
+        match wiki.purged_sessions(ws, proj).await {
+            Ok(purged) if crate::wiki::is_purged_session_page(&page_path, &purged) => {
+                debug!(path = %page_path, "ignoring event for a purged session page");
+                continue;
+            }
+            Ok(_) => {}
+            Err(e) => warn!(path = %page_path, error = %e, "purged-session lookup failed"),
+        }
         match wiki.reindex_page(ws, proj, page_path.clone()).await {
             Ok(_) => debug!(path = %page_path, "reindexed via watcher"),
             Err(e) => warn!(path = %page_path, error = %e, "watcher reindex failed"),
@@ -303,7 +313,15 @@ async fn reindex_project_dir(
         }
     };
 
+    let purged = wiki.purged_sessions(ws, proj).await.unwrap_or_else(|e| {
+        warn!(error = %e, "purged-session lookup failed; not gating this pass");
+        std::collections::HashSet::new()
+    });
     for path in pages {
+        if crate::wiki::is_purged_session_page(&path, &purged) {
+            debug!(path = %path, "skipping a purged session page");
+            continue;
+        }
         match wiki.reindex_page(ws, proj, path.clone()).await {
             Ok(_) => debug!(path = %path, "reindexed via watcher directory event"),
             Err(e) => warn!(path = %path, error = %e, "watcher directory reindex failed"),
@@ -321,6 +339,9 @@ pub(crate) struct ReconcileStats {
     /// These are skipped wholesale rather than failing scope resolution on
     /// every page, every pass, forever (see #613).
     pub skipped_orphans: usize,
+    /// Session pages left on disk by a purge whose file cleanup failed, and
+    /// deliberately not re-indexed (#701).
+    pub skipped_purged_sessions: usize,
 }
 
 async fn reconcile(wiki: &Wiki) -> WikiResult<ReconcileStats> {
@@ -357,7 +378,19 @@ async fn reconcile(wiki: &Wiki) -> WikiResult<ReconcileStats> {
         let pages = tokio::task::spawn_blocking(move || walk_markdown(&proj_root))
             .await
             .map_err(|e| WikiError::Io(std::io::Error::other(e.to_string())))??;
+        // Once per directory, not once per page: a project accumulates one
+        // tombstone per purge, and the set is only consulted for the
+        // `sessions/<id>.md` paths that a session purge could have left behind.
+        let purged = wiki.purged_sessions(ws, proj).await?;
         for path in pages {
+            if crate::wiki::is_purged_session_page(&path, &purged) {
+                debug!(
+                    path = %path,
+                    "skipping reconcile of a purged (tombstoned) session page",
+                );
+                stats.skipped_purged_sessions += 1;
+                continue;
+            }
             if let Err(e) = wiki.reindex_page(ws, proj, path.clone()).await {
                 warn!(path = %path, error = %e, "reconcile reindex failed");
             } else {
@@ -368,6 +401,7 @@ async fn reconcile(wiki: &Wiki) -> WikiResult<ReconcileStats> {
     info!(
         indexed = stats.indexed,
         skipped_orphans = stats.skipped_orphans,
+        skipped_purged_sessions = stats.skipped_purged_sessions,
         "reconciliation pass complete",
     );
     Ok(stats)
@@ -600,6 +634,104 @@ mod tests {
             .unwrap();
         let wiki = Wiki::new(tmp.path(), store.writer.clone()).unwrap();
         (tmp, store, wiki, ws, proj)
+    }
+
+    /// A purge whose page-file cleanup failed must not be undone by the next
+    /// tick (#701).
+    ///
+    /// The guard #696 added closes the window where a reindex interleaves
+    /// between the database delete and the file cleanup. It cannot cover the
+    /// case where the file *outlives* the purge: a cleanup failure is a
+    /// reported, already-tested outcome, and after one the rows are gone while
+    /// the markdown is still on disk. Reverting the tombstone gate fails this.
+    #[tokio::test]
+    async fn purged_session_page_is_not_resurrected_by_a_reconcile_tick() {
+        let (tmp, store, wiki, ws, proj) = setup().await;
+        let sid = ai_memory_core::SessionId::new();
+        store
+            .writer
+            .begin_session(ai_memory_core::NewSession {
+                id: sid,
+                workspace_id: ws,
+                project_id: proj,
+                agent_kind: ai_memory_core::AgentKind::ClaudeCode,
+                cwd: None,
+                actor_user: None,
+            })
+            .await
+            .unwrap();
+
+        let sessions_dir = tmp
+            .path()
+            .join("wiki")
+            .join(ws.to_string())
+            .join(proj.to_string())
+            .join("sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let abs = sessions_dir.join(format!("{sid}.md"));
+        std::fs::write(&abs, "---\ntitle: Session\n---\n\nzimbabwe pineapple\n").unwrap();
+        let path = PagePath::new(format!("sessions/{sid}.md")).unwrap();
+        let page_id = wiki.reindex_page(ws, proj, path.clone()).await.unwrap();
+        store.writer.end_session(sid, Some(page_id)).await.unwrap();
+        assert_eq!(
+            store
+                .reader
+                .search_pages("zimbabwe".into(), 10)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "precondition: the session page is indexed",
+        );
+
+        // Make the unlink fail the way a read-only mount or a stray permission
+        // does — the markdown itself stays intact and readable.
+        let original = std::fs::metadata(&sessions_dir).unwrap().permissions();
+        let mut locked = original.clone();
+        locked.set_readonly(true);
+        std::fs::set_permissions(&sessions_dir, locked).unwrap();
+        let outcome = wiki
+            .purge_session(ws, proj, sid, None, ai_memory_store::Compaction::Skip)
+            .await
+            .unwrap();
+        std::fs::set_permissions(&sessions_dir, original).unwrap();
+
+        // Preconditions: this is the reported `files_failed` state.
+        assert_eq!(
+            outcome.files_failed,
+            vec![path.clone()],
+            "precondition: the unlink must have failed",
+        );
+        assert!(abs.exists(), "precondition: the page file survived");
+        assert!(
+            store
+                .reader
+                .search_pages("zimbabwe".into(), 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "precondition: the purge made the page unsearchable",
+        );
+
+        let stats = reconcile(&wiki).await.unwrap();
+        assert_eq!(
+            stats.skipped_orphans, 0,
+            "a session purge leaves the project row, so the orphan guard passes",
+        );
+        assert_eq!(
+            stats.skipped_purged_sessions, 1,
+            "the leftover page is skipped, and the pass says so",
+        );
+
+        let back = store
+            .reader
+            .search_pages("zimbabwe".into(), 10)
+            .await
+            .unwrap();
+        assert!(
+            back.is_empty(),
+            "a purged session's page must not be resurrected from a leftover file: {back:?}",
+        );
     }
 
     /// `extract_project_ids` must parse a valid `<ws>/<proj>/<path>` triplet.

--- a/crates/ai-memory-wiki/src/wiki.rs
+++ b/crates/ai-memory-wiki/src/wiki.rs
@@ -46,6 +46,25 @@ pub struct ReindexSummary {
     /// tombstoned (#607) — a purge whose on-disk removal did not complete.
     /// Their pages are deliberately not resurrected.
     pub skipped_purged: usize,
+    /// Session pages skipped because the session was purged and tombstoned
+    /// (#701) — the same case one level down, for a purge whose page-file
+    /// removal did not complete.
+    pub skipped_purged_sessions: usize,
+}
+
+/// Whether `path` is the page of a session this scope has tombstoned.
+///
+/// Only `sessions/<id>.md` can be resurrected this way: every other page is
+/// unrelated to a session purge, so the set is consulted for nothing else.
+pub(crate) fn is_purged_session_page(path: &PagePath, purged: &HashSet<SessionId>) -> bool {
+    if purged.is_empty() {
+        return false;
+    }
+    path.as_str()
+        .strip_prefix("sessions/")
+        .and_then(|rest| rest.strip_suffix(".md"))
+        .and_then(|id| id.parse::<SessionId>().ok())
+        .is_some_and(|id| purged.contains(&id))
 }
 
 enum PageStoreRemoval {
@@ -1217,6 +1236,27 @@ impl Wiki {
         }
     }
 
+    /// Session ids this scope has tombstoned, as a set for the reindex gate.
+    ///
+    /// The session-level twin of [`WriterHandle::scope_is_purged`], and read
+    /// the same way: once per directory per reindex pass, by the callers that
+    /// walk a tree, rather than once per page (#701).
+    ///
+    /// # Errors
+    /// Propagates the store error.
+    pub async fn purged_sessions(
+        &self,
+        workspace_id: WorkspaceId,
+        project_id: ProjectId,
+    ) -> WikiResult<HashSet<SessionId>> {
+        Ok(self
+            .writer
+            .purged_session_ids(workspace_id, project_id)
+            .await?
+            .into_iter()
+            .collect())
+    }
+
     /// Purge a session and its page files under one exclusive mutation guard.
     /// Admission must run before this call. File failures do not roll back the
     /// committed database purge and are returned for partial-failure reporting.
@@ -1646,7 +1686,16 @@ impl Wiki {
             let pages = tokio::task::spawn_blocking(move || crate::watcher::walk_markdown(&pr))
                 .await
                 .map_err(|e| WikiError::Io(std::io::Error::other(e.to_string())))??;
+            let purged = self.purged_sessions(ws, proj).await?;
             for path in pages {
+                if is_purged_session_page(&path, &purged) {
+                    tracing::debug!(
+                        path = %path,
+                        "skipping reindex of a purged (tombstoned) session page",
+                    );
+                    summary.skipped_purged_sessions += 1;
+                    continue;
+                }
                 self.reindex_page(ws, proj, path).await?;
                 summary.pages += 1;
             }


### PR DESCRIPTION
Fixes #701.

## Why the other shape does not work

I offered two shapes on the issue. Shape A — make the leftover file inert — is dead, and the measurement is the reason, so it is worth recording rather than just dropping.

Under the failure mode the repro induces (no write permission on the directory), each candidate mitigation, tried in isolation:

```
unlink (what cleanup does)         FAIL  Permission denied
rename within the directory        FAIL  Permission denied
create marker file beside it       FAIL  Permission denied
chmod the file to 000              OK
truncate the file to 0             OK
```

`rename` and a marker file need exactly the permission the `unlink` just lacked, so they are circular. `chmod` and `truncate` need different authority — the file's ownership rather than the directory's write bit — so they do survive that mode, and since the image runs as `USER ai-memory` rather than root, a `chmod 000` really does make the file unreadable.

But on a read-only mount every one of them fails:

```
unlink:   Read-only file system      chmod:    Read-only file system
rename:   Read-only file system      truncate: Read-only file system
marker:   Read-only file system      file still readable: yes
```

And by construction it cannot cover the routes where no cleanup code runs at all — a crash between the commit and the cleanup, or a request cancelled after the purge was enqueued. Shape A acts on the write side, which is the side that just failed or never ran. I did not test Windows, where `set_permissions` only toggles the readonly attribute and does not block reads, or a file held open by another process.

So the gate goes on the read side, which always runs.

## The fix

The same shape `reindex_all` already uses for a tombstoned scope (#607): the callers that walk a tree load the scope's tombstones once and skip the pages belonging to them. `reindex_page` is not changed, so this reads exactly like the `scope_is_purged` check above it. Only `sessions/<id>.md` is ever tested against the set; every other page short-circuits.

## Cost

This is the objection worth answering, because a per-page form would be real. Measured on 500 pages with 50 tombstones, release build:

| | |
|---|---|
| warm reconcile, gated | **55.7 µs/page** (`main` measures 64–71 µs/page — no measurable delta) |
| gate, per tick | **27.8 µs total** — one query, set of 50 |
| gate, per page (the form not taken) | **21.0 µs/page** |

Per page would have added roughly 66 ms and 3,132 extra writer-queue commands to every 30-second tick on a 3,132-page instance. Per tick it is one query per directory. The set holds session ids at 16 bytes each; an instance where all 2,624 sessions had been purged carries about 126 KB.

The bound this accepts: a session purged after the set is loaded, but before a later page in the same pass is reached, is not gated by that pass. That is one tick, the next pass gates it, and it is the same staleness the scope tombstone already carries.

## Test

The regression is the reproduction from the issue, unchanged in its assertions. Disabling the gate fails it twice: `skipped_purged_sessions` stays 0, and with that assertion removed the decisive one fires —

```
a purged session's page must not be resurrected from a leftover file:
[PageHit { path: PagePath("sessions/01a08c1d-...md"), title: "Session",
           snippet: "\n<mark>zimbabwe</mark> pineapple\n" }]
```

## Gates

`cargo fmt --all -- --check`, `git diff --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --all-targets` (3,176 passed, 0 failed) and `cargo deny check` (advisories/bans/licenses/sources ok) all pass.

## Note

I could not reopen #701 — this account has `pull` only, and `reopenIssue` returns 422 — so it is still showing closed. Worth reopening or relabelling as you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
