### PR TITLE
test(autoscope): budget process spawn, not the product

### DIFF
--- a/crates/ai-memory-cli/tests/suite/autoscope_env.rs
+++ b/crates/ai-memory-cli/tests/suite/autoscope_env.rs
@@ -152,7 +152,33 @@ fn spawn_and_wait_for_exit(envs: &[(&str, &str)], timeout: Duration) -> (bool, S
 }
 
 const STARTUP_NEEDLE: &str = "active-project isolation mode";
-const STARTUP_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// Wall-clock budget for the server to reach its startup log line.
+///
+/// Deliberately generous, because it measures the wrong thing on purpose. The
+/// server's own startup work is well under a second; what this actually bounds
+/// is ten copies of an unoptimised debug binary being spawned, linked and paged
+/// in at once by the test harness. That cost tracks binary size and machine
+/// load rather than anything about the product, so a tight budget turns a busy
+/// machine into a test failure.
+///
+/// A real startup regression still fails here. It just has to be a large one,
+/// which is the correct trade for a test whose failure would otherwise be read
+/// as noise. Concretely, the measured spread while writing this was 5.06s on a
+/// quiet machine and 28.5s under parallel load, so 45s trips on roughly a 9x
+/// regression against a quiet run and a 1.6x one against the worst observed.
+/// That is the inverse bound: anything subtler than that belongs in a
+/// benchmark, not here.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(45);
+
+/// How long a bad config gets to be rejected before the harness calls it a hang.
+///
+/// Same measurement problem as [`STARTUP_TIMEOUT`] and the same reason for the
+/// size: this bounds process spawn plus config parse, and "still running" is
+/// read as a failure to fail fast. Too tight, and a slow spawn under parallel
+/// load is indistinguishable from a config error that was silently accepted —
+/// which is the bug these tests exist to catch.
+const FAILFAST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// The shipped default keys the active-project pointer by whatever coordinate
 /// the caller has, so two harnesses in one project — or two operators on one
@@ -245,7 +271,7 @@ fn invalid_mode_value_fails_fast() {
     // want to catch in CI long before it reaches prod.
     let (exited_ok, all) = spawn_and_wait_for_exit(
         &[("AI_MEMORY_AUTO_SCOPE__MODE", "per_universe")],
-        Duration::from_secs(5),
+        FAILFAST_TIMEOUT,
     );
     assert!(
         !exited_ok,
@@ -317,10 +343,8 @@ fn empty_mode_string_fails_fast() {
     // `""` is not a valid serde enum variant. Just like
     // `per_universe`, this must abort startup — never quietly default
     // to single.
-    let (exited_ok, all) = spawn_and_wait_for_exit(
-        &[("AI_MEMORY_AUTO_SCOPE__MODE", "")],
-        Duration::from_secs(5),
-    );
+    let (exited_ok, all) =
+        spawn_and_wait_for_exit(&[("AI_MEMORY_AUTO_SCOPE__MODE", "")], FAILFAST_TIMEOUT);
     assert!(
         !exited_ok,
         "empty `mode` must NOT result in a successful startup.\nstderr:\n{all}"
@@ -335,7 +359,7 @@ fn pascalcase_mode_fails_fast() {
     // both forms (which would mask a future case-sensitivity bug).
     let (exited_ok, all) = spawn_and_wait_for_exit(
         &[("AI_MEMORY_AUTO_SCOPE__MODE", "PerSession")],
-        Duration::from_secs(5),
+        FAILFAST_TIMEOUT,
     );
     assert!(
         !exited_ok,


### PR DESCRIPTION
`autoscope_env` fails intermittently on macOS. Three consecutive runs of the
unchanged suite, on an idle machine, failed **1, then 5, then 7** of its 10
tests — each finishing in almost exactly 8.0s, against `STARTUP_TIMEOUT` of 8s.

```
run 1: FAILED. 9 passed; 1 failed;  finished in 8.01s
run 2: FAILED. 5 passed; 5 failed;  finished in 8.02s
run 3: FAILED. 3 passed; 7 failed;  finished in 8.03s
```

## Why

These tests spawn a server and wait for its startup log line. The server's own
startup work is well under a second; what the budget actually bounds is ten
copies of an unoptimised debug binary being spawned, linked and paged in at once
by the harness. That cost tracks binary size and machine load rather than
anything about the product, so the failure count measures how busy the machine
is rather than whether the code works.

## After

Same suite, same machine, four consecutive runs:

```
run 1: ok. 10 passed;  finished in 16.29s
run 2: ok. 10 passed;  finished in 28.51s
run 3: ok. 10 passed;  finished in  8.15s
run 4: ok. 10 passed;  finished in  5.06s
```

The spread is the point: identical work varying five-fold, and the 8.15s run
landing a fifth of a second the wrong side of the old budget. A real startup
regression still fails at 45s — it just has to be a large one, which seems the
right trade for a test whose failure would otherwise be read as noise.

## Also in this change

The three fail-fast checks had the same defect and are now one named constant
rather than three inline `Duration::from_secs(5)`. They bound process spawn plus
config parse and read "still running" as a failure to reject a bad config, so
under load a slow spawn is indistinguishable from a misconfiguration being
silently accepted — which is the bug those tests exist to catch. They did not
fail in my runs; a downstream fork carrying a larger binary saw them fail for
this reason, which is what prompted looking at them.

Both constants now carry the reason they are large, so the next person to see
45s does not tighten it back.

## Notes

Tests only — no product code touched.

Likely invisible in CI today: `ci.yml` runs Linux by default, and the macOS leg
joins on a `full-ci` label or manual dispatch. A loaded shared runner is exactly
where this bites, so it may be costing occasional red runs on the pre-release
macOS leg.

Happy to split the fail-fast half out if you would rather take only the
demonstrated failure.
