### PR TITLE
perf(wiki): let the path shape decide before the tombstone lookup (#701)

### DIFF
--- a/crates/ai-memory-wiki/src/watcher.rs
+++ b/crates/ai-memory-wiki/src/watcher.rs
@@ -256,14 +256,24 @@ async fn handle_event(wiki: &Wiki, event: notify_debouncer_full::DebouncedEvent)
             continue;
         }
         // A tombstoned session's page must not come back from a file its
-        // purge could not remove (#701). One query, for one event.
-        match wiki.purged_sessions(ws, proj).await {
-            Ok(purged) if crate::wiki::is_purged_session_page(&page_path, &purged) => {
-                debug!(path = %page_path, "ignoring event for a purged session page");
-                continue;
+        // purge could not remove (#701). The path shape decides whether the
+        // lookup is worth a round trip: only `sessions/<id>.md` can be that
+        // file, so an ordinary edit to `index.md` or a decision page never
+        // queries. The sweep paths amortise the same set over a whole
+        // directory instead; this one sees a single file per event.
+        if let Some(session) = crate::wiki::session_id_for_page(&page_path) {
+            match wiki.purged_sessions(ws, proj).await {
+                Ok(purged) if purged.contains(&session) => {
+                    debug!(path = %page_path, "ignoring event for a purged session page");
+                    continue;
+                }
+                Ok(_) => {}
+                // Fails open, deliberately: a transient lookup error must not
+                // stop the watcher from indexing edits. The cost of failing
+                // open here is bounded — the next reconcile pass loads the set
+                // again and skips the page then.
+                Err(e) => warn!(path = %page_path, error = %e, "purged-session lookup failed"),
             }
-            Ok(_) => {}
-            Err(e) => warn!(path = %page_path, error = %e, "purged-session lookup failed"),
         }
         match wiki.reindex_page(ws, proj, page_path.clone()).await {
             Ok(_) => debug!(path = %page_path, "reindexed via watcher"),
@@ -313,6 +323,10 @@ async fn reindex_project_dir(
         }
     };
 
+    // Fails open for the same reason the single-event path does: a lookup
+    // error must not stop a directory event from indexing. `Wiki::reindex_all`
+    // is the one caller that fails closed, because an operator-triggered
+    // reindex should report the failure rather than quietly skip the gate.
     let purged = wiki.purged_sessions(ws, proj).await.unwrap_or_else(|e| {
         warn!(error = %e, "purged-session lookup failed; not gating this pass");
         std::collections::HashSet::new()

--- a/crates/ai-memory-wiki/src/wiki.rs
+++ b/crates/ai-memory-wiki/src/wiki.rs
@@ -52,19 +52,29 @@ pub struct ReindexSummary {
     pub skipped_purged_sessions: usize,
 }
 
-/// Whether `path` is the page of a session this scope has tombstoned.
+/// The session a page belongs to, for paths that name one.
 ///
-/// Only `sessions/<id>.md` can be resurrected this way: every other page is
-/// unrelated to a session purge, so the set is consulted for nothing else.
-pub(crate) fn is_purged_session_page(path: &PagePath, purged: &HashSet<SessionId>) -> bool {
-    if purged.is_empty() {
-        return false;
-    }
+/// Pure path shape, no I/O: only `sessions/<id>.md` can be resurrected by a
+/// purge whose file cleanup failed, so this is what decides whether the
+/// tombstone set is worth consulting — or, on the single-event path, whether
+/// it is worth loading at all.
+pub(crate) fn session_id_for_page(path: &PagePath) -> Option<SessionId> {
     path.as_str()
         .strip_prefix("sessions/")
         .and_then(|rest| rest.strip_suffix(".md"))
         .and_then(|id| id.parse::<SessionId>().ok())
-        .is_some_and(|id| purged.contains(&id))
+}
+
+/// Whether `path` is the page of a session this scope has tombstoned.
+///
+/// For callers that already hold the scope's set. The empty-set and
+/// path-shape checks come first so a sweep over a project with no purges
+/// never parses an id.
+pub(crate) fn is_purged_session_page(path: &PagePath, purged: &HashSet<SessionId>) -> bool {
+    if purged.is_empty() {
+        return false;
+    }
+    session_id_for_page(path).is_some_and(|id| purged.contains(&id))
 }
 
 enum PageStoreRemoval {


### PR DESCRIPTION
Follow-up to #706, which Copilot reviewed correctly and which I did not land in time: the fix was committed six minutes after that PR merged, so `main` still carries the finding.

## What

`handle_event` runs the `purged_sessions` lookup for every markdown event, but the gate can only ever match `sessions/<id>.md` — an edit to `index.md` or a decision page pays a writer round trip to learn nothing. That is the same per-page cost #706 argued against for the sweep paths, so it should not have been on the event path either.

`is_purged_session_page` is split so `session_id_for_page` is the pure path shape, with no I/O, and the event path loads the set only when the path names a session at all. The sweep paths (`reindex_project_dir`, `reconcile`, `reindex_all`) are untouched — they already amortise one lookup over a whole directory.

## A property #706 left implicit

Worth reading rather than discovering: the gate **fails open in the watcher and closed in `reindex_all`**. `handle_event` and `reindex_project_dir` warn and index anyway when the lookup fails, because a transient store error must not stop the watcher, and a page that slips through is caught by the next reconcile pass. `reindex_all` propagates with `?`, because an operator who asked for a reindex should be told the gate could not run rather than have it silently skipped. This change does not alter that behaviour — it writes it down, in the commit body and beside each `Err` arm.

## Verification

The #701 regression re-verified on this base, both directions: it passes, and with the gate disabled it fails on `skipped_purged_sessions` staying 0, then — with that assertion removed — on the decisive one:

```
a purged session's page must not be resurrected from a leftover file:
[PageHit { path: PagePath("sessions/01a08c44-...md"), title: "Session",
           snippet: "\n<mark>zimbabwe</mark> pineapple\n" }]
```

`cargo fmt --all -- --check`, `git diff --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --all-targets` (3,180 passed, 0 failed) and `cargo deny check` all pass.

No changelog entry: the behaviour described in #706's entry is unchanged, only the cost of getting there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
