### PR TITLE
test(windows): make purge-resurrection setup portable

### DIFF
--- a/crates/ai-memory-wiki/src/watcher.rs
+++ b/crates/ai-memory-wiki/src/watcher.rs
@@ -684,16 +684,33 @@ mod tests {
             "precondition: the session page is indexed",
         );
 
-        // Make the unlink fail the way a read-only mount or a stray permission
-        // does — the markdown itself stays intact and readable.
+        // Make the unlink fail the way a read-only mount or a sharing
+        // violation does — the markdown itself stays intact and readable.
+        #[cfg(unix)]
         let original = std::fs::metadata(&sessions_dir).unwrap().permissions();
-        let mut locked = original.clone();
-        locked.set_readonly(true);
-        std::fs::set_permissions(&sessions_dir, locked).unwrap();
+        #[cfg(unix)]
+        {
+            let mut locked = original.clone();
+            locked.set_readonly(true);
+            std::fs::set_permissions(&sessions_dir, locked).unwrap();
+        }
+        #[cfg(windows)]
+        let _file_lock = {
+            use std::os::windows::fs::OpenOptionsExt;
+
+            // Windows checks the file handle's share mode when unlinking;
+            // a readonly directory does not prevent deletion there.
+            std::fs::OpenOptions::new()
+                .read(true)
+                .share_mode(0x0000_0001 | 0x0000_0002) // FILE_SHARE_READ | FILE_SHARE_WRITE
+                .open(&abs)
+                .unwrap()
+        };
         let outcome = wiki
             .purge_session(ws, proj, sid, None, ai_memory_store::Compaction::Skip)
             .await
             .unwrap();
+        #[cfg(unix)]
         std::fs::set_permissions(&sessions_dir, original).unwrap();
 
         // Preconditions: this is the reported `files_failed` state.


### PR DESCRIPTION
## What changed

The purge-resurrection regression test now uses a platform-appropriate failure setup: Unix keeps the readonly-directory case, while Windows holds the page open without delete sharing so unlink reliably fails. The production tombstone and reconcile assertions are unchanged.

## Why

On Windows, a readonly directory does not prevent deleting an otherwise shareable file. On main at 0e47a7cf50a3c5750ca0475e4c77a1dba171d9f0, cargo test --workspace --all-targets therefore failed the test precondition with an empty files_failed result. This keeps the existing regression coverage meaningful on both supported filesystem families. Fixes #712.

## Test plan

- [x] cargo fmt --all -- --check
- [x] git diff --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace --all-targets (3137 passed, 11 ignored)
- [x] cargo fmt --check --manifest-path companions/ai-memory-importer/Cargo.toml
- [x] cargo clippy --manifest-path companions/ai-memory-importer/Cargo.toml --all-targets -- -D warnings
- [x] cargo test --manifest-path companions/ai-memory-importer/Cargo.toml (19 passed)
- [x] focused purge-resurrection regression (1 passed)
- [ ] cargo deny check (not installed on this machine)

## Commit attribution

- [x] Commit author uses the verified GitHub noreply address.

## Release impact

- [x] Patch - test-only portability fix; no user-facing behavior change.

## CHANGELOG (merge gate)

- [x] Exempt: test-only churn; no user-facing behavior changed.

## Notes for reviewers

The Windows handle uses FILE_SHARE_READ and FILE_SHARE_WRITE but omits FILE_SHARE_DELETE, which is the native way to make remove_file report a sharing violation while keeping the file readable.